### PR TITLE
[Docs] Sync drifted content from litellm repo (apr24)

### DIFF
--- a/blog/gemini_3/index.md
+++ b/blog/gemini_3/index.md
@@ -479,8 +479,8 @@ For Gemini 3 Pro Preview, LiteLLM automatically maps `reasoning_effort` to the n
 | `"none"` | `"low"` | Gemini 3 cannot fully disable thinking |
 
 #### Default Behavior
+LiteLLM **does not** set `thinking_level` when you omit `reasoning_effort`. The Gemini API applies its **native defaults**, matching a direct call to Google.
 
-If you don't specify `reasoning_effort`, LiteLLM automatically sets `thinking_level="low"` for Gemini 3 models, to avoid high costs. 
 
 ### Example Usage
 
@@ -542,7 +542,7 @@ curl http://localhost:4000/v1/chat/completions \
    - Degraded reasoning performance
    - Failure on complex tasks
 
-3. **Automatic Defaults**: If you don't specify `reasoning_effort`, LiteLLM automatically sets `thinking_level="low"` for optimal performance.
+3. **Thinking defaults come from the API**: If you omit `reasoning_effort`, LiteLLM does **not** override `thinking_level`. Set `reasoning_effort` or native thinking parameters when you want a predictable cost or latency profile (for example `reasoning_effort="low"` for lighter reasoning).
 
 ## Cost Tracking: Prompt Caching & Context Window
 

--- a/blog/gemini_embedding_2_ga/index.md
+++ b/blog/gemini_embedding_2_ga/index.md
@@ -1,0 +1,172 @@
+---
+slug: gemini_embedding_2_ga
+title: "Gemini Embedding 2 (GA): Multimodal Embeddings on LiteLLM"
+date: 2026-04-24T10:00:00
+authors:
+  - sameer
+description: "Use generally available gemini-embedding-2 for multimodal embeddings on LiteLLM via Gemini API and Vertex AI—the same flows as preview, stable model id."
+tags: [gemini, embeddings, multimodal, vertex ai]
+hide_table_of_contents: false
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Gemini Embedding 2 (GA): Multimodal Embeddings
+
+Litellm now fully supports Gemini Embedding 2 GA.
+
+:::info
+For end-to-end behavior, input shapes, and MIME types, see the [Gemini Embedding 2 Preview walkthrough](/blog/gemini_embedding_2_multimodal). This post focuses on **GA naming**, **cost map** coverage.
+:::
+
+{/* truncate */}
+
+## Supported Input Types
+
+| Modality | Supported Formats |
+|----------|-------------------|
+| **Text** | Plain text |
+| **Image** | PNG, JPEG |
+| **Audio** | MP3, WAV |
+| **Video** | MP4, MOV |
+| **Documents** | PDF |
+
+## Input Formats
+
+LiteLLM accepts three input formats for multimodal content:
+
+1. **Data URIs** – Base64-encoded inline: `data:image/png;base64,<encoded_data>`
+2. **GCS URLs** – Cloud Storage paths (Vertex AI): `gs://bucket/path/to/file.png`
+3. **Gemini File References** – Pre-uploaded files (Gemini API): `files/abc123`
+
+## Quick Start
+
+<Tabs>
+<TabItem value="gemini" label="Gemini API">
+
+```python
+from litellm import embedding
+import os
+
+os.environ["GEMINI_API_KEY"] = "your-api-key"
+
+# Text + Image (base64)
+response = embedding(
+    model="gemini/gemini-embedding-2",
+    input=[
+        "The food was delicious and the waiter...",
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
+    ],
+)
+print(response)
+```
+
+</TabItem>
+
+<TabItem value="vertex" label="Vertex AI">
+
+```python
+import litellm
+from litellm import embedding
+
+litellm.vertex_project = "your-project-id"
+litellm.vertex_location = "us-central1"
+
+# Text + Image (GCS URL)
+response = embedding(
+    model="vertex_ai/gemini-embedding-2",
+    input=[
+        "Describe this image",
+        "gs://my-bucket/images/photo.png"
+    ],
+)
+print(response)
+```
+
+</TabItem>
+
+<TabItem value="proxy" label="LiteLLM Proxy">
+
+**1. Config (config.yaml)**
+
+```yaml
+model_list:
+  - model_name: gemini-embedding-2
+    litellm_params:
+      model: gemini/gemini-embedding-2
+      api_key: os.environ/GEMINI_API_KEY
+  - model_name: vertex-gemini-embedding-2
+    litellm_params:
+      model: vertex_ai/gemini-embedding-2
+      vertex_project: os.environ/VERTEXAI_PROJECT
+      vertex_location: global
+
+general_settings:
+  master_key: sk-1234
+```
+
+**2. Start proxy**
+
+```bash
+litellm --config config.yaml
+```
+
+**3. Call embeddings** (OpenAI-compatible **`POST /v1/embeddings`** on the proxy)
+
+```bash
+curl -sS -X POST http://localhost:4000/v1/embeddings \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-embedding-2",
+    "input": [
+      "The food was delicious and the waiter...",
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Input Format Examples
+
+| Format | Example | Provider |
+|--------|---------|----------|
+| **Data URI** | `data:image/png;base64,...` | Gemini, Vertex AI |
+| **GCS URL** | `gs://bucket/path/image.png` | Vertex AI |
+| **File reference** | `files/abc123` | Gemini API only |
+
+### Supported MIME Types for Data URIs
+
+- **Images:** `image/png`, `image/jpeg`
+- **Audio:** `audio/mpeg`, `audio/wav`
+- **Video:** `video/mp4`, `video/quicktime`
+- **Documents:** `application/pdf`
+
+### GCS URL MIME Inference
+
+For Vertex AI, MIME types are inferred from file extensions:
+
+- `.png` → `image/png`
+- `.jpg` / `.jpeg` → `image/jpeg`
+- `.mp3` → `audio/mpeg`
+- `.wav` → `audio/wav`
+- `.mp4` → `video/mp4`
+- `.mov` → `video/quicktime`
+- `.pdf` → `application/pdf`
+
+## Optional Parameters
+
+| Parameter | Description | Maps to |
+|-----------|-------------|---------|
+| `dimensions` | Output embedding size | `outputDimensionality` |
+
+```python
+response = embedding(
+    model="gemini/gemini-embedding-2",
+    input=["text to embed"],
+    dimensions=768,  # Optional: control output vector size
+)
+```

