### PR TITLE
docs(presidio): fix Docker port mappings in tutorial

### DIFF
--- a/docs/tutorials/presidio_pii_masking.md
+++ b/docs/tutorials/presidio_pii_masking.md
@@ -51,7 +51,7 @@ services:
   presidio-analyzer:
     image: mcr.microsoft.com/presidio-analyzer:latest
     ports:
-      - "5002:5002"
+      - "5002:3000"
     environment:
       - GRPC_PORT=5001
     networks:
@@ -60,7 +60,7 @@ services:
   presidio-anonymizer:
     image: mcr.microsoft.com/presidio-anonymizer:latest
     ports:
-      - "5001:5001"
+      - "5001:3000"
     networks:
       - presidio-network
 
@@ -498,14 +498,14 @@ services:
   presidio-analyzer-1:
     image: mcr.microsoft.com/presidio-analyzer:latest
     ports:
-      - "5002:5002"
+      - "5002:3000"
     deploy:
       replicas: 3
       
   presidio-anonymizer-1:
     image: mcr.microsoft.com/presidio-anonymizer:latest
     ports:
-      - "5001:5001"
+      - "5001:3000"
     deploy:
       replicas: 3
 ```


### PR DESCRIPTION
## Summary
- fix Presidio docker-compose examples to map host ports to container port `3000`
- update both the quickstart and high-availability snippets in the tutorial
- align docs with actual Presidio container behavior to prevent connection reset errors

## Test plan
- [x] `docker-compose up -d` with updated mapping starts both containers
- [x] `curl -X POST http://localhost:5002/analyze ...` returns `200 OK`
- [x] Verified tutorial file diff only changes port mappings

Made with [Cursor](https://cursor.com)