### PR TITLE
docs: add DATABASE_*_READ_REPLICA env vars to reference

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -555,13 +555,18 @@ router_settings:
 | COMPETITOR_LLM_TEMPERATURE | Temperature setting for the LLM used in competitor discovery. Default is 0.3
 | CURSOR_API_BASE | API base URL for Cursor AI provider integration. Default is https://api.cursor.com
 | DATABASE_HOST | Hostname for the database server
+| DATABASE_HOST_READ_REPLICA | Hostname for the read-replica database server. Only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True` to assemble `DATABASE_URL_READ_REPLICA` from RDS IAM env vars
 | DATABASE_NAME | Name of the database
+| DATABASE_NAME_READ_REPLICA | Database name for the read replica (defaults to `DATABASE_NAME`). Only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True`
 | DATABASE_PASSWORD | Password for the database user
 | DATABASE_PORT | Port number for database connection
+| DATABASE_PORT_READ_REPLICA | Port number for the read replica (default 5432). Only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True`
 | DATABASE_SCHEMA | Schema name used in the database
+| DATABASE_SCHEMA_READ_REPLICA | Schema name for the read replica (defaults to `DATABASE_SCHEMA`). Only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True`
 | DATABASE_URL | Connection URL for the database
 | DATABASE_URL_READ_REPLICA | Optional read-replica connection URL. When set, the proxy routes read-only queries (find_*, count, group_by, query_raw/_first) to this endpoint while writes continue to use `DATABASE_URL`. Useful for Aurora-style clusters with separate reader/writer endpoints. Falls back to writer-only behavior when unset. With `IAM_TOKEN_DB_AUTH=True`, the reader IAM token is auto-refreshed alongside the writer
 | DATABASE_USER | Username for database connection
+| DATABASE_USER_READ_REPLICA | Database user for the read replica (defaults to `DATABASE_USER`). Only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True`
 | DATABASE_USERNAME | Alias for database user
 | DATABRICKS_API_BASE | Base URL for Databricks API
 | DATABRICKS_API_KEY | API key (Personal Access Token) for Databricks API authentication


### PR DESCRIPTION
## Summary

- Documents the 5 RDS IAM read-replica env vars consumed by `init_iam_db_url_from_env()` in `litellm/proxy/auth/rds_iam_token.py`: `DATABASE_HOST_READ_REPLICA`, `DATABASE_PORT_READ_REPLICA`, `DATABASE_USER_READ_REPLICA`, `DATABASE_NAME_READ_REPLICA`, `DATABASE_SCHEMA_READ_REPLICA`.
- These are only used by the componentized deployment (experimental) when `IAM_TOKEN_DB_AUTH=True`; the wording calls that out.
- Unblocks `tests/documentation_tests/test_env_keys.py` in litellm (the `Unit Tests: Documentation Validation` job currently fails because these keys are in code but missing from the reference page).

## Test plan

- [ ] Once merged, re-run the litellm CI job `documentation` on the relevant PR and confirm `test_env_keys.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)