### PR TITLE
docs: add Claude Code compatibility matrix page

### DIFF
--- a/docs/claude_code_compatibility.md
+++ b/docs/claude_code_compatibility.md
@@ -1,0 +1,33 @@
+---
+title: Claude Code Compatibility
+sidebar_label: Claude Code Compatibility
+---
+
+import ClaudeCodeCompatibilityTable from '@site/src/components/ClaudeCodeCompatibilityTable';
+
+# Claude Code × LiteLLM compatibility matrix
+
+This table is regenerated daily by an automated populator that runs the
+[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) against
+the latest stable LiteLLM proxy across each supported provider, with
+Haiku 4.5, Sonnet 4.6, and Opus 4.7 in parallel. A cell goes green only
+if all three model tiers pass.
+
+<ClaudeCodeCompatibilityTable />
+
+## Legend
+
+| Glyph | Meaning |
+| --- | --- |
+| ✅ | All three model tiers pass for this `(feature, provider)` cell. |
+| ❌ | At least one model tier failed. Hover for the upstream error. |
+| — | No test ran for this combination. |
+| n/a | Not applicable (e.g. provider doesn't expose this feature). Hover for the reason. |
+
+## Source
+
+The matrix JSON lives at
+[`src/data/compatibility-matrix.json`](https://github.com/BerriAI/litellm-docs/blob/main/src/data/compatibility-matrix.json).
+The populator is in
+[`tests/claude_code/cron_vm/`](https://github.com/BerriAI/litellm/tree/main/tests/claude_code/cron_vm)
+on the main repo.

--- a/sidebars.js
+++ b/sidebars.js
@@ -139,6 +139,7 @@ const sidebars = {
           type: "category",
           label: "Claude Code",
           items: [
+            "claude_code_compatibility",
             "tutorials/claude_responses_api",
             "tutorials/claude_code_max_subscription",
             "tutorials/claude_code_byok",

--- a/src/components/ClaudeCodeCompatibilityTable/index.tsx
+++ b/src/components/ClaudeCodeCompatibilityTable/index.tsx
@@ -71,7 +71,9 @@ export default function ClaudeCodeCompatibilityTable(): JSX.Element {
         <span>
           claude code <code>{m.claude_code_version}</code>
         </span>
-        <span>generated {m.generated_at}</span>
+        <span>
+          generated <code>{m.generated_at}</code>
+        </span>
       </div>
       <table className={styles.table}>
         <thead>

--- a/src/components/ClaudeCodeCompatibilityTable/index.tsx
+++ b/src/components/ClaudeCodeCompatibilityTable/index.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import matrix from "@site/src/data/compatibility-matrix.json";
+import styles from "./styles.module.css";
+
+/**
+ * Claude Code compatibility matrix table.
+ *
+ * Renders the JSON published daily by the populator
+ * (`tests/claude_code/cron_vm/run_daily.sh` in BerriAI/litellm) into a
+ * features-by-providers grid. Each cell shows pass / fail / not_tested /
+ * not_applicable; failure cells expose the upstream error on hover.
+ *
+ * The JSON is bundled at build time (no fetch), so the docs page works
+ * offline and the matrix value at any commit is whatever the JSON
+ * checked into that commit said.
+ */
+
+type CellStatus = "pass" | "fail" | "not_tested" | "not_applicable";
+
+interface Cell {
+  status: CellStatus;
+  error?: string;
+  reason?: string;
+}
+
+interface Feature {
+  id: string;
+  name: string;
+  providers: Record<string, Cell>;
+}
+
+interface Matrix {
+  schema_version: string;
+  generated_at: string;
+  litellm_version: string;
+  claude_code_version: string;
+  providers: string[];
+  features: Feature[];
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  bedrock_invoke: "Bedrock (Invoke)",
+  bedrock_converse: "Bedrock (Converse)",
+  vertex_ai: "Vertex AI",
+  azure: "Azure (Foundry)",
+};
+
+const STATUS_GLYPH: Record<CellStatus, string> = {
+  pass: "✅",
+  fail: "❌",
+  not_tested: "—",
+  not_applicable: "n/a",
+};
+
+function cellTitle(cell: Cell): string {
+  if (cell.status === "fail" && cell.error) return cell.error;
+  if (cell.status === "not_applicable" && cell.reason) return cell.reason;
+  if (cell.status === "not_tested") return "no test ran for this combination";
+  return "passing";
+}
+
+export default function ClaudeCodeCompatibilityTable(): JSX.Element {
+  const m = matrix as Matrix;
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.meta}>
+        <span>
+          litellm <code>{m.litellm_version}</code>
+        </span>
+        <span>
+          claude code <code>{m.claude_code_version}</code>
+        </span>
+        <span>generated {m.generated_at}</span>
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.featureCol}>Feature</th>
+            {m.providers.map((p) => (
+              <th key={p}>{PROVIDER_LABELS[p] ?? p}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {m.features.map((feature) => (
+            <tr key={feature.id}>
+              <th scope="row" className={styles.featureCol}>
+                {feature.name}
+              </th>
+              {m.providers.map((p) => {
+                const cell = feature.providers[p] ?? { status: "not_tested" as const };
+                return (
+                  <td
+                    key={p}
+                    className={styles[`status_${cell.status}`]}
+                    title={cellTitle(cell)}
+                  >
+                    {STATUS_GLYPH[cell.status]}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/ClaudeCodeCompatibilityTable/styles.module.css
+++ b/src/components/ClaudeCodeCompatibilityTable/styles.module.css
@@ -1,0 +1,54 @@
+.wrapper {
+  margin: 1rem 0 2rem 0;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.meta code {
+  background: var(--ifm-code-background);
+  padding: 0 0.25rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--ifm-table-border-color);
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.featureCol {
+  text-align: left !important;
+  white-space: nowrap;
+}
+
+.status_pass {
+  background: rgba(46, 160, 67, 0.12);
+}
+
+.status_fail {
+  background: rgba(248, 81, 73, 0.12);
+  cursor: help;
+}
+
+.status_not_tested {
+  color: var(--ifm-color-emphasis-500);
+}
+
+.status_not_applicable {
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+  cursor: help;
+}

--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-04-29T01:08:49Z",
+  "litellm_version": "v1.83.10-stable",
+  "claude_code_version": "2.1.121",
+  "providers": [
+    "anthropic",
+    "bedrock_invoke",
+    "bedrock_converse",
+    "vertex_ai",
+    "azure"
+  ],
+  "features": [
+    {
+      "id": "basic_messaging_non_streaming",
+      "name": "Basic messaging (non-streaming)",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "basic_messaging_streaming",
+      "name": "Basic messaging (streaming)",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "tool_use",
+      "name": "Tool use",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "prompt_caching_5m",
+      "name": "Prompt caching (5m TTL)",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "vision",
+      "name": "Vision",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+        }
+      }
+    },
+    {
+      "id": "extended_thinking",
+      "name": "Extended thinking",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-sonnet-4-6] no `thinking` content block observed in stream-json events"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "tool_use_streaming",
+      "name": "Tool use (streaming / fine-grained)",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "thinking_with_tool_use",
+      "name": "Extended thinking + tool use",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "pdf_input",
+      "name": "PDF document input",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "prompt_caching_1h",
+      "name": "Prompt caching (1h TTL)",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    },
+    {
+      "id": "web_search",
+      "name": "Web search (server tool)",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] no server_tool_use / web_search_tool_result block observed; the proxy may have stripped the WebSearch server tool or its result block"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+        },
+        "azure": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+        }
+      }
+    }
+  ]
+}

--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-04-29T01:08:49Z",
-  "litellm_version": "v1.83.10-stable",
-  "claude_code_version": "2.1.121",
+  "generated_at": "2026-05-07T15:28:48Z",
+  "litellm_version": "v1.83.14-stable",
+  "claude_code_version": "2.1.126",
   "providers": [
     "anthropic",
     "bedrock_invoke",
@@ -19,20 +19,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude returned empty assistant text"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -44,20 +41,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -69,20 +63,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -94,20 +85,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -116,24 +104,19 @@
       "name": "Vision",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+          "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+          "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+          "status": "pass"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; stderr=error: unknown option '--image'"
+          "status": "pass"
         }
       }
     },
@@ -142,24 +125,19 @@
       "name": "Extended thinking",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-sonnet-4-6] no `thinking` content block observed in stream-json events"
+          "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -171,20 +149,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -196,20 +171,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -221,20 +193,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\",\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -246,20 +215,17 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     },
@@ -268,24 +234,20 @@
       "name": "Web search (server tool)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] no server_tool_use / web_search_tool_result block observed; the proxy may have stripped the WebSearch server tool or its result block"
+          "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=400; text=API Error: 400 {\"error\":{\"message\":\"{\\\"message\\\":\\\"context_management: Extra inputs are not permitted\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_converse": {
           "status": "fail",
           "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-vertex] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"[{\\n  \\\"error\\\": {\\n    \\\"code\\\": 403,\\n    \\\"message\\\": \\\"Request had insufficient authentication scopes.\\\",\\n    \\\"status\\\": \\\"PERMISSION_DENIED\\\",\\n    \\\"details\\\": [\\n      {\\n        \\\"@type\\\": \\\"type.googleapis.com/google.rpc.ErrorInfo\\\",\\n        \\\"reason\\\": \\\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\\\",\\n        \\\"domain\\\": \\\"googleapis.com\\\",\\n        \\\"metadata\\\": {\\n          \\\"method\\\": \\\"google.cloud.aiplatform.v1.PredictionService.StreamRawPredict\\\",\\n          \\\"service\\\": \\\"aiplatform.googleapis.com\\\"\\n        }\\n      }\\n    ]\\n  }\\n}\\n]. Received Model Group=claude-haiku-4-5-vertex\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
+          "status": "pass"
         },
         "azure": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
+          "status": "pass"
         }
       }
     }


### PR DESCRIPTION
## Summary
Adds a new docs page — **Claude Code Compatibility** — that renders a daily-regenerated matrix of Claude Code × LiteLLM across the supported providers (Anthropic, Bedrock Invoke, Bedrock Converse, Vertex AI, Azure Foundry).

This PR ships only the **renderer** and a placeholder dataset. A daily populator (`tests/claude_code/cron_vm/run_daily.sh` in [BerriAI/litellm](https://github.com/BerriAI/litellm)) will open follow-up PRs that update **only** `src/data/compatibility-matrix.json`, so the page reflects current compatibility without ever touching the renderer.

## What's here
- `docs/claude_code_compatibility.md` — page shell (frontmatter + legend + mount of the component).
- `src/components/ClaudeCodeCompatibilityTable/index.tsx` — features × providers grid. Each cell is `pass` / `fail` / `not_tested` / `not_applicable`. **Failure cells expose the upstream error on hover** so users can see exactly *why* a combination is red.
- `src/components/ClaudeCodeCompatibilityTable/styles.module.css` — green / red / gray tints; respects Docusaurus theme variables.
- `src/data/compatibility-matrix.json` — initial dataset (will be overwritten by the populator on its next run).
- `sidebars.js` — adds the page under the existing **Claude Code** category in the proxy sidebar.

## Design notes
- The component is intentionally dumb: no fetching, no sorting, no filtering. The JSON is bundled at build time, so the docs build is hermetic and the matrix shown at any commit is whatever the JSON checked in at that commit said.
- A cell goes green only if **all three model tiers** (Haiku 4.5, Sonnet 4.6, Opus 4.7) pass — that is what the populator already encodes.
- `not_applicable` cells (e.g. a feature a provider doesn't expose) carry a `reason` string the renderer surfaces on hover, distinct from real failures.

## Screenshots
| State | Glyph |
|---|---|
| All three tiers pass | ✅ |
| One or more tiers failed | ❌ (hover for upstream error) |
| No test ran | — |
| Not applicable | n/a (hover for reason) |

## Follow-ups (not in this PR)
- Daily PR-creation wiring on the populator side ([BerriAI/litellm#26491](https://github.com/BerriAI/litellm/pull/26491)).
- A short-circuit check in the populator that no-ops the PR when the JSON is byte-identical to `main`.