### PR TITLE
[Placeholder] Release Notes: Pass-through endpoint auth default flip (breaking)

### DIFF
--- a/release_notes/_draft-passthrough-auth-breaking/index.md
+++ b/release_notes/_draft-passthrough-auth-breaking/index.md
@@ -1,0 +1,65 @@
+---
+title: "[DRAFT] Pass-through endpoints — auth defaults flip + OSS unlock"
+slug: "draft-passthrough-auth-breaking"
+date: 2026-04-30T00:00:00
+draft: true
+unlisted: true
+hide_table_of_contents: true
+---
+
+> **Placeholder — do not merge as-is.**
+>
+> This is a parking spot for the breaking-change warning that needs to ship
+> alongside the release that lands [PR #26827](https://github.com/BerriAI/litellm/pull/26827).
+> When the release version is cut, move the `:::warning` block below into the
+> corresponding `release_notes/<version>/index.md` and delete this folder.
+
+## Why a placeholder
+
+[PR #26827](https://github.com/BerriAI/litellm/pull/26827) changes the default
+authentication behavior for pass-through endpoints configured under
+`general_settings.pass_through_endpoints`. Operators upgrading without changing
+their config will see previously-unauthenticated forwarders start requiring a
+valid LiteLLM API key.
+
+## Drop-in warning block
+
+Paste this admonition into the next release notes file (above `## Key Highlights`),
+matching the format used in [v1.83.7](../v1.83.7/index.md):
+
+```mdx
+:::warning
+
+**Breaking change — pass-through endpoints now require authentication by default.**
+`general_settings.pass_through_endpoints` entries that omit an explicit `auth`
+key will now require a valid LiteLLM API key. Previously the omitted-`auth`
+default was unauthenticated and the safe `auth: true` setting was rejected on
+the OSS tier. Operators who relied on unauthenticated forwarders (e.g. webhook
+receivers) must explicitly set `auth: false` on those entries before upgrading.
+The `auth: true` setting is no longer enterprise-gated —
+[PR #26827](https://github.com/BerriAI/litellm/pull/26827).
+
+:::
+```
+
+## Operator action required
+
+For each entry under `general_settings.pass_through_endpoints` in your proxy
+config, decide whether the route should require LiteLLM authentication:
+
+```yaml
+general_settings:
+  pass_through_endpoints:
+    # Public webhook receiver — must opt out explicitly after this release:
+    - path: "/webhooks/stripe"
+      target: "https://internal-svc/stripe"
+      auth: false
+
+    # Authenticated forwarder — was enterprise-only before this release,
+    # now available on OSS:
+    - path: "/anthropic-mirror"
+      target: "https://api.anthropic.com"
+      auth: true
+```
+
+Entries with no `auth` key will default to `auth: true` after the upgrade.


### PR DESCRIPTION
## Summary

- Placeholder PR — parks a release-notes warning block for the breaking change introduced by [BerriAI/litellm#26827](https://github.com/BerriAI/litellm/pull/26827) (still open, base `litellm_internal_staging`).
- Adds `release_notes/_draft-passthrough-auth-breaking/index.md` with a drop-in `:::warning` admonition matching the v1.83.7 format.
- Frontmatter sets `draft: true` + `unlisted: true` so the entry does not surface on the live release-notes sidebar before the upstream PR lands.

## What is the breaking change

[BerriAI/litellm#26827](https://github.com/BerriAI/litellm/pull/26827) flips the default for `general_settings.pass_through_endpoints[*].auth` from `false` to `true` and removes the enterprise-only gate on `auth: true`.

Operator-visible behavior change: any pass-through entry that omits `auth` now requires a valid LiteLLM API key on every request. Operators who relied on the unauthenticated default for things like webhook receivers must explicitly set `auth: false` before upgrading.

## How to use this placeholder

When the release that includes BerriAI/litellm#26827 is cut:

1. Copy the `:::warning` block out of `release_notes/_draft-passthrough-auth-breaking/index.md` into `release_notes/<version>/index.md` above `## Key Highlights`.
2. Delete the `release_notes/_draft-passthrough-auth-breaking/` folder.
3. Close this PR (or merge it bundled with the release-notes PR).

## Test plan

- [ ] Verify the draft folder does not appear in the local docs build sidebar (`npm run start` → release-notes section).
- [ ] When the upstream release ships, confirm the warning text matches the actual merged behavior of #26827 (default value, OSS gating, operator-action wording).
- [ ] Confirm `docs/proxy/pass_through.md` is also updated in a follow-up PR — the `auth: boolean` line currently says "Enterprise" and will be wrong after #26827 lands.