### PR TITLE
docs(embedding): default encoding_format and LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT

### DIFF
--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -153,6 +153,8 @@ Here's how to call an OpenAI-Compatible Endpoint with the LiteLLM Proxy Server
 
 ## Embeddings
 
+vLLM serves OpenAI-compatible `/v1/embeddings`. When clients omit `encoding_format`, LiteLLM defaults it for OpenAI-compatible embedding routing (request → model `litellm_params` → `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT` → `float`). See [Embeddings](../proxy/embedding.md#embedding-encoding-format).
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -833,6 +833,7 @@ router_settings:
 | LITELLM_DETAILED_TIMING | When true, adds detailed per-phase timing headers to responses (`x-litellm-timing-{pre-processing,llm-api,post-processing,message-copy}-ms`). Default is false. See [latency overhead docs](../troubleshoot/latency_overhead.md)
 | LITELLM_DD_AGENT_PORT | Port of DataDog agent for LiteLLM-specific log intake. Default is 10518
 | LITELLM_DD_LLM_OBS_PORT | Port for Datadog LLM Observability agent. Default is 8126
+| LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT | Default `encoding_format` for OpenAI-compatible embedding calls when it is not set on the request or in model `litellm_params` (e.g. `float`, `base64`). Fallback is `float`. See [Embeddings](./embedding.md#embedding-encoding-format).
 | LITELLM_DONT_SHOW_FEEDBACK_BOX | Flag to hide feedback box in LiteLLM UI
 | LITELLM_DROP_PARAMS | Parameters to drop in LiteLLM requests
 | LITELLM_MODIFY_PARAMS | Parameters to modify in LiteLLM requests

--- a/docs/proxy/embedding.md
+++ b/docs/proxy/embedding.md
@@ -17,6 +17,28 @@ The `/v1/embeddings` endpoint follows the [OpenAI embeddings API specification](
 | Array of tokens (integers) | `"input": [1234, 5678, 9012]` |
 | Array of token arrays | `"input": [[1234, 5678], [9012, 3456]]` |
 
+## Default `encoding_format` {#embedding-encoding-format}
+
+For embeddings routed through LiteLLM’s **OpenAI-compatible embedding path** (for example OpenAI models, `openai/...` with a custom `api_base`, or the proxy `/v1/embeddings` route that forwards to that path), LiteLLM sends an explicit `encoding_format` when the caller omits it.
+
+**Resolution order** (first match wins):
+
+1. Value in the embedding request body (`encoding_format` in JSON).
+2. Per-model default from `litellm_params.encoding_format` in `config.yaml`.
+3. Process environment variable **`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`** (e.g. `float` or `base64`).
+4. Fallback **`float`**.
+
+You can still override per request from any OpenAI-compatible client:
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/embeddings' \
+  --header 'Authorization: Bearer sk-1234' \
+  --header 'Content-Type: application/json' \
+  --data '{"model": "my-embedding-model", "input": "hello", "encoding_format": "base64"}'
+```
+
+See also: [Config settings](./config_settings.md) (`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`).
+
 ## Quick start
 Here's how to route between GPT-J embedding (sagemaker endpoint), Amazon Titan embedding (Bedrock) and Azure OpenAI embedding on the proxy server: 
 
@@ -56,12 +78,6 @@ curl --location 'http://0.0.0.0:4000/v1/embeddings' \
     "model": "sagemaker-embeddings",
 }'
 ```
-
-
-
-
-
-
 
 
 

--- a/docs/proxy/embedding.md
+++ b/docs/proxy/embedding.md
@@ -17,28 +17,6 @@ The `/v1/embeddings` endpoint follows the [OpenAI embeddings API specification](
 | Array of tokens (integers) | `"input": [1234, 5678, 9012]` |
 | Array of token arrays | `"input": [[1234, 5678], [9012, 3456]]` |
 
-## Default `encoding_format` {#embedding-encoding-format}
-
-For embeddings routed through LiteLLM’s **OpenAI-compatible embedding path** (for example OpenAI models, `openai/...` with a custom `api_base`, or the proxy `/v1/embeddings` route that forwards to that path), LiteLLM sends an explicit `encoding_format` when the caller omits it.
-
-**Resolution order** (first match wins):
-
-1. Value in the embedding request body (`encoding_format` in JSON).
-2. Per-model default from `litellm_params.encoding_format` in `config.yaml`.
-3. Process environment variable **`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`** (e.g. `float` or `base64`).
-4. Fallback **`float`**.
-
-You can still override per request from any OpenAI-compatible client:
-
-```bash
-curl --location 'http://0.0.0.0:4000/v1/embeddings' \
-  --header 'Authorization: Bearer sk-1234' \
-  --header 'Content-Type: application/json' \
-  --data '{"model": "my-embedding-model", "input": "hello", "encoding_format": "base64"}'
-```
-
-See also: [Config settings](./config_settings.md) (`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`).
-
 ## Quick start
 Here's how to route between GPT-J embedding (sagemaker endpoint), Amazon Titan embedding (Bedrock) and Azure OpenAI embedding on the proxy server: 
 
@@ -78,6 +56,25 @@ curl --location 'http://0.0.0.0:4000/v1/embeddings' \
     "model": "sagemaker-embeddings",
 }'
 ```
+## Default `encoding_format` {#embedding-encoding-format}
 
+For embeddings routed through LiteLLM’s **OpenAI-compatible embedding path** (for example OpenAI models, `openai/...` with a custom `api_base`, or the proxy `/v1/embeddings` route that forwards to that path), LiteLLM sends an explicit `encoding_format` when the caller omits it.
 
+**Resolution order** (first match wins):
+
+1. Value in the embedding request body (`encoding_format` in JSON).
+2. Per-model default from `litellm_params.encoding_format` in `config.yaml`.
+3. Process environment variable **`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`** (e.g. `float` or `base64`).
+4. Fallback **`float`**.
+
+You can still override per request from any OpenAI-compatible client:
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/embeddings' \
+  --header 'Authorization: Bearer sk-1234' \
+  --header 'Content-Type: application/json' \
+  --data '{"model": "my-embedding-model", "input": "hello", "encoding_format": "base64"}'
+```
+
+See also: [Config settings](./config_settings.md) (`LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT`).
 


### PR DESCRIPTION
## Summary
Documents OpenAI-compatible embedding `encoding_format` behavior: resolution order (request → `litellm_params` → `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT` → `float`), with examples and cross-links.

## Files
- `docs/proxy/embedding.md` — dedicated section + curl example
- `docs/proxy/config_settings.md` — env var row
- `docs/providers/vllm.md` — short pointer for vLLM embeddings

Pairs with LiteLLM core change (PR `litellm_default_embedding_encoding_format` / embedding default behavior).

Made with [Cursor](https://cursor.com)