### PR TITLE
Add New Relic extension documentation

### DIFF
--- a/docs/observability/newrelic.md
+++ b/docs/observability/newrelic.md
@@ -12,7 +12,7 @@ This page covers using New Relic with LiteLLM in proxy mode. You can also use Ne
 The New Relic integration requires the New Relic Python Agent to instrument the LiteLLM proxy process. The `litellm-newrelic` image is a purpose-built variant of the standard `litellm` image that includes the New Relic Python Agent and starts the proxy via `newrelic-admin`. Simply use this image in place of the standard `litellm` image.
 
 ```shell
-docker pull litellm/litellm-newrelic:latest
+docker pull docker.litellm.ai/berriai/litellm-newrelic:latest
 ```
 
 ## Enable New Relic LiteLLM Extension

--- a/docs/observability/newrelic.md
+++ b/docs/observability/newrelic.md
@@ -1,0 +1,82 @@
+import Image from '@theme/IdealImage';
+
+# Prerequisite
+In order to use LiteLLM with New Relic, you will need to have a New Relic account and [license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/).
+
+This page covers using New Relic with LiteLLM in proxy mode. You can also use New Relic with the LiteLLM SDK by including the New Relic Python Agent in your application. Please refer to the New Relic AI Monitoring [documentation](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/).
+
+# Quick Start
+
+## Enable New Relic Python Agent instrumentation
+
+The LiteLLM proxy has an optional configuration to enable instrumentation with the New Relic Python Agent. In order for the New Relic extension to work within the LiteLLM proxy, the New Relic Python Agent must instrument the process. This will result in the LiteLLM proxy reporting telemetry about the proxy to New Relic.
+
+In order to enable the New Relic Python Agent with the LiteLLM proxy, include the following environment variable when starting the proxy.
+
+```shell
+USE_NEWRELIC=true
+```
+
+## Enable New Relic LiteLLM Extension
+
+The New Relic LiteLLM extension is implemented as a callback. A common way to enable the callback is via the `config.yaml` definition. In order to enable the New Relic extension, add a callback configuration similar to the following in your `config.yaml`. The callbacks can include a number of different extensions. As long as "newrelic" is included in the list, the New Relic LiteLLM extension will be invoked.
+
+```yaml
+litellm_settings:
+  callbacks: ["newrelic"]
+```
+
+## Required environment variables
+
+In order for the New Relic Python Agent to report telemetry to New Relic, there are a few environment variables that should be set.
+
+The `NEW_RELIC_APP_NAME` environment variable should have a value for the name that you wish the LiteLLM server to appear as in New Relic's UI. The `NEW_RELIC_LICENSE_KEY` environment variable value is a license key for the New Relic account you want the telemetry to be reported to.
+
+When running the LiteLLM proxy container image, `USE_NEWRELIC=true` is required to enable the New Relic Python Agent. This instructs the container entrypoint to start the proxy via `newrelic-admin`, which initializes the agent before the proxy process begins. If you are running the proxy outside of the container image, you will need to start the process with `newrelic-admin run-program` instead.
+
+```shell
+NEW_RELIC_APP_NAME=<app name>
+NEW_RELIC_LICENSE_KEY=<license key>
+
+USE_NEWRELIC=true
+```
+
+# Advanced Configuration
+
+## Disable sending LLM messages to New Relic
+
+There are two options to disable sending LLM messages to New Relic. Using either of these options will disable sending LLM messages to New Relic; you do not need to set both.
+
+The `config.yaml` file can be used to set a flag that will disable sending LLM messages to New Relic. As you might want LLM messages to be sent elsewhere (logs) but not to New Relic, there is a New Relic specific configuration value that can be set. Adding the following to your `config.yaml` will prevent LLM messages from being sent to New Relic.
+
+```yaml
+litellm_settings:
+  callbacks: ["newrelic"]
+  newrelic_params:
+    turn_off_message_logging: true
+```
+
+The other option is to use an environment variable to disable sending LLM messages to New Relic. This can be achieved with the following environment variable.
+
+```shell
+NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=false
+```
+
+### New Relic Agent Configuration
+
+The New Relic Python Agent has a [number of ways](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/) to accept configuration. As shown above, environment variables can be used to set various optional configuration within the agent.
+
+There is also an agent configuration file that could be used instead of environment variables. If you prefer to use the configuration file, you'll need to ensure the configuration file is accessible. You should also set the following environment variable to point to your configuration file.
+
+```shell
+NEW_RELIC_CONFIG_FILE=</path/to/newrelic/configuration_file>
+```
+
+### Recommended configuration overrides
+
+The New Relic LiteLLM Extension will send telemetry to New Relic so that the messages appear as part of the New Relic AI Monitoring feature. When using this feature, there are some configurations that are recommended to be set. This configurations can be set via environment variables or in a configuration file. The following environment variables are recommended.
+
+```shell
+NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_ATTRIBUTE_VALUE=4095
+NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED=100000
+```

