### PR TITLE
[Docs] Config Settings: Document JWT_ISSUER Env Var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -794,6 +794,7 @@ router_settings:
 | JITTER | Jitter factor for retry delay calculations. Default is 0.75
 | JSON_LOGS | Enable JSON formatted logging
 | JWT_AUDIENCE | Expected audience for JWT tokens
+| JWT_ISSUER | Expected issuer (`iss` claim) for JWT tokens. When set, PyJWT verifies the `iss` claim and rejects tokens from other issuers
 | JWT_PUBLIC_KEY_URL | URL to fetch public key for JWT verification
 | LAGO_API_BASE | Base URL for Lago API
 | LAGO_API_CHARGE_BY | Parameter to determine charge basis in Lago


### PR DESCRIPTION
## Summary

Adds the `JWT_ISSUER` row to the environment-variables reference table in [docs/proxy/config_settings.md](docs/proxy/config_settings.md).

`JWT_ISSUER` is a new env var introduced by [BerriAI/litellm#27008](https://github.com/BerriAI/litellm/pull/27008) — when set, PyJWT verifies the `iss` claim and rejects JWTs from other issuers.

## Why

The `litellm` repo runs `tests/documentation_tests/test_env_keys.py` in CI, which scans `os.getenv()` / `litellm.get_secret(_str)?` calls and asserts every key is listed in this doc's reference table. Without this entry the documentation check on #27008 fails with:

> Keys not documented in 'environment settings - Reference': {'JWT_ISSUER'}

## Test plan

- [x] Verified locally by symlinking this branch into `litellm/docs/my-website` and re-running `uv run python tests/documentation_tests/test_env_keys.py` — passes ("All keys are documented").