### PR TITLE
docs(gemini-embeddings): clarify Gemini API vs Vertex response shape

### DIFF
--- a/blog/gemini_embedding_2_multimodal/index.md
+++ b/blog/gemini_embedding_2_multimodal/index.md
@@ -4,7 +4,7 @@ title: "Gemini Embedding 2 Preview: Multimodal Embeddings on LiteLLM"
 date: 2025-03-11T10:00:00
 authors:
   - sameer
-description: "Generate embeddings from text, images, audio, video, and PDFs with gemini-embedding-2-preview on LiteLLM via Gemini API and Vertex AI."
+description: "Generate embeddings from text, images, audio, video, and PDFs with gemini-embedding-2-preview on LiteLLM via Gemini API (one vector per input, OpenAI-compatible) and Vertex AI (single unified vector per request)."
 tags: [gemini, embeddings, multimodal, vertex ai]
 hide_table_of_contents: false
 ---
@@ -14,7 +14,15 @@ import TabItem from '@theme/TabItem';
 
 # Gemini Embedding 2 Preview: Multimodal Embeddings
 
-LiteLLM now supports **multimodal embeddings** with `gemini-embedding-2-preview`—generating a single embedding from a mix of text, images, audio, video, and PDF content. Available via both the **Gemini API** (API key) and **Vertex AI** (GCP credentials).
+LiteLLM now supports **multimodal embeddings** with `gemini-embedding-2-preview`—mixing text, images, audio, video, and PDF content in a single request. Available via both the **Gemini API** (API key) and **Vertex AI** (GCP credentials).
+
+:::info Response shape differs by provider
+
+- **Gemini API** (`gemini/...`): each input element returns its own embedding, indexed `0..N-1` — same shape as OpenAI's `/embeddings`. LiteLLM routes to the [`batchEmbedContents`](https://ai.google.dev/api/embeddings#method:-models.batchembedcontents) endpoint with one `EmbedContentRequest` per input.
+- **Vertex AI** (`vertex_ai/...`): all input elements are combined into a single unified embedding via [`embedContent`](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-embeddings-api). Vertex AI does not expose `batchEmbedContents` for Gemini embedding models, so `N` parts → `1` vector. To get one vector per item, call `embedding(...)` once per input.
+
+:::
+
 
 {/* truncate */}
 