--- a/docs/observability/newrelic.md
+++ b/docs/observability/newrelic.md
@@ -7,14 +7,12 @@ This page covers using New Relic with LiteLLM in proxy mode. You can also use Ne
 
 # Quick Start
 
-## Enable New Relic Python Agent instrumentation
+## Use the litellm-newrelic Docker image
 
-The LiteLLM proxy has an optional configuration to enable instrumentation with the New Relic Python Agent. In order for the New Relic extension to work within the LiteLLM proxy, the New Relic Python Agent must instrument the process. This will result in the LiteLLM proxy reporting telemetry about the proxy to New Relic.
-
-In order to enable the New Relic Python Agent with the LiteLLM proxy, include the following environment variable when starting the proxy.
+The New Relic integration requires the New Relic Python Agent to instrument the LiteLLM proxy process. The `litellm-newrelic` image is a purpose-built variant of the standard `litellm` image that includes the New Relic Python Agent and starts the proxy via `newrelic-admin`. Simply use this image in place of the standard `litellm` image.
 
 ```shell
-USE_NEWRELIC=true
+docker pull litellm/litellm-newrelic:latest
 ```
 
 ## Enable New Relic LiteLLM Extension
@@ -32,13 +30,9 @@ In order for the New Relic Python Agent to report telemetry to New Relic, there 
 
 The `NEW_RELIC_APP_NAME` environment variable should have a value for the name that you wish the LiteLLM server to appear as in New Relic's UI. The `NEW_RELIC_LICENSE_KEY` environment variable value is a license key for the New Relic account you want the telemetry to be reported to.
 
-When running the LiteLLM proxy container image, `USE_NEWRELIC=true` is required to enable the New Relic Python Agent. This instructs the container entrypoint to start the proxy via `newrelic-admin`, which initializes the agent before the proxy process begins. If you are running the proxy outside of the container image, you will need to start the process with `newrelic-admin run-program` instead.
-
 ```shell
 NEW_RELIC_APP_NAME=<app name>
 NEW_RELIC_LICENSE_KEY=<license key>
-
-USE_NEWRELIC=true
 ```
 
 # Advanced Configuration

--- a/docs/observability/newrelic.md
+++ b/docs/observability/newrelic.md
@@ -1,32 +1,29 @@
 import Image from '@theme/IdealImage';
 