--- a/docs/completion/web_search.md
+++ b/docs/completion/web_search.md
@@ -596,3 +596,87 @@ Expected Response
 
 </TabItem>
 </Tabs>
+
+## Web Search Cost Tracking
+
+LiteLLM tracks web search costs automatically based on provider-specific billing models. The cost is added on top of the standard token-based pricing.
+
+### How providers charge for web search
+
+| Provider | Billing Unit | How it works |
+|----------|-------------|--------------|
+| **Gemini 3.x** (3-flash, 3-pro, 3.1-*) | Per search query | Each internal search query is billed individually. One prompt may trigger multiple queries. |
+| **Gemini 2.x** (2.0-flash, 2.5-flash, 2.5-pro) | Per grounded prompt | Flat fee per API call that uses grounding, regardless of how many queries are executed internally. |
+| **OpenAI** (gpt-4o-search, gpt-5-search) | Per search context size | Cost varies by `search_context_size` (`low`, `medium`, `high`). |
+| **Anthropic** (Claude with web search) | Per search request | Fixed cost per web search tool invocation. |
+| **Perplexity** (sonar, sonar-pro) | Per search context size | Cost varies by `search_context_size`. |
+
+### Pricing configuration
+
+Web search costs are defined in `model_prices_and_context_window.json` using two fields:
+
+- **`search_context_cost_per_query`**: the cost per billable unit (per search context size tier).
+- **`web_search_billing_unit`** *(on Gemini models)*: `"per_query"` (each search query is billed individually) or `"per_prompt"` (default — flat fee per API call that uses search).
+
+```json
+{
+    "gemini/gemini-3-flash-preview": {
+        "web_search_billing_unit": "per_query",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        }
+    },
+    "gemini/gemini-2.5-flash": {
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        }
+    }
+}
+```
+
+:::info
+Models without `web_search_billing_unit` default to `"per_prompt"` — one flat charge per API call that uses web search, regardless of how many internal queries the model executes.
+:::
+
+You can override these in your proxy config using `model_info`:
+
+```yaml
+model_list:
+  - model_name: gemini-3-flash
+    litellm_params:
+      model: gemini/gemini-3-flash-preview
+    model_info:
+      web_search_billing_unit: per_query
+      search_context_cost_per_query:
+        search_context_size_low: 0.014
+        search_context_size_medium: 0.014
+        search_context_size_high: 0.014
+```
+
+### How LiteLLM tracks search usage
+
+The number of web search requests is stored in `usage.prompt_tokens_details.web_search_requests`. LiteLLM extracts this from each provider's response:
+
+- **Gemini**: Extracted from `groundingMetadata.webSearchQueries` in the response. For Gemini 2.x, clamped to 1 (per-prompt billing).
+- **OpenAI**: Reported directly in the usage metadata.
+- **Anthropic**: Reported via `server_tool_use.web_search_requests`.
+- **xAI**: Mapped from `num_sources_used` in the response.
+
+```python
+response = litellm.completion(
+    model="gemini/gemini-3-flash-preview",
+    messages=[{"role": "user", "content": "Latest tech news?"}],
+    web_search_options={"search_context_size": "medium"},
+)
+
+# Check web search usage
+print(response.usage.prompt_tokens_details.web_search_requests)  # e.g., 3
+
+# Get total cost (includes token cost + web search cost)
+cost = litellm.completion_cost(completion_response=response)
+print(f"Total cost: ${cost}")
+```

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -83,7 +83,7 @@ Note: Reasoning cannot be turned off on Gemini 2.5 Pro models.
 :::
 
 :::tip Gemini 3 Models
