### PR TITLE
docs(auth): add scope and wildcard support for JWT routing overrides

### DIFF
--- a/docs/proxy/oauth2.md
+++ b/docs/proxy/oauth2.md
@@ -83,5 +83,7 @@ general_settings:
         path: "oauth2"
 ```
 
-For full `routing_overrides` behavior and list-based selectors, see [`/proxy/token_auth`](./token_auth.md#route-jwt-shaped-machine-tokens-to-oauth2).
+Selectors support shell-style wildcards (`*`, `?`, case-sensitive) and accept either a single string or a list of strings.
+
+For full `routing_overrides` behavior — supported selectors, wildcard and list semantics, and matching rules — see [`/proxy/token_auth`](./token_auth.md#route-jwt-shaped-machine-tokens-to-oauth2).
 

--- a/docs/proxy/token_auth.md
+++ b/docs/proxy/token_auth.md
@@ -814,10 +814,26 @@ general_settings:
 
 ### Matching behavior
 
-- A rule matches when all configured selectors match token claims
-- Supported selectors: `iss` (required), `client_id` (optional), `aud` (optional)
-- Selector values support both string and list forms
-- If no rule matches, LiteLLM continues with standard JWT validation
+- A rule matches when **all** configured selectors match the corresponding token claims (AND semantics).
+- Supported selectors: `iss` (required), `client_id` (optional), `scope` (optional), `aud` (optional).
+- Selector values can be a single string or a list of strings (the claim must match at least one entry, using the rules below).
+- **Wildcards:** selectors may use shell-style `*` and `?`. Matching is **case-sensitive**—use the same casing your IdP emits in JWT claims.
+- **`scope` claim as a space-delimited string:** OAuth/OIDC often sends `scope` as one string (e.g. `openid profile App:LiteLLM`). LiteLLM splits that string **only when matching the `scope` selector**, so a configured value like `App:LiteLLM` can match. **`iss`, `aud`, and `client_id` are never split on spaces**; the full claim string is used (routing uses unverified claims only for path selection; final auth still validates the token).
+- If no rule matches, LiteLLM continues with standard JWT validation.
+
+### Example: `scope` and wildcard `client_id`
+
+```yaml title="config.yaml"
+general_settings:
+  enable_jwt_auth: true
+  enable_oauth2_auth: false
+  litellm_jwtauth:
+    routing_overrides:
+      - iss: "machine-issuer.example.com"
+        scope: "App:LiteLLM"
+        client_id: "*MID_LITELLM"
+        path: "oauth2"
+```
 
 ### List-based override example
 


### PR DESCRIPTION
## Summary

Backfills this docs site with the documentation that originally shipped under `docs/my-website/` in [BerriAI/litellm#25939](https://github.com/BerriAI/litellm/pull/25939) / [#26325](https://github.com/BerriAI/litellm/pull/26325). After the docs source was migrated out of the litellm repo, those doc edits could no longer be carried in the code PR and were dropped on rebase — this PR brings them over.

## Changes

- **`docs/proxy/token_auth.md`** — expand the "Matching behavior" section under `routing_overrides`:
  - AND semantics across configured selectors
  - new optional `scope` selector
  - list/string selector forms
  - shell-style wildcards (`*`, `?`), case-sensitive
  - scope-only space-split rule (`iss`, `aud`, `client_id` are never split on spaces)
  - new worked example combining `scope` with a wildcard `client_id`
- **`docs/proxy/oauth2.md`** — short cross-reference to the new wildcard/scope behavior, pointing readers at `token_auth.md`.

No content changes outside these two files.

## Related

- Code change: BerriAI/litellm#26325 (targets `litellm_internal_staging`)
- Originally bundled with: BerriAI/litellm#25939

## Test plan

- [ ] Render `docs/proxy/token_auth.md` locally and confirm the new "Matching behavior" bullets and the `Example: scope and wildcard client_id` YAML block are formatted correctly.
- [ ] Render `docs/proxy/oauth2.md` locally and confirm the cross-reference link to `token_auth.md#route-jwt-shaped-machine-tokens-to-oauth2` resolves.

Made with [Cursor](https://cursor.com)