### PR TITLE
[Docs] Document route_all_chat_openai_to_responses flag

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -432,9 +432,59 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 | fine tuned `gpt-3.5-turbo-1106` | `response = completion(model="ft:gpt-3.5-turbo-1106", messages=messages)` |
 | fine tuned `gpt-3.5-turbo-0613` | `response = completion(model="ft:gpt-3.5-turbo-0613", messages=messages)` |
 
-## Getting Reasoning Content in `/chat/completions`
+## [BETA] Route all .completions requests to Responses API (better quality)
+ When enabled, LiteLLM sends OpenAI traffic from `litellm.completion()` and the proxy `/chat/completions` endpoint through the [Responses API](https://platform.openai.com/docs/api-reference/responses) instead of Chat Completions. That path generally matches OpenAI's latest model behavior and quality (for example, reasoning output on GPT‑5 class models).
 
-GPT-5 models return reasoning content when called via the Responses API. You can call these models via the `/chat/completions` endpoint by using the `openai/responses/` prefix.
+You can opt in globally or per request:
+
+**Option A — per-request prefix:** Use the `openai/responses/` model prefix.
+
+**Option B — global flag (recommended):** Set `route_all_chat_openai_to_responses = True` to automatically route all OpenAI `/chat/completions` requests through the Responses API, no model prefix needed.
+
+<Tabs>
+<TabItem value="sdk-global" label="SDK - Global Flag">
+
+```python
+import litellm
+
+litellm.route_all_chat_openai_to_responses = True
+
+response = litellm.completion(
+    model="gpt-5.4",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    reasoning_effort="low",
+)
+```
+
+</TabItem>
+<TabItem value="proxy-global" label="PROXY - Global Flag">
+
+Set in your proxy config:
+```yaml
+litellm_settings:
+  route_all_chat_openai_to_responses: true
+```
+
+Then call normally — no model prefix needed:
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+    "model": "gpt-5.4",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}],
+    "reasoning_effort": "low"
+}'
+```
+
+</TabItem>
+</Tabs>
+
+:::note
+`route_all_chat_openai_to_responses` only applies to the `openai` provider. Azure OpenAI is unaffected. You can also set it via env var: `LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES=true`.
+:::
+
+**Option A — per-request prefix:** You can also prefix individual model names with `openai/responses/` to route just that call through the Responses API.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -197,6 +197,7 @@ router_settings:
 | key_generation_settings | object | Restricts who can generate keys. [Further docs](./virtual_keys.md#restricting-key-generation) |
 | disable_add_transform_inline_image_block | boolean | For Fireworks AI models - if true, turns off the auto-add of `#transform=inline` to the url of the image_url, if the model is not a vision model. |
 | use_chat_completions_url_for_anthropic_messages | boolean | If true, routes OpenAI `/v1/messages` requests through chat/completions instead of the Responses API. Can also be set via env var `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true`. |
+| route_all_chat_openai_to_responses | boolean | If true, routes all OpenAI `/chat/completions` requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via env var `LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES=true`. |
 | skip_system_message_in_guardrail | boolean | If true, unified guardrails omit `role: system` from scanned input on **chat completions** and **Anthropic `/v1/messages`** only; the LLM still receives full messages. Per-guardrail override: `litellm_params.skip_system_message_in_guardrail` on each guardrail. [Guardrails quick start](./guardrails/quick_start#skip-system-messages-in-guardrail-evaluation) |
 | disable_hf_tokenizer_download | boolean | If true, it defaults to using the openai tokenizer for all models (including huggingface models). |
 | enable_json_schema_validation | boolean | If true, enables json schema validation for all requests. |
@@ -868,6 +869,7 @@ router_settings:
 | LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE | AWS KMS encrypted license for LiteLLM
 | LITELLM_TOKEN | Access token for LiteLLM integration
 | LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES | When set to "true", routes OpenAI /v1/messages requests through chat/completions instead of the Responses API for Anthropic models. Can also be set via `litellm_settings.use_chat_completions_url_for_anthropic_messages`
+| LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES | When set to "true", routes all OpenAI /chat/completions requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via `litellm_settings.route_all_chat_openai_to_responses`
 | LITELLM_USER_AGENT | Custom user agent string for LiteLLM API requests. Used for partner telemetry attribution
 | LITELLM_WORKER_STARTUP_HOOKS | Comma-separated list of `module.path:function_name` callables to run in each worker process during startup. Runs early in the worker lifecycle (before config/DB loading). Useful for re-initializing per-process state like [gflags](https://github.com/google/python-gflags). See [Worker Startup Hooks](/proxy/worker_startup_hooks) for details
 | LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD | If true, prints the standard logging payload to the console - useful for debugging


### PR DESCRIPTION
## Relevant issues

Ports the docs portion of [BerriAI/litellm#25359](https://github.com/BerriAI/litellm/pull/25359) (docs check on that PR fails because docs have moved to this repo).

## Summary

Documents the new `route_all_chat_openai_to_responses` global flag (and its `LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES` env var). When enabled, OpenAI `/chat/completions` requests are routed through the Responses API bridge without needing the `openai/responses/` model prefix.

## Changes

- \`docs/providers/openai.md\`: replace the old "Getting Reasoning Content in \`/chat/completions\`" section with a \`[BETA]\` section covering both the global flag (Option B, recommended) and the per-request prefix (Option A).
- \`docs/proxy/config_settings.md\`: add \`litellm_settings.route_all_chat_openai_to_responses\` and the \`LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES\` env var entries.

No content changes beyond what is in [BerriAI/litellm#25359](https://github.com/BerriAI/litellm/pull/25359).

## Testing

Docs-only change.

## Type

📖 Documentation