-For **Gemini 3+ models** (e.g., `gemini-3-pro-preview`), LiteLLM automatically maps `reasoning_effort` to the new `thinking_level` parameter instead of `thinking_budget`. The `thinking_level` parameter uses `"low"` or `"high"` values for better control over reasoning depth.
+For **Gemini 3+ models** (e.g., `gemini-3-pro-preview`), LiteLLM maps `reasoning_effort` to the `thinking_level` field instead of `thinking_budget` when you set it. Supported levels depend on the model (Flash-family models also support `minimal` and `medium`). If you omit `reasoning_effort`, LiteLLM does **not** send a default `thinking_level` — the request uses the **Gemini API defaults** (Gemini 3 Flash defaults to `high` on the API).
 :::
 
 :::warning Image Models
@@ -104,12 +104,12 @@ For **Gemini 3+ models** (e.g., `gemini-3-pro-preview`), LiteLLM automatically m
 
 | reasoning_effort | thinking_level | Notes |
 | ---------------- | -------------- | ----- |
-| "minimal"        | "low" | Minimizes latency and cost |
+| "minimal"        | `"minimal"` (Flash / some 3.1) or `"low"` | Flash-family IDs use `minimal` when supported |
 | "low"            | "low" | Best for simple instruction following or chat |
-| "medium"         | "high" | Maps to high (medium not yet available) |
+| "medium"         | `"medium"` or `"high"` | `"medium"` where the API supports it; otherwise `"high"` |
 | "high"           | "high" | Maximizes reasoning depth |
-| "disable"        | "low" | Cannot fully disable thinking in Gemini 3 |
-| "none"           | "low" | Cannot fully disable thinking in Gemini 3 |
+| "disable"        | `"minimal"` (Flash) or `"low"` | Cannot fully disable thinking in Gemini 3 |
+| "none"           | `"minimal"` (Flash) or `"low"` | Cannot fully disable thinking in Gemini 3 |
 
 <Tabs>
 <TabItem value="sdk" label="SDK">

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -433,7 +433,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 | fine tuned `gpt-3.5-turbo-0613` | `response = completion(model="ft:gpt-3.5-turbo-0613", messages=messages)` |
 
 ## [BETA] Route all .completions requests to Responses API (better quality)
