### PR TITLE
docs(blog): make /blog responsive

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,25 @@
 }
 
 /* =========================================
+   GLOBAL — prevent horizontal overflow on mobile
+   Defensive: ensures no page can cause body-level x-scroll
+   (e.g. wide flex/marquee containers, long unbreakable tokens).
+   ========================================= */
+html,
+body,
+#__docusaurus {
+  overflow-x: hidden;
+  overflow-x: clip;
+}
+
+/* Break the flex-item min-width:auto chain that lets nowrap children
+   (marquees, long pre/code blocks) push wrappers wider than the viewport. */
+#__docusaurus,
+#__docusaurus > * {
+  min-width: 0;
+}
+
+/* =========================================
    DARK MODE Variables
    ========================================= */
 [data-theme='dark'] {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,11 +34,7 @@
   --ifm-container-width-xl: 1560px;
 }
 
-/* =========================================
-   GLOBAL — prevent horizontal overflow on mobile
-   Defensive: ensures no page can cause body-level x-scroll
-   (e.g. wide flex/marquee containers, long unbreakable tokens).
-   ========================================= */
+
 html,
 body,
 #__docusaurus {

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -1,8 +1,15 @@
 /* ── Page shell ───────────────────────────────────────────────────────── */
 .page {
+  width: 100%;
   max-width: 860px;
   margin: 0 auto;
   padding: 0 2rem;
+  /* Required: as a flex item of .main-wrapper, default min-width: auto
+     would let the marquee's intrinsic content size push the page wider
+     than the viewport. */
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* ── Hero ─────────────────────────────────────────────────────────────── */
@@ -220,6 +227,77 @@
 
 .pageLink:hover {
   color: #0ea5e9;
+}
+
+/* ── Mobile (≤640px) ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .page {
+    padding: 0 1.25rem;
+  }
+
+  .hero {
+    padding: 2rem 0 0;
+  }
+
+  .heroTitle {
+    font-size: 2rem;
+  }
+
+  .heroSub {
+    font-size: 0.9rem;
+  }
+
+  .hiringBtn {
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+  }
+
+  .marqueeWrap {
+    margin: 2rem 0 0;
+    padding: 1rem 0;
+  }
+
+  .fadeLeft,
+  .fadeRight {
+    width: 2.5rem;
+  }
+
+  .marqueeItem {
+    padding: 0 0.9rem;
+    font-size: 0.78rem;
+  }
+
+  .marqueeSep {
+    margin-left: 0.8rem;
+  }
+
+  .post {
+    padding: 1.5rem 0;
+  }
+
+  .title {
+    font-size: 1.2rem;
+  }
+
+  .desc {
+    font-size: 0.85rem;
+  }
+
+  .pagination {
+    padding: 1rem 0 3rem;
+    gap: 1rem;
+  }
+
+  .pageLink {
+    font-size: 0.8rem;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .marqueeTrack {
+    animation: none;
+  }
 }
 
 /* ── Dark mode ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Add mobile styles to the swizzled `BlogListPage` (hero, marquee, posts, pagination).
- Fix horizontal overflow caused by the marquee's `white-space: nowrap` propagating width up the flex chain — break it with `min-width: 0` on `.page` and `#__docusaurus > *`, plus defensive `overflow-x: clip`.

<img width="290" height="583" alt="Screenshot 2026-04-30 at 00 12 37" src="https://github.com/user-attachments/assets/aa232a49-30c8-41e5-99c4-39ad18d468fd" />
<br>

<img width="290" height="554" alt="Screenshot 2026-04-30 at 00 13 03" src="https://github.com/user-attachments/assets/d0aeec03-0cf2-48b3-a07c-3dfb6744240c" />
