### PR TITLE
docs(search): fix 404 url for brave search

### DIFF
--- a/docs/search/brave.md
+++ b/docs/search/brave.md
@@ -2,7 +2,7 @@
 
 Get started by creating a free API key via https://brave.com/search/api/.
 
-For documentation on other parameters supported by the Brave Search API, visit https://api-dashboard.search.brave.com/api-reference/web/search.
+For documentation on other parameters supported by the Brave Search API, visit https://api-dashboard.search.brave.com/api-reference/web/search/post.
 
 ## LiteLLM Python SDK
 


### PR DESCRIPTION
Fixed the 404 error from the link to the brave search api documentation.