### PR TITLE
docs: PEP 440 version naming — v1.84.0 release notes + cleaner-release-versions blog

### DIFF
--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -33,10 +33,12 @@ Starting with **`1.84.0`**:
 
 | Scenario | Old name | New name |
 |---|---|---|
-| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` (Docker + PyPI) |
-| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` (Docker + PyPI) |
-| Release candidate | `v1.84.0-rc` | `1.84.0-rc.1` (Docker) / `1.84.0rc1` (PyPI) |
-| Nightly | `v1.83.0-nightly` | `1.84.0-dev.42` (Docker) / `1.84.0.dev42` (PyPI) |
+| Weekly scheduled stable | `v1.83.3-stable` | `1.84.0` or `v1.84.0` (Docker) / `1.84.0` (PyPI) |
+| Hotfix on the current stable | `v1.83.3-stable.patch.1` (Docker only - no PyPI release) | `1.84.1` or `v1.84.1` (Docker) / `1.84.1` (PyPI) |
+| Release candidate | `v1.84.0-rc` | `1.84.0-rc.1` or `v1.84.0-rc.1` (Docker) / `1.84.0rc1` (PyPI) |
+| Nightly | `v1.83.0-nightly` | `1.84.0-dev.42` or `v1.84.0-dev.42` (Docker) / `1.84.0.dev42` (PyPI) |
+
+On Docker, every channel is published in both bare (`1.84.0`) and `v`-prefixed (`v1.84.0`) form going forward — both resolve to the same image digest, so existing pins that include the `v` prefix keep working. On PyPI, every channel uses the bare PEP 440 form (`1.84.0`, never `v1.84.0`).
 
 The hotfix row is the meaningful one. Under the old scheme there was no PyPI publication for `v1.83.3-stable.patch.1`. Under the new scheme, hotfixes ship to both registries and PyPI as a normal release.
 
