### PR TITLE
[Docs] Add 6 missing env var entries to config_settings.md

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -488,6 +488,7 @@ router_settings:
 | AZURE_STORAGE_CLIENT_SECRET | The Application Client Secret to use for Authentication to Azure Blob Storage logging
 | AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY | Cost per GB per day for Azure Vector Store service
 | BACKGROUND_HEALTH_CHECK_MAX_TOKENS | Optional global default for `max_tokens` on proxy background health checks when a model has no `health_check_max_tokens`. If unset, non-wildcard models default to 1. Applies to wildcard routes when set. Default is unset
+| BACKGROUND_HEALTH_CHECK_MAX_TOKENS_REASONING | For **non-wildcard** reasoning models (`supports_reasoning(model)=true`), this takes precedence over `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` when set. If unset, reasoning models fall back to `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` (if set) or default behavior. Wildcard routes ignore this. Default is unset
 | BATCH_STATUS_POLL_INTERVAL_SECONDS | Interval in seconds for polling batch status. Default is 3600 (1 hour)
 | BATCH_STATUS_POLL_MAX_ATTEMPTS | Maximum number of attempts for polling batch status. Default is 24 (for 24 hours)
 | BEDROCK_MAX_POLICY_SIZE | Maximum size for Bedrock policy. Default is 75
@@ -720,6 +721,11 @@ router_settings:
 | GITHUB_COPILOT_TOKEN_DIR | Directory to store GitHub Copilot token for `github_copilot` llm provider
 | GITHUB_COPILOT_API_KEY_FILE | File to store GitHub Copilot API key for `github_copilot` llm provider
 | GITHUB_COPILOT_ACCESS_TOKEN_FILE | File to store GitHub Copilot access token for `github_copilot` llm provider
+| GITHUB_COPILOT_API_BASE | Base URL for GitHub Copilot API. For GitHub Enterprise subscriptions with custom host, it is similar to https://copilot-api.my-company.ghe.com. Default is https://api.githubcopilot.com
+| GITHUB_COPILOT_DEVICE_CODE_URL | URL for GitHub Copilot device code authentication. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/device/code. Default is https://github.com/login/device/code
+| GITHUB_COPILOT_ACCESS_TOKEN_URL | URL for GitHub Copilot access token retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/oauth/access_token. Default is https://github.com/login/oauth/access_token
+| GITHUB_COPILOT_API_KEY_URL | URL for GitHub Copilot API key retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/api/v3/copilot_internal/v2/token. Default is https://api.github.com/copilot_internal/v2/token
+| GITHUB_COPILOT_CLIENT_ID | Client ID for GitHub Copilot device flow authentication. This is used by the `github_copilot` provider for device code authentication. Default is "Iv1.b507a08c87ecfe98"
 | GREENSCALE_API_KEY | API key for Greenscale service
 | GREENSCALE_ENDPOINT | Endpoint URL for Greenscale service
 | GRAYSWAN_API_BASE | Base URL for GraySwan API. Default is https://api.grayswan.ai


### PR DESCRIPTION
## Relevant issues

## Summary

### Problem

Six environment variables are referenced in the [litellm source tree](https://github.com/BerriAI/litellm) but were missing from the \`docs/proxy/config_settings.md\` reference table in this repo. The \`tests/documentation_tests/test_env_keys.py\` validator in the main repo fails as a result.

### Fix

Add the 6 missing rows. Descriptions are copied verbatim from the entries that already exist in the litellm repo's legacy \`docs/my-website/docs/proxy/config_settings.md\`.

## Changes

- \`docs/proxy/config_settings.md\`: +6 lines, no deletions.
  - \`BACKGROUND_HEALTH_CHECK_MAX_TOKENS_REASONING\` (inserted after \`BACKGROUND_HEALTH_CHECK_MAX_TOKENS\`)
  - \`GITHUB_COPILOT_API_BASE\`, \`GITHUB_COPILOT_DEVICE_CODE_URL\`, \`GITHUB_COPILOT_ACCESS_TOKEN_URL\`, \`GITHUB_COPILOT_API_KEY_URL\`, \`GITHUB_COPILOT_CLIENT_ID\` (grouped with existing \`GITHUB_COPILOT_*\` entries)

## Testing

Cloned BerriAI/litellm with the follow-up PR that migrates documentation_tests from CircleCI to a new GitHub Actions workflow. That workflow checks out this repo and runs \`tests/documentation_tests/test_env_keys.py\` against it; the 6 keys listed above are exactly the ones flagged as \"not documented\".

## Type

📖 Documentation