### PR TITLE
[Test] Break Vercel build to test required status check

### DIFF
--- a/blog/redis_circuit_breaker/index.md
+++ b/blog/redis_circuit_breaker/index.md
@@ -105,7 +105,7 @@ The circuit breaker is on by default in all LiteLLM versions since `v1.82.0`. No
 - A slow Redis is more dangerous than a downed one: 30-second timeouts across 100+ pods overwhelm Postgres at 100× normal load
 - LiteLLM's AI Gateway uses a circuit breaker that fast-fails Redis calls at 0ms after 5 consecutive failures
 - Three states: CLOSED (normal), OPEN (fast-fail + DB fallback), HALF-OPEN (probe recovery)
-- Auth, rate limiting, and spend tracking continue working during Redis outages
+- Auth, rate limiting, and spend tracking keep working during Redis outages
 - Resilient, production-grade behavior — enabled by default since `v1.82.0`, no configuration required
 
 ---

--- a/blog/security_update_march_2026/index.md
+++ b/blog/security_update_march_2026/index.md
@@ -101,7 +101,7 @@ pip show litellm
 
 Go to the proxy base url, and check the version of the installed LiteLLM.
 
-![Proxy version check](../../img/security_update_march_2026/proxy_version_broken.png)
+![Proxy version check](../../img/security_update_march_2026/proxy_version.png)
 </TabItem>
 <TabItem value="github" label="GitHub Actions">
 

--- a/blog/security_update_march_2026/index.md
+++ b/blog/security_update_march_2026/index.md
@@ -101,7 +101,7 @@ pip show litellm
 
 Go to the proxy base url, and check the version of the installed LiteLLM.
 
-![Proxy version check](../../img/security_update_march_2026/proxy_version.png)
+![Proxy version check](../../img/security_update_march_2026/proxy_version_broken.png)
 </TabItem>
 <TabItem value="github" label="GitHub Actions">
 


### PR DESCRIPTION
## Summary

Intentionally breaks an image path in the March 2026 security update blog post to test that the Vercel build required status check blocks merging.

Changed `proxy_version.png` to `proxy_version_broken.png` (file does not exist).

## Type

✅ Test