### PR TITLE
docs: add Okta OIDC SSO environment variables to reference

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -962,6 +962,12 @@ router_settings:
 | NO_PROXY | List of addresses to bypass proxy
 | NON_LLM_CONNECTION_TIMEOUT | Timeout in seconds for non-LLM service connections. Default is 15
 | OAUTH_TOKEN_INFO_ENDPOINT | Endpoint for OAuth token info retrieval
+| OKTA_CLIENT_ID | Client ID for Okta OIDC SSO authentication
+| OKTA_CLIENT_SECRET | Client secret for Okta OIDC SSO authentication. Not required when PKCE is enabled
+| OKTA_ISSUER | Okta authorization server issuer URL (e.g. https://your-domain.okta.com/oauth2/default). Used to derive authorize, token, and userinfo endpoints automatically
+| OKTA_AUTHORIZATION_ENDPOINT | Override for the Okta authorization endpoint (derived from OKTA_ISSUER when not set)
+| OKTA_TOKEN_ENDPOINT | Override for the Okta token endpoint (derived from OKTA_ISSUER when not set)
+| OKTA_USERINFO_ENDPOINT | Override for the Okta userinfo endpoint (derived from OKTA_ISSUER when not set)
 | OPENAI_BASE_URL | Base URL for OpenAI API
 | OPENAI_API_BASE | Base URL for OpenAI API. Default is https://api.openai.com/
 | OPENAI_API_KEY | API key for OpenAI services


### PR DESCRIPTION
## Summary

Adds six new Okta OIDC environment variables to the environment variables reference table in `config_settings.md`:

- `OKTA_CLIENT_ID` — Client ID for Okta OIDC SSO authentication
- `OKTA_CLIENT_SECRET` — Client secret for Okta OIDC SSO (not required when PKCE is enabled)
- `OKTA_ISSUER` — Okta authorization server issuer URL; used to auto-derive authorize/token/userinfo endpoints
- `OKTA_AUTHORIZATION_ENDPOINT` — Optional override for the authorization endpoint
- `OKTA_TOKEN_ENDPOINT` — Optional override for the token endpoint
- `OKTA_USERINFO_ENDPOINT` — Optional override for the userinfo endpoint

These variables were introduced by first-class Okta OIDC support in BerriAI/litellm#27595.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)