### PR TITLE
docs: rename CoWork to Cowork in Claude Desktop tutorial title

### DIFF
--- a/docs/tutorials/claude_desktop_cowork.md
+++ b/docs/tutorials/claude_desktop_cowork.md
@@ -1,4 +1,4 @@
-# Claude Desktop (CoWork) Integration
+# Claude Desktop (Cowork) Integration
 
 Route Claude Desktop requests through LiteLLM Proxy to get unified logging, budget controls, and access to any model.
 


### PR DESCRIPTION
## Changes

Renames "CoWork" → "Cowork" in the Claude Desktop tutorial page title.

## Pre-Submission Checklist

- [x] Single-line title change only