### PR TITLE
docs(gemini): Gemini 3 thinking defaults and opt-in legacy flag

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -295,7 +295,15 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
+For **Gemini 3+ models**, LiteLLM now follows provider defaults by default and does **not** force `thinkingLevel` when you pass Anthropic-style `thinking={"type":"enabled","budget_tokens":...}`.
 
+If you want the legacy LiteLLM behavior (force `thinkingLevel="low"` for Pro and `thinkingLevel="minimal"` for Flash), enable:
+
+```python
+import litellm
+
+litellm.enable_gemini_default_thinking_level_low = True
+```
 
 ## Usage - `service_tier`
 


### PR DESCRIPTION
Documents Gemini 3+ behavior for Anthropic-style `thinking` params: LiteLLM follows provider defaults and does not force `thinkingLevel` unless `litellm.enable_gemini_default_thinking_level_low` is set to `True`.

Pairs with the LiteLLM implementation that gates legacy forced `thinkingLevel` mapping behind this flag.

Made with [Cursor](https://cursor.com)