### PR TITLE
observability: Splunk Observability Cloud + OTEL proxy guide

### DIFF
--- a/docs/integrations/observability_index.md
+++ b/docs/integrations/observability_index.md
@@ -22,6 +22,7 @@ items={[
   { icon: "📊", title: "MLflow", description: "Experiment tracking.", to: "/docs/observability/mlflow" },
   { icon: "🏋️", title: "Weights & Biases", description: "ML experiment tracking.", to: "/docs/observability/wandb_integration" },
   { icon: "📉", title: "PostHog", description: "Product analytics.", to: "/docs/observability/posthog_integration" },
+  { icon: "🔭", title: "Splunk Observability Cloud", description: "OTLP traces to Splunk.", to: "/docs/observability/splunk_observability_cloud" },
 ]}
 />
 

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -79,6 +79,19 @@ OTEL_HEADERS="authorization=Bearer <project-api-key>"
 
 </TabItem>
 
+<TabItem value="splunk" label="Splunk Observability Cloud">
+
+```shell
+OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<realm>.observability.splunkcloud.com/v2/trace/otlp"
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS="X-SF-Token=<your-ingest-access-token>"
+OTEL_SERVICE_NAME="litellm-proxy"
+```
+
+For **LiteLLM Proxy** setup, ingest token patterns, and trace verification, see **[Splunk Observability Cloud (OpenTelemetry)](/docs/observability/splunk_observability_cloud)**.
+
+</TabItem>
+
 </Tabs>
 
 Use just 1 line of code, to instantly log your LLM responses **across all providers** with OpenTelemetry:

