### PR TITLE
Thorough Otel documentation

### DIFF
--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -10,15 +10,7 @@ OpenTelemetry is a CNCF standard for observability. It connects to any observabi
 
 :::note Change in v1.81.0
 
-From v1.81.0, the request/response will be set as attributes on the parent "Received Proxy Server Request" span by default. This allows you to see the request/response in the parent span in your observability tool.
-
-**Note:** When making multiple LLM calls within an external OTEL span context, the last call's attributes will overwrite previous calls' attributes on the parent span.
-
-To use the older behavior with nested "litellm_request" spans (which creates separate spans for each call), set the following environment variable:
-
-```shell
-USE_OTEL_LITELLM_REQUEST_SPAN=true
-```
+From v1.81.0, the request/response is set as attributes on the parent `Received Proxy Server Request` span by default — there is **no** separate `litellm_request` span unless you opt in. To restore nested `litellm_request` spans, set `USE_OTEL_LITELLM_REQUEST_SPAN=true`. See [Span Hierarchy](#span-hierarchy) for the full picture and [Why don't I see a `litellm_request` span?](#why-dont-i-see-a-litellm_request-span) for when to flip the flag.
 
 :::
 
@@ -100,6 +92,98 @@ Use just 1 line of code, to instantly log your LLM responses **across all provid
 litellm.callbacks = ["otel"]
 ```
 
+## Span Hierarchy
+
+Every LLM request handled by the LiteLLM Proxy produces a tree of spans rooted at `Received Proxy Server Request`. Conditional spans below are only emitted when their controlling flag is set or their feature is in use.
+
+```
+Received Proxy Server Request                      (SpanKind.SERVER, root)
+│
+├── litellm_request                                (INTERNAL, only when USE_OTEL_LITELLM_REQUEST_SPAN=true)
+│   ├── raw_gen_ai_request                         (INTERNAL — provider request/response, content-capture-gated)
+│   └── guardrail                                  (INTERNAL — one per executed guardrail)
+│
+├── raw_gen_ai_request                             (INTERNAL — when litellm_request is collapsed into the root)
+├── guardrail                                      (INTERNAL — when litellm_request is collapsed into the root)
+│
+├── auth, router, self, proxy_pre_call,            (INTERNAL — service-hook spans, see below)
+│   redis, postgres, batch_write_to_db
+│
+└── Failed Proxy Server Request                    (INTERNAL — only on exception)
+```
+
+In **semconv mode** (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), the LLM-call span is renamed to `{operation} {model}` (e.g. `chat gpt-4`), promoted to `SpanKind.CLIENT`, and `raw_gen_ai_request` is suppressed. See [Opt-In to Latest GenAI Semantic Conventions](#opt-in-to-latest-genai-semantic-conventions).
+
+The SDK (no proxy) emits `litellm_request` as the root if no parent context exists — there is no `Received Proxy Server Request` span in pure-SDK use.
+
+### Span name reference
+
+| Span name | Span kind | Parent | When emitted |
+|---|---|---|---|
+| `Received Proxy Server Request` | `SERVER` | root (or external `traceparent` if present) | Once per HTTP request to the LiteLLM Proxy |
+| `litellm_request` | `INTERNAL` | proxy root (proxy) or root (SDK) | When `USE_OTEL_LITELLM_REQUEST_SPAN=true` (proxy) or no parent context exists (SDK). In semconv mode replaced by `{operation} {model}` |
+| `raw_gen_ai_request` | `INTERNAL` | `litellm_request` if present, else proxy root | One per upstream provider call. Carries provider-native request/response under `llm.{provider}.*`. Suppressed in semconv mode and when message content capture is disabled |
+| `guardrail` | `INTERNAL` (OpenInference kind = `guardrail`) | `litellm_request` if present, else proxy root | One span per guardrail execution (pre-call, during-call, or post-call) |
+| `Failed Proxy Server Request` | `INTERNAL` | proxy root | When the proxy raises an exception before completing the request |
+| `{route}` (e.g. `/user/info`, `/key/info`) | `INTERNAL` | proxy root | Management-endpoint calls (non-LLM proxy routes) |
+| `auth`, `router`, `self`, `proxy_pre_call`, `redis`, `postgres`, `batch_write_to_db`, `reset_budget_job`, `pod_lock_manager` | `INTERNAL` | proxy root | Service-hook spans — see below |
+
+### Service-hook spans (a.k.a. "infrastructure" spans)
+
+LiteLLM has a separate hook (`async_service_success_hook` / `async_service_failure_hook`) that records timing for internal subsystems like the router, auth checks, Redis, Postgres, and the proxy pre-call pipeline. When the OTEL integration is active and a parent span is in context, each of these hooks creates an INTERNAL child span.
+
+The span **name is the `ServiceTypes` enum value** (`auth`, `router`, `self`, `proxy_pre_call`, `redis`, `postgres`, …). The full set is defined in `litellm/types/services.py`. `self` is the LiteLLM SDK itself (e.g. timing of `make_openai_chat_completion_request`); `router` may appear multiple times per request (once for `async_get_available_deployment`, once for the wrapping `acompletion`).
+
+Each service-hook span carries:
+
+| Attribute | Value |
+|---|---|
+| `service` | The service enum value (e.g. `"router"`, `"redis"`) |
+| `call_type` | The specific operation (e.g. `"async_get_available_deployment"`, `"acompletion"`, `"add_litellm_data_to_request"`) |
+| `error` | Set on failure spans only |
+| (custom event_metadata) | Whatever the caller attached |
+
+These spans are **operational/infrastructure spans**, not GenAI semantic spans. They are useful for SRE-level debugging (where is time being spent inside LiteLLM?) but they do **not** carry `gen_ai.*` attributes. If you only want AI-semantic spans in your backend, filter on the presence of `gen_ai.system` (or on span name).
+
+There is currently **no env var that disables individual service-hook spans**. If you need them filtered, do it at the OTLP collector / backend layer (e.g. via a tail-based sampler that drops by `name`).
+
+### Why don't I see a `litellm_request` span?
+
+Behavior changed in **v1.81.0**. By default, `USE_OTEL_LITELLM_REQUEST_SPAN=false` and the proxy collapses the `litellm_request` span into the parent `Received Proxy Server Request` span — its `gen_ai.*` attributes are set on the parent instead. This:
+
+- Avoids duplicating attributes across parent and child.
+- Reduces span count (and storage cost) by ~1 span per request.
+- Keeps the trace shallow when a parent context already exists.
+
+To restore the older nested behavior — where every LLM call gets its own `litellm_request` span as a child of the proxy root span — set:
+
+```shell
+USE_OTEL_LITELLM_REQUEST_SPAN=true
+```
+
+This is the right setting if:
+
+- One HTTP request makes multiple `litellm.completion` calls — under the default behavior the last call's attributes overwrite earlier ones on the shared parent.
+- You want a clean parent for `raw_gen_ai_request` and `guardrail` children that is not the HTTP request span.
+- Your backend's UI is built around AI-semantic span names like `litellm_request`.
+
+This is **not a regression**; the change is intentional. The flag is read fresh on every request, so it can be flipped without restarting.
+
+In semconv mode (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), the LLM-call span is **always** emitted (named `{operation} {model}`) and `USE_OTEL_LITELLM_REQUEST_SPAN` does not apply.
+
+### Context propagation (W3C `traceparent`)
+
+LiteLLM honors the W3C Trace Context header. If your client (or upstream gateway) sends a `traceparent` header, LiteLLM creates the `Received Proxy Server Request` span as a child of that external trace, so LiteLLM's spans appear inline inside whatever distributed trace your application already has.
+
+Parent-context resolution order (highest priority first):
+
+1. Explicit `litellm_parent_otel_span` in the request `metadata`.
+2. Inbound `traceparent` HTTP header (extracted via `TraceContextTextMapPropagator`).
+3. The currently-active span in the OTEL global context (thread-local).
+4. None — LiteLLM's span is the root.
+
+To force every LiteLLM trace to be its own root regardless of inbound headers or active context, set `OTEL_IGNORE_CONTEXT_PROPAGATION=true`.
+
 ## Running Multiple OpenTelemetry Handlers
 
 You can run more than one OpenTelemetry handler in the same process, for example a generic OTLP exporter alongside a backend-specific subclass. Set `skip_set_global=True` on every handler past the first so each one gets its own private `TracerProvider`, `MeterProvider`, and `LoggerProvider`. Spans, metrics, and log events then flow only through that handler's exporter.
@@ -125,6 +209,16 @@ litellm.callbacks = [primary, secondary]
 ```
 
 Init order does not matter. Both handlers receive their own spans regardless of which is constructed first.
+
+### Cross-collector behavior (e.g. LangSmith + generic OTEL)
+
+When two OTEL-emitting integrations are active at once — for instance a customized LangSmith OTEL handler plus the generic `otel` exporter — both honor the same `traceparent` propagation rules and the same parent-resolution order described in [Context propagation](#context-propagation-w3c-traceparent). As long as one handler uses `skip_set_global=True`, both will:
+
+- See the same `trace_id` for a given request.
+- Emit the same span hierarchy (`Received Proxy Server Request` → `litellm_request` if enabled → `raw_gen_ai_request` / `guardrail`).
+- Differ only in which exporter they ship spans to.
+
+If a customized LangSmith OTEL handler is configured to mount `litellm_request` only when the request carries a `traceparent` (otherwise no-op), the generic OTEL handler still emits its full hierarchy. The two views remain readable independently because the span names and attributes are identical.
 
 ## Capturing Message Content
 
@@ -200,24 +294,26 @@ Setting `mask_output` to `True` will make the output from being logged for this 
 
 Be aware that if you are continuing an existing trace, and you set `update_trace_keys` to include either `input` or `output` and you set the corresponding `mask_input` or `mask_output`, then that trace will have its existing input and/or output replaced with a redacted message.
 
-## Support
-
-For any question or issue with the integration you can reach out to the OpenLLMetry maintainers on [Slack](https://traceloop.com/slack) or via [email](mailto:dev@traceloop.com).
-
 ## Troubleshooting
+
+### I don't see a `litellm_request` span
+
+Expected behavior under the v1.81.0+ default (`USE_OTEL_LITELLM_REQUEST_SPAN=false`): the proxy root span absorbs the LLM-call attributes and there is no separate `litellm_request` span. To restore nested spans, set `USE_OTEL_LITELLM_REQUEST_SPAN=true`. See [Why don't I see a `litellm_request` span?](#why-dont-i-see-a-litellm_request-span).
+
+If you're in semconv mode, the LLM-call span exists but is renamed to `{operation} {model}` (e.g. `chat gpt-4`) — search by `gen_ai.system` rather than by the literal name `litellm_request`.
+
+### I only see infrastructure spans (`router`, `auth`, `redis`, `proxy_pre_call`)
+
+Those are [service-hook spans](#service-hook-spans-aka-infrastructure-spans). They're emitted alongside the AI-semantic spans (`raw_gen_ai_request`, `guardrail`, and `litellm_request` if enabled), not instead of them. If you genuinely don't see any `gen_ai.*` attributes anywhere in your trace:
+
+1. Verify `litellm.callbacks` (or `litellm_settings.callbacks`) includes `"otel"`.
+2. Verify the request actually hit a `/chat/completions` (or other LLM) route — management endpoints (`/key/info`, `/user/info`, …) won't have `gen_ai.*` attributes.
+3. Check whether `litellm.turn_off_message_logging=true` and/or `mask_input`/`mask_output` are set — they suppress message and raw-provider attributes.
+4. Set `USE_OTEL_LITELLM_REQUEST_SPAN=true` so the LLM attributes land on a span named `litellm_request` instead of being co-mingled with HTTP request attributes on `Received Proxy Server Request`.
 
 ### Trace LiteLLM Proxy user/key/org/team information on failed requests
 
-LiteLLM emits the user_api_key_metadata
-- key hash
-- key_alias
-- org_id
-- user_id
-- team_id
-
-for successful + failed requests
-
-click under `litellm_request` in the trace
+LiteLLM emits `metadata.user_api_key_*` attributes (key hash, key alias, org ID, user ID, team ID) on **both successful and failed** requests. They appear on the `litellm_request` span when present, otherwise on `Received Proxy Server Request`.
 
 <Image img={require('../../img/otel_debug_trace.png')} />
 
@@ -229,7 +325,76 @@ If you don't see traces landing on your integration, set `OTEL_DEBUG="True"` in 
 export OTEL_DEBUG="True"
 ```
 
-This will emit any logging issues to the console.
+This will emit any logging issues to the console. Common causes:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` points to an HTTPS endpoint but the protocol is `grpc` (or vice-versa).
+- `OTEL_HEADERS` is missing the auth header your backend expects.
+- A firewall/sidecar is dropping outbound OTLP traffic on 4317/4318.
+- For gRPC, `grpcio` isn't installed (`uv add "litellm[grpc]"`).
+
+### Spans are getting truncated or dropped
+
+OTLP exporters batch spans. Very large `gen_ai.input.messages`/`gen_ai.output.messages` (e.g. multi-megabyte prompts) can exceed default OTLP attribute size limits at the collector. Either:
+
+- Move large payloads off-trace (set `litellm.turn_off_message_logging=true` and rely on Spend Logs / cold storage, referenced via `metadata.cold_storage_object_key`).
+- Raise the collector's `max_attribute_value_length` and OTLP receiver `max_recv_msg_size_mib`.
+
+## Configuration Reference
+
+All flags below are read from environment variables unless noted. Boolean flags accept `true`/`false` (case-insensitive).
+
+### Exporter & resource
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OTEL_EXPORTER` (alias: `OTEL_EXPORTER_OTLP_PROTOCOL`) | `console` | Exporter type. Common values: `console`, `otlp_http`, `otlp_grpc`, `http/json`, `http/protobuf`, `grpc` |
+| `OTEL_ENDPOINT` (alias: `OTEL_EXPORTER_OTLP_ENDPOINT`) | none | OTLP endpoint URL |
+| `OTEL_HEADERS` (alias: `OTEL_EXPORTER_OTLP_HEADERS`) | none | Comma-separated `key=value,key2=value2` header list |
+| `OTEL_SERVICE_NAME` | `litellm` | Resource attribute `service.name` |
+| `OTEL_ENVIRONMENT_NAME` | `production` | Resource attribute `deployment.environment` |
+| `OTEL_MODEL_ID` | `OTEL_SERVICE_NAME` | Resource attribute `model_id` |
+| `OTEL_TRACER_NAME` | `litellm` | Tracer name |
+| `LITELLM_METER_NAME` | `litellm` | Meter name (when metrics enabled) |
+| `LITELLM_LOGGER_NAME` | `litellm` | Logger name (when events enabled) |
+| `OTEL_LOGS_EXPORTER` | none | Logs exporter (e.g. `console`) when events are enabled |
+
+### Span / metric / event toggles
+
+| Variable | Default | Effect |
+|---|---|---|
+| `USE_OTEL_LITELLM_REQUEST_SPAN` | `false` | Force `litellm_request` to always be emitted as a child of the proxy root span. See [Why don't I see a `litellm_request` span?](#why-dont-i-see-a-litellm_request-span) |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` | unset | Set to `gen_ai_latest_experimental` to switch to the [latest GenAI semantic conventions](#opt-in-to-latest-genai-semantic-conventions). Comma-separable per OTEL spec |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | spec default (`NO_CONTENT`) | `NO_CONTENT` / `SPAN_ONLY` / `EVENT_ONLY` / `SPAN_AND_EVENT`. Boolean form accepted (`true`→`EVENT_ONLY`, `false`→`NO_CONTENT`) |
+| `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS` | `false` | Enable OTLP metrics (TTFT, TPOT, response duration, cost, token usage, operation duration) |
+| `LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS` | `false` | Enable OTLP semantic logs (`gen_ai.content.prompt`/`gen_ai.content.completion`, or `gen_ai.client.inference.operation.details` in semconv mode) |
+| `OTEL_IGNORE_CONTEXT_PROPAGATION` | `false` | If `true`, ignore inbound `traceparent` headers and any active span — every LiteLLM trace becomes its own root |
+| `OTEL_DEBUG` / `DEBUG_OTEL` | `false` | Print exporter and span-creation diagnostics to stderr |
+| `litellm.turn_off_message_logging` (Python global / `litellm_settings.turn_off_message_logging`) | `false` | Kill-switch for content capture. Suppresses `llm.{provider}.*` raw request/response, `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.content.*` log events. Overrides per-handler `capture_message_content` |
+
+### Per-request redaction (request `metadata`)
+
+Per-request keys you can pass in `metadata` to redact a single call without disabling logging globally.
+
+| Key | Effect |
+|---|---|
+| `mask_input` | When `true`, redacts the input messages on this request |
+| `mask_output` | When `true`, redacts the output messages on this request |
+| `update_trace_keys` | Controls which trace keys (`input`, `output`) get replaced when continuing an existing trace |
+| `generation_name` | Overrides the `raw_gen_ai_request` span's name with this value |
+
+### `OpenTelemetryConfig` programmatic equivalents
+
+| Field | Default | Purpose |
+|---|---|---|
+| `exporter` | `console` | Same as `OTEL_EXPORTER` |
+| `endpoint` | none | Same as `OTEL_ENDPOINT` |
+| `headers` | none | Same as `OTEL_HEADERS` |
+| `enable_metrics` | `false` | Same as `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS` |
+| `enable_events` | `false` | Same as `LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS` |
+| `capture_message_content` | env var | Per-handler override; same value space as `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` |
+| `semconv_stability` | env var | Same as `OTEL_SEMCONV_STABILITY_OPT_IN` |
+| `skip_set_global` | `false` | Don't claim the process-global `TracerProvider`/`MeterProvider`/`LoggerProvider` |
+| `ignore_context_propagation` | `false` | Same as `OTEL_IGNORE_CONTEXT_PROPAGATION` |
 
 ## Appendix: Spans, Metrics, and Attributes Reference
 
@@ -282,6 +447,24 @@ Common labels on every histogram: `gen_ai.operation.name`, `gen_ai.system`, `gen
 | Vendor/model latency (excludes overhead) | `gen_ai.client.response.duration` |
 | Vendor/model latency (includes overhead) | `gen_ai.client.operation.duration` |
 
+### Spans → Derived Metrics
+
+Even with metrics off, every metric below can be derived from spans. This is what most dashboards do.
+
+| Metric | How to derive from spans |
+|---|---|
+| **TTFT** (Time to First Token) | Streaming requests only. Use the dedicated `gen_ai.client.response.time_to_first_token` metric, or capture `completion_start_time` from request `kwargs` via a custom callback. |
+| **TPOT** (Time per Output Token) | Use the `gen_ai.client.response.time_per_output_token` metric, or derive as `gen_ai.client.response.duration ÷ gen_ai.usage.output_tokens`. |
+| **Total response duration** | `gen_ai.client.response.duration` metric, or `end_time − start_time` of the LLM-call span (or proxy root span minus LiteLLM overhead — see `hidden_params.litellm_overhead_time_ms`). |
+| **Vendor (provider) latency** | Duration of the `raw_gen_ai_request` span (default mode) — pure time spent waiting on the upstream provider. In semconv mode, use `gen_ai.client.response.duration`. |
+| **LiteLLM overhead** | `hidden_params.litellm_overhead_time_ms` on the proxy root span. Or `Received Proxy Server Request.duration − raw_gen_ai_request.duration`. |
+| **Token usage** | `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens` on the LLM span (or `gen_ai.client.token.usage` metric). |
+| **Cost** | `gen_ai.cost.total_cost` (and the rest of `gen_ai.cost.*`) on the LLM span; or `gen_ai.client.token.cost` metric. |
+| **Guardrail evaluation time** | Duration of each `guardrail` span. Disambiguate by `guardrail_name` and `guardrail_mode`. |
+| **Router / auth / Redis / DB latency** | Duration of the corresponding [service-hook span](#service-hook-spans-aka-infrastructure-spans) (`router`, `auth`, `redis`, `postgres`, …). |
+| **Retry / fallback count** | `hidden_params.x-litellm-attempted-retries` and `hidden_params.x-litellm-attempted-fallbacks` on the proxy root span. |
+| **Streaming?** | `llm.is_streaming` attribute (`"True"`/`"False"`). |
+
 ### Attributes Reference
 
 Attributes set on the LLM-call span. Names follow [OTEL GenAI semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/).
@@ -301,8 +484,128 @@ Attributes set on the LLM-call span. Names follow [OTEL GenAI semconv](https://o
 | `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions` | when message content capture permits, JSON-encoded array of `{role, parts: [...]}` objects | unchanged |
 | `gen_ai.cost.input_cost`, `output_cost`, `total_cost` (and related cost breakdown attrs) | LiteLLM-specific cost attributes | unchanged |
 
-Attributes set on the proxy request frame include `metadata.user_api_key_*`, `metadata.team_id`, `metadata.requester_*`, `litellm.call_id`, and the same `gen_ai.cost.*` set when the request flows through the proxy.
+#### `gen_ai.cost.*` (cost breakdown, all modes)
+
+LiteLLM expands every key from `standard_logging_payload["cost_breakdown"]` as `gen_ai.cost.{key}`. Currently observed keys:
+
+| Attribute | Meaning |
+|---|---|
+| `gen_ai.cost.input_cost` | Prompt token cost (USD) |
+| `gen_ai.cost.output_cost` | Completion token cost (USD) |
+| `gen_ai.cost.total_cost` | Charged total (USD) |
+| `gen_ai.cost.tool_usage_cost` | Cost attributable to tool/function calls |
+| `gen_ai.cost.original_cost` | Pre-discount cost |
+| `gen_ai.cost.discount_percent`, `gen_ai.cost.discount_amount` | Discount applied |
+| `gen_ai.cost.margin_percent`, `gen_ai.cost.margin_fixed_amount`, `gen_ai.cost.margin_total_amount` | Margin components |
+
+#### `litellm.*` (proxy root and LLM span)
+
+| Attribute | Value |
+|---|---|
+| `litellm.call_id` | Unique per `litellm.completion` invocation. Use this to correlate trace data with LiteLLM Spend Logs and the LiteLLM UI |
+| `litellm.request.type` | Same as `call_type` (e.g. `acompletion`, `aembedding`, `aimage_generation`) |
+
+#### `llm.*` (proxy root and LLM span)
+
+| Attribute | Value |
+|---|---|
+| `llm.request.type` | LiteLLM `call_type` |
+| `llm.is_streaming` | `"True"` or `"False"` |
+| `llm.user` | `user` parameter, if set |
+
+#### `llm.{provider}.*` (raw provider request/response, default mode only)
+
+Set **only on `raw_gen_ai_request`**, to avoid attribute duplication. For each key in the raw provider request body, LiteLLM emits `llm.{provider}.{key}`. Same for the raw response body.
+
+Examples observed for `openai`:
+
+```
+llm.openai.messages
+llm.openai.model
+llm.openai.temperature
+llm.openai.max_tokens
+llm.openai.id
+llm.openai.object
+llm.openai.created
+llm.openai.choices
+llm.openai.usage
+llm.openai.system_fingerprint
+llm.openai.service_tier
+llm.openai.extra_body
+```
+
+For Anthropic, replace `openai` with `anthropic` (`llm.anthropic.messages`, `llm.anthropic.stop_reason`, etc.). Same pattern for every other provider.
+
+These attributes are suppressed when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=NO_CONTENT`, when `litellm.turn_off_message_logging=true`, or in semconv mode (where the entire `raw_gen_ai_request` span is suppressed).
+
+#### `metadata.*` (proxy root, sometimes LLM span)
+
+LiteLLM iterates `standard_logging_payload["metadata"]` and emits each entry as `metadata.{key}`. Common keys (not exhaustive):
+
+| Attribute | Meaning |
+|---|---|
+| `metadata.user_api_key_hash` | SHA hash of the virtual key used |
+| `metadata.user_api_key_alias` | Virtual-key alias |
+| `metadata.user_api_key_team_id`, `metadata.user_api_key_team_alias` | Team identifiers |
+| `metadata.user_api_key_org_id`, `metadata.user_api_key_org_alias` | Organization identifiers |
+| `metadata.user_api_key_user_id`, `metadata.user_api_key_user_email` | LiteLLM internal user identifiers |
+| `metadata.user_api_key_end_user_id` | End-user passed in request |
+| `metadata.user_api_key_project_id`, `metadata.user_api_key_project_alias` | Project identifiers |
+| `metadata.user_api_key_spend`, `metadata.user_api_key_max_budget`, `metadata.user_api_key_budget_reset_at` | Budget state |
+| `metadata.user_api_key_request_route` | Route hit (e.g. `/v1/chat/completions`) |
+| `metadata.requester_ip_address`, `metadata.user_agent` | Client identifiers |
+| `metadata.requester_metadata`, `metadata.requester_custom_headers` | Headers and request context |
+| `metadata.applied_guardrails` | List of guardrails that ran on this request |
+| `metadata.mcp_tool_call_metadata`, `metadata.vector_store_request_metadata` | MCP and vector-store request info |
+| `metadata.usage_object` | Full token-usage object |
+| `metadata.spend_logs_metadata` | Custom metadata persisted to Spend Logs |
+| `metadata.cold_storage_object_key` | When request payloads are offloaded to cold storage |
+| `metadata.user_api_key_auth_metadata` | Extra auth context |
+
+Plus `hidden_params` — a single attribute holding a JSON-serialized dict that includes `litellm_overhead_time_ms`, `api_base`, `response_cost`, `additional_headers`, `model_id`, `x-litellm-attempted-retries`, `x-litellm-attempted-fallbacks`, etc.
+
+#### Guardrail span attributes
+
+Set on each `guardrail` child span:
+
+| Attribute | Value |
+|---|---|
+| `openinference.span.kind` | `"guardrail"` (per OpenInference convention) |
+| `guardrail_name` | E.g. `"presidio-pii"`, `"lakera"`, `"aporia"` |
+| `guardrail_mode` | `"pre_call"`, `"during_call"`, `"post_call"`, etc. |
+| `masked_entity_count` | If the guardrail masked entities |
+| `guardrail_response` | The guardrail's response/action |
+
+The span's `start_time`/`end_time` come from the guardrail's own timing, so the span duration equals the **guardrail evaluation time**.
+
+There is no separate `guardrail_pre`/`guardrail_post` span name today — both are emitted as `guardrail` and disambiguated via the `guardrail_mode` attribute.
+
+#### Service-hook span attributes
+
+See [Service-hook spans](#service-hook-spans-aka-infrastructure-spans). Each carries `service`, `call_type`, optional `error`, plus any custom event metadata the caller attached.
+
+#### Exception attributes
+
+On `Failed Proxy Server Request` (and on any LLM-call span on failure):
+
+| Attribute | Value |
+|---|---|
+| `exception` | `str(original_exception)` |
+| Span status | `StatusCode.ERROR` |
+
+#### Resource attributes (every span)
+
+| Attribute | Default | Override |
+|---|---|---|
+| `service.name` | `litellm` | `OTEL_SERVICE_NAME` |
+| `deployment.environment` | `production` | `OTEL_ENVIRONMENT_NAME` |
+| `model_id` | matches `service.name` | `OTEL_MODEL_ID` |
+| `telemetry.sdk.{language,name,version}` | set by SDK | — |
 
 ### Stability
 
 Span names, metric names, and the attribute set above are stable across LiteLLM patch releases. The LLM-call span name and kind change between [Default mode and Semconv mode](#opt-in-to-latest-genai-semantic-conventions) and migrate via the documented opt-in flag rather than between releases.
+
+## Support
+
+For LiteLLM OTEL integration questions, file an issue at [BerriAI/litellm](https://github.com/BerriAI/litellm/issues). For OpenLLMetry / Traceloop semantic-convention questions, see [Slack](https://traceloop.com/slack) or email [dev@traceloop.com](mailto:dev@traceloop.com).

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -126,6 +126,73 @@ litellm.callbacks = [primary, secondary]
 
 Init order does not matter. Both handlers receive their own spans regardless of which is constructed first.
 
+## Capturing Message Content
+
+LiteLLM honors the standard `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable to control whether prompts and completions are captured, and where:
+
+```shell
+# Do not capture message content
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=NO_CONTENT
+
+# Capture content on span attributes only
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
+
+# Capture content on event attributes only
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=EVENT_ONLY
+
+# Capture content on both spans and events
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
+```
+
+The legacy boolean form is also accepted: `true` maps to `EVENT_ONLY`, `false` maps to `NO_CONTENT`.
+
+### Per-handler content policy
+
+When running multiple OpenTelemetry handlers, set `capture_message_content` on each `OpenTelemetryConfig` so the handlers can have different content policies. For example, send full prompts to a debugging backend while stripping content from a compliance-focused OTLP collector:
+
+```python
+import litellm
+from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+
+stripped = OpenTelemetry(config=OpenTelemetryConfig(
+    exporter="otlp_http",
+    endpoint="https://compliance-collector/v1/traces",
+    capture_message_content="NO_CONTENT",
+))
+
+verbose = OpenTelemetry(config=OpenTelemetryConfig(
+    exporter="otlp_http",
+    endpoint="https://debug-collector/v1/traces",
+    capture_message_content="SPAN_AND_EVENT",
+    skip_set_global=True,
+))
+
+litellm.callbacks = [stripped, verbose]
+```
+
+The per-handler `capture_message_content` field overrides the env var. If neither is set, behavior falls back to the legacy `litellm.turn_off_message_logging` kill-switch (see the section below). When `litellm.turn_off_message_logging=True`, content is suppressed regardless of the per-handler setting.
+
+## Opt-In to Latest GenAI Semantic Conventions
+
+Set `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` to emit spans that follow the [latest OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/):
+
+```shell
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
+
+With the flag set:
+
+- The LLM-call span is named `{operation} {model}` (for example, `chat gpt-4` or `embeddings text-embedding-3-small`) instead of `litellm_request`.
+- Span kind is `CLIENT` instead of `INTERNAL`.
+- The non-standard `raw_gen_ai_request` child span is suppressed.
+- `gen_ai.provider.name` is emitted alongside the legacy `gen_ai.system` attribute.
+- Request parameters (`gen_ai.request.frequency_penalty`, `presence_penalty`, `top_k`, `seed`, `stop_sequences`, `stream`, `choice.count`) and cache-token usage (`gen_ai.usage.cache_creation.input_tokens`, `gen_ai.usage.cache_read.input_tokens`) are emitted when present.
+- The legacy per-message and per-choice events are replaced by a single `gen_ai.client.inference.operation.details` event carrying `gen_ai.input.messages` and `gen_ai.output.messages` arrays.
+
+`OpenTelemetryConfig.semconv_stability` is the programmatic equivalent. The flag is comma-separable per the OTEL spec.
+
+Default behavior is unchanged when the variable is unset, so existing dashboards keep working. Setting the flag aligns LiteLLM with what other OTEL Python GenAI instrumentations (`opentelemetry-instrumentation-openai-v2`, Google GenAI, etc.) emit.
+
 ## Redacting Messages, Response Content from OpenTelemetry Logging
 
 ### Redact Messages and Responses from all OpenTelemetry Logging

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -128,7 +128,7 @@ Init order does not matter. Both handlers receive their own spans regardless of 
 
 ## Capturing Message Content
 
-LiteLLM honors the standard `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable to control whether prompts and completions are captured, and where:
+LiteLLM uses the standard `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable to control whether prompts and completions are captured, and where:
 
 ```shell
 # Do not capture message content
@@ -144,7 +144,7 @@ OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=EVENT_ONLY
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
 ```
 
-The legacy boolean form is also accepted: `true` maps to `EVENT_ONLY`, `false` maps to `NO_CONTENT`.
+A boolean form is also accepted: `true` maps to `EVENT_ONLY`, `false` maps to `NO_CONTENT`.
 
 ### Per-handler content policy
 
@@ -170,7 +170,7 @@ verbose = OpenTelemetry(config=OpenTelemetryConfig(
 litellm.callbacks = [stripped, verbose]
 ```
 
-The per-handler `capture_message_content` field overrides the env var. If neither is set, behavior falls back to the legacy `litellm.turn_off_message_logging` kill-switch (see the section below). When `litellm.turn_off_message_logging=True`, content is suppressed regardless of the per-handler setting.
+The per-handler `capture_message_content` field overrides the env var. If neither is set, behavior falls back to the `litellm.turn_off_message_logging` kill-switch (see the section below). When `litellm.turn_off_message_logging=True`, content is suppressed regardless of the per-handler setting.
 
 ## Opt-In to Latest GenAI Semantic Conventions
 
@@ -180,18 +180,9 @@ Set `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` to emit spans tha
 OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
 ```
 
-With the flag set:
-
-- The LLM-call span is named `{operation} {model}` (for example, `chat gpt-4` or `embeddings text-embedding-3-small`) instead of `litellm_request`.
-- Span kind is `CLIENT` instead of `INTERNAL`.
-- The non-standard `raw_gen_ai_request` child span is suppressed.
-- `gen_ai.provider.name` is emitted alongside the legacy `gen_ai.system` attribute.
-- Request parameters (`gen_ai.request.frequency_penalty`, `presence_penalty`, `top_k`, `seed`, `stop_sequences`, `stream`, `choice.count`) and cache-token usage (`gen_ai.usage.cache_creation.input_tokens`, `gen_ai.usage.cache_read.input_tokens`) are emitted when present.
-- The legacy per-message and per-choice events are replaced by a single `gen_ai.client.inference.operation.details` event carrying `gen_ai.input.messages` and `gen_ai.output.messages` arrays.
+This changes the LLM-call span name, kind, and structure, suppresses the non-standard `raw_gen_ai_request` child span, adds the `gen_ai.provider.name` attribute alongside `gen_ai.system`, populates additional request and cache-token attributes when present, and consolidates the per-message events into a single `gen_ai.client.inference.operation.details` event. See the [Spans Reference](#spans-reference) and [Attributes Reference](#attributes-reference) below for the per-row differences.
 
 `OpenTelemetryConfig.semconv_stability` is the programmatic equivalent. The flag is comma-separable per the OTEL spec.
-
-Default behavior is unchanged when the variable is unset, so existing dashboards keep working. Setting the flag aligns LiteLLM with what other OTEL Python GenAI instrumentations (`opentelemetry-instrumentation-openai-v2`, Google GenAI, etc.) emit.
 
 ## Redacting Messages, Response Content from OpenTelemetry Logging
 
@@ -239,3 +230,79 @@ export OTEL_DEBUG="True"
 ```
 
 This will emit any logging issues to the console.
+
+## Appendix: Spans, Metrics, and Attributes Reference
+
+This appendix enumerates every span, metric, and AI-semantic attribute LiteLLM emits, including how each changes when [semconv mode](#opt-in-to-latest-genai-semantic-conventions) is enabled.
+
+### Spans Reference
+
+The LLM-call span is the AI-semantic core. Its name, kind, and supporting child spans depend on whether semconv mode is active.
+
+| Span | Kind | Default mode | Semconv mode |
+|---|---|---|---|
+| Proxy request frame | `SERVER` | `Received Proxy Server Request` | `Received Proxy Server Request` (unchanged) |
+| LLM-call span | `INTERNAL` (default) / `CLIENT` (semconv) | `litellm_request` (only when `USE_OTEL_LITELLM_REQUEST_SPAN=true`; otherwise attributes land on the proxy frame span) | `{operation} {model}` (always; e.g. `chat gpt-4`, `embeddings text-embedding-3-small`) |
+| Raw provider payload | `INTERNAL` | `raw_gen_ai_request` (when message content capture is permitted) | not emitted (data lives on the LLM-call span and the consolidated event) |
+| Guardrail check | `INTERNAL` | one span per guardrail invocation, named per guardrail | unchanged |
+| Management endpoint | `INTERNAL` | one span per proxy admin call, named per endpoint | unchanged |
+
+Operation names emitted in semconv mode: `chat` (default), `embeddings` (when call type contains `embedding`), `text_completion` (when call type contains `text_completion`).
+
+### Events Reference
+
+Events land on the LiteLLM-managed `LoggerProvider` when `enable_events=True` on the config.
+
+| Event | Default mode | Semconv mode |
+|---|---|---|
+| Per-message prompt | `gen_ai.content.prompt` (one event per input message) | replaced by the consolidated event |
+| Per-choice completion | `gen_ai.content.completion` (one event per choice) | replaced by the consolidated event |
+| Consolidated inference details | not emitted | `gen_ai.client.inference.operation.details` (one event per call, carrying `gen_ai.input.messages` and `gen_ai.output.messages` arrays per the spec) |
+
+### Metrics Reference
+
+LiteLLM emits the following histograms when `enable_metrics=True` is set on the `OpenTelemetryConfig`. Metric names match the OTEL GenAI semantic conventions.
+
+| Metric | Unit | Description |
+|---|---|---|
+| `gen_ai.client.operation.duration` | `s` | End-to-end operation duration including LiteLLM overhead. |
+| `gen_ai.client.token.usage` | `{token}` | Token usage. Records two histograms per call (label `gen_ai.token.type` is `"input"` or `"output"`). |
+| `gen_ai.client.token.cost` | `USD` | Computed request cost. |
+| `gen_ai.client.response.time_to_first_token` | `s` | Time from request start to first streamed token (streaming requests only). |
+| `gen_ai.client.response.time_per_output_token` | `s` | Average time per output token (generation time / completion tokens). |
+| `gen_ai.client.response.duration` | `s` | LLM API generation time, excluding LiteLLM overhead. |
+
+Common labels on every histogram: `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.framework="litellm"`.
+
+| Common metric ask | Metric |
+|---|---|
+| TTFT | `gen_ai.client.response.time_to_first_token` |
+| TPS | derived as `1 / gen_ai.client.response.time_per_output_token` |
+| Token usage | `gen_ai.client.token.usage` (split by `gen_ai.token.type`) |
+| Vendor/model latency (excludes overhead) | `gen_ai.client.response.duration` |
+| Vendor/model latency (includes overhead) | `gen_ai.client.operation.duration` |
+
+### Attributes Reference
+
+Attributes set on the LLM-call span. Names follow [OTEL GenAI semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/).
+
+| Attribute | Default mode | Semconv mode |
+|---|---|---|
+| `gen_ai.operation.name` | the litellm `call_type` (e.g. `acompletion`) | the semconv operation (`chat`, `embeddings`, `text_completion`) |
+| `gen_ai.system` | provider name (e.g. `openai`) | unchanged |
+| `gen_ai.provider.name` | not set | provider name (the renamed Required attribute per spec) |
+| `gen_ai.framework` | `litellm` | `litellm` |
+| `gen_ai.request.model` | model | model |
+| `gen_ai.request.max_tokens`, `temperature`, `top_p` | when set in the request | when set in the request |
+| `gen_ai.request.frequency_penalty`, `presence_penalty`, `top_k`, `seed`, `stop_sequences`, `stream`, `choice.count` | not set | when set in the request |
+| `gen_ai.response.model`, `gen_ai.response.id`, `gen_ai.response.finish_reasons` | when present in the response | unchanged |
+| `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.total_tokens` | when present | unchanged |
+| `gen_ai.usage.cache_creation.input_tokens`, `gen_ai.usage.cache_read.input_tokens` | not set | when present in the response |
+| `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions` | when message content capture permits, JSON-encoded array of `{role, parts: [...]}` objects | unchanged |
+| `gen_ai.cost.input_cost`, `output_cost`, `total_cost` (and related cost breakdown attrs) | LiteLLM-specific cost attributes | unchanged |
+
+Attributes set on the proxy request frame include `metadata.user_api_key_*`, `metadata.team_id`, `metadata.requester_*`, `litellm.call_id`, and the same `gen_ai.cost.*` set when the request flows through the proxy.
+
+### Stability
+
+Span names, metric names, and the attribute set above are stable across LiteLLM patch releases. The LLM-call span name and kind change between [Default mode and Semconv mode](#opt-in-to-latest-genai-semantic-conventions) and migrate via the documented opt-in flag rather than between releases.

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -112,7 +112,7 @@ Received Proxy Server Request                      (SpanKind.SERVER, root)
 └── Failed Proxy Server Request                    (INTERNAL — only on exception)
 ```
 
-In **semconv mode** (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), the LLM-call span is renamed to `{operation} {model}` (e.g. `chat gpt-4`), promoted to `SpanKind.CLIENT`, and `raw_gen_ai_request` is suppressed. See [Opt-In to Latest GenAI Semantic Conventions](#opt-in-to-latest-genai-semantic-conventions).
+In **semconv mode** (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), when an LLM-call span is created its name becomes `{operation} {model}` (e.g. `chat gpt-4`) with `SpanKind.CLIENT`, and `raw_gen_ai_request` is suppressed. The same `USE_OTEL_LITELLM_REQUEST_SPAN` gating decides whether the span is emitted at all. See [Opt-In to Latest GenAI Semantic Conventions](#opt-in-to-latest-genai-semantic-conventions).
 
 The SDK (no proxy) emits `litellm_request` as the root if no parent context exists — there is no `Received Proxy Server Request` span in pure-SDK use.
 
@@ -169,7 +169,7 @@ This is the right setting if:
 
 This is **not a regression**; the change is intentional. The flag is read fresh on every request, so it can be flipped without restarting.
 
-In semconv mode (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), the LLM-call span is **always** emitted (named `{operation} {model}`) and `USE_OTEL_LITELLM_REQUEST_SPAN` does not apply.
+In semconv mode (`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), the same `USE_OTEL_LITELLM_REQUEST_SPAN` gating still decides whether the LLM-call span is emitted; semconv mode only changes the span's name (to `{operation} {model}`), kind (to `CLIENT`), and child structure.
 
 ### Context propagation (W3C `traceparent`)
 
@@ -264,7 +264,12 @@ verbose = OpenTelemetry(config=OpenTelemetryConfig(
 litellm.callbacks = [stripped, verbose]
 ```
 
-The per-handler `capture_message_content` field overrides the env var. If neither is set, behavior falls back to the `litellm.turn_off_message_logging` kill-switch (see the section below). When `litellm.turn_off_message_logging=True`, content is suppressed regardless of the per-handler setting.
+Resolution order (highest priority first):
+
+1. `litellm.turn_off_message_logging=True` forces `NO_CONTENT` (dynamic kill-switch; overrides everything below).
+2. `OpenTelemetryConfig.capture_message_content` (per-handler field, sampled at handler init).
+3. `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env var (sampled at handler init).
+4. The legacy per-instance `message_logging` flag — defaults to `True`, which maps to `SPAN_AND_EVENT`.
 
 ## Opt-In to Latest GenAI Semantic Conventions
 
@@ -364,7 +369,7 @@ All flags below are read from environment variables unless noted. Boolean flags 
 |---|---|---|
 | `USE_OTEL_LITELLM_REQUEST_SPAN` | `false` | Force `litellm_request` to always be emitted as a child of the proxy root span. See [Why don't I see a `litellm_request` span?](#why-dont-i-see-a-litellm_request-span) |
 | `OTEL_SEMCONV_STABILITY_OPT_IN` | unset | Set to `gen_ai_latest_experimental` to switch to the [latest GenAI semantic conventions](#opt-in-to-latest-genai-semantic-conventions). Comma-separable per OTEL spec |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | spec default (`NO_CONTENT`) | `NO_CONTENT` / `SPAN_ONLY` / `EVENT_ONLY` / `SPAN_AND_EVENT`. Boolean form accepted (`true`→`EVENT_ONLY`, `false`→`NO_CONTENT`) |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset → falls back to legacy `message_logging` (default `True` → `SPAN_AND_EVENT`) | `NO_CONTENT` / `SPAN_ONLY` / `EVENT_ONLY` / `SPAN_AND_EVENT`. Boolean form accepted (`true`→`EVENT_ONLY`, `false`→`NO_CONTENT`) |
 | `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS` | `false` | Enable OTLP metrics (TTFT, TPOT, response duration, cost, token usage, operation duration) |
 | `LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS` | `false` | Enable OTLP semantic logs (`gen_ai.content.prompt`/`gen_ai.content.completion`, or `gen_ai.client.inference.operation.details` in semconv mode) |
 | `OTEL_IGNORE_CONTEXT_PROPAGATION` | `false` | If `true`, ignore inbound `traceparent` headers and any active span — every LiteLLM trace becomes its own root |
@@ -407,7 +412,7 @@ The LLM-call span is the AI-semantic core. Its name, kind, and supporting child 
 | Span | Kind | Default mode | Semconv mode |
 |---|---|---|---|
 | Proxy request frame | `SERVER` | `Received Proxy Server Request` | `Received Proxy Server Request` (unchanged) |
-| LLM-call span | `INTERNAL` (default) / `CLIENT` (semconv) | `litellm_request` (only when `USE_OTEL_LITELLM_REQUEST_SPAN=true`; otherwise attributes land on the proxy frame span) | `{operation} {model}` (always; e.g. `chat gpt-4`, `embeddings text-embedding-3-small`) |
+| LLM-call span | `INTERNAL` (default) / `CLIENT` (semconv) | `litellm_request` (only when `USE_OTEL_LITELLM_REQUEST_SPAN=true`; otherwise attributes land on the proxy frame span) | `{operation} {model}` (e.g. `chat gpt-4`, `embeddings text-embedding-3-small`); same `USE_OTEL_LITELLM_REQUEST_SPAN` gating as default mode |
 | Raw provider payload | `INTERNAL` | `raw_gen_ai_request` (when message content capture is permitted) | not emitted (data lives on the LLM-call span and the consolidated event) |
 | Guardrail check | `INTERNAL` | one span per guardrail invocation, named per guardrail | unchanged |
 | Management endpoint | `INTERNAL` | one span per proxy admin call, named per endpoint | unchanged |

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -880,8 +880,8 @@ router_settings:
 | LITELLM_LOG_FILE | File path to write LiteLLM logs to. When set, logs will be written to both console and the specified file
 | LITELLM_LOGGER_NAME | Name for OTEL logger 
 | LITELLM_METER_NAME | Name for OTEL Meter 
-| LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS | Optionally enable semantic logs for OTEL
-| LITELLM_OTEL_INTEGRATION_ENABLE_METRICS | Optionally enable emantic metrics for OTEL
+| LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS | Optionally enable semantic logs (`gen_ai.content.prompt`/`gen_ai.content.completion`, or `gen_ai.client.inference.operation.details` in semconv mode) for OTEL. Default `false`. See [OpenTelemetry](/docs/observability/opentelemetry_integration#configuration-reference)
+| LITELLM_OTEL_INTEGRATION_ENABLE_METRICS | Optionally enable semantic metrics (TTFT, TPOT, response duration, cost, token usage) for OTEL. Default `false`. See [OpenTelemetry](/docs/observability/opentelemetry_integration#metrics-reference)
 | LITELLM_ENABLE_PYROSCOPE | If true, enables Pyroscope CPU profiling. Profiles are sent to PYROSCOPE_SERVER_ADDRESS. Off by default. See [Pyroscope profiling](/proxy/pyroscope_profiling).
 | LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS | When `true`, if a team's legacy `model_aliases` entry maps a public model name to an internal `model_name_<team_id>_<uuid>` deployment, pre-call handling can skip that rewrite when team-scoped sibling deployments exist for the public name—so load balancing / `order` apply across siblings. Default is `false` for backwards compatibility. See [Team-scoped models and legacy aliases](./load_balancing#team-scoped-models-and-legacy-model_aliases). When stale aliases are detected and this flag is off, the proxy may log a one-time warning.
 | PYROSCOPE_APP_NAME | Application name reported to Pyroscope. Required when LITELLM_ENABLE_PYROSCOPE is true. No default.
@@ -988,8 +988,12 @@ router_settings:
 | OTEL_SERVICE_NAME | Service name identifier for OpenTelemetry
 | OTEL_TRACER_NAME | Tracer name for OpenTelemetry tracing
 | OTEL_LOGS_EXPORTER | Exporter type for OpenTelemetry logs (e.g., console)
-| OTEL_IGNORE_CONTEXT_PROPAGATION | When true, ignore parent span context propagation in OpenTelemetry callbacks
+| OTEL_IGNORE_CONTEXT_PROPAGATION | When true, ignore parent span context propagation (inbound `traceparent` headers and any active span) so every LiteLLM trace is its own root. Default `false`
 | OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT | Controls whether prompts and completions are captured in OpenTelemetry traces. Accepts `NO_CONTENT` (default per spec), `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT`, or the boolean form (`true` maps to `EVENT_ONLY`, `false` to `NO_CONTENT`)
+| OTEL_SEMCONV_STABILITY_OPT_IN | Set to `gen_ai_latest_experimental` to emit spans following the latest [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/). Renames the LLM-call span to `{operation} {model}`, suppresses `raw_gen_ai_request`, adds `gen_ai.provider.name`, and consolidates events. Comma-separable per OTEL spec
+| USE_OTEL_LITELLM_REQUEST_SPAN | When `true`, the proxy emits a discrete `litellm_request` span per LLM call as a child of the `Received Proxy Server Request` span. Default `false` (since v1.81.0); LLM-call attributes are set directly on the proxy root span. See [Why don't I see a `litellm_request` span?](/docs/observability/opentelemetry_integration#why-dont-i-see-a-litellm_request-span)
+| OTEL_DEBUG | When `true`, prints exporter and span-creation diagnostics to stderr. Useful when traces aren't reaching your backend. Default `false`
+| DEBUG_OTEL | Alias for `OTEL_DEBUG`
 | PAGERDUTY_API_KEY | API key for PagerDuty Alerting
 | PANW_PRISMA_AIRS_API_KEY | API key for PANW Prisma AIRS service
 | PANW_PRISMA_AIRS_API_BASE | Base URL for PANW Prisma AIRS service

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -989,6 +989,7 @@ router_settings:
 | OTEL_TRACER_NAME | Tracer name for OpenTelemetry tracing
 | OTEL_LOGS_EXPORTER | Exporter type for OpenTelemetry logs (e.g., console)
 | OTEL_IGNORE_CONTEXT_PROPAGATION | When true, ignore parent span context propagation in OpenTelemetry callbacks
+| OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT | Controls whether prompts and completions are captured in OpenTelemetry traces. Accepts `NO_CONTENT` (default per spec), `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT`, or the boolean form (`true` maps to `EVENT_ONLY`, `false` to `NO_CONTENT`)
 | PAGERDUTY_API_KEY | API key for PagerDuty Alerting
 | PANW_PRISMA_AIRS_API_KEY | API key for PANW Prisma AIRS service
 | PANW_PRISMA_AIRS_API_BASE | Base URL for PANW Prisma AIRS service

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -739,6 +739,12 @@ You will see `raw_request` in your Langfuse Metadata. This is the RAW CURL comma
 
 ## OpenTelemetry
 
+:::tip
+
+The full OpenTelemetry reference — span hierarchy, every emitted span and attribute, metrics, semconv mode, and troubleshooting — lives at [Observability → OpenTelemetry Integration](/docs/observability/opentelemetry_integration). The section below is a proxy-focused quickstart.
+
+:::
+
 :::info 
 
 [Optional] Customize OTEL Service Name and OTEL TRACER NAME by setting the following variables in your environment


### PR DESCRIPTION
Adds sections to the OpenTelemetry page about new flags / options / spans.
<img width="762" height="548" alt="Screenshot 2026-05-07 at 4 26 00 PM" src="https://github.com/user-attachments/assets/9588d73e-e317-4574-be33-2c66625b8ba4" />
<img width="759" height="395" alt="Screenshot 2026-05-07 at 4 26 09 PM" src="https://github.com/user-attachments/assets/e4d41897-c85d-4a21-86d1-68f556efc9f7" />
<img width="764" height="662" alt="Screenshot 2026-05-07 at 4 26 21 PM" src="https://github.com/user-attachments/assets/3bc6b5fe-6012-4e45-9678-ed9773360bdc" />