### PR TITLE
docs: drop -stable suffix from v1.83.10 and v1.81.3 release notes

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -27,7 +27,7 @@ _March 16, 2026_
 | [v1.81.12](/release_notes/v1.81.12/v1-81-12) | Feb 14, 2026 | Guardrail Policy Templates & Action Builder                |
 | [v1.81.9](/release_notes/v1.81.9/v1-81-9)   | Feb 7, 2026  | Control which MCP Servers are exposed on the Internet      |
 | [v1.81.6](/release_notes/v1.81.6/v1-81-6)   | Jan 31, 2026 | Logs v2 with Tool Call Tracing                             |
-| [v1.81.3](/release_notes/v1.81.3-stable/v1-81-3)   | Jan 26, 2026 | Performance — 25% CPU Usage Reduction                      |
+| [v1.81.3](/release_notes/v1.81.3/v1-81-3)   | Jan 26, 2026 | Performance — 25% CPU Usage Reduction                      |
 | [v1.81.0](/release_notes/v1.81.0/v1-81-0)          | Jan 18, 2026 | Claude Code — Web Search Across All Providers              |
 | [v1.80.15](/release_notes/v1.80.15/v1-80-15)       | Jan 10, 2026 | Manus API Support                                          |
 | [v1.80.8](/release_notes/v1.80.8-stable/v1-80-8)   | Dec 6, 2025  | Introducing A2A Agent Gateway                              |

--- a/release_notes/v1.81.3/index.md
+++ b/release_notes/v1.81.3/index.md
@@ -1,5 +1,5 @@
 ---
-title: "v1.81.3-stable - Performance - 25% CPU Usage Reduction"
+title: "v1.81.3 - Performance - 25% CPU Usage Reduction"
 slug: "v1-81-3"
 date: 2026-01-26T10:00:00
 authors:

--- a/release_notes/v1.83.10/index.md
+++ b/release_notes/v1.83.10/index.md
@@ -1,6 +1,6 @@
 ---
-title: "v1.83.10-stable - Claude Opus 4.7, Prompt Compression & Multi-Window Budgets"
-slug: "v1-83-10-stable"
+title: "v1.83.10 - Claude Opus 4.7, Prompt Compression & Multi-Window Budgets"
+slug: "v1-83-10"
 date: 2026-04-27T00:00:00
 authors:
   - name: Krrish Dholakia


### PR DESCRIPTION
## Summary

The release-notes sidebar currently shows `v1.83.10-stable` and `v1.81.3-stable`. With the move to PEP 440 naming this looks inconsistent next to the newer `v1.83.7`, `v1.83.3`, etc. entries. This PR renames the two directories (which the Docusaurus sidebar generator uses as labels) and cleans up the matching titles / slug / href.

## Changes

- Renamed `release_notes/v1.83.10-stable/` → `release_notes/v1.83.10/` (with `git mv`, history preserved)
- Renamed `release_notes/v1.81.3-stable/` → `release_notes/v1.81.3/`
- Dropped `-stable` from the `title` in both `index.md` files
- Dropped `-stable` from the `slug` in `release_notes/v1.83.10/index.md` (`v1-83-10-stable` → `v1-83-10`); the v1.81.3 slug was already `v1-81-3`
- Updated the v1.81.3 href on the Release Notes overview table

## Intentionally NOT changed

These reference real published artifacts whose tags / refs include `-stable`:

- Docker tags `docker.litellm.ai/berriai/litellm:v1.81.3-stable` and `...:main-v1.83.10-stable` in the Deploy sections
- The "Full Changelog" link `…/compare/v1.83.7-stable...v1.83.10-stable` (real Git tags)
- Historical body text (e.g. "Backfill release notes for v1.83.3-stable")
- Older `release_notes/v1.*-stable/` directories — incremental cleanup, not a sweep

## New URLs

- `https://docs.litellm.ai/release_notes/v1.83.10/v1-83-10`
- `https://docs.litellm.ai/release_notes/v1.81.3/v1-81-3`

The previous `-stable` URLs will 404 (matches the precedent of past renames in this repo, which also shipped without redirects).

## Test plan

- [x] `npm run build` succeeds; only pre-existing `Broken anchor` warnings remain (the `/docs/proxy/logging#prometheus` warning shows up identically in many older release notes — not introduced by this PR).
- [x] No new `Broken link` warnings.
- [x] `grep -rn "v1\.83\.10-stable\|v1\.81\.3-stable" release_notes/ blog/` — every remaining hit is one of the intentional exceptions above.
- [ ] After deploy, confirm sidebar shows `v1.83.10` and `v1.81.3` (no `-stable`) and the new URLs render.