--- a/docs/observability/splunk_observability_cloud.md
+++ b/docs/observability/splunk_observability_cloud.md
@@ -1,0 +1,125 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Splunk Observability Cloud (OpenTelemetry)
+
+Send LiteLLM traces to [Splunk Observability Cloud](https://www.splunk.com/en_us/products/observability-cloud.html) using the built-in **`otel`** callback and standard OpenTelemetry OTLP environment variables.
+
+LiteLLM uses the same OpenTelemetry path as the [OpenTelemetry integration](./opentelemetry_integration.md). Splunk’s OTLP/HTTP trace ingest URL uses **`/v2/trace/otlp`** (not **`/v1/traces`**); LiteLLM normalizes generic collector URLs but **preserves** Splunk-style `/v2/trace/otlp` endpoints so spans reach Splunk correctly.
+
+:::tip Video walkthrough
+
+If you recorded a Loom demo of this setup, add a public **Loom share** or **`loom.com/embed/...`** iframe here (same pattern as other tutorials, e.g. [OpenWebUI](/docs/tutorials/openweb_ui)), or link the video in your pull request description.
+
+:::
+
+## Prerequisites
+
+1. Splunk Observability Cloud account and an **ingest access token** (used as `X-SF-Token`).
+2. Your **realm** (for example `eu1`, `us0`) from the Splunk Observability Cloud UI or docs.
+3. OpenTelemetry OTLP packages (same as the main OTEL guide):
+
+```shell
+uv add opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+## Environment variables
+
+LiteLLM reads configuration via `OpenTelemetryConfig.from_env()` (see [`opentelemetry.py` in the LiteLLM repo](https://github.com/BerriAI/litellm/blob/main/litellm/integrations/opentelemetry.py)).
+
+| Purpose | Variable |
+|--------|----------|
+| Trace ingest URL (Splunk OTLP/HTTP) | `OTEL_EXPORTER_OTLP_ENDPOINT` — e.g. `https://ingest.<realm>.observability.splunkcloud.com/v2/trace/otlp` |
+| Auth | `OTEL_EXPORTER_OTLP_HEADERS` or `OTEL_HEADERS` — e.g. `X-SF-Token=<your-access-token>` (comma-separated `key=value` pairs for multiple headers) |
+| Protocol | `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` for OTLP/HTTP (use `grpc` only if you target a gRPC OTLP endpoint) |
+| Optional resource naming | `OTEL_SERVICE_NAME`, `OTEL_ENVIRONMENT_NAME`, etc. |
+
+**Precedence:** `OTEL_EXPORTER_OTLP_PROTOCOL` is read before legacy `OTEL_EXPORTER`. If both are set, the OTLP protocol variable wins. `OTEL_EXPORTER_OTLP_ENDPOINT` is preferred over `OTEL_ENDPOINT` when both are set.
+
+:::warning Sensitive data in traces
+
+OpenTelemetry spans may include request/response content and metadata. Review [redacting messages and responses](/docs/observability/opentelemetry_integration#redacting-messages-response-content-from-opentelemetry-logging) and [scrubbing / PII guidance](/docs/observability/scrub_data) before enabling full payloads in production.
+
+:::
+
+## LiteLLM Proxy
+
+<Tabs>
+<TabItem value="yaml" label="config.yaml">
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  callbacks: ["otel"]
+
+general_settings:
+  master_key: sk-1234
+
+environment_variables:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_EXPORTER_OTLP_HEADERS: "os.environ/SPLUNK_OTEL_HEADERS"
+  OTEL_SERVICE_NAME: "litellm-proxy"
+```
+
+Point `SPLUNK_OTEL_HEADERS` (or inline the header string) at a secret that expands to `X-SF-Token=<token>`.
+
+</TabItem>
+<TabItem value="env" label=".env (example)">
+
+```dotenv
+SPLUNK_ACCESS_TOKEN=your-ingest-access-token
+
+OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS=X-SF-Token=${SPLUNK_ACCESS_TOKEN}
+OTEL_SERVICE_NAME=litellm-proxy
+```
+
+Load these into the process environment before starting the proxy (for example `export` / systemd / Kubernetes secrets).
+
+</TabItem>
+</Tabs>
+
+Start the proxy:
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+## Python SDK
+
+```python
+import os
+import litellm
+
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
+    "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
+)
+os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "X-SF-Token=your-ingest-access-token"
+os.environ["OTEL_SERVICE_NAME"] = "my-app"
+
+litellm.callbacks = ["otel"]
+
+response = litellm.completion(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+## Verify traces
+
+1. In Splunk Observability Cloud, open **APM** / **Traces** (product names may vary by version).
+2. Filter by service name (`OTEL_SERVICE_NAME`, default `litellm` if unset).
+3. Optionally set `OTEL_DEBUG=True` in LiteLLM’s environment to surface exporter issues in logs (see [OpenTelemetry troubleshooting](/docs/observability/opentelemetry_integration#not-seeing-traces-land-on-integration)).
+
+## See also
+
+- [OpenTelemetry — Tracing LLMs](./opentelemetry_integration.md)
+- [Splunk Observability Cloud — OTLP exporter](https://docs.splunk.com/observability/en/gdi/opentelemetry/opentelemetry.html) (vendor docs)

--- a/docs/observability/splunk_observability_cloud.md
+++ b/docs/observability/splunk_observability_cloud.md
@@ -1,6 +1,3 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Splunk Observability Cloud (OpenTelemetry)
 
 Send LiteLLM traces to [Splunk Observability Cloud](https://www.splunk.com/en_us/products/observability-cloud.html) using the built-in **`otel`** callback and standard OpenTelemetry OTLP environment variables.
@@ -17,15 +14,21 @@ Or [watch on Loom](https://www.loom.com/share/9dc21b753bbe4f6fb3c1b44c06e39c20).
 
 1. Splunk Observability Cloud account and an **ingest access token** (used as `X-SF-Token`).
 2. Your **realm** (for example `eu1`, `us0`) from the Splunk Observability Cloud UI or docs.
-3. OpenTelemetry OTLP packages (same as the main OTEL guide):
 
-```shell
-uv add opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+## LiteLLM Proxy
+
+Same flow as integrations like [Datadog Logs](./datadog#datadog-logs): configure **`config.yaml`**, then set environment variables, then start the proxy.
+
+**Step 1:** In `config.yaml`, enable the OpenTelemetry callback:
+
+```yaml
+litellm_settings:
+  callbacks: ["otel"]
 ```
 
-## Environment variables
+**Step 2:** Set the OTLP environment variables LiteLLM reads via `OpenTelemetryConfig.from_env()` (see [`opentelemetry.py` in the LiteLLM repo](https://github.com/BerriAI/litellm/blob/main/litellm/integrations/opentelemetry.py) and the [OpenTelemetry integration](./opentelemetry_integration.md) doc).
 
-LiteLLM reads configuration via `OpenTelemetryConfig.from_env()` (see [`opentelemetry.py` in the LiteLLM repo](https://github.com/BerriAI/litellm/blob/main/litellm/integrations/opentelemetry.py)).
+You can load them from the process environment, a `.env` file, or the proxy **`environment_variables`** block in `config.yaml` ([config fields](/docs/proxy/configs)).
 
 | Purpose | Variable |
 |--------|----------|
@@ -36,81 +39,17 @@ LiteLLM reads configuration via `OpenTelemetryConfig.from_env()` (see [`opentele
 
 **Precedence:** `OTEL_EXPORTER_OTLP_PROTOCOL` is read before legacy `OTEL_EXPORTER`. If both are set, the OTLP protocol variable wins. `OTEL_EXPORTER_OTLP_ENDPOINT` is preferred over `OTEL_ENDPOINT` when both are set.
 
-:::warning Sensitive data in traces
-
-OpenTelemetry spans may include request/response content and metadata. Review [redacting messages and responses](/docs/observability/opentelemetry_integration#redacting-messages-response-content-from-opentelemetry-logging) and [scrubbing / PII guidance](/docs/observability/scrub_data) before enabling full payloads in production.
-
-:::
-
-## LiteLLM Proxy
-
-<Tabs>
-<TabItem value="yaml" label="config.yaml">
-
-```yaml
-model_list:
-  - model_name: gpt-4o-mini
-    litellm_params:
-      model: gpt-4o-mini
-      api_key: os.environ/OPENAI_API_KEY
-
-litellm_settings:
-  callbacks: ["otel"]
-
-general_settings:
-  master_key: sk-1234
-
-environment_variables:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_EXPORTER_OTLP_HEADERS: "os.environ/SPLUNK_OTEL_HEADERS"
-  OTEL_SERVICE_NAME: "litellm-proxy"
+```shell
+OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
+OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+OTEL_EXPORTER_OTLP_HEADERS="X-SF-Token=<your-ingest-access-token>"
+OTEL_SERVICE_NAME="litellm-proxy"
 ```
 
-Point `SPLUNK_OTEL_HEADERS` (or inline the header string) at a secret that expands to `X-SF-Token=<token>`.
-
-</TabItem>
-<TabItem value="env" label=".env (example)">
-
-```dotenv
-SPLUNK_ACCESS_TOKEN=your-ingest-access-token
-
-OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-OTEL_EXPORTER_OTLP_HEADERS=X-SF-Token=${SPLUNK_ACCESS_TOKEN}
-OTEL_SERVICE_NAME=litellm-proxy
-```
-
-Load these into the process environment before starting the proxy (for example `export` / systemd / Kubernetes secrets).
-
-</TabItem>
-</Tabs>
-
-Start the proxy:
+**Step 3:** Start the proxy:
 
 ```bash
 litellm --config /path/to/config.yaml
-```
-
-## Python SDK
-
-```python
-import os
-import litellm
-
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
-    "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
-)
-os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
-os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "X-SF-Token=your-ingest-access-token"
-os.environ["OTEL_SERVICE_NAME"] = "my-app"
-
-litellm.callbacks = ["otel"]
-
-response = litellm.completion(
-    model="gpt-4o-mini",
-    messages=[{"role": "user", "content": "Hello"}],
-)
 ```
 
 ## Verify traces

--- a/docs/observability/splunk_observability_cloud.md
+++ b/docs/observability/splunk_observability_cloud.md
@@ -26,7 +26,7 @@ litellm_settings:
   callbacks: ["otel"]
 ```
 
-**Step 2:** Set the OTLP environment variables LiteLLM reads via `OpenTelemetryConfig.from_env()` (see [`opentelemetry.py` in the LiteLLM repo](https://github.com/BerriAI/litellm/blob/main/litellm/integrations/opentelemetry.py) and the [OpenTelemetry integration](./opentelemetry_integration.md) doc).
+**Step 2:** Set the OTLP environment variables below.
 
 You can load them from the process environment, a `.env` file, or the proxy **`environment_variables`** block in `config.yaml` ([config fields](/docs/proxy/configs)).
 

--- a/docs/observability/splunk_observability_cloud.md
+++ b/docs/observability/splunk_observability_cloud.md
@@ -7,11 +7,11 @@ Send LiteLLM traces to [Splunk Observability Cloud](https://www.splunk.com/en_us
 
 LiteLLM uses the same OpenTelemetry path as the [OpenTelemetry integration](./opentelemetry_integration.md). Splunk’s OTLP/HTTP trace ingest URL uses **`/v2/trace/otlp`** (not **`/v1/traces`**); LiteLLM normalizes generic collector URLs but **preserves** Splunk-style `/v2/trace/otlp` endpoints so spans reach Splunk correctly.
 
-:::tip Video walkthrough
+## Video walkthrough
 
-If you recorded a Loom demo of this setup, add a public **Loom share** or **`loom.com/embed/...`** iframe here (same pattern as other tutorials, e.g. [OpenWebUI](/docs/tutorials/openweb_ui)), or link the video in your pull request description.
+<iframe width="840" height="500" src="https://www.loom.com/embed/9dc21b753bbe4f6fb3c1b44c06e39c20" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen title="LiteLLM Splunk Observability Cloud OTEL demo"></iframe>
 
-:::
+Or [watch on Loom](https://www.loom.com/share/9dc21b753bbe4f6fb3c1b44c06e39c20).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Add **Splunk Observability Cloud (OpenTelemetry)** (`docs/observability/splunk_observability_cloud.md`) — short guide for sending LiteLLM Proxy traces to Splunk via the **`otel`** callback: Splunk OTLP/HTTP URL (`/v2/trace/otlp`), Step 1/2/3 (`config.yaml` → env vars → start proxy), optional [Loom walkthrough](https://www.loom.com/share/9dc21b753bbe4f6fb3c1b44c06e39c20), verify in Splunk, links to OpenTelemetry + Splunk vendor docs.
- **OpenTelemetry integration** (`docs/observability/opentelemetry_integration.md`): new **Splunk Observability Cloud** tab with minimal `OTEL_*` shell example and link to the Splunk page.
- **Observability overview** (`docs/integrations/observability_index.md`): add a **Splunk Observability Cloud** card.