### PR TITLE
[Fix] Redis circuit breaker blog: minor copy edit

### DIFF
--- a/blog/redis_circuit_breaker/index.md
+++ b/blog/redis_circuit_breaker/index.md
@@ -98,7 +98,7 @@ REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD=5   # failures before opening
 REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT=60  # seconds before probe
 ```
 
-The circuit breaker ships on by default in all LiteLLM versions since `v1.82.0`. No configuration needed for most deployments.
+The circuit breaker is on by default in all LiteLLM versions since `v1.82.0`. No configuration needed for most deployments.
 
 ## Key Takeaways
 


### PR DESCRIPTION
## Summary

Changes "ships on by default" to "is on by default" in the Redis circuit breaker blog post — minor phrasing cleanup.

## Type

🧹 Refactoring