-# Prerequisite
-In order to use LiteLLM with New Relic, you will need to have a New Relic account and [license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/).
+# New Relic
+
+## Prerequisite
+In order to use LiteLLM with New Relic, you will need to have a New Relic account and [license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/). If you do not have a New Relic account yet, you can create a [free tier account](https://newrelic.com/pricing/free-tier).
 
 This page covers using New Relic with LiteLLM in proxy mode. You can also use New Relic with the LiteLLM SDK by including the New Relic Python Agent in your application. Please refer to the New Relic AI Monitoring [documentation](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/).
 
-# Quick Start
+## Configuration
 
-## Use the litellm-newrelic Docker image
+### Enable New Relic LiteLLM callback
 
-The New Relic integration requires the New Relic Python Agent to instrument the LiteLLM proxy process. The `litellm-newrelic` image is a purpose-built variant of the standard `litellm` image that includes the New Relic Python Agent and starts the proxy via `newrelic-admin`. Simply use this image in place of the standard `litellm` image.
-
-```shell
-docker pull docker.litellm.ai/berriai/litellm-newrelic:latest
-```
-
-## Enable New Relic LiteLLM Extension
-
-The New Relic LiteLLM extension is implemented as a callback. A common way to enable the callback is via the `config.yaml` definition. In order to enable the New Relic extension, add a callback configuration similar to the following in your `config.yaml`. The callbacks can include a number of different extensions. As long as "newrelic" is included in the list, the New Relic LiteLLM extension will be invoked.
+The New Relic LiteLLM extension is implemented as a callback. A common way to enable the callback is via the `config.yaml` file. When configured via `config.yaml`, the `callbacks` list can include several values. As long as `newrelic` is included in the list, the New Relic LiteLLM callback will be invoked. The following example would enable the New Relic callback within LiteLLM.
 
 ```yaml
 litellm_settings:
   callbacks: ["newrelic"]
 ```
 
-## Required environment variables
+You can also configure the callback via the LiteLLM administrative UI. If you use this option, please see the
+[LiteLLM admin UI documentation](https://docs.litellm.ai/docs/proxy/ui) to access the admin UI and include the New Relic callback within the `Settings` section.
 
-In order for the New Relic Python Agent to report telemetry to New Relic, there are a few environment variables that should be set.
+### Required environment variables
+
+The [New Relic Python Agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) requires configuration to report telemetry to New Relic. The New Relic Python Agent supports defining [configuration](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/) via both a configuration file and environment variables. With LiteLLM, it is recommended to use environment variables, but both options will work.
 
 The `NEW_RELIC_APP_NAME` environment variable should have a value for the name that you wish the LiteLLM server to appear as in New Relic's UI. The `NEW_RELIC_LICENSE_KEY` environment variable value is a license key for the New Relic account you want the telemetry to be reported to.
 
@@ -35,13 +32,174 @@ NEW_RELIC_APP_NAME=<app name>
 NEW_RELIC_LICENSE_KEY=<license key>
 ```
 
-# Advanced Configuration
+## Running LiteLLM with New Relic Python Agent
 
-## Disable sending LLM messages to New Relic
+The [New Relic Python Agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) is used within applications to report [Application Performance Monitoring (APM)](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm/) telemetry to New Relic. By following the steps below, a New Relic customer will receive both the APM telemetry for LiteLLM as well as the LLM messages within [AI Monitoring](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/) from their LiteLLM server.
 
-There are two options to disable sending LLM messages to New Relic. Using either of these options will disable sending LLM messages to New Relic; you do not need to set both.
+### Building a New Relic-enabled container (recommended)
 
-The `config.yaml` file can be used to set a flag that will disable sending LLM messages to New Relic. As you might want LLM messages to be sent elsewhere (logs) but not to New Relic, there is a New Relic specific configuration value that can be set. Adding the following to your `config.yaml` will prevent LLM messages from being sent to New Relic.
+The official LiteLLM containers include the New Relic callback, but do not include the New Relic Python Agent. The easiest way to include the New Relic Python Agent is to create a new container image that layers the agent on top of an existing LiteLLM image. By doing this, you will be able to define the official LiteLLM image version to use as a base.
+
+In order to build a LiteLLM container with the New Relic Python Agent inside of it, you can use the following `Dockerfile`, `entrypoint.sh`, and `supervisord.conf` files. This process will use an official LiteLLM container as a base image, install the New Relic Python Agent, and add new entrypoint and supervisord configuration files. The resulting container will run LiteLLM with the New Relic Python Agent reporting APM telemetry to New Relic. With the callback enabled and the environment variables set above, you will also report the LLM messages to New Relic.
+
+To build the container image, copy the `Dockerfile`, `entrypoint.sh`, and `supervisord.conf` files to a directory. From this directory, you can build an image from the CLI using the following command.
+
+```shell
+docker build -f Dockerfile -t litellm-newrelic:local .
+```
+
+If you wish to specify the LiteLLM image version to use as a base, pass `--build-arg BASE_IMAGE=…` and/or `--build-arg BASE_TAG=…` to target a different base image or tag similar to the following command.
+
+```shell
+BASE_TAG=v1.83.14-stable
+docker build \
+  --build-arg BASE_IMAGE=docker.litellm.ai/berriai/litellm \
+  --build-arg BASE_TAG=${BASE_TAG} \
+  -f Dockerfile \
+  -t litellm-newrelic:${BASE_TAG} \
+  .
+```
+
+You may use any docker name for the output image that suits your image naming policy. You will also likely want to push the resulting docker image to your container repository of choice.
+
+#### `Dockerfile`
+
+The Dockerfile defines the layers added on top of an official LiteLLM container. You should pick the version you want to use by setting `BASE_TAG` when you actually build the image. This Dockerfile installs the New Relic Python Agent, then adds new supervisor and entrypoint files that run LiteLLM with the New Relic Python Agent.
+
+```dockerfile
+ARG BASE_IMAGE=docker.litellm.ai/berriai/litellm
+ARG BASE_TAG=main-stable
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+USER root
+
+# Install New Relic agent (ensurepip bootstraps pip in case base image venv omits it)
+RUN python -m ensurepip && python -m pip install --no-cache-dir 'newrelic>=12.1.0,<13'
+
+# Copy New Relic-specific configuration files
+COPY supervisord.conf /etc/supervisord_newrelic.conf
+COPY entrypoint.sh /app/docker/newrelic/entrypoint.sh
+RUN chmod +x /app/docker/newrelic/entrypoint.sh
+
+# Override entrypoint to always use newrelic-admin
+ENTRYPOINT ["/app/docker/newrelic/entrypoint.sh"]
+
+LABEL org.opencontainers.image.description="LiteLLM with New Relic APM and AI monitoring"
+```
+
+#### `entrypoint.sh`
+
+This `entrypoint.sh` is a copy of LiteLLM's default `docker/prod_entrypoint.sh`, modified to run either supervisord or the `litellm` process wrapped by the New Relic Python Agent.
+
+```sh
+#!/bin/sh
+# This entry point is a copy of the litellm docker/prod_entrypoint.sh file
+# with these changes:
+#
+#  - Use the New Relic-specific supervisor file
+#  - Wrap the litellm command with New Relic Python Agent
+
+if [ "$SEPARATE_HEALTH_APP" = "1" ]; then
+    export LITELLM_ARGS="$@"
+    export SUPERVISORD_STOPWAITSECS="${SUPERVISORD_STOPWAITSECS:-3600}"
+    exec supervisord -c /etc/supervisord_newrelic.conf
+fi
+
+exec newrelic-admin run-program litellm "$@"
+```
+
+#### `supervisord.conf`
+
+If you use supervisord to run LiteLLM alongside the separate health app, this version will ensure the main LiteLLM process is started with the New Relic Python Agent.
+
+```ini
+# This config is a copy of the litellm docker/supervisord.conf with a change to the `main` program
+# to wrap the litellm command with the New Relic Python Agent.
+
+[supervisord]
+nodaemon=true
+loglevel=info
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+
+[group:litellm]
+programs=main,health
+
+[program:main]
+command=sh -c 'exec newrelic-admin run-program python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000 $LITELLM_ARGS'
+autostart=true
+autorestart=true
+startretries=3
+priority=1
+exitcodes=0
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=%(ENV_SUPERVISORD_STOPWAITSECS)s
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+environment=PYTHONUNBUFFERED=true
+
+[program:health]
+command=sh -c '[ "$SEPARATE_HEALTH_APP" = "1" ] && exec uvicorn litellm.proxy.health_endpoints.health_app_factory:build_health_app --factory --host 0.0.0.0 --port=${SEPARATE_HEALTH_PORT:-4001} || exit 0'
+autostart=true
+autorestart=true
+startretries=3
+priority=2
+exitcodes=0
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=%(ENV_SUPERVISORD_STOPWAITSECS)s
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+environment=PYTHONUNBUFFERED=true
+
+[eventlistener:process_monitor]
+command=python -c "from supervisor import childutils; import os, signal; [os.kill(os.getppid(), signal.SIGTERM) for h,p in iter(lambda: childutils.listener.wait(), None) if h['eventname'] in ['PROCESS_STATE_FATAL', 'PROCESS_STATE_EXITED'] and dict([x.split(':') for x in p.split(' ')])['processname'] in ['main', 'health'] or childutils.listener.ok()]"
+events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
+autostart=true
+autorestart=true
+```
+
+### Running from LiteLLM source
+
+The LiteLLM source uses `uv` to manage dependencies. To run the New Relic integration for LiteLLM, install the New Relic Python Agent locally first. The easiest way is to use `uv` to install it.
+
+```shell
+make install-proxy-dev
+uv pip install 'newrelic>=12.1.0,<13'
+```
+
+You can then run `litellm` locally from source using the New Relic Python Agent with this command. Add any additional options that you might need to the end of the command such as `--config config.yaml` or `--debug`.
+
+```shell
+uv run newrelic-admin run-program litellm
+```
+
+### Verification
+
+#### LiteLLM container logs
+
+When the New Relic callback initializes, it writes an INFO log message confirming initialization and whether LLM content recording is enabled. If INFO log messages are not visible, set the `LITELLM_LOG=INFO` environment variable to enable them. Look for a message in this form:
+
+```log
+New Relic AI Monitoring initialized for app: {app-name}, content recording: {True / False}
+```
+
+#### New Relic AI Monitoring
+
+[New Relic AI Monitoring](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/) can be used to verify the LLM metadata and/or content have been received. From the `AI Responses` view, you should see the LLM requests in the `Responses` table shortly after a request is returned by LiteLLM. If LLM content recording is enabled, the LLM request/response messages will appear in the `Responses` table. Selecting a row on the table will display more details about the LLM request. The trace details may take 2-3 minutes to appear.
+
+## Advanced configuration options
+
+### Disable sending LLM messages to New Relic
+
+You can disable sending LLM messages to New Relic in any of the following ways.
+
+The `config.yaml` file can be used to set a flag that will disable sending LLM messages to New Relic. As you might want LLM messages to be sent elsewhere (logs) but not to New Relic, there is a New Relic-specific configuration value that can be set. Adding the following to your `config.yaml` will prevent LLM messages from being sent to New Relic.
 
 ```yaml
 litellm_settings:
@@ -50,11 +208,13 @@ litellm_settings:
     turn_off_message_logging: true
 ```
 
-The other option is to use an environment variable to disable sending LLM messages to New Relic. This can be achieved with the following environment variable.
+The New Relic callback also utilizes an environment variable option to disable recording content. This environment variable defaults to `true`. You can turn off recording content messages by setting the following environment variable to `false`.
 
 ```shell
 NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=false
 ```
+
+If you are using the LiteLLM Administrative UI to add the New Relic callback, the form has an option that will accept a boolean value. This boolean value follows the same rules as the environment variable (`true` or blank to record LLM messages, `false` to turn off recording content messages).
 
 ### New Relic Agent Configuration
 
@@ -68,9 +228,13 @@ NEW_RELIC_CONFIG_FILE=</path/to/newrelic/configuration_file>
 
 ### Recommended configuration overrides
 
-The New Relic LiteLLM Extension will send telemetry to New Relic so that the messages appear as part of the New Relic AI Monitoring feature. When using this feature, there are some configurations that are recommended to be set. This configurations can be set via environment variables or in a configuration file. The following environment variables are recommended.
+The New Relic LiteLLM Extension will send telemetry to New Relic so that the messages appear as part of the New Relic AI Monitoring feature. When using this feature, the following configurations are recommended. These configurations can be set via environment variables or in a configuration file.
 
 ```shell
 NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_ATTRIBUTE_VALUE=4095
 NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED=100000
 ```
+
+## Support
+
+For support with this integration, contact [New Relic support](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support/).

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -924,6 +924,8 @@ router_settings:
 | MICROSOFT_USERINFO_ENDPOINT | Custom userinfo endpoint URL for Microsoft SSO (overrides default Microsoft Graph userinfo endpoint)
 | MODEL_COST_MAP_MAX_SHRINK_RATIO | Maximum allowed shrinkage ratio when validating a fetched model cost map against the local backup. Rejects the fetched map if it is smaller than this fraction of the backup. Default is 0.5
 | MODEL_COST_MAP_MIN_MODEL_COUNT | Minimum number of models a fetched cost map must contain to be considered valid. Default is 50
+| NEW_RELIC_APP_NAME | Application name for New Relic AI Monitoring integration |
+| NEW_RELIC_LICENSE_KEY | License key for New Relic authentication |
 | NO_DOCS | Flag to disable Swagger UI documentation
 | NO_OPENAPI | Flag to disable the /openapi.json endpoint
 | NO_REDOC | Flag to disable Redoc documentation


### PR DESCRIPTION
This PR is paired with a [PR](https://github.com/BerriAI/litellm/pull/26989) to litellm that includes the New Relic extension. Please consider them as a set.

New Relic is requesting to add a New Relic specific logging extension. This document update provides the initial public documentation to help customers make use of the extension. This includes how to run it, required environment variables, and options for how to configure if LLM content should be included in events sent to New Relic.