- When enabled, LiteLLM sends OpenAI traffic from `litellm.completion()` and the proxy `/chat/completions` endpoint through the [Responses API](https://platform.openai.com/docs/api-reference/responses) instead of Chat Completions. That path generally matches OpenAI's latest model behavior and quality (for example, reasoning output on GPT‑5 class models).
+ When enabled, LiteLLM sends OpenAI traffic from `litellm.completion()` and the proxy `/chat/completions` endpoint through the [Responses API](https://platform.openai.com/docs/api-reference/responses) instead of Chat Completions. That path generally matches OpenAI’s latest model behavior and quality (for example, reasoning output on GPT‑5 class models).
 
 You can opt in globally or per request:
 

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -2061,7 +2061,7 @@ assert isinstance(
 
 ## Media Resolution Control (Images & Videos)
 
-For Gemini 3+ models, LiteLLM supports per-part media resolution control using OpenAI's `detail` parameter. This allows you to specify different resolution levels for individual images and videos in your request, whether using `image_url` or `file` content types.
+LiteLLM supports per-part media resolution control using OpenAI's `detail` parameter for all Gemini models. This allows you to specify different resolution levels for individual images and videos in your request, whether using `image_url` or `file` content types.
 
 **Supported `detail` values:**
 - `"low"` - Maps to `media_resolution: "low"` (280 tokens for images, 70 tokens per frame for videos)
@@ -2146,12 +2146,12 @@ response = completion(
 </Tabs>
 
 :::info
-**Per-Part Resolution:** Each image or video in your request can have its own `detail` setting, allowing mixed-resolution requests (e.g., a high-res chart alongside a low-res icon). This feature works with both `image_url` and `file` content types, and is only available for Gemini 3+ models.
+**Per-Part Resolution:** Each image or video in your request can have its own `detail` setting, allowing mixed-resolution requests (e.g., a high-res chart alongside a low-res icon). This feature works with both `image_url` and `file` content types across all Gemini models.
 :::
 
 ## Video Metadata Control
 
-For Gemini 3+ models, LiteLLM supports fine-grained video processing control through the `video_metadata` field. This allows you to specify frame extraction rates and time ranges for video analysis.
+LiteLLM supports fine-grained video processing control through the `video_metadata` field for all Gemini models (1.x, 2.x, 3+). This allows you to specify frame extraction rates and time ranges for video analysis.
 
 **Supported `video_metadata` parameters:**
 
@@ -2168,8 +2168,11 @@ For Gemini 3+ models, LiteLLM supports fine-grained video processing control thr
 - `fps` remains unchanged
 :::
 
+:::tip
+Video clipping (`start_offset`/`end_offset`) and frame rate control (`fps`) are supported by all Gemini models, but analysis quality is significantly higher with the **Gemini 2.5 series** (e.g., `gemini-2.5-flash`, `gemini-2.5-pro`).
+:::
+
 :::warning
-- **Gemini 3+ Only:** This feature is only available for Gemini 3.0 and newer models
 - **Video Files Recommended:** While `video_metadata` is designed for video files, error handling for other media types is delegated to the Vertex AI API
 - **File Formats Supported:** Works with `gs://`, `https://`, and base64-encoded video files
 :::

--- a/docs/proxy/response_headers.md
+++ b/docs/proxy/response_headers.md
@@ -51,11 +51,42 @@ These headers are useful for clients to understand the current rate limit status
 ## LiteLLM Specific Headers
 | Header | Type | Description | Available on Pass-Through Endpoints |
 |--------|------|-------------|-------------|
-| `x-litellm-call-id` | string | Unique identifier for the API call | ✅ |
-| `x-litellm-model-id` | string | Unique identifier for the model used | |
-| `x-litellm-model-api-base` | string | Base URL of the API endpoint | ✅ |
-| `x-litellm-version` | string | Version of LiteLLM being used | |
-| `x-litellm-model-group` | string | Model group identifier | |
+| `x-litellm-call-id` | string | Id for this request | ✅ |
+| `x-litellm-model-id` | string | Deployment id (`model_info.id`) | |
+| `x-litellm-model-api-base` | string | API base URL | ✅ |
+| `x-litellm-version` | string | LiteLLM version | |
+| `x-litellm-model-group` | string | Routed `model_list[].model_name` (client `model`) | |
+
+### Example
+
+```yaml
+model_list:
+  - model_name: my-chat-model          # clients call this
+    litellm_params:
+      model: gpt-4o-mini               # LiteLLM calls this upstream
+    model_info:
+      id: "7c9f2a1b3d8e4f0a2c6b5d9e1f3a7b8c"   # optional; auto-generated if omitted
+```
+
+| Header | Example | Notes |
+|--------|---------|-------|
+| `x-litellm-model-group` | `my-chat-model` | `model_name` / request `model`; not `litellm_params.model`. |
+| `x-litellm-model-id` | `7c9f2a1b3d8e4f0a2c6b5d9e1f3a7b8c` | Which deployment row; use with `/v1/model/info?litellm_model_id=...`. |
+| Response body `model` | often `my-chat-model` | Often restamped to match the client; upstream id stays in config. |
+
+### More examples (illustrative)
+
+| Header | Example | Meaning |
+|--------|---------|---------|
+| `x-litellm-response-cost` | `0.000214` | This call (USD). |
+| `x-litellm-key-spend` | `12.847` | Key total after this call. |
+| `x-litellm-response-duration-ms` | `842.3` | Proxy end-to-end (ms). |
+| `x-litellm-overhead-duration-ms` | `15.1` | LiteLLM overhead (ms). |
+| `x-litellm-attempted-retries` | `0` | Retries. |
+| `x-litellm-attempted-fallbacks` | `1` | Fallbacks to another deployment. |
+| `x-litellm-call-id` | `019b2c4d-e5f6-7890-abcd-ef1234567890` | Logs / tracing. |
+| `x-litellm-version` | `1.55.3` | Version. |
+| `x-litellm-model-api-base` | `https://api.openai.com/v1` | Provider base (no query string). |
 
 ## Response headers from LLM providers
 

--- a/docs/response_api.md
+++ b/docs/response_api.md
@@ -1505,6 +1505,84 @@ curl http://localhost:4000/v1/responses \
 
 
 
+### Opt-in bridge for `openai/` models with custom `api_base`
+
+If you're using an **OpenAI-compatible third-party provider** (e.g. llama.cpp, vLLM, LM Studio) via `openai/` prefix with a custom `api_base`, LiteLLM will normally forward `/responses` requests directly to that endpoint. If the provider only supports `/chat/completions`, the request will fail.
+
+Use either of these to force the `/responses` → `/chat/completions` bridge:
+
+1. **`use_chat_completions_api: true`** — makes it explicit that LiteLLM will call the provider’s chat-completions API.
+2. **`openai/chat_completions/<model_name>`** — same pattern as `responses/` on chat completions: the model id encodes the routing choice.
+
+#### Python SDK Usage
+
+```python showLineNumbers title="Force bridge for custom openai/ endpoint (flag)"
+import litellm
+
+response = litellm.responses(
+    model="openai/my-custom-model",
+    input="Hello!",
+    api_base="http://localhost:8080",
+    api_key="fake-key",
+    use_chat_completions_api=True,
+)
+
+print(response)
+```
+
+Or encode it in the model id:
+
+```python showLineNumbers title="Force bridge via openai/chat_completions/ model prefix"
+import litellm
+
+response = litellm.responses(
+    model="openai/chat_completions/my-custom-model",
+    input="Hello!",
+    api_base="http://localhost:8080",
+    api_key="fake-key",
+)
+
+print(response)
+```
+
+#### LiteLLM Proxy Usage
+
+**Setup Config:**
+
+```yaml showLineNumbers title="config.yaml — bridge for custom openai/ endpoint"
+model_list:
+- model_name: my-local-model
+  litellm_params:
+    model: openai/my-custom-model
+    api_base: http://localhost:8080/v1
+    api_key: fake-key
+    use_chat_completions_api: true
+```
+
+Alternatively set `model: openai/chat_completions/my-custom-model` instead of the flag.
+
+**Start Proxy:**
+
+```bash showLineNumbers title="Start LiteLLM Proxy"
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+**Make Request:**
+
+```bash showLineNumbers title="Request via bridge"
+curl http://localhost:4000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "my-local-model",
+    "input": "Hello!"
+  }'
+```
+
+This is particularly useful when connecting clients that hardcode the `/responses` endpoint (e.g. OpenAI Codex CLI with `wire_api = "responses"`) to local or third-party OpenAI-compatible providers that only expose `/chat/completions`.
+
 ## Server-side compaction
 
 For long-running conversations, you can enable **server-side compaction** so that when the rendered context size crosses a threshold, the server automatically runs compaction in-stream and emits a compaction item—no separate `POST /v1/responses/compact` call is required.

--- a/release_notes/v1.82.3/index.md
+++ b/release_notes/v1.82.3/index.md
@@ -262,6 +262,9 @@ pip install litellm==1.82.3
 - **[OpenRouter](../../docs/providers/openrouter)**
     - Image edit support for OpenRouter models - [PR #22403](https://github.com/BerriAI/litellm/pull/22403)
 
+- **[Google Gemini](../../docs/providers/gemini)**
+    - Gemini 3 — no injected default `thinking_level` when `reasoning_effort` is omitted (matches Gemini API; Flash may default to `high` vs old `minimal`) — [Gemini 3 blog](../../blog/gemini_3)
+
 - **[Google Vertex AI](../../docs/providers/vertex)**
     - VIDEO modality token usage tracking in `completion_tokens_details` - [PR #22550](https://github.com/BerriAI/litellm/pull/22550)
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,8 @@
   --ifm-font-size-base: 15px;
   --ifm-line-height-base: 1.65;
   --ifm-border-radius: 6px;
+  /* Code fences: slightly more inset than Infima default (1rem), esp. next to bash left accent */
+  --ifm-pre-padding: 1.25rem;
   /* Wider reading column — reduces excessive whitespace on large monitors */
   --ifm-container-width: 1380px;
   --ifm-container-width-xl: 1560px;
@@ -307,6 +309,38 @@ li.tabs__item--active {
   border-radius: var(--ifm-border-radius);
   font-size: 12.5px !important;
   line-height: 1.6;
+}
+
+/* Docusaurus line-number mode uses vertical-only padding on the inner wrapper; restore horizontal inset */
+.theme-code-block span[class*='codeLineContent'] {
+  padding-left: var(--ifm-pre-padding);
+}
+
+/* Doc + blog: both render under `article > .markdown`. Blog prose `.markdown code` and
+   `pre:not(.prism-code) code` were zeroing inner padding on fenced blocks — match Infima/CodeBlock. */
+article .markdown pre:not(.prism-code) code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+
+article .markdown pre.prism-code code[class*='codeBlockLinesWithNumbering'] {
+  padding: var(--ifm-pre-padding) 0 !important;
+  font-size: var(--ifm-code-font-size) !important;
+  line-height: var(--ifm-pre-line-height) !important;
+  background: transparent !important;
+  border: none !important;
+  color: inherit !important;
+}
+
+article .markdown pre.prism-code code[class*='codeBlockLines']:not([class*='codeBlockLinesWithNumbering']) {
+  padding: var(--ifm-pre-padding) !important;
+  font-size: var(--ifm-code-font-size) !important;
+  line-height: var(--ifm-pre-line-height) !important;
+  background: transparent !important;
+  border: none !important;
+  color: inherit !important;
 }
 
 [data-theme='dark'] .prism-code {


### PR DESCRIPTION
## Summary

Port doc changes that landed on litellm's \`litellm_internal_staging\` branch since the last drift sync (apr23) but weren't mirrored into litellm-docs. Staging is used as the source of truth since it is a superset of main for docs — main had no unique doc commits.

## Changes

- **Gemini 3 thinking defaults**: LiteLLM no longer injects a default \`thinking_level\` when \`reasoning_effort\` is omitted; the Gemini API native default applies instead (blog, provider doc, release notes)
- **Vertex Gemini media resolution & video metadata**: clarified that per-part \`detail\` and \`video_metadata\` apply to all Gemini models, not just 3+
- **Web search cost tracking**: new section in \`docs/completion/web_search.md\` explaining per-provider billing models and \`search_context_cost_per_query\` / \`web_search_billing_unit\` configuration
- **Response API opt-in bridge**: documented \`use_chat_completions_api\` and \`openai/chat_completions/<model_name>\` for OpenAI-compatible third-party providers
- **Response headers clarity**: clarified \`x-litellm-model-group\` vs \`x-litellm-model-id\` with an example block
- **Gemini Embedding 2 GA**: new blog post
- **Code-block padding CSS**: parity with litellm repo (variables and \`article .markdown pre\` rules); preserves litellm-docs-only \`.blog-wrapper article .markdown pre code\` rule

## Type

📖 Documentation