### PR TITLE
docs(prod): warn about $(nproc) on Kubernetes; add Downward API guidance

### DIFF
--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -68,7 +68,48 @@ These specifications provide:
 
 ## 3. On Kubernetes — Match Uvicorn Workers to CPU Count [Suggested CMD]
 
-Use this Docker `CMD`. It automatically matches Uvicorn workers to the pod’s CPU count, ensuring each worker uses one core efficiently for better throughput and stable latency.
+Match Uvicorn workers to the pod's CPU allocation so each worker uses roughly one core for better throughput and stable latency.
+
+:::warning
+
+**Do not use `$(nproc)` on Kubernetes.** `nproc` reports the underlying **node's** CPU count, not the pod's cgroup CPU request or limit. On a 16-vCPU node with a pod that has `requests.cpu: 4` and `limits.cpu: 8`, `nproc` returns `16`, spawning 2-4× more workers than the pod can actually run. The result is CPU oversubscription, context-switching overhead, and worse latency — the opposite of the goal.
+
+Use the [Kubernetes Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) to read the pod's actual CPU request instead.
+
+:::
+
+### Recommended: Downward API + `--num_workers`
+
+In your pod spec, expose `requests.cpu` as an environment variable, then pass it to LiteLLM:
+
+```yaml
+# pod / deployment spec
+env:
+  - name: CPU_REQUEST
+    valueFrom:
+      resourceFieldRef:
+        resource: requests.cpu
+        divisor: "1"   # whole cores; use 1 m for milli-cores
+```
+
+```shell
+# container CMD
+CMD ["sh", "-c", "litellm --port 4000 --config ./proxy_server_config.yaml --num_workers ${CPU_REQUEST:-4}"]
+```
+
+The `${CPU_REQUEST:-4}` default ensures the container still starts if the env var is missing (e.g. local Docker run).
+
+### Alternative: hardcode `--num_workers`
+
+If you don't want to wire up the Downward API, hardcode the worker count to match the pod's CPU request directly in the manifest:
+
+```shell
+CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers", "4"]
+```
+
+### Bare-metal / VM only: `$(nproc)`
+
+`nproc` is correct **only** when the LiteLLM process has access to all the host's CPUs (bare-metal or single-tenant VM, no cgroup CPU limit). In that case:
 
 ```shell
 CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers", "$(nproc)"]
@@ -78,8 +119,8 @@ CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers"
 > You can configure this either via CLI or environment variable:
 
 ```shell
-# CLI
-CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers", "$(nproc)", "--max_requests_before_restart", "10000"]
+# CLI (Kubernetes — Downward API)
+CMD ["sh", "-c", "litellm --port 4000 --config ./proxy_server_config.yaml --num_workers ${CPU_REQUEST:-4} --max_requests_before_restart 10000"]
 
 # or ENV (for deployment manifests / containers)
 export MAX_REQUESTS_BEFORE_RESTART=10000
@@ -89,7 +130,7 @@ export MAX_REQUESTS_BEFORE_RESTART=10000
 
 ```shell
 # Use Gunicorn for more stable worker recycling
-CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers", "$(nproc)", "--run_gunicorn", "--max_requests_before_restart", "10000"]
+CMD ["sh", "-c", "litellm --port 4000 --config ./proxy_server_config.yaml --num_workers ${CPU_REQUEST:-4} --run_gunicorn --max_requests_before_restart 10000"]
 ```
 
 


### PR DESCRIPTION
## Summary

Closes BerriAI/litellm#26620.

The "Match Uvicorn Workers to CPU Count" section in the production docs recommends `--num_workers $(nproc)` for Kubernetes deployments. **`nproc` is incorrect on Kubernetes** — it reports the host **node's** CPU count, not the pod's cgroup CPU request or limit.

Concrete failure mode (from #26620):

| Setting | Value |
|---|---|
| Node | `e2-standard-16` (16 vCPU) |
| Pod `requests.cpu` | `4` |
| Pod `limits.cpu` | `8` |
| `$(nproc)` returns | **16** |
| Workers spawned | 16 |
| Workers the pod can actually run | 4–8 |

This causes CPU oversubscription, context-switching overhead, and worse latency — the opposite of what the section is trying to achieve.

## Fix

Restructure section 3 of `docs/proxy/prod.md`:

1. **Warning admonition** explaining the cgroup mismatch with a concrete example.
2. **Recommended:** Kubernetes Downward API recipe that exposes `requests.cpu` as `$CPU_REQUEST` in the container env, then uses `--num_workers ${CPU_REQUEST:-4}` in the `CMD`.
3. **Alternative:** hardcoded `--num_workers 4` for users who prefer not to wire up the Downward API.
4. **Bare-metal / VM only:** keep the original `$(nproc)` `CMD`, scoped to environments where the process actually has access to all host CPUs.

The two follow-up shell blocks (`--max_requests_before_restart` and `--run_gunicorn` variants) are updated to use the same `${CPU_REQUEST:-4}` pattern so they stay consistent with the recommended K8s setup.

## Files changed

- `docs/proxy/prod.md` — section 3 only

## Why this is correct

The Downward API approach is the standard Kubernetes idiom for surfacing pod-level resource requests/limits to the container at runtime. It's documented at https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/.

The `${CPU_REQUEST:-4}` default keeps the container bootable in non-K8s environments (local Docker, etc.) where the env var won't be injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
