### PR TITLE
docs(release-notes): backfill v1.83.10 breaking-change entry for client-tag stripping

### DIFF
--- a/release_notes/v1.83.10/index.md
+++ b/release_notes/v1.83.10/index.md
@@ -63,6 +63,37 @@ pip install litellm==1.83.10
 
 ---
 
+## Breaking Changes
+
+#### Caller-supplied `tags` are stripped unless the key/team opts in
+
+- **What changed:** Tags supplied by the caller — `metadata.tags`, `litellm_metadata.tags`, root-level `tags`, and the `x-litellm-tags` header — are stripped from the request before [tag-based routing](../../docs/proxy/tag_routing) and [tag-based spend attribution](../../docs/proxy/cost_tracking#custom-tags) run, unless the calling key or its parent team carries `metadata.allow_client_tags: true`. Tags configured on the model deployment, key metadata, or team metadata are unaffected. The proxy logs a `WARNING` line on each strip:
+  ```
+  Stripped caller-supplied tags from metadata, tags (root): this key/team does not have `allow_client_tags: true` in its metadata. Set it to opt into client-supplied routing/budget tags.
+  ```
+  — [PR #25905](https://github.com/BerriAI/litellm/pull/25905)
+
+- **Who is affected:** Any deployment that relied on clients passing `tags` in the request body or `x-litellm-tags` header for tag-based cost tracking, tag budgets, or tag-based routing. After upgrade, those tags will silently fall through to the default bucket / default deployment, and per-tag spend reports will appear empty.
+
+- **Restore prior behavior:** Set `allow_client_tags: true` in the metadata of the affected key (or the team owning it). Either flag is sufficient — if the key or its parent team carries the flag, caller-supplied tags pass through.
+  ```bash
+  # Per key
+  curl -L -X POST 'http://0.0.0.0:4000/key/generate' \
+    -H 'Authorization: Bearer sk-1234' \
+    -H 'Content-Type: application/json' \
+    -d '{"metadata": {"allow_client_tags": true}}'
+
+  # Per team
+  curl -L -X POST 'http://0.0.0.0:4000/team/new' \
+    -H 'Authorization: Bearer sk-1234' \
+    -H 'Content-Type: application/json' \
+    -d '{"metadata": {"allow_client_tags": true}}'
+  ```
+
+  Existing keys/teams can be patched with `/key/update` or `/team/update` carrying the same `metadata` payload.
+
+---
+
 ## New Models / Updated Models
 
 #### New Model Support (10 new models)


### PR DESCRIPTION
## Summary

Backfills a **Breaking Changes** section in the [v1.83.10 release notes](https://docs.litellm.ai/release_notes/v1.83.10) for the change that gated caller-supplied tags behind `allow_client_tags: true` ([PR #25905](https://github.com/BerriAI/litellm/pull/25905)).

The behavior change shipped in v1.83.10-stable but was not called out in the release notes, the [All settings](https://docs.litellm.ai/docs/proxy/config_settings) page, or any of the tag/cost-tracking pages. Customers relying on client-supplied tags for cost attribution have hit silent breakage on upgrade.

The new entry documents:
- **What changed** — slots that are stripped (`metadata.tags`, `litellm_metadata.tags`, root `tags`, `x-litellm-tags`), with the proxy's WARNING log signature so operators can grep for it
- **Who is affected** — only deployments that relied on **client-supplied** tags; deployment / key / team metadata tags are unaffected
- **Restore prior behavior** — `allow_client_tags: true` on the key or team metadata, with curl recipes for both `/key/generate` and `/team/new`

## Test plan
- [ ] Render `release_notes/v1.83.10/index.md` locally; confirm new section sits cleanly between **Key Highlights** and **New Models / Updated Models**
- [ ] Confirm intra-doc links resolve: `../../docs/proxy/tag_routing` and `../../docs/proxy/cost_tracking#custom-tags`
- [ ] Confirm external link resolves: PR #25905