### PR TITLE
docs(snowflake): comprehensive rewrite of Snowflake Cortex provider page

### DIFF
--- a/docs/providers/snowflake.md
+++ b/docs/providers/snowflake.md
@@ -2,6 +2,9 @@
 sidebar_label: Snowflake Cortex
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Snowflake Cortex
 
 LiteLLM supports all models on the Snowflake Cortex REST API, including models from Anthropic (Claude), OpenAI (GPT), Meta (Llama), Mistral, DeepSeek, and Snowflake.

--- a/docs/providers/snowflake.md
+++ b/docs/providers/snowflake.md
@@ -1,109 +1,353 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+---
+sidebar_label: Snowflake Cortex
+---
+
+# Snowflake Cortex
+
+LiteLLM supports all models on the Snowflake Cortex REST API, including models from Anthropic (Claude), OpenAI (GPT), Meta (Llama), Mistral, DeepSeek, and Snowflake.
+
+| | |
+|---|---|
+| Description | Snowflake Cortex REST API provides access to leading frontier LLMs through OpenAI-compatible and Anthropic-compatible endpoints. All inference runs within Snowflake's security perimeter. |
+| Provider Route on LiteLLM | `snowflake/` |
+| Provider Docs | [Cortex REST API ↗](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api) |
+| API Endpoints | Chat Completions: `https://{account}.snowflakecomputing.com/api/v2/cortex/v1/chat/completions` <br/> Messages: `https://{account}.snowflakecomputing.com/api/v2/cortex/v1/messages` <br/> Legacy: `https://{account}.snowflakecomputing.com/api/v2/cortex/inference:complete` |
+| Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings` |
 
 
-# Snowflake
-| Property                   | Details                                                                                                   |
-|----------------------------|-----------------------------------------------------------------------------------------------------------|
-| Description                | The Snowflake Cortex LLM REST API lets you access the COMPLETE and EMBED functions via HTTP POST requests |
-| Provider Route on LiteLLM  | `snowflake/`                                                                                              |
-| Link to Provider Doc       | [Snowflake ↗](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api)              |
-| Base URLs                  | `https://{account-id}.snowflakecomputing.com/api/v2/cortex/inference:complete`,`https://{account-id}.snowflakecomputing.com/api/v2/cortex/inference:embed`|
-| Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings`                                                        |
+Tip : We support ALL Snowflake Cortex models. Use `model=snowflake/<model-name>` as a prefix when sending LiteLLM requests.
 
 
-## Supported OpenAI Parameters
-```
-    "temperature",
-    "max_tokens",
-    "top_p",
-    "response_format"
-```
+## Authentication
 
-## API KEYS
+Snowflake Cortex REST API supports three authentication methods.
 
-Snowflake does have API keys. Instead, you access the Snowflake API with your JWT token and account identifier.
+### Programmatic Access Token (PAT) — Recommended
 
-It is also possible to use [programmatic access tokens](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) (PAT). It can be defined by using 'pat/' prefix
-
+The simplest approach. Generate a PAT in Snowsight under **User Menu → My Profile → Programmatic Access Tokens**.
 
 ```python
