### PR TITLE
Add Bedrock Claude Platform docs

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -7,7 +7,7 @@ ALL Bedrock models (Anthropic, Meta, Deepseek, Mistral, Amazon, etc.) are Suppor
 | Property | Details |
 |-------|-------|
 | Description | Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs). |
-| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/qwen2/`](./bedrock_imported.md#qwen2-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc), [`bedrock/moonshot`](./bedrock_imported.md#moonshot-kimi-k2-thinking) |
+| Provider Route on LiteLLM | `bedrock/`, [`bedrock/claude_platform/`](#claude-platform-on-aws), [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/qwen2/`](./bedrock_imported.md#qwen2-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc), [`bedrock/moonshot`](./bedrock_imported.md#moonshot-kimi-k2-thinking) |
 | Provider Doc | [Amazon Bedrock ↗](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
 | Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings`, `/images/generations`, `/v1/realtime`|
 | Rerank Endpoint | `/rerank` |
@@ -1465,6 +1465,83 @@ model_list:
 
 </TabItem>
 </Tabs>
+
+## Claude Platform on AWS
+
+Use the `bedrock/claude_platform/<model>` route to call Claude Platform on AWS through the Bedrock auth path. LiteLLM sends requests to the Anthropic Messages endpoint through the AWS gateway, so the same configured model can be used with OpenAI-compatible `/chat/completions` and Anthropic-compatible `/v1/messages`.
+
+Required configuration:
+
+- AWS credentials available to `boto3`, or a Claude Platform API credential passed through LiteLLM.
+- `aws_region_name`, unless you set a custom Claude Platform gateway base URL.
+- `workspace_id` for your Claude Platform workspace.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+
+response = completion(
+    model="bedrock/claude_platform/claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
+    aws_region_name="us-east-1",
+    workspace_id="workspace-id",
+)
+
+print(response)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: claude-platform-sonnet
+    litellm_params:
+      model: bedrock/claude_platform/claude-sonnet-4-6
+      aws_region_name: us-east-1
+      workspace_id: workspace-id
+```
+
+</TabItem>
+</Tabs>
+
+### Test with OpenAI chat completions
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/chat/completions' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <proxy-key>' \
+  --data '{
+    "model": "claude-platform-sonnet",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a short hello world response."
+      }
+    ]
+  }'
+```
+
+### Test with Anthropic Messages
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/messages' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <proxy-key>' \
+  --header 'anthropic-version: 2023-06-01' \
+  --data '{
+    "model": "claude-platform-sonnet",
+    "max_tokens": 256,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a short hello world response."
+      }
+    ]
+  }'
+```
 
 ## Alternate user/assistant messages
 


### PR DESCRIPTION
## Summary
Adds Bedrock provider documentation for the Claude Platform on AWS route introduced in LiteLLM PR #27678. The docs now show SDK and proxy configuration plus examples for OpenAI-compatible chat completions and Anthropic-compatible Messages requests.

## Repro
A user configuring `bedrock/claude_platform/<model>` needed docs showing the route shape, required workspace and region configuration, and how to call the configured proxy model through both supported request surfaces.

## Evidence
Docusaurus build completed successfully locally. The build also reported pre-existing broken anchors in release-note pages unrelated to this Bedrock docs change.

## Tests
- `npm ci` (passed)
- `npm run build` (passed; generated static files successfully)

## CI
- Vercel: green (preview deployed successfully)
- Vercel Preview Comments: green

## Review
- No automated code-review bot review was posted after the wait window.
