### PR TITLE
Add Bedrock Claude Platform docs page

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -7,7 +7,7 @@ ALL Bedrock models (Anthropic, Meta, Deepseek, Mistral, Amazon, etc.) are Suppor
 | Property | Details |
 |-------|-------|
 | Description | Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs). |
-| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/qwen2/`](./bedrock_imported.md#qwen2-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc), [`bedrock/moonshot`](./bedrock_imported.md#moonshot-kimi-k2-thinking) |
+| Provider Route on LiteLLM | `bedrock/`, [`bedrock/claude_platform/`](./bedrock_claude_platform.md), [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/qwen2/`](./bedrock_imported.md#qwen2-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc), [`bedrock/moonshot`](./bedrock_imported.md#moonshot-kimi-k2-thinking) |
 | Provider Doc | [Amazon Bedrock ↗](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
 | Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings`, `/images/generations`, `/v1/realtime`|
 | Rerank Endpoint | `/rerank` |

--- a/docs/providers/bedrock_claude_platform.md
+++ b/docs/providers/bedrock_claude_platform.md
@@ -1,0 +1,79 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Claude Platform on AWS
+
+Use the `bedrock/claude_platform/<model>` route to call Claude Platform on AWS through the Bedrock auth path. LiteLLM sends requests to the Anthropic Messages endpoint through the AWS gateway, so the same configured model can be used with OpenAI-compatible `/chat/completions` and Anthropic-compatible `/v1/messages`.
+
+Required configuration:
+
+- AWS credentials available to `boto3`, or a Claude Platform API credential passed through LiteLLM.
+- `aws_region_name`, unless you set a custom Claude Platform gateway base URL.
+- `workspace_id` for your Claude Platform workspace.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+
+response = completion(
+    model="bedrock/claude_platform/claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
+    aws_region_name="us-east-1",
+    workspace_id="workspace-id",
+)
+
+print(response)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: claude-platform-sonnet
+    litellm_params:
+      model: bedrock/claude_platform/claude-sonnet-4-6
+      aws_region_name: us-east-1
+      workspace_id: workspace-id
+```
+
+</TabItem>
+</Tabs>
+
+## Test with OpenAI chat completions
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/chat/completions' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <proxy-key>' \
+  --data '{
+    "model": "claude-platform-sonnet",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a short hello world response."
+      }
+    ]
+  }'
+```
+
+## Test with Anthropic Messages
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/messages' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <proxy-key>' \
+  --header 'anthropic-version: 2023-06-01' \
+  --data '{
+    "model": "claude-platform-sonnet",
+    "max_tokens": 256,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a short hello world response."
+      }
+    ]
+  }'
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "test:bedrock-claude-platform-docs": "node scripts/validate_bedrock_claude_platform_docs.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.8.1",

--- a/scripts/validate_bedrock_claude_platform_docs.js
+++ b/scripts/validate_bedrock_claude_platform_docs.js
@@ -1,0 +1,54 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const docId = "providers/bedrock_claude_platform";
+const docPath = path.join(repoRoot, "docs", "providers", "bedrock_claude_platform.md");
+const bedrockPath = path.join(repoRoot, "docs", "providers", "bedrock.md");
+const sidebars = require(path.join(repoRoot, "sidebars.js"));
+
+function flattenSidebarItems(items) {
+  return items.flatMap((item) => {
+    if (typeof item === "string") {
+      return [item];
+    }
+
+    if (item.type === "doc") {
+      return [item.id];
+    }
+
+    if (Array.isArray(item.items)) {
+      return flattenSidebarItems(item.items);
+    }
+
+    return [];
+  });
+}
+
+assert.ok(fs.existsSync(docPath), `${docId} page should exist`);
+
+const allSidebarDocIds = flattenSidebarItems(sidebars.tutorialSidebar);
+assert.ok(
+  allSidebarDocIds.includes(docId),
+  `${docId} should be listed in tutorialSidebar`
+);
+
+const bedrockDoc = fs.readFileSync(bedrockPath, "utf8");
+assert.match(
+  bedrockDoc,
+  /\[`bedrock\/claude_platform\/`\]\(\.\/bedrock_claude_platform\.md\)/,
+  "Bedrock overview should link to the Claude Platform page"
+);
+
+const claudePlatformDoc = fs.readFileSync(docPath, "utf8");
+assert.match(
+  claudePlatformDoc,
+  /# Claude Platform on AWS/,
+  "Claude Platform page should include the expected title"
+);
+assert.match(
+  claudePlatformDoc,
+  /bedrock\/claude_platform\/<model>/,
+  "Claude Platform page should document the route shape"
+);

--- a/sidebars.js
+++ b/sidebars.js
@@ -897,6 +897,7 @@ const sidebars = {
           label: "Bedrock",
           items: [
             "providers/bedrock",
+            "providers/bedrock_claude_platform",
             "providers/bedrock_embedding",
             "providers/bedrock_imported",
             "providers/bedrock_image_gen",


### PR DESCRIPTION
## Summary
Adds a standalone Bedrock Claude Platform on AWS provider page and links it from the Bedrock overview. The new page is registered under the Bedrock sidebar group so it appears as its own navigation entry.

## Repro
A Bedrock route guide was proposed as inline content on the main Bedrock page, so it did not have its own provider page or sidebar entry under Bedrock.

## Evidence
Could not upload visual evidence to an external gist because the available GitHub credentials do not include gist publishing access. Terminal and manual proof transcript:

```text
npm run test:bedrock-claude-platform-docs: passed
npm ci: passed
npm run build: passed; build completed with pre-existing broken-link/blog warnings outside this change
Manual preview: /docs/providers/bedrock_claude_platform rendered with the Claude Platform on AWS title and the Bedrock sidebar entry selected under Bedrock.
```

## Tests
- `npm run test:bedrock-claude-platform-docs` (passed; failed before the page/sidebar entry existed)
- `npm ci` (passed)
- `npm run build` (passed; build completed with pre-existing broken-link/blog warnings outside this change)

## CI
- Vercel: all jobs green
- Vercel Preview Comments: all jobs green

## Review
- No automated code-review bot review was posted after the wait window.
