### PR TITLE
[Fix] Release Notes: Correct v1.84.0-rc.1 Docker Tag

### DIFF
--- a/release_notes/v1.84.0-rc.1/index.md
+++ b/release_notes/v1.84.0-rc.1/index.md
@@ -30,7 +30,7 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:main-v1.84.0-rc.1
+docker.litellm.ai/berriai/litellm:1.84.0-rc.1
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

The Docker install command on the `v1.84.0-rc.1` release notes points at a tag that does not exist on the registry:

```
docker.litellm.ai/berriai/litellm:main-v1.84.0-rc.1   # 404 manifest unknown
```

The image was published under the new PEP 440-style tag instead:

```
docker.litellm.ai/berriai/litellm:1.84.0-rc.1         # ✓
```

This PR updates the one line on `release_notes/v1.84.0-rc.1/index.md` so users running the copy-paste command actually pull the rc image.

Other `main-v*` references in the docs are left alone:
- Historical release notes (`v1.83.x`, `v1.81.x`, …) — those tags really did ship under that format.
- `docs/proxy/deploy.md` — uses the rolling `main-stable` / `main-latest` tags, which still exist on the registry.

## Test plan

- [x] `curl` against `ghcr.io/v2/berriai/litellm/manifests/1.84.0-rc.1` returns HTTP 200 with digest `sha256:6c9ed01488e3…`
- [x] `curl` against the old `main-v1.84.0-rc.1` tag returns HTTP 404
- [x] `docker.litellm.ai` confirmed as a CNAME to `ghcr.io` (same digest)