### PR TITLE
docs(proxy): add Redis support for virtual key authentication caching

### DIFF
--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -22,6 +22,39 @@ calling the LLM API again.
 - S3 Bucket Cache
 - GCS Bucket Cache
 
+## Virtual Key Authentication Cache (Redis)
+
+When the proxy verifies a **virtual key** (customer API key), results are cached so the database is not queried on every request. By default that cache lives **only in each worker process**—so after a deploy, new pods or extra Uvicorn workers each warm their own cache and can trigger more DB reads until warmed.
+
+Set `litellm_settings.enable_redis_auth_cache: true` to mirror virtual-key auth data into **the same Redis instance** configured under `litellm_settings.cache` / `cache_params`. Workers and replicas then share cached auth entries across the cluster.
+
+**Requirements**
+
+- `litellm_settings.cache` must be **`true`** (Redis for the proxy is initialized during cache setup). See [All settings](./config_settings).
+- `cache_params.type` must be **`redis`** (or Redis Cluster, per your cache config); the auth cache attaches to that Redis client. See [supported `cache_params`](#supported-cache_params-on-proxy-configyaml).
+- Optionally set **`general_settings.user_api_key_cache_ttl`** (seconds): TTL applies to both the in-memory and Redis tiers when Redis auth caching is enabled, so stale keys expire consistently.
+
+Example:
+
+```yaml
+litellm_settings:
+  cache: true
+  enable_redis_auth_cache: true
+  cache_params:
+    type: redis
+    host: os.environ/REDIS_HOST
+    port: 6379
+
+general_settings:
+  user_api_key_cache_ttl: 300 # optional; seconds
+```
+
+:::tip
+
+Startup logs distinguish the two modes: with `enable_redis_auth_cache: true`, you should see a message that virtual-key lookups are shared across workers.
+
+:::
+
 ## Quick Start
 
 <Tabs>

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -97,6 +97,11 @@ litellm_settings:
     ttl: 600 # ttl for caching
     disable_copilot_system_to_assistant: False # DEPRECATED - GitHub Copilot API supports system prompts.
 
+  # Virtual key auth cache — shares API key / virtual-key auth across workers via Redis.
+  # Reduces DB round trips when caches are cold on new workers or pods.
+  # Requires litellm_settings.cache: true AND cache_params.type: redis above.
+  enable_redis_auth_cache: false
+
 callback_settings:
   otel:
     message_logging: boolean # OTEL logging callback specific settings
@@ -192,6 +197,7 @@ router_settings:
 | context_window_fallbacks | array of objects | Fallbacks to use when a ContextWindowExceededError is encountered. [Further docs](./reliability#context-window-fallbacks) |
 | cache | boolean | If true, enables caching. [Further docs](./caching) |
 | cache_params | object | Parameters for the cache. [Further docs](./caching#supported-cache_params-on-proxy-configyaml) |
+| enable_redis_auth_cache | boolean | When `true`, stores virtual-key auth payloads in Redis (same client as response caching) so every worker/pod shares cached auth lookups—fewer repeated database reads on cache misses. **Requires `cache: true` and `cache_params.type: redis`** (Redis or Redis Cluster). Optional: set `general_settings.user_api_key_cache_ttl` so TTL applies consistently to memory and Redis. [Further docs](./caching#virtual-key-authentication-cache-redis) |
 | disable_end_user_cost_tracking | boolean | If true, turns off end user cost tracking on prometheus metrics + litellm spend logs table on proxy. |
 | disable_end_user_cost_tracking_prometheus_only | boolean | If true, turns off end user cost tracking on prometheus metrics only. |
 | key_generation_settings | object | Restricts who can generate keys. [Further docs](./virtual_keys.md#restricting-key-generation) |


### PR DESCRIPTION
Enhance caching documentation by introducing the Virtual Key Authentication Cache feature using Redis. This allows shared caching of virtual-key auth data across workers, reducing database queries. Updated configuration settings to include `enable_redis_auth_cache` and its requirements.