### PR TITLE
docs: nest cost config under litellm settings

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -27,6 +27,14 @@ litellm_settings:
   # Networking settings
   request_timeout: 10 # (int) llm requesttimeout in seconds. Raise Timeout error if call takes longer than 10s. Sets litellm.request_timeout
   force_ipv4: boolean # If true, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6 + Anthropic API
+
+  # Cost tracking settings
+  cost_discount_config:
+    vertex_ai: 0.05 # Apply a 5% discount to Vertex AI costs
+    gemini: 0.05 # Apply a 5% discount to Gemini costs
+  cost_margin_config:
+    global: 0.05 # Apply a 5% margin to all providers
+    openai: 0.10 # Apply a 10% margin to OpenAI costs
   
   # Debugging - see debugging docs for more options
   # Use `--debug` or `--detailed_debug` CLI flags, or set LITELLM_LOG env var to "INFO", "DEBUG", or "ERROR"
@@ -194,6 +202,8 @@ router_settings:
 | cache_params | object | Parameters for the cache. [Further docs](./caching#supported-cache_params-on-proxy-configyaml) |
 | disable_end_user_cost_tracking | boolean | If true, turns off end user cost tracking on prometheus metrics + litellm spend logs table on proxy. |
 | disable_end_user_cost_tracking_prometheus_only | boolean | If true, turns off end user cost tracking on prometheus metrics only. |
+| cost_discount_config | object | Provider-specific percentage discounts applied to cost calculations. Configure under `litellm_settings`. [Further docs](./provider_discounts) |
+| cost_margin_config | object | Provider-specific or global percentage/fixed margins applied to cost calculations. Configure under `litellm_settings`. [Further docs](./provider_margins) |
 | key_generation_settings | object | Restricts who can generate keys. [Further docs](./virtual_keys.md#restricting-key-generation) |
 | disable_add_transform_inline_image_block | boolean | For Fireworks AI models - if true, turns off the auto-add of `#transform=inline` to the url of the image_url, if the model is not a vision model. |
 | use_chat_completions_url_for_anthropic_messages | boolean | If true, routes OpenAI `/v1/messages` requests through chat/completions instead of the Responses API. Can also be set via env var `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true`. |

--- a/docs/proxy/provider_discounts.md
+++ b/docs/proxy/provider_discounts.md
@@ -8,11 +8,12 @@ Apply percentage-based discounts to specific providers. This is useful for negot
 
 ```yaml
 # Apply 5% discount to all Vertex AI and Gemini costs
-cost_discount_config:
-  vertex_ai: 0.05  # 5% discount
-  gemini: 0.05     # 5% discount
-  openrouter: 0.05 # 5% discount
-  # openai: 0.10   # 10% discount (example)
+litellm_settings:
+  cost_discount_config:
+    vertex_ai: 0.05  # 5% discount
+    gemini: 0.05     # 5% discount
+    openrouter: 0.05 # 5% discount
+    # openai: 0.10   # 10% discount (example)
 ```
 
 **Step 2: Start proxy**

--- a/docs/proxy/provider_margins.md
+++ b/docs/proxy/provider_margins.md
@@ -124,11 +124,12 @@ You can also configure margins directly in your `config.yaml` file.
 
 ```yaml
 # Apply margins to providers
-cost_margin_config:
-  global: 0.05            # 5% global margin on all providers
-  openai: 0.10            # 10% margin for OpenAI (overrides global)
-  anthropic:
-    fixed_amount: 0.001   # $0.001 fixed fee per request
+litellm_settings:
+  cost_margin_config:
+    global: 0.05            # 5% global margin on all providers
+    openai: 0.10            # 10% margin for OpenAI (overrides global)
+    anthropic:
+      fixed_amount: 0.001   # $0.001 fixed fee per request
 ```
 
 **Step 2: Start proxy**
@@ -157,24 +158,27 @@ The margin will be automatically applied to all cost calculations for the config
 
 **Example 1: Percentage-only margin**
 ```yaml
-cost_margin_config:
-  openai: 0.10  # 10% margin
+litellm_settings:
+  cost_margin_config:
+    openai: 0.10  # 10% margin
 ```
 If base cost is $1.00, final cost = $1.00 x 1.10 = $1.10
 
 **Example 2: Fixed amount only**
 ```yaml
-cost_margin_config:
-  anthropic:
-    fixed_amount: 0.001  # $0.001 per request
+litellm_settings:
+  cost_margin_config:
+    anthropic:
+      fixed_amount: 0.001  # $0.001 per request
 ```
 If base cost is $1.00, final cost = $1.00 + $0.001 = $1.001
 
 **Example 3: Global margin with provider override**
 ```yaml
-cost_margin_config:
-  global: 0.05   # 5% global margin
-  openai: 0.10   # 10% margin for OpenAI (overrides global)
+litellm_settings:
+  cost_margin_config:
+    global: 0.05   # 5% global margin
+    openai: 0.10   # 10% margin for OpenAI (overrides global)
 ```
 - OpenAI requests: 10% margin applied
 - All other providers: 5% margin applied
@@ -189,10 +193,11 @@ Margins and discounts are calculated independently:
 
 **Example:**
 ```yaml
-cost_discount_config:
-  openai: 0.05  # 5% discount
-cost_margin_config:
-  openai: 0.10  # 10% margin
+litellm_settings:
+  cost_discount_config:
+    openai: 0.05  # 5% discount
+  cost_margin_config:
+    openai: 0.10  # 10% margin
 ```
 
 If base cost is $1.00:


### PR DESCRIPTION
## Summary

- Nest `cost_discount_config` and `cost_margin_config` under `litellm_settings` in provider discount/margin docs.
- Add both cost config options to the all-settings docs reference.
- Update margin examples so copied YAML matches the proxy UI/config endpoint format.