@@ -48,7 +50,7 @@ If a maintenance patch is needed on a pre-cutover release line (e.g. a fix on `1
 
 ## A few things worth knowing
 
-- **The `v` prefix is optional on Docker tags.** Both `ghcr.io/berriai/litellm:1.84.0` and `ghcr.io/berriai/litellm:v1.84.0` are published and resolve to the same image (same `sha256` digest), so tooling that conventionally prefixes git-tag style references with `v` keeps working. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0` (not `==v1.84.0`).
+- **The `v` prefix is optional on Docker tags.** Every Docker tag going forward is published in both bare and `v`-prefixed form — `ghcr.io/berriai/litellm:1.84.0` and `ghcr.io/berriai/litellm:v1.84.0` resolve to the same image (same `sha256` digest), and the same applies to release-candidate and dev/nightly tags. Existing pins that include the `v` prefix keep working without change. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0` (not `==v1.84.0`).
 - **`litellm-dev`** - there's a separate `litellm-dev` PyPI package and `*-dev` Docker image family for ad-hoc and one-off builds (e.g. testing a fix before it lands in a release). **Not for production use.** Anything pinned to the standard `litellm` package or `ghcr.io/berriai/litellm:*` Docker tags will never accidentally pick up a `litellm-dev` build.
 - **`:latest` Docker tag** points to the most recent stable release on each registry, advancing automatically when a new stable ships. For production deployments we still recommend pinning to a content tag (e.g. `:1.84.0`) so deploys are reproducible.
 - **Image signing** ([cosign verify](/blog/ci-cd-v2-improvements#verify-docker-image-signatures)) and verification commands continue to work unchanged with the new tag shapes.

--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -48,6 +48,7 @@ If a maintenance patch is needed on a pre-cutover release line (e.g. a fix on `1
 
 ## A few things worth knowing
 
+- **The `v` prefix is optional on Docker tags.** Both `ghcr.io/berriai/litellm:1.84.0` and `ghcr.io/berriai/litellm:v1.84.0` are published and resolve to the same image (same `sha256` digest), so tooling that conventionally prefixes git-tag style references with `v` keeps working. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0` (not `==v1.84.0`).
 - **`litellm-dev`** - there's a separate `litellm-dev` PyPI package and `*-dev` Docker image family for ad-hoc and one-off builds (e.g. testing a fix before it lands in a release). **Not for production use.** Anything pinned to the standard `litellm` package or `ghcr.io/berriai/litellm:*` Docker tags will never accidentally pick up a `litellm-dev` build.
 - **`:latest` Docker tag** points to the most recent stable release on each registry, advancing automatically when a new stable ships. For production deployments we still recommend pinning to a content tag (e.g. `:1.84.0`) so deploys are reproducible.
 - **Image signing** ([cosign verify](/blog/ci-cd-v2-improvements#verify-docker-image-signatures)) and verification commands continue to work unchanged with the new tag shapes.

--- a/release_notes/v1.84.0/index.md
+++ b/release_notes/v1.84.0/index.md
@@ -45,7 +45,7 @@ pip install litellm==1.84.0
 
 ## Version naming change
 
-> **Starting with `v1.84.0`, LiteLLM versions follow [PEP 440](https://peps.python.org/pep-0440/).** Stable releases drop the `-stable` suffix — the Docker tag for this release is `litellm:1.84.0` (or equivalently `litellm:v1.84.0` — both Docker tags are published and resolve to the same image), not `litellm:1.84.0-stable`. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0`. If you pin LiteLLM in deployment tooling (Helm values, `requirements.txt`, Renovate rules, etc.), update those pins to the PEP 440 form.
+> **Starting with `v1.84.0`, LiteLLM versions follow [PEP 440](https://peps.python.org/pep-0440/).** Stable releases drop the `-stable` suffix — the Docker tag for this release is `litellm:1.84.0`, not `litellm:1.84.0-stable`. Every Docker tag is published in both bare and `v`-prefixed form (`litellm:1.84.0` and `litellm:v1.84.0` resolve to the same image), so existing pins that include the `v` prefix keep working. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0`. If you pin LiteLLM in deployment tooling (Helm values, `requirements.txt`, Renovate rules, etc.), update those pins to the PEP 440 form.
 
 Mapping from the legacy suffix scheme to the new PEP 440 scheme:
 

--- a/release_notes/v1.84.0/index.md
+++ b/release_notes/v1.84.0/index.md
@@ -43,6 +43,23 @@ pip install litellm==1.84.0
 </TabItem>
 </Tabs>
 
+## Version naming change
+
+> **Starting with `v1.84.0`, LiteLLM versions follow [PEP 440](https://peps.python.org/pep-0440/).** Stable releases drop the `-stable` suffix — the Docker tag for this release is `litellm:1.84.0`, not `litellm:1.84.0-stable`. If you pin LiteLLM in deployment tooling (Helm values, `requirements.txt`, Renovate rules, etc.), update those pins to the PEP 440 form.
+
+Mapping from the legacy suffix scheme to the new PEP 440 scheme:
+
+| Channel | Legacy (≤ `v1.83.x`) | New (≥ `v1.84.0`) |
+| --- | --- | --- |
+| Stable | `vX.Y.Z-stable` | `vX.Y.Z` |
+| Stable patch | `vX.Y.Z-stable.patch.N` | `vX.Y.Z.postN` |
+| Release candidate | `vX.Y.Z.rc.N` / `vX.Y.Z-rc.N` | `vX.Y.ZrcN` |
+| Dev / nightly | `vX.Y.Z-nightly` / `vX.Y.Z.dev.N` | `vX.Y.Z.devN` |
+
+This is a naming change only — release cadence, stability guarantees, and image contents are unchanged. The `v1.84.0-rc.1` tag (cut before the switch) keeps the legacy form for historical continuity; every tag from `v1.84.0` onward uses the PEP 440 form.
+
+---
+
 > **Heads up — large bundle of behavioral changes.** This release consolidates a lot of reliability and hardening work that shipped in tight sequence. The **Important Behavior Changes** section below covers everything that changes a default, removes a configuration shortcut, or alters a request/response shape, with the opt-out you need to keep prior behavior. Read that section before upgrading a production deployment. If you already validated against `v1.84.0-rc.1`, see the **Changes since v1.84.0-rc.1** section for the post-rc delta.
 
 ## Key Highlights

--- a/release_notes/v1.84.0/index.md
+++ b/release_notes/v1.84.0/index.md
@@ -45,7 +45,7 @@ pip install litellm==1.84.0
 
 ## Version naming change
 
-> **Starting with `v1.84.0`, LiteLLM versions follow [PEP 440](https://peps.python.org/pep-0440/).** Stable releases drop the `-stable` suffix — the Docker tag for this release is `litellm:1.84.0`, not `litellm:1.84.0-stable`. If you pin LiteLLM in deployment tooling (Helm values, `requirements.txt`, Renovate rules, etc.), update those pins to the PEP 440 form.
+> **Starting with `v1.84.0`, LiteLLM versions follow [PEP 440](https://peps.python.org/pep-0440/).** Stable releases drop the `-stable` suffix — the Docker tag for this release is `litellm:1.84.0` (or equivalently `litellm:v1.84.0` — both Docker tags are published and resolve to the same image), not `litellm:1.84.0-stable`. PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0`. If you pin LiteLLM in deployment tooling (Helm values, `requirements.txt`, Renovate rules, etc.), update those pins to the PEP 440 form.
 
 Mapping from the legacy suffix scheme to the new PEP 440 scheme:
 


### PR DESCRIPTION
## Summary

- `v1.84.0` is the first stable LiteLLM release without the `-stable` suffix. Add a short section near the top of the v1.84.0 release notes that explains the switch and maps the legacy suffix scheme to the new [PEP 440](https://peps.python.org/pep-0440/) scheme.
- Clarify in both the v1.84.0 release notes and the existing `cleaner_release_versions` blog post that the `v` prefix is **optional** on Docker tags — `ghcr.io/berriai/litellm:1.84.0` and `ghcr.io/berriai/litellm:v1.84.0` are both published and resolve to the same image digest (`sha256:29252f25ed1b...` for v1.84.0). PyPI versions remain the bare PEP 440 form: `pip install litellm==1.84.0`.
- Calls out the practical impact for anyone pinning LiteLLM in Helm values, `requirements.txt`, Renovate, etc., and clarifies that the `v1.84.0-rc.1` tag (cut before the switch) intentionally keeps the legacy form.

## Mapping included in the new release-notes section

| Channel | Legacy (≤ `v1.83.x`) | New (≥ `v1.84.0`) |
| --- | --- | --- |
| Stable | `vX.Y.Z-stable` | `vX.Y.Z` |
| Stable patch | `vX.Y.Z-stable.patch.N` | `vX.Y.Z.postN` |
| Release candidate | `vX.Y.Z.rc.N` / `vX.Y.Z-rc.N` | `vX.Y.ZrcN` |
| Dev / nightly | `vX.Y.Z-nightly` / `vX.Y.Z.dev.N` | `vX.Y.Z.devN` |

## Test plan

- [ ] Docusaurus build picks up the new `## Version naming change` section under `release_notes/v1.84.0/index.md` without sidebar / TOC changes.
- [ ] Blog post `cleaner_release_versions` renders the new `v`-prefix bullet under "A few things worth knowing".