### PR TITLE
docs(guardrails): add during_call mode to Model Armor guardrail docs

### DIFF
--- a/docs/proxy/guardrails/model_armor.md
+++ b/docs/proxy/guardrails/model_armor.md
@@ -27,7 +27,7 @@ guardrails:
   - guardrail_name: model-armor-shield
     litellm_params:
       guardrail: model_armor
-      mode: [pre_call, post_call]  # Run on both input and output
+      mode: [pre_call, during_call, post_call]  # Run on input, parallel, and output
       template_id: "your-template-id"  # Required: Your Model Armor template ID
       project_id: "your-project-id"    # Your GCP project ID
       location: "us-central1"          # GCP location (default: us-central1)
@@ -41,7 +41,8 @@ guardrails:
 #### Supported values for `mode`
 
 - `pre_call` Run **before** LLM call, on **input**
-- `post_call` Run **after** LLM call, on **input & output**
+- `during_call` Run **in parallel** with LLM call, on **input**
+- `post_call` Run **after** LLM call, on **output**
 
 ### 2. Start LiteLLM Gateway 
 
@@ -74,7 +75,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 - `api_key` - str - Google Cloud service account credentials (optional if using ADC)
 - `api_base` - str - Custom Model Armor API endpoint (optional)
 - `default_on` - bool - Whether to run the guardrail by default. Default is `false`.
-- `mode` - Union[str, list[str]] - Mode to run the guardrail. Either `pre_call` or `post_call`. Default is `pre_call`.
+- `mode` - Union[str, list[str]] - Mode to run the guardrail. Supported values: `pre_call`, `during_call`, `post_call`. Default is `pre_call`.
 
 ### Model Armor Specific
 


### PR DESCRIPTION
## Summary

Ported from https://github.com/BerriAI/litellm/pull/26394 as requested by maintainer.

The current Model Armor documentation is outdated — it only lists `pre_call` and `post_call` modes, but `during_call` support was added in BerriAI/litellm#15970.

### Changes
- Added `during_call` mode to the YAML example, supported values section, and common params
- Fixed `post_call` description from "input & output" to "output" (it only checks the model response)

## Code References
- **Default event hooks** include all three modes: [`model_armor.py` L65-69](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py#L65-L69)
- **`during_call` handler** (`async_moderation_hook`): [`model_armor.py` L469-562](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py#L469-L562)

## Test plan
- [ ] Verify docs render correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)