### PR TITLE
[Docs] Blog: Clarify Stable and Hotfix Names Apply to Both Docker and PyPI

### DIFF
--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -33,8 +33,8 @@ Starting with **`1.84.0`**:
 
 | Scenario | Old name | New name |
 |---|---|---|
-| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` |
-| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` |
+| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` (Docker + PyPI) |
+| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` (Docker + PyPI) |
 | Release candidate | `v1.84.0-rc` | `1.84.0-rc.1` (Docker) / `1.84.0rc1` (PyPI) |
 | Nightly | `v1.83.0-nightly` | `1.84.0-dev.42` (Docker) / `1.84.0.dev42` (PyPI) |
 


### PR DESCRIPTION
## Summary

Follow-up to #36 ([cleaner-release-versions blog post](https://docs.litellm.ai/blog/cleaner-release-versions)).

In the **Side-by-side** table under *What's new*, the rc and nightly rows already split the new name into `(Docker)` / `(PyPI)`, but the stable and hotfix rows showed a single bare name. That made it look asymmetric — readers asked whether the single name was the Docker name, the PyPI name, or both.

This change annotates the stable and hotfix rows with `(Docker + PyPI)` so every row in the new-name column spells out which registries the name applies to.

## Diff

```diff
 | Scenario | Old name | New name |
 |---|---|---|
-| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` |
-| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` |
+| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` (Docker + PyPI) |
+| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` (Docker + PyPI) |
 | Release candidate | `v1.84.0-rc` | `1.84.0-rc.1` (Docker) / `1.84.0rc1` (PyPI) |
 | Nightly | `v1.83.0-nightly` | `1.84.0-dev.42` (Docker) / `1.84.0.dev42` (PyPI) |
```

## Test plan

- [ ] Vercel/Docusaurus preview renders the table with the updated annotations