### PR TITLE
docs: add May townhall announcement banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -259,6 +259,14 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: 'may_townhall_2026',
+        content:
+          '📅 <strong>LiteLLM May Town Hall</strong> — Monday, May 18 at 7:30 AM PST. Hear product updates, roadmap, and Q&A. <a href="https://forms.gle/rVeiTtpY96EKLT9i9" target="_blank" rel="noopener noreferrer">Register now →</a>',
+        backgroundColor: '#0078d4',
+        textColor: '#ffffff',
+        isCloseable: false,
+      },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.png',
       navbar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -958,3 +958,36 @@ video {
 [data-theme='dark'].blog-wrapper article .markdown a {
   color: #38bdf8;
 }
+
+/* =========================================
+   ANNOUNCEMENT BAR
+   ========================================= */
+div[class*='announcementBar'] {
+  background: #0078d4 !important;
+  border-bottom: none !important;
+  padding: 10px 0 !important;
+  font-family: var(--ifm-font-family-base);
+  font-size: 14px !important;
+  letter-spacing: 0.01em;
+}
+
+div[class*='announcementBar'] div[class*='content'] {
+  font-weight: 400 !important;
+  line-height: 1.5;
+}
+
+div[class*='announcementBar'] a {
+  color: #ffffff !important;
+  text-decoration: underline !important;
+  text-underline-offset: 2px;
+  font-weight: 600 !important;
+  margin-left: 4px;
+}
+
+div[class*='announcementBar'] a:hover {
+  opacity: 0.9;
+}
+
+[data-theme='dark'] div[class*='announcementBar'] {
+  background: #1a5fb4 !important;
+}


### PR DESCRIPTION
## Summary
- Add site-wide announcement bar promoting May townhall (May 18, 7:30 AM PST)
- Blue banner with direct link to Google Form registration
- Styled for both light and dark mode, non-dismissible
- Custom CSS for polished appearance

## Test plan
- [ ] Verify banner renders on docs homepage
- [ ] Verify "Register now" links to Google Form
- [ ] Verify dark mode styling