### PR TITLE
Add category filter tabs to blog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -180,7 +180,7 @@ const config = {
         blogTitle: 'Blog',
         blogSidebarTitle: 'All Posts',
         blogSidebarCount: 'ALL',
-        postsPerPage: 10,
+        postsPerPage: 'ALL',
         showReadingTime: false,
         sortPosts: 'descending',
         include: ['**/index.{md,mdx}'],

--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -1,7 +1,29 @@
-import React from 'react';
+import React, {useState} from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
+
+const TABS = [
+  {id: 'all', label: 'All'},
+  {id: 'engineering', label: 'Engineering'},
+  {id: 'security', label: 'Security'},
+  {id: 'infrastructure', label: 'Performance / Reliability'},
+];
+
+const SECURITY_TAGS = ['security', 'incident-report'];
+const INFRA_TAGS = ['performance', 'reliability', 'infrastructure'];
+
+function hasTag(item, tagSet) {
+  const tags = item.content?.metadata?.tags || [];
+  return tags.some(t => tagSet.includes(t.label));
+}
+
+function filterItems(items, tab) {
+  if (tab === 'all') return items;
+  if (tab === 'security') return items.filter(i => hasTag(i, SECURITY_TAGS));
+  if (tab === 'infrastructure') return items.filter(i => hasTag(i, INFRA_TAGS));
+  return items.filter(i => !hasTag(i, SECURITY_TAGS) && !hasTag(i, INFRA_TAGS));
+}
 
 // ── Provider marquee ──────────────────────────────────────────────────────
 const PROVIDERS = [
@@ -101,6 +123,8 @@ function Pagination({metadata}) {
 export default function BlogListPage(props) {
   const items = props.items || [];
   const metadata = props.metadata || {};
+  const [activeTab, setActiveTab] = useState('all');
+  const filtered = filterItems(items, activeTab);
 
   return (
     <Layout
@@ -123,9 +147,26 @@ export default function BlogListPage(props) {
 
         <ProviderMarquee />
 
+        {/* Tabs */}
+        <nav className={styles.tabs} aria-label="Filter posts by category">
+          {TABS.map(tab => (
+            <button
+              key={tab.id}
+              className={`${styles.tab} ${activeTab === tab.id ? styles.tabActive : ''}`}
+              onClick={() => setActiveTab(tab.id)}
+              aria-pressed={activeTab === tab.id}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+
         {/* Post list */}
         <main className={styles.list}>
-          {items.map(({content}) => (
+          {filtered.length === 0 && (
+            <p className={styles.emptyMsg}>No posts on this page match the selected filter.</p>
+          )}
+          {filtered.map(({content}) => (
             <PostRow key={content.metadata.permalink} post={content.metadata} />
           ))}
         </main>

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -127,6 +127,43 @@
   font-weight: 300;
 }
 
+/* ── Tabs ─────────────────────────────────────────────────────────────── */
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 0;
+}
+
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -1px;
+}
+
+.tab:hover {
+  color: #111827;
+}
+
+.tabActive {
+  color: #0ea5e9;
+  border-bottom-color: #0ea5e9;
+}
+
+.emptyMsg {
+  padding: 2rem 0;
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+
 /* ── Post list ────────────────────────────────────────────────────────── */
 .list {
   margin-top: 0.5rem;
@@ -280,4 +317,21 @@
 [data-theme='dark'] .metaDash,
 [data-theme='dark'] .authorSep {
   color: #4b5563;
+}
+
+[data-theme='dark'] .tabs {
+  border-bottom-color: #374151;
+}
+
+[data-theme='dark'] .tab {
+  color: #9ca3af;
+}
+
+[data-theme='dark'] .tab:hover {
+  color: #f9fafb;
+}
+
+[data-theme='dark'] .tabActive {
+  color: #38bdf8;
+  border-bottom-color: #38bdf8;
 }


### PR DESCRIPTION
<img width="1366" height="875" alt="Screenshot 2026-05-06 at 5 40 46 PM" src="https://github.com/user-attachments/assets/42bdd5e0-cd63-4634-87dd-8c5edd54fcf8" />

## Summary
- Add tab bar to blog listing page with **All**, **Engineering**, **Security**, and **Performance / Reliability** filters
- Posts tagged `security` or `incident-report` show under Security tab
- Posts tagged `performance`, `reliability`, or `infrastructure` show under Performance / Reliability tab
- Engineering tab shows everything else
- Changed `postsPerPage` from 10 to `ALL` so filtering works across all posts (not per-page)
- Includes dark mode styles for tabs

## Test plan
- [ ] Visit `/blog` and verify all 4 tabs render
- [ ] Click **Security** — only CVEs, incident reports, and security posts show
- [ ] Click **Performance / Reliability** — redis circuit breaker, middleware bottleneck, observatory, proxy overhead posts show
- [ ] Click **Engineering** — no security or perf/reliability posts appear
- [ ] Click **All** — all posts visible
- [ ] Toggle dark mode — tabs styled correctly