### PR TITLE
docs(datadog): add DD_LLMOBS_ML_APP env var

### DIFF
--- a/docs/observability/datadog.md
+++ b/docs/observability/datadog.md
@@ -305,6 +305,7 @@ LiteLLM supports customizing the following Datadog environment variables
 | `LITELLM_DD_AGENT_PORT` | Port of DataDog agent for log intake | "10518" | ❌ No |
 | `DD_ENV` | Environment tag for your logs (e.g., "production", "staging") | "unknown" | ❌ No |
 | `DD_SERVICE` | Service name for your logs | "litellm-server" | ❌ No |
+| `DD_LLMOBS_ML_APP` | Default ml_app name for LLM Observability (Application column). Can be overridden per-request via `metadata.ml_app`. | Falls back to `DD_SERVICE` | ❌ No |
 | `DD_SOURCE` | Source name for your logs | "litellm" | ❌ No |
 | `DD_VERSION` | Version tag for your logs | "unknown" | ❌ No |
 | `HOSTNAME` | Hostname tag for your logs | "" | ❌ No |

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -580,6 +580,7 @@ router_settings:
 | DD_SOURCE | Source identifier for Datadog logs
 | DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE | Resource name for Datadog tracing of streaming chunk yields. Default is "streaming.chunk.yield"
 | DD_ENV | Environment identifier for Datadog logs. Only supported for `datadog_llm_observability` callback
+| DD_LLMOBS_ML_APP | Default ml_app name for Datadog LLM Observability (Application column). Falls back to DD_SERVICE. Can be overridden per-request via `metadata.ml_app`.
 | DD_SERVICE | Service identifier for Datadog logs. Defaults to "litellm-server"
 | DD_VERSION | Version identifier for Datadog logs. Defaults to "unknown"
 | DATADOG_MOCK | Enable mock mode for Datadog integration testing. When set to true, intercepts Datadog API calls and returns mock responses without making actual network calls. Default is false


### PR DESCRIPTION
## Summary

Documents the `DD_LLMOBS_ML_APP` environment variable in two pages:

- `docs/proxy/config_settings.md` — env var reference table (required for the litellm `documentation_test_env_keys` CI check)
- `docs/observability/datadog.md` — Datadog setup table

## Why

Companion docs PR for [BerriAI/litellm#25684](https://github.com/BerriAI/litellm/pull/25684), which adds per-request `ml_app` override support via `metadata.ml_app` with `DD_LLMOBS_ML_APP` → `DD_SERVICE` fallback. Without this docs entry, the litellm `documentation` and `code-quality` CI checks fail because `DD_LLMOBS_ML_APP` is referenced in code but undocumented.