### PR TITLE
[Docs] Release Notes: Promote v1.83.14 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,21 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.82.3 — Nebius AI, gpt-5.4, Gemini 3.x, FLUX Kontext, and 116 New Models](/release_notes/v1.82.3/v1-82-3)
+### [v1.83.14 — GPT-5.5, Prompt Compression & Memory API](/release_notes/v1.83.14/v1-83-14)
 
-_March 16, 2026_
+_April 27, 2026_
 
-116 new models including Nebius AI, gpt-5.4, Gemini 3.x, and FLUX Kontext.
+Day-0 GPT-5.5 / GPT-5.5 Pro support, server-side Prompt Compression callback, `/v1/memory` CRUD endpoints, LLM-as-a-Judge guardrail, MCP OAuth hardening, and per-member team budgets.
+
+---
+
+## Latest Release Candidate
+
+### [v1.84.0-rc.1 — Reliability hardening + multi-pod budget accuracy](/release_notes/v1.84.0-rc.1/v1-84-0-rc-1)
+
+_May 5, 2026_
+
+Pass-through endpoints auth-by-default, multi-pod budget enforcement accuracy, non-blocking Prisma DB reconnect, ~700 MB lower memory via lazy-loaded routers, durable agent workflow run tracking. Read the **Important Behavior Changes** section before upgrading a production deployment.
 
 ---
 
@@ -22,6 +32,9 @@ _March 16, 2026_
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.83.14](/release_notes/v1.83.14/v1-83-14) | Apr 27, 2026 | GPT-5.5, Prompt Compression & Memory API                   |
+| [v1.83.10](/release_notes/v1.83.10/v1-83-10) | Apr 27, 2026 | Claude Opus 4.7, Prompt Compression & Multi-Window Budgets |
+| [v1.82.3](/release_notes/v1.82.3/v1-82-3)   | Mar 16, 2026 | Nebius AI, gpt-5.4, Gemini 3.x, FLUX Kontext, and 116 new models |
 | [v1.82.0](/release_notes/v1.82.0/v1-82-0)   | Feb 28, 2026 | Realtime Guardrails, Projects Management, and 10+ Performance Optimizations |
 | [v1.81.14](/release_notes/v1.81.14/v1-81-14) | Feb 21, 2026 | New Gateway Level Guardrails & Compliance Playground       |
 | [v1.81.12](/release_notes/v1.81.12/v1-81-12) | Feb 14, 2026 | Guardrail Policy Templates & Action Builder                |

--- a/release_notes/v1.83.14/index.md
+++ b/release_notes/v1.83.14/index.md
@@ -1,6 +1,6 @@
 ---
-title: "v1.83.14.rc.1 - GPT-5.5, Prompt Compression & Memory API"
-slug: "v1-83-14-rc-1"
+title: "v1.83.14 - GPT-5.5, Prompt Compression & Memory API"
+slug: "v1-83-14"
 date: 2026-04-27T00:00:00
 authors:
   - name: Krrish Dholakia
@@ -38,20 +38,18 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:main-v1.83.14.rc.1
+docker.litellm.ai/berriai/litellm:main-v1.83.14-stable
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.83.14.rc1
+pip install litellm==1.83.14
 ```
 
 </TabItem>
 </Tabs>
-
-> This is a release candidate cut on top of `v1.83.10-stable`. Validate on a staging proxy before promoting to the next stable tag.
 
 ## Key Highlights
 
@@ -346,7 +344,7 @@ pip install litellm==1.83.14.rc1
 - @Michael-RZ-Berri made their first contribution in [#26124](https://github.com/BerriAI/litellm/pull/26124)
 - @anmolg1997 made their first contribution in [#26228](https://github.com/BerriAI/litellm/pull/26228)
 
-**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.83.10-stable...v1.83.14.rc.1
+**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.83.10-stable...v1.83.14-stable
 
 ---
 


### PR DESCRIPTION
## Summary

Promotes the **v1.83.14.rc.1** release notes to **v1.83.14** stable. The `v1.83.14-stable` git tag is the same SHA as `v1.83.14.rc.1` (`3d2b8fed3281f60fcf6908c43df7823d6966897d`), so the rc entry is renamed in place rather than being kept as a separate historical record — matching the bare-version folder convention used by recent stables (`v1.83.10`, `v1.83.7`, `v1.83.3`, etc.).

### Changes inside the promoted file

- `title` and `slug` drop the `rc.1` suffix
- Docker tag points at `main-v1.83.14-stable`
- `pip install` pins to `1.83.14`
- rc disclaimer removed
- Full Changelog compares `v1.83.10-stable...v1.83.14-stable`

### `release_notes/index.md` (Release Notes landing page)

- **Latest Release** moves to v1.83.14
- New **Latest Release Candidate** callout for v1.84.0-rc.1 (links to the entry being added in [#82](https://github.com/BerriAI/litellm-docs/pull/82))
- `v1.83.14`, `v1.83.10`, `v1.82.3` added to the Recent Releases table

## Test plan

- [x] Folder rename + slug change picked up by the auto-generated sidebar
- [x] Docker / pip values match the `v1.83.14-stable` git tag
- [x] Full Changelog link resolves on github.com
- [x] No `rc.1` / `rc1` strings remain in the promoted file
- [ ] Landing-page link to `/release_notes/v1.84.0-rc.1/v1-84-0-rc-1` resolves once #82 merges