### PR TITLE
docs(github-copilot): adds GITHUB_COPILOT_ENABLE_AUTH_RECOVERY

### DIFF
--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -181,7 +181,7 @@ curl http://localhost:4000/v1/chat/completions \
 
 ### Environment Variables
 
-You can customize token storage locations:
+You can customize token storage locations, authentication recovery, and endpoints:
 
 ```bash showLineNumbers title="Environment Variables"
 # Optional: Custom token directory
@@ -192,6 +192,11 @@ export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
 
 # Optional: Custom API key file name
 export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
+
+# Optional: On a 401, delete the cached OAuth access token and re-run device-flow
+# authentication. Requires an interactive terminal, so do not enable on headless
+# proxy or CI deployments. Default: false
+export GITHUB_COPILOT_ENABLE_AUTH_RECOVERY="true"
 
 # Optional: Custom Copilot endpoints for authentication and usage
 # (needed when using GitHub Enterprise subscriptions with custom endpoints or self-hosted GitHub servers

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -819,6 +819,7 @@ router_settings:
 | GITHUB_COPILOT_ACCESS_TOKEN_URL | URL for GitHub Copilot access token retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/oauth/access_token. Default is https://github.com/login/oauth/access_token
 | GITHUB_COPILOT_API_KEY_URL | URL for GitHub Copilot API key retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/api/v3/copilot_internal/v2/token. Default is https://api.github.com/copilot_internal/v2/token
 | GITHUB_COPILOT_CLIENT_ID | Client ID for GitHub Copilot device flow authentication. This is used by the `github_copilot` provider for device code authentication. Default is "Iv1.b507a08c87ecfe98"
+| GITHUB_COPILOT_ENABLE_AUTH_RECOVERY | Set to `true` to enable GitHub Copilot authentication recovery on 401 responses. Default is `false`. When enabled, LiteLLM deletes the stale cached GitHub OAuth access token and re-runs device-flow authentication. Device flow needs an interactive terminal, so do not enable on headless proxy or CI deployments. When disabled, 401 responses are returned to the caller and the cached token must be cleared manually.
 | GREENSCALE_API_KEY | API key for Greenscale service
 | GREENSCALE_ENDPOINT | Endpoint URL for Greenscale service
 | GRAYSWAN_API_BASE | Base URL for GraySwan API. Default is https://api.grayswan.ai


### PR DESCRIPTION
## Summary

This PR documents the new `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` environment variable introduced in BerriAI/litellm#26706.

That PR makes the GitHub Copilot authenticator delete its cached OAuth access token and re-run the device flow when GitHub returns a 401, so users no longer have to manually clear `~/.config/litellm/github_copilot/` after a stale-token event such as machine sleep/wake or server-side revocation. The behavior is gated on the new environment variable and defaults to `false`.

## Changes

- `docs/providers/github_copilot.md`: Adds `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` to the Environment Variables example block, with a comment describing the recovery action and warning that device flow needs an interactive terminal, so the flag should not be enabled on headless proxy or CI deployments.
- `docs/proxy/config_settings.md`: Adds the environment variable to the proxy environment-variable reference table, covering both the enabled path (delete cached OAuth token, re-run device flow, headless caveat) and the disabled-default path (401 propagates to caller, cached token must be cleared manually).

## Test Plan

- [x] Docusaurus build succeeds, verified by the Vercel preview pipeline.
- [x] The provider page renders the comment block correctly inside the existing bash code fence.
- [x] The `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` row appears in the correct alphabetical position between `GITHUB_COPILOT_CLIENT_ID` and `GREENSCALE_API_KEY` in the proxy environment-variable table.