-import os 
-os.environ["SNOWFLAKE_JWT"] = "YOUR JWT"
-os.environ["SNOWFLAKE_ACCOUNT_ID"] = "YOUR ACCOUNT IDENTIFIER"
+import os
+from litellm import completion
+
+os.environ["SNOWFLAKE_API_KEY"] = "pat/<your-programmatic-access-token>"
+os.environ["SNOWFLAKE_API_BASE"] = "https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
+
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
 ```
+
+### JWT (Key-Pair Authentication)
+
+Generate a JWT from a Snowflake key pair. See [Key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
+```python
+import os
+from litellm import completion
+
+os.environ["SNOWFLAKE_JWT"] = "<your-jwt-token>"
+os.environ["SNOWFLAKE_ACCOUNT_ID"] = "<orgname>-<account_name>"
+
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+### Pass credentials as parameters
+
+```python
+from litellm import completion
+
+# Using PAT
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Hello!"}],
+    api_key="pat/<your-pat-token>",
+    api_base="https://<account>.snowflakecomputing.com/api/v2/cortex/v1",
+)
+
+# Using JWT
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Hello!"}],
+    api_key="<your-jwt-token>",
+    account_id="<orgname>-<account_name>",
+)
+```
+
+For all authentication options, see [Authenticating to Cortex REST API](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#authenticating-cortex-rest-api-requests).
+
 ## Usage
 
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
 ```python
-from litellm import completion, embedding
+from litellm import completion
+import os
 
-## set ENV variables
-os.environ["SNOWFLAKE_JWT"] = "JWT_TOKEN"
-os.environ["SNOWFLAKE_ACCOUNT_ID"] = "YOUR ACCOUNT IDENTIFIER"
+os.environ["SNOWFLAKE_API_KEY"] = "pat/<your-pat>"
+os.environ["SNOWFLAKE_API_BASE"] = "https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
 
-# Snowflake completion call
 response = completion(
-    model="snowflake/mistral-7b", 
-    messages = [{ "content": "Hello, how are you?","role": "user"}]
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "What is Snowflake Cortex?"}],
 )
-
-# Snowflake embedding call
-response = embedding(
-    model="snowflake/mistral-7b", 
-    input = ["My text"]
-)
-
-# Pass`api_key` and `account_id` as parameters
-response = completion(
-    model="snowflake/mistral-7b", 
-    messages = [{ "content": "Hello, how are you?","role": "user"}],
-    account_id="AAAA-BBBB",
-    api_key="JWT_TOKEN"
-)
-
-# using PAT
-response = completion(
-    model="snowflake/mistral-7b", 
-    messages = [{ "content": "Hello, how are you?","role": "user"}],
-    api_key="pat/PAT_TOKEN"
-)
+print(response.choices[0].message.content)
 ```
 
-## Usage with LiteLLM Proxy 
+</TabItem>
+<TabItem value="proxy" label="PROXY">
 
-#### 1. Required env variables
-```bash
-export SNOWFLAKE_JWT=""
-export SNOWFLAKE_ACCOUNT_ID = ""
-```
+**1. Config**
 
-#### 2. Start the proxy~
 ```yaml
 model_list:
-  - model_name: mistral-7b
+  - model_name: claude-sonnet
     litellm_params:
-        model: snowflake/mistral-7b
-        api_key: YOUR_API_KEY
-        api_base: https://YOUR-ACCOUNT-ID.snowflakecomputing.com/api/v2/cortex/inference:complete
-
+      model: snowflake/claude-sonnet-4-5
+      api_key: pat/<your-pat>
+      api_base: https://<account>.snowflakecomputing.com/api/v2/cortex/v1
+  - model_name: llama4-maverick
+    litellm_params:
+      model: snowflake/llama4-maverick
+      api_key: pat/<your-pat>
+      api_base: https://<account>.snowflakecomputing.com/api/v2/cortex/v1
 ```
+
+**2. Start proxy**
 
 ```bash
 litellm --config /path/to/config.yaml
 ```
 
-#### 3. Test it
-```shell
+**3. Test**
+
+```bash
 curl --location 'http://0.0.0.0:4000/chat/completions' \
 --header 'Content-Type: application/json' \
---data ' {
-      "model": "snowflake/mistral-7b",
-      "messages": [
-        {
-          "role": "user",
-          "content": "Hello, how are you?"
-        }
-      ]
-    }
-'
+--data '{
+    "model": "claude-sonnet",
+    "messages": [
+        {"role": "user", "content": "What is Snowflake Cortex?"}
+    ]
+}'
 ```
+
+</TabItem>
+</Tabs>
+
+## Supported OpenAI Parameters
+
+```
+temperature, max_tokens, top_p, stream, response_format,
+tools, tool_choice
+```
+
+## Streaming
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+os.environ["SNOWFLAKE_API_KEY"] = "pat/<your-pat>"
+os.environ["SNOWFLAKE_API_BASE"] = "https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
+
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Write a haiku about data."}],
+    stream=True,
+)
+
+for chunk in response:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "claude-sonnet",
+    "messages": [{"role": "user", "content": "Write a haiku about data."}],
+    "stream": true
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## Tool / Function Calling
+
+Supported on Claude and select models. LiteLLM automatically transforms OpenAI tool format to Snowflake's `tool_spec` format.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os, json
+
+os.environ["SNOWFLAKE_API_KEY"] = "pat/<your-pat>"
+os.environ["SNOWFLAKE_API_BASE"] = "https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+response = completion(
+    model="snowflake/claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "What's the weather in San Francisco?"}],
+    tools=tools,
+    tool_choice="auto",
+)
+
+print(response.choices[0].message.tool_calls)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: claude-sonnet
+    litellm_params:
+      model: snowflake/claude-sonnet-4-5
+      api_key: pat/<your-pat>
+      api_base: https://<account>.snowflakecomputing.com/api/v2/cortex/v1
+```
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "claude-sonnet",
+    "messages": [{"role": "user", "content": "What is the weather in SF?"}],
+    "tools": [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"]
+            }
+        }
+    }],
+    "tool_choice": "auto"
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## Thinking / Reasoning
+
+Claude 3.7 Sonnet, Claude 4 Opus, and DeepSeek R1 on Cortex support extended thinking. LiteLLM translates `reasoning_effort` to the provider's thinking parameter.
+
+| `reasoning_effort` | `budget_tokens` |
+|---|---|
+| `"low"` | 1024 |
+| `"medium"` | 2048 |
+| `"high"` | 4096 |
+
+```python
+from litellm import completion
+
+response = completion(
+    model="snowflake/claude-3-7-sonnet",
+    messages=[{"role": "user", "content": "Solve: what is 127 * 389?"}],
+    reasoning_effort="low",
+)
+print(response.choices[0].message.content)
+```
+
+## Prompt Caching
+
+Snowflake Cortex supports prompt caching to reduce costs:
+
+- **OpenAI models**: Implicit caching for prompts ≥ 1,024 tokens (no code changes needed)
+- **Claude models**: Explicit caching via `cache_control` breakpoints
+
+Cached input tokens are billed at **10% of the regular input rate** (90% discount) when ≥ 1,024 tokens are cached.
+
+See [Cortex REST API Billing & Cost Analysis](https://www.snowflake.com/en/developers/guides/cortex-rest-api-billing-cost/) for details.
+
+## Embeddings
+
+```python
+from litellm import embedding
+import os
+
+os.environ["SNOWFLAKE_API_KEY"] = "pat/<your-pat>"
+os.environ["SNOWFLAKE_API_BASE"] = "https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
+
+response = embedding(
+    model="snowflake/snowflake-arctic-embed-l-v2.0",
+    input=["Snowflake Cortex provides LLM inference"],
+)
+print(response.data[0]["embedding"][:5])
+```
+
+## Supported Models
+
+All models are available through the `snowflake/` prefix.
+
+:::tip
+For current model availability, rate limits, and pricing, see the official [Cortex REST API docs](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api) and [Service Consumption Table](https://www.snowflake.com/legal-files/CreditConsumptionTable.pdf).
+:::
+
+### Chat Completion Models
+
+| Model | `litellm` model name | Function Calling | Vision | Prompt Caching |
+|---|---|---|---|---|
+| Claude Sonnet 4.5 | `snowflake/claude-sonnet-4-5` | ✅ | ✅ | ✅ |
+| Claude Sonnet 4.6 | `snowflake/claude-sonnet-4-6` | ✅ | ✅ | ✅ |
+| Claude 4 Sonnet | `snowflake/claude-4-sonnet` | ✅ | ✅ | ✅ |
+| Claude 4 Opus | `snowflake/claude-4-opus` | ✅ | ✅ | ✅ |
+| Claude Haiku 4.5 | `snowflake/claude-haiku-4-5` | ✅ | ✅ | ✅ |
+| Claude 3.7 Sonnet | `snowflake/claude-3-7-sonnet` | ✅ | ✅ | ✅ |
+| Claude 3.5 Sonnet | `snowflake/claude-3-5-sonnet` | ✅ | ✅ | ✅ |
+| OpenAI GPT-4.1 | `snowflake/openai-gpt-4.1` | ✅ | ✅ | ✅ |
+| OpenAI GPT-5 | `snowflake/openai-gpt-5` | ✅ | ✅ | ✅ |
+| OpenAI GPT-5 Mini | `snowflake/openai-gpt-5-mini` | ✅ | | |
+| OpenAI GPT-5 Nano | `snowflake/openai-gpt-5-nano` | ✅ | | |
+| DeepSeek R1 | `snowflake/deepseek-r1` | | | |
+| Mistral Large 2 | `snowflake/mistral-large2` | ✅ | | |
+| Llama 3.1 8B | `snowflake/llama3.1-8b` | | | |
+| Llama 3.1 70B | `snowflake/llama3.1-70b` | ✅ | | |
+| Llama 3.1 405B | `snowflake/llama3.1-405b` | ✅ | | |
+| Llama 3.3 70B | `snowflake/llama3.3-70b` | ✅ | | |
+| Llama 4 Maverick | `snowflake/llama4-maverick` | ✅ | | |
+| Snowflake Llama 3.3 70B | `snowflake/snowflake-llama-3.3-70b` | ✅ | | |
+
+### Embedding Models
+
+| Model | `litellm` model name |
+|---|---|
+| Snowflake Arctic Embed L v2.0 | `snowflake/snowflake-arctic-embed-l-v2.0` |
+| Snowflake Arctic Embed M v2.0 | `snowflake/snowflake-arctic-embed-m-v2.0` |
+


### PR DESCRIPTION
## Summary

Rewrites the Snowflake Cortex provider docs page from ~110 words to ~1,200 words, matching the coverage level of Databricks, Bedrock, and OpenRouter.

## What's new

- **Authentication**: PAT , JWT, Auth 
- **Streaming**: SDK + Proxy examples
- **Tool / Function Calling**: SDK + Proxy examples (auto-transforms to Snowflake tool_spec format)
- **Thinking / Reasoning**: Claude 3.7, Claude 4 Opus, DeepSeek R1 with `reasoning_effort`
- **Prompt Caching**: OpenAI implicit, Claude explicit, 90% discount at ≥1,024 tokens
- **Embeddings**: Arctic Embed models
- **Full model table**: 20+ models with capability flags (function calling, vision, caching)
- **Updated endpoints**: New OpenAI-compatible `/api/v2/cortex/v1/chat/completions` + Anthropic Messages API

## Before → After

| | Before | After |
|---|---|---|
| Word count | ~110 | ~1,200 |
| Sections | 3 | 10+ |
| Models listed | 1 (mistral-7b) | 20+ |
| SDK + Proxy tabs | No | Yes |
| Streaming | No | Yes |
| Tool calling | No | Yes |
| Thinking/reasoning | No | Yes |
| Prompt caching | No | Yes |

## References

- [Cortex REST API docs](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api)
- [Service Consumption Table (pricing)](https://www.snowflake.com/legal-files/CreditConsumptionTable.pdf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-path code modifications.
> 
> **Overview**
> **Rewrites** `docs/providers/snowflake.md` from a short legacy Cortex LLM page into a full **Snowflake Cortex** guide aligned with other major provider docs.
> 
> The page now documents **PAT** (`SNOWFLAKE_API_KEY` / `api_base` on `/api/v2/cortex/v1`) and **JWT** auth, drops the old `inference:complete`-only focus in favor of **OpenAI-compatible chat** and **Messages** URLs (with legacy noted), and expands **SDK + Proxy** tabs for usage, **streaming**, **tools** (including OpenAI → `tool_spec`), **`reasoning_effort`** for thinking models, **prompt caching**, and **embeddings**.
> 
> It adds a **20+ model capability table** (function calling, vision, caching) and updates examples from `mistral-7b` to current Cortex model names like `claude-sonnet-4-5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a79c3d00dff2de2eb55fc8b0cd1e7b674771b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->