### PR TITLE
docs(enterprise): clarify which legacy guardrail callbacks are Enterprise-only

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -25,9 +25,12 @@ LiteLLM OSS already covers the fundamentals — an OpenAI-compatible gateway, vi
 | **Auth** | API keys | SSO + SCIM, OIDC/JWT |
 | **Key Management** | Virtual keys, users, teams across LLM APIs, MCPs, and Agents | Organizations, org/team admins, delegated admin roles |
 | **Security** | — | Key rotations, read/write to secret manager |
-| **Guardrails** | Always-on / request-based | Key and team scoped guardrails |
+| **Guardrails** | Always-on / request-based<sup>[1](#guardrails-oss-vs-enterprise)</sup> | Key and team scoped guardrails |
 | **Logging** | Request/response logging, Prometheus metrics | Per-key / per-team routing to Langfuse, Langsmith, Arize and more. Management-op logs |
 | **Deployment** | Single-region proxy | Control plane for multi-region architecture |
+
+<a id="guardrails-oss-vs-enterprise"></a>
+<sup>1</sup> The OSS guardrail framework supports custom guardrails plus Presidio (PII masking). Several built-in callback integrations &mdash; including `llmguard_moderations`, `llamaguard_moderations`, `hide_secrets`, `openai_moderations`, `google_text_moderation`, `lakera_prompt_injection`, and `aporia_prompt_injection` &mdash; require a LiteLLM Enterprise license.
 
 ## Core Enterprise Features
 


### PR DESCRIPTION
Closes BerriAI/litellm#27072

## What

The OSS-vs-Enterprise comparison row for **Guardrails** in `docs/enterprise.md` previously read:

> | **Guardrails** | Always-on / request-based | Key and team scoped guardrails |

This is misleading: while the guardrail framework itself is OSS, several of the built-in callback integrations advertised in the older guardrails docs (`old_guardrails.md`) actually require an Enterprise license — users who try to enable them on the OSS build are greeted with `You must be a LiteLLM Enterprise user to use this feature.`

## Source-of-truth check

Looked at `litellm/proxy/common_utils/callback_utils.py` (callback name → implementation switch). The callbacks that import from `litellm_enterprise.*` and raise `CommonProxyErrors.missing_enterprise_package` are:

- `llmguard_moderations`
- `llamaguard_moderations`
- `hide_secrets`
- `openai_moderations`
- `google_text_moderation`
- `lakera_prompt_injection`
- `aporia_prompt_injection`

`presidio` (PII masking) and `detect_prompt_injection` are OSS.

## Change

Adds a footnote to the OSS column of the Guardrails row that lists the callback names that require Enterprise. Keeps the table layout intact and does not move any other docs.

## Why this matters

Per the bug, users implement features against the comparison table believing them to be OSS, then only discover the licensing requirement at deploy time. The footnote turns the failure mode into a docs lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)