### PR TITLE
docs: add MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE to environment variables reference

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -628,6 +628,7 @@ router_settings:
 | MCP_OAUTH2_TOKEN_EXPIRY_BUFFER_SECONDS | Seconds to subtract from token expiry when computing cache TTL. Default is 60
 | MCP_PER_USER_TOKEN_DEFAULT_TTL | Default TTL in seconds for per-user MCP OAuth tokens stored in Redis. Default is 43200 (12 hours)
 | MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS | Seconds to subtract from per-user MCP OAuth token expiry when computing Redis TTL. Default is 60
+| MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE | Maximum number of cached token exchange entries. Default is 500
 | DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT | Default token count for mock response completions. Default is 20
 | DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT | Default token count for mock response prompts. Default is 10
 | DEFAULT_MODEL_CREATED_AT_TIME | Default creation timestamp for models. Default is 1677610602


### PR DESCRIPTION
## Summary

- Adds `MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE` to the environment variables reference table

This is needed to fix a CI documentation validation test failure in [BerriAI/litellm#26993](https://github.com/BerriAI/litellm/pull/26993) which adds the OBO (On-Behalf-Of) token exchange feature for MCP servers. The new constant controls the cache size for token exchange entries.

## Changes

- Added `| MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE | Maximum number of cached token exchange entries. Default is 500 |` to the environment variables reference table in `config_settings.md`