### PR TITLE
docs: clarify reasoning_effort -> thinking adaptive mapping for Claude 4.6/4.7

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1490,7 +1490,7 @@ LiteLLM translates OpenAI's `reasoning_effort` to Anthropic's `thinking` paramet
 
 This means **any value other than `"none"` for `reasoning_effort` will automatically turn thinking on for these models**, even though the OpenAI-compatible request body does not have a separate `thinking` field. This is intended to match Anthropic's own recommended usage: budget_tokens has been deprecated on 4.6 models and rejected entirely on Opus 4.7, where only adaptive is a supported thinking mode.
 
-You can disable thinking either by omitting `reasoning_effort` entirely or setting it to `"none"` — LiteLLM will not send a `thinking` field in that case. You can still pass the native `thinking` parameter directly if you wish to explicitly control thinking with a fixed budget on prior models:
+You can disable thinking either by omitting `reasoning_effort` entirely or setting it to `"none"`. LiteLLM will not send a `thinking` field in that case. You can still pass the native `thinking` parameter directly if you wish to explicitly control thinking with a fixed budget on prior models:
 
 ```python
 from litellm import completion

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1479,7 +1479,7 @@ LiteLLM translates OpenAI's `reasoning_effort` to Anthropic's `thinking` paramet
 | "high"           | "budget_tokens": 4096 |
 
 :::note
-For Claude 4.6 and 4.7 models (e.g., `claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6`), `reasoning_effort` is mapped to Anthropic's [adaptive thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking/adaptive-thinking) plus the `output_config.effort` parameter, **not** to a fixed `budget_tokens`. Specifically, on the OpenAI-compatible `/chat/completions` route LiteLLM injects:
+`reasoning_effort` maps to Anthropic's [adaptive thinking](https: //docs.claude.com/en/docs/build-with-claude/extended-thinking/adaptive-thinking) plus the `output_config.effort` parameter on Claude 4.6 and 4.7 models (including `claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6`, etc. ), **not** `budget_tokens`. In particular, LiteLLM will inject the following into the underlying Anthropic request on the OpenAI-compatible `/chat/completions` route:
 
 ```json
 {
@@ -1488,9 +1488,9 @@ For Claude 4.6 and 4.7 models (e.g., `claude-opus-4-6`, `claude-opus-4-7`, `clau
 }
 ```
 
-into the underlying Anthropic request. This means **setting `reasoning_effort` to any value other than `"none"` automatically enables thinking** on these models, even though the OpenAI-compatible request body has no separate `thinking` field. This matches Anthropic's recommended usage: `budget_tokens` is deprecated on 4.6 and rejected entirely on Opus 4.7, where adaptive is the only supported thinking mode.
+This means **any value other than `"none"` for `reasoning_effort` will automatically turn thinking on for these models**, even though the OpenAI-compatible request body does not have a separate `thinking` field. This is intended to match Anthropic's own recommended usage: budget_tokens has been deprecated on 4.6 models and rejected entirely on Opus 4.7, where only adaptive is a supported thinking mode.
 
-To opt out of thinking, either omit `reasoning_effort` or set it to `"none"` — LiteLLM will then not send a `thinking` field at all. To control thinking explicitly with a fixed budget on older models, pass the native `thinking` parameter directly:
+You can disable thinking either by omitting `reasoning_effort` entirely or setting it to `"none"` — LiteLLM will not send a `thinking` field in that case. You can still pass the native `thinking` parameter directly if you wish to explicitly control thinking with a fixed budget on prior models:
 
 ```python
 from litellm import completion
@@ -1510,7 +1510,7 @@ resp = completion(
 )
 ```
 
-The Anthropic `/v1/messages` passthrough route is unaffected by this mapping — `thinking` is passed through verbatim.
+The Anthropic `/v1/messages` passthrough route is unaffected by this reasoning effort mapping. `thinking` is passed through unchanged.
 :::
 
 <Tabs>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1479,17 +1479,38 @@ LiteLLM translates OpenAI's `reasoning_effort` to Anthropic's `thinking` paramet
 | "high"           | "budget_tokens": 4096 |
 
 :::note
-For Claude Opus 4.6, all `reasoning_effort` values (`low`, `medium`, `high`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets, pass the native `thinking` parameter directly:
+For Claude 4.6 and 4.7 models (e.g., `claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6`), `reasoning_effort` is mapped to Anthropic's [adaptive thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking/adaptive-thinking) plus the `output_config.effort` parameter, **not** to a fixed `budget_tokens`. Specifically, on the OpenAI-compatible `/chat/completions` route LiteLLM injects:
+
+```json
+{
+  "thinking": {"type": "adaptive"},
+  "output_config": {"effort": "<low|medium|high|xhigh|max>"}
+}
+```
+
+into the underlying Anthropic request. This means **setting `reasoning_effort` to any value other than `"none"` automatically enables thinking** on these models, even though the OpenAI-compatible request body has no separate `thinking` field. This matches Anthropic's recommended usage: `budget_tokens` is deprecated on 4.6 and rejected entirely on Opus 4.7, where adaptive is the only supported thinking mode.
+
+To opt out of thinking, either omit `reasoning_effort` or set it to `"none"` — LiteLLM will then not send a `thinking` field at all. To control thinking explicitly with a fixed budget on older models, pass the native `thinking` parameter directly:
 
 ```python
 from litellm import completion
 
+# Disable thinking on Claude 4.6/4.7
 resp = completion(
-    model="anthropic/claude-opus-4-6",
+    model="anthropic/claude-opus-4-7",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    reasoning_effort="none",  # no thinking field sent
+)
+
+# Explicit budget (pre-4.6 models; deprecated on 4.6, rejected on Opus 4.7)
+resp = completion(
+    model="anthropic/claude-sonnet-4-5-20250929",
     messages=[{"role": "user", "content": "What is the capital of France?"}],
     thinking={"type": "enabled", "budget_tokens": 1024},
 )
 ```
+
+The Anthropic `/v1/messages` passthrough route is unaffected by this mapping — `thinking` is passed through verbatim.
 :::
 
 <Tabs>


### PR DESCRIPTION
## Summary

Customer feedback flagged that setting `reasoning_effort` on the OpenAI-compatible `/chat/completions` route silently injects `thinking: {type: "adaptive"}` into the underlying Anthropic request for Claude 4.6/4.7 models. The docs only mentioned this for Claude Opus 4.6 and didn't make it obvious that thinking gets enabled automatically.

This PR:
- Expands the note to cover both Claude 4.6 and 4.7 model families (matches actual behavior in `litellm/llms/anthropic/chat/transformation.py:800-805`)
- Calls out explicitly that setting `reasoning_effort` enables thinking on these models
- Clarifies that the `/v1/messages` passthrough route is not affected by this mapping

## Linear

LIT-2758: https://linear.app/litellm-ai/issue/LIT-2758/investigate-anthropic-bedrock-effort-passthrough-behavior