### PR TITLE
docs: add Claude Mythos guide to Bedrock Mantle page

### DIFF
--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -15,7 +15,7 @@ Use this provider to call Bedrock Mantle models with accurate **AWS Bedrock pric
 
 ## Claude Mythos
 
-Claude Mythos (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle with **1M token input context**, 128K output, and support for reasoning, vision, and tool use.
+[Claude Mythos](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-mythos-preview.html) (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle with **1M token input context**, 128K output, and support for reasoning, vision, and tool use.
 
 Use the `bedrock/mantle/` route prefix with standard AWS credentials.
 

--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -13,6 +13,105 @@ Use this provider to call Bedrock Mantle models with accurate **AWS Bedrock pric
 
 :::
 
+## Claude Mythos
+
+Claude Mythos (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle with **1M token input context**, 128K output, and support for reasoning, vision, and tool use.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+
+response = completion(
+    model="bedrock_mantle/anthropic.claude-mythos-preview",
+    messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
+)
+print(response)
+```
+
+</TabItem>
+<TabItem value="reasoning" label="SDK (Extended Thinking)">
+
+```python
+from litellm import completion
+import os
+
+os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+
+response = completion(
+    model="bedrock_mantle/anthropic.claude-mythos-preview",
+    messages=[{"role": "user", "content": "Solve step by step: what is 2 + 2?"}],
+    thinking={"type": "enabled", "budget_tokens": 5000},
+)
+print(response)
+```
+
+</TabItem>
+<TabItem value="messages" label="SDK (/messages)">
+
+Use the native Anthropic Messages API format via `bedrock/mantle/` prefix:
+
+```python
+import asyncio
+import litellm
+import os
+
+os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+
+async def main():
+    response = await litellm.anthropic_messages(
+        model="bedrock/mantle/anthropic.claude-mythos-preview",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
+    )
+    print(response)
+
+asyncio.run(main())
+```
+
+</TabItem>
+<TabItem value="proxy" label="LiteLLM Proxy">
+
+**1. Add to config.yaml**
+
+```yaml
+model_list:
+  - model_name: claude-mythos
+    litellm_params:
+      model: bedrock_mantle/anthropic.claude-mythos-preview
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+```
+
+**2. Start the proxy**
+
+```shell
+litellm --config /path/to/config.yaml
+```
+
+**3. Call via OpenAI SDK**
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="anything",
+    base_url="http://0.0.0.0:4000",
+)
+
+response = client.chat.completions.create(
+    model="claude-mythos",
+    messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
+)
+print(response)
+```
+
+</TabItem>
+</Tabs>
+
 ## API Key
 
 ```python

--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -17,6 +17,8 @@ Use this provider to call Bedrock Mantle models with accurate **AWS Bedrock pric
 
 Claude Mythos (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle with **1M token input context**, 128K output, and support for reasoning, vision, and tool use.
 
+Use the `bedrock/mantle/` route prefix with standard AWS credentials.
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
@@ -24,10 +26,12 @@ Claude Mythos (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle
 from litellm import completion
 import os
 
-os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
+os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
+os.environ['AWS_REGION_NAME'] = "us-east-1"
 
 response = completion(
-    model="bedrock_mantle/anthropic.claude-mythos-preview",
+    model="bedrock/mantle/anthropic.claude-mythos-preview",
     messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
 )
 print(response)
@@ -40,10 +44,12 @@ print(response)
 from litellm import completion
 import os
 
-os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
+os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
+os.environ['AWS_REGION_NAME'] = "us-east-1"
 
 response = completion(
-    model="bedrock_mantle/anthropic.claude-mythos-preview",
+    model="bedrock/mantle/anthropic.claude-mythos-preview",
     messages=[{"role": "user", "content": "Solve step by step: what is 2 + 2?"}],
     thinking={"type": "enabled", "budget_tokens": 5000},
 )
@@ -53,14 +59,14 @@ print(response)
 </TabItem>
 <TabItem value="messages" label="SDK (/messages)">
 
-Use the native Anthropic Messages API format via `bedrock/mantle/` prefix:
-
 ```python
 import asyncio
 import litellm
 import os
 
-os.environ['BEDROCK_MANTLE_API_KEY'] = "your-bedrock-api-key"
+os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
+os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
+os.environ['AWS_REGION_NAME'] = "us-east-1"
 
 async def main():
     response = await litellm.anthropic_messages(
@@ -82,8 +88,8 @@ asyncio.run(main())
 model_list:
   - model_name: claude-mythos
     litellm_params:
-      model: bedrock_mantle/anthropic.claude-mythos-preview
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      model: bedrock/mantle/anthropic.claude-mythos-preview
+      aws_region_name: us-east-1
 ```
 
 **2. Start the proxy**

--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -19,45 +19,10 @@ Claude Mythos (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle
 
 Use the `bedrock/mantle/` route prefix with standard AWS credentials.
 
+### /messages
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
-
-```python
-from litellm import completion
-import os
-
-os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
-os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
-os.environ['AWS_REGION_NAME'] = "us-east-1"
-
-response = completion(
-    model="bedrock/mantle/anthropic.claude-mythos-preview",
-    messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
-)
-print(response)
-```
-
-</TabItem>
-<TabItem value="reasoning" label="SDK (Extended Thinking)">
-
-```python
-from litellm import completion
-import os
-
-os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
-os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
-os.environ['AWS_REGION_NAME'] = "us-east-1"
-
-response = completion(
-    model="bedrock/mantle/anthropic.claude-mythos-preview",
-    messages=[{"role": "user", "content": "Solve step by step: what is 2 + 2?"}],
-    thinking={"type": "enabled", "budget_tokens": 5000},
-)
-print(response)
-```
-
-</TabItem>
-<TabItem value="messages" label="SDK (/messages)">
 
 ```python
 import asyncio
@@ -80,7 +45,7 @@ asyncio.run(main())
 ```
 
 </TabItem>
-<TabItem value="proxy" label="LiteLLM Proxy">
+<TabItem value="ai-gateway" label="AI Gateway">
 
 **1. Add to config.yaml**
 
@@ -92,27 +57,81 @@ model_list:
       aws_region_name: us-east-1
 ```
 
-**2. Start the proxy**
+**2. Start LiteLLM AI Gateway**
 
 ```shell
 litellm --config /path/to/config.yaml
 ```
 
-**3. Call via OpenAI SDK**
+**3. Call `/v1/messages` via curl**
+
+```bash
+curl -X POST http://0.0.0.0:4000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "claude-mythos",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "Explain quantum entanglement simply."}
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+### /chat/completions
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
 
 ```python
-import openai
+from litellm import completion
+import os
 
-client = openai.OpenAI(
-    api_key="anything",
-    base_url="http://0.0.0.0:4000",
-)
+os.environ['AWS_ACCESS_KEY_ID'] = "your-aws-access-key"
+os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
+os.environ['AWS_REGION_NAME'] = "us-east-1"
 
-response = client.chat.completions.create(
-    model="claude-mythos",
+response = completion(
+    model="bedrock/mantle/anthropic.claude-mythos-preview",
     messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
 )
 print(response)
+```
+
+</TabItem>
+<TabItem value="ai-gateway-chat" label="AI Gateway">
+
+**1. Add to config.yaml**
+
+```yaml
+model_list:
+  - model_name: claude-mythos
+    litellm_params:
+      model: bedrock/mantle/anthropic.claude-mythos-preview
+      aws_region_name: us-east-1
+```
+
+**2. Start LiteLLM AI Gateway**
+
+```shell
+litellm --config /path/to/config.yaml
+```
+
+**3. Call `/v1/chat/completions` via curl**
+
+```bash
+curl -X POST http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "claude-mythos",
+    "messages": [
+      {"role": "user", "content": "Explain quantum entanglement simply."}
+    ]
+  }'
 ```
 
 </TabItem>


### PR DESCRIPTION
## What changed

Adds a **Claude Mythos** section at the top of the Bedrock Mantle docs page, with four tabs:

- **SDK** — `bedrock_mantle/anthropic.claude-mythos-preview` via `litellm.completion()`
- **SDK (Extended Thinking)** — same model with `thinking` param
- **SDK (/messages)** — native Anthropic Messages API via `bedrock/mantle/anthropic.claude-mythos-preview` and `litellm.anthropic_messages()`
- **LiteLLM Proxy** — config.yaml + OpenAI SDK call

Model details: 1M input context, 128K output, supports reasoning/vision/tool use.

## Type

- [x] Documentation