@@ -166,3 +174,31 @@ response = embedding(
     dimensions=768,  # Optional: control output vector size
 )
 ```
+
+## Combined Embeddings (Gemini API, opt-in)
+
+By default the Gemini API path returns one embedding per input element (OpenAI-compatible). To fuse several modalities into a **single** vector — e.g., a product represented by its name + photo — wrap them in a nested list:
+
+```python
+from litellm import embedding
+
+# Default: 2 inputs → 2 separate embeddings
+embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=["a red shoe", "data:image/png;base64,..."],
+)
+
+# Combined: text + image fused into 1 embedding
+embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=[["a red shoe", "data:image/png;base64,..."]],
+)
+
+# Mixed: 1 combined entity + 1 plain text → 2 embeddings total
+embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=[["a red shoe", "data:image/png;base64,..."], "just text"],
+)
+```
+
+Useful for multi-modal retrieval where a single entity has more than one modality. See the [embedding docs](../../docs/embedding/supported_embedding#combined-multimodal-embeddings) for details. On Vertex AI this opt-in is unnecessary — every request already returns one combined vector.

--- a/docs/embedding/supported_embedding.md
+++ b/docs/embedding/supported_embedding.md
@@ -515,10 +515,11 @@ All models listed [here](https://ai.google.dev/gemini-api/docs/models/gemini) ar
 | :---               | :---                                                  |
 | text-embedding-004 | `embedding(model="gemini/text-embedding-004", input)` |
 | gemini-embedding-2-preview | `embedding(model="gemini/gemini-embedding-2-preview", input)` | [Multimodal docs](#gemini-embedding-2-preview-multimodal) |
+| gemini-embedding-2 *(GA)* | `embedding(model="gemini/gemini-embedding-2", input)` | [Multimodal docs](#gemini-embedding-2-preview-multimodal) · [GA notes](/blog/gemini_embedding_2_ga) |
 
 ### Gemini Embedding 2 Preview (Multimodal)
 
-`gemini-embedding-2-preview` supports **multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details.
+`gemini-embedding-2-preview` supports **multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details. The GA model id `gemini-embedding-2` exposes the same behavior—swap the model name in any example below. See [GA blog](/blog/gemini_embedding_2_ga) for cost-map coverage and pricing notes.
 
 :::info Response shape
 

--- a/docs/embedding/supported_embedding.md
+++ b/docs/embedding/supported_embedding.md
@@ -520,6 +520,13 @@ All models listed [here](https://ai.google.dev/gemini-api/docs/models/gemini) ar
 
 `gemini-embedding-2-preview` supports **multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details.
 
+:::info Response shape
+
+For the Gemini API path (`gemini/gemini-embedding-2-preview`), each input element returns its **own** embedding (indexed `0..N-1`)—same semantics as OpenAI's `/embeddings`. LiteLLM routes to Gemini's `batchEmbedContents` endpoint with one `EmbedContentRequest` per input. This differs from the Vertex AI path, which combines all parts into a single unified vector—see [Vertex AI embeddings docs](../providers/vertex_embedding#gemini-embedding-2-preview-multimodal).
+
+:::
+
+
 **Input formats:**
 - **Data URIs:** `data:image/png;base64,<encoded_data>`
 - **Gemini file references:** `files/abc123` (pre-uploaded via Gemini Files API)
@@ -565,6 +572,56 @@ curl -X POST http://localhost:4000/embeddings \
 </Tabs>
 
 **Optional:** `dimensions` maps to Gemini's `outputDimensionality`.
+
+#### Combined Multimodal Embeddings
+
+By default, each element in the `input` list produces a **separate** embedding (OpenAI-compatible). To combine multiple inputs into a **single** embedding (e.g., text + image representing one entity), wrap them in a nested list:
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import embedding
+
+# Separate: 2 inputs → 2 embeddings
+response = embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=["a red shoe", "data:image/png;base64,..."],
+)
+# response.data has 2 embeddings
+
+# Combined: text + image → 1 embedding
+response = embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=[["a red shoe", "data:image/png;base64,..."]],
+)
+# response.data has 1 embedding representing both together
+
+# Mixed: 1 combined + 1 separate → 2 embeddings
+response = embedding(
+    model="gemini/gemini-embedding-2-preview",
+    input=[["a red shoe", "data:image/png;base64,..."], "just text"],
+)
+# response.data has 2 embeddings
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```bash
+curl -X POST http://localhost:4000/embeddings \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-embedding-2-preview",
+    "input": [["a red shoe", "data:image/png;base64,..."], "just text"]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+This is useful for representing multi-modal entities (e.g., a product with a name + photo) as a single vector for search and retrieval. Gemini API only — Vertex AI always returns a single combined vector regardless of input shape (see [Vertex AI embeddings docs](../providers/vertex_embedding#gemini-embedding-2-preview-multimodal)).
 
 
 ## Vertex AI Embedding Models

--- a/docs/providers/vertex_embedding.md
+++ b/docs/providers/vertex_embedding.md
@@ -80,6 +80,7 @@ All models listed [here](https://github.com/BerriAI/litellm/blob/57f37f743886a02
 | text-embedding-preview-0409 | `embedding(model="vertex_ai/text-embedding-preview-0409", input)` |
 | text-multilingual-embedding-preview-0409 | `embedding(model="vertex_ai/text-multilingual-embedding-preview-0409", input)` | 
 | gemini-embedding-2-preview | `embedding(model="vertex_ai/gemini-embedding-2-preview", input)` | [Multimodal docs](#gemini-embedding-2-preview-multimodal) |
+| gemini-embedding-2 *(GA)* | `embedding(model="vertex_ai/gemini-embedding-2", input)` | [Multimodal docs](#gemini-embedding-2-preview-multimodal) · [GA notes](/blog/gemini_embedding_2_ga) |
 | Fine-tuned OR Custom Embedding models | `embedding(model="vertex_ai/<your-model-id>", input)` | 
 
 ### Supported OpenAI (Unified) Params
@@ -260,7 +261,7 @@ model_list:
 
 ### Gemini Embedding 2 Preview (Multimodal)
 
-`gemini-embedding-2-preview` supports **unified multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details.
+`gemini-embedding-2-preview` supports **unified multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details. The GA model id `gemini-embedding-2` exposes the same behavior—swap the model name in any example below. See [GA blog](/blog/gemini_embedding_2_ga) for cost-map coverage and pricing notes.
 
 :::warning Response shape — Vertex returns one combined vector
 

--- a/docs/providers/vertex_embedding.md
+++ b/docs/providers/vertex_embedding.md
@@ -262,6 +262,15 @@ model_list:
 
 `gemini-embedding-2-preview` supports **unified multimodal embeddings**—text, images, audio, video, and PDF in a single request. See [blog post](/blog/gemini_embedding_2_multimodal) for details.
 
+:::warning Response shape — Vertex returns one combined vector
+
+Vertex AI's Gemini embedding endpoint only exposes single-content `embedContent` (no `batchEmbedContents`), so passing `N` items in `input=[...]` returns **1 unified embedding** that fuses all parts—not N separate vectors. To get one vector per item, call `embedding(...)` once per input.
+
+This differs from the Gemini API path (`gemini/gemini-embedding-2-preview`), which returns one embedding per input element (OpenAI-compatible). See [Gemini embedding docs](../embedding/supported_embedding#gemini-embedding-2-preview-multimodal).
+
+:::
+
+
 **Input formats:**
 - **Data URIs:** `data:image/png;base64,<encoded_data>`
 - **GCS URLs:** `gs://bucket/path/to/file.png` (MIME type inferred from extension)


### PR DESCRIPTION
## Summary

Documents how `gemini-embedding-2-preview` now matches the OpenAI `/embeddings` contract on the Gemini API path, and clarifies the Vertex AI limitation. Also documents the new opt-in combined-multimodal syntax.

## The OpenAI embeddings contract

OpenAI's `/embeddings` endpoint: send N inputs, get N embeddings back, indexed 0..N-1.

**Request:**
```bash
curl https://api.openai.com/v1/embeddings \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "text-embedding-3-small",
    "input": ["hello", "world"]
  }'
```

**Response:**
```json
{
  "data": [
    { "index": 0, "embedding": [...] },
    { "index": 1, "embedding": [...] }
  ]
}
```

LiteLLM's job is to keep this contract no matter the underlying provider.

## Before this fix — Gemini was breaking the contract

Same request to Gemini via LiteLLM:

```bash
curl http://localhost:4000/embeddings \
  -d '{
    "model": "gemini/gemini-embedding-2-preview",
    "input": ["hello", "world", "data:image/png;base64,..."]
  }'
```

Returned **1 fused embedding** with `index=0`, instead of 3 separate ones. Multimodal inputs were silently routed to `embedContent` (which aggregates parts into one vector). Indices were also hardcoded to 0.

```json
{ "data": [ { "index": 0, "embedding": [...] } ] }   // ❌ wrong shape
```

## After — OpenAI-compatible again

Same call now returns the expected shape:

```json
{
  "data": [
    { "index": 0, "embedding": [...] },
    { "index": 1, "embedding": [...] },
    { "index": 2, "embedding": [...] }
  ]
}
```

Routed to Gemini's `batchEmbedContents` endpoint, one `EmbedContentRequest` per input.

## Vertex AI is different (and stays that way)

Vertex's Gemini embedding endpoint only exposes `embedContent` (no `batchEmbedContents`), so:

```bash
curl http://localhost:4000/embeddings \
  -d '{
    "model": "vertex_ai/gemini-embedding-2-preview",
    "input": ["hello", "gs://bucket/img.png"]
  }'
```

Returns **1 combined embedding** — not a bug, the API simply doesn't support batching. To get N→N on Vertex, loop the call. Documented as a `:::warning`.

## New: opt-in combined multimodal (Gemini API)

If you actually *want* a fused vector on the Gemini API path (e.g., a product = name + photo), wrap the items in a nested list:

```bash
curl http://localhost:4000/embeddings \
  -d '{
    "model": "gemini/gemini-embedding-2-preview",
    "input": [["a red shoe", "data:image/png;base64,..."], "just text"]
  }'
```

→ 2 embeddings: 1 fused (shoe + photo) + 1 plain text.

## Context

This documents behavior from two upstream PRs already merged into the `litellm_staging_03_21_2026` staging branch (umbrella PR BerriAI/litellm#24340 still open):

- BerriAI/litellm#24337 — fix: separate embeddings + correct indices
- BerriAI/litellm#24341 — feat: combined multimodal via nested input

Both ship to `main` once the staging branch is released.

## Files

- `blog/gemini_embedding_2_multimodal/index.md` — corrected intro, added combined-opt-in section.
- `docs/embedding/supported_embedding.md` — `:::info` on response shape, `#### Combined Multimodal Embeddings` subsection.
- `docs/providers/vertex_embedding.md` — `:::warning` explaining the Vertex single-vector limitation and the workaround.
