### PR TITLE
docs(tutorials/claude-code): modernize Bedrock × Claude Code quickstart

### DIFF
--- a/docs/tutorials/claude_responses_api.md
+++ b/docs/tutorials/claude_responses_api.md
@@ -38,19 +38,19 @@ Create a secure configuration using environment variables:
 ```yaml
 model_list:
   # Configure the models you want to use
-  - model_name: claude-sonnet-4-5-20250929
+  - model_name: claude-opus-4-7
     litellm_params:
-      model: anthropic/claude-sonnet-4-5-20250929
+      model: anthropic/claude-opus-4-7
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-sonnet-4-6
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
 
   - model_name: claude-haiku-4-5-20251001
     litellm_params:
       model: anthropic/claude-haiku-4-5-20251001
-      api_key: os.environ/ANTHROPIC_API_KEY
-
-  - model_name: claude-opus-4-5-20251101
-    litellm_params:
-      model: anthropic/claude-opus-4-5-20251101
       api_key: os.environ/ANTHROPIC_API_KEY
 
 litellm_settings:
@@ -85,7 +85,7 @@ curl -X POST http://0.0.0.0:4000/v1/messages \
 -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
 -H "Content-Type: application/json" \
 -d '{
-    "model": "claude-3-5-sonnet-20241022",
+    "model": "claude-opus-4-7",
     "max_tokens": 1000,
     "messages": [{"role": "user", "content": "What is the capital of France?"}]
 }'
@@ -122,24 +122,24 @@ export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 Start Claude Code with the model you want to use:
 
 ```bash
-# Specify model at startup
-claude --model claude-sonnet-4-5-20250929
+# Specify model at startup (Opus 4.7 — newest Claude Code model)
+claude --model claude-opus-4-7
 
 # Or specify a different model
+claude --model claude-sonnet-4-6
 claude --model claude-haiku-4-5-20251001
-claude --model claude-opus-4-5-20251101
 
 # Or change model during a session
 claude
-/model claude-sonnet-4-5-20250929
+/model claude-opus-4-7
 ```
 
 Alternatively, set default models with environment variables:
 
 ```bash
-export ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-5-20250929
+export ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-7
+export ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6
 export ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5-20251001
-export ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-5-20251101
 claude
 ```
 
@@ -148,11 +148,11 @@ claude
 Claude Code supports extended context (1 million tokens) using the `[1m]` suffix:
 
 ```bash
-# Use Sonnet with 1M context (requires quotes in shell)
-claude --model 'claude-sonnet-4-5-20250929[1m]'
+# Use Opus 4.7 with 1M context (requires quotes in shell)
+claude --model 'claude-opus-4-7[1m]'
 
 # Inside a Claude Code session (no quotes needed)
-/model claude-sonnet-4-5-20250929[1m]
+/model claude-opus-4-7[1m]
 ```
 
 :::warning
@@ -195,47 +195,64 @@ Common issues and solutions:
 
 Expand your configuration to support multiple providers and models:
 
+:::tip Check live compatibility before you wire up a provider
+
+Compatibility between Claude Code features and each provider (Anthropic, Bedrock, Vertex AI, Azure) changes as Claude Code and LiteLLM ship updates. The [Claude Code × LiteLLM compatibility matrix](https://docs.litellm.ai/docs/claude_code_compatibility) is regenerated daily against the latest stable LiteLLM proxy across Haiku 4.5, Sonnet 4.6, and Opus 4.7 — check it first to see which `(feature, provider)` cells are currently green.
+
+:::
+
 <Tabs>
 <TabItem value="multi-provider" label="Multi-Provider Setup">
 
 ```yaml
 model_list:
   # Anthropic models
-  - model_name: claude-3-5-sonnet-20241022
+  - model_name: claude-opus-4-7
     litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
-      api_key: os.environ/ANTHROPIC_API_KEY
-  
-  - model_name: claude-3-5-haiku-20241022
-    litellm_params:
-      model: anthropic/claude-3-5-haiku-20241022
+      model: anthropic/claude-opus-4-7
       api_key: os.environ/ANTHROPIC_API_KEY
 
-  # AWS Bedrock
-  - model_name: claude-bedrock
+  - model_name: claude-sonnet-4-6
     litellm_params:
-      model: bedrock/anthropic.claude-haiku-4-5-20251001:0
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # AWS Bedrock (Invoke — recommended for Claude Code today, see note below)
+  - model_name: claude-bedrock-opus
+    litellm_params:
+      model: bedrock/invoke/us.anthropic.claude-opus-4-7
       aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
       aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-      aws_region_name: us-east-1
+      aws_region_name: us-west-2
+
+  - model_name: claude-bedrock-sonnet
+    litellm_params:
+      model: bedrock/invoke/us.anthropic.claude-sonnet-4-6
+      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_region_name: us-west-2
+
+  - model_name: claude-bedrock-haiku
+    litellm_params:
+      model: bedrock/invoke/us.anthropic.claude-haiku-4-5-20251001-v1:0
+      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_region_name: us-west-2
 
   # Azure Foundry
-  - model_name: claude-4-azure
+  - model_name: claude-opus-azure
     litellm_params:
-      model: azure_ai/claude-opus-4-1
+      model: azure_ai/claude-opus-4-7
       api_key: os.environ/AZURE_AI_API_KEY
       api_base: os.environ/AZURE_AI_API_BASE # https://my-resource.services.ai.azure.com/anthropic
 
   # Google Vertex AI
-  - model_name: anthropic-vertex
+  - model_name: claude-opus-vertex
     litellm_params:
-      model: vertex_ai/claude-haiku-4-5@20251001
+      model: vertex_ai/claude-opus-4-7
       vertex_ai_project: "my-test-project"
-      vertex_ai_location: "us-east-1"
-      vertex_credentials: os.environ/VERTEX_FILE_PATH_ENV_VAR # os.environ["VERTEX_FILE_PATH_ENV_VAR"] = "/path/to/service_account.json" 
-
-
-
+      vertex_ai_location: "us-east5"
+      vertex_credentials: os.environ/VERTEX_FILE_PATH_ENV_VAR # os.environ["VERTEX_FILE_PATH_ENV_VAR"] = "/path/to/service_account.json"
 
 litellm_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
@@ -244,24 +261,79 @@ litellm_settings:
 Switch between models seamlessly:
 
 ```bash
-# Use Claude for complex reasoning
-claude --model claude-3-5-sonnet-20241022
+# Use Anthropic API directly (newest Claude Code model)
+claude --model claude-opus-4-7
 
-# Use Haiku for fast responses
-claude --model claude-3-5-haiku-20241022
-
-# Use Bedrock deployment
-claude --model claude-bedrock
+# Use Bedrock deployment (Opus 4.7 via Invoke)
+claude --model claude-bedrock-opus
 
 # Use Azure Foundry deployment
-claude --model claude-4-azure
+claude --model claude-opus-azure
 
 # Use Vertex AI deployment
-claude --model anthropic-vertex
+claude --model claude-opus-vertex
 ```
 
 </TabItem>
 </Tabs>
+
+### Bedrock-specific setup for Claude Code
+
+Two extra steps make Claude Code work cleanly against Bedrock through LiteLLM today. Please do both before launching `claude` against a Bedrock-backed model.
+
+:::note Temporary workaround
+
+The Invoke preference and the beta-header flag below are temporary. LiteLLM already re-implements many Anthropic-API features on top of Bedrock inside the gateway, and we're steadily extending that coverage on the Converse path. Soon, these workarounds will no longer be necessary.
+
+:::
+
+#### 1. Prefer Bedrock Invoke
+
+In the config above, Bedrock models use the `bedrock/invoke/<model-id>` prefix — currently the smoother path for Claude Code traffic. If you'd like to try Converse, swap the prefix from `bedrock/invoke/` to `bedrock/converse/` and check the matrix for the feature you need.
+
+#### 2. Disable Claude Code's experimental beta headers for Bedrock
+
+Claude Code attaches Anthropic experimental beta headers (e.g. `anthropic-beta: prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20`) on every request. These work great against Anthropic's first-party API, but Bedrock doesn't currently accept all of them and might return a `400 invalid beta flag` error. Set the **`CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`** environment variable to `1` to strip those headers.
+
+The recommended place to set it is your **global Claude Code user settings file** at:
+
+```
+~/.claude/settings.json
+```
+
+(That's `/Users/<you>/.claude/settings.json` on macOS / Linux, or `C:\Users\<you>\.claude\settings.json` on Windows. All Claude Code clients, incl. CLI, VS Code extension, JetBrains plugin, etc., read from this file.)
+
+**How to edit it:**
+
+1. Open `~/.claude/settings.json` in your editor of choice. If it doesn't exist yet, create it.
+
+   ```bash
+   # macOS / Linux - open with your default editor
+   ${EDITOR:-nano} ~/.claude/settings.json
+
+   # Or with VS Code
+   code ~/.claude/settings.json
+   ```
+
+2. Add (or merge into the existing) `env` block:
+
+   ```json title="~/.claude/settings.json"
+   {
+     "env": {
+       "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"
+     }
+   }
+   ```
+
+3. **Fully quit and reopen Claude Code** so the new setting is picked up. For IDE plugins (VS Code, JetBrains), restart your IDE.
+
+:::tip Alternative: project-scoped or shell-scoped
+
+If you only want to disable beta headers for a single project, put the same `env` block in `.claude/settings.json` (committed) or `.claude/settings.local.json` (gitignored, personal) at the project root.
+
+Shell-level exports also work for the CLI (`export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` before launching `claude`), but **not** IDE plugins.
+
+:::
 
 <Image img={require('../../img/release_notes/claude_code_demo.png')} style={{ width: '500px', height: 'auto' }} />
 


### PR DESCRIPTION
## Summary

Refresh `docs/tutorials/claude_responses_api.md` so the Claude Code quickstart reflects the current Claude Code stack and the recommended path through LiteLLM on Bedrock.

- Updated all examples (Anthropic config, curl, `claude --model`, `ANTHROPIC_DEFAULT_*_MODEL`, `[1m]` context) to **Opus 4.7 / Sonnet 4.6 / Haiku 4.5**.
- Switched the Bedrock entries in the multi-provider config to `bedrock/invoke/<id>` using cross-region inference profile IDs (`us.anthropic.claude-opus-4-7`, etc.).
- New **"Bedrock-specific setup for Claude Code"** subsection with:
  - A single interim-framing note above both steps (LiteLLM is steadily extending Bedrock coverage; the workarounds drop off as the matrix turns green).
  - Step 1 — Prefer Bedrock Invoke; how to swap to Converse if desired.
  - Step 2 — Detailed walkthrough for setting `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` in `~/.claude/settings.json` (including Windows path, IDE plugin behavior, full-restart requirement, and project-/shell-scoped alternatives).
- Linked the [Claude Code × LiteLLM compatibility matrix](https://docs.litellm.ai/docs/claude_code_compatibility) as the live source of truth for per-provider feature support.

## Test plan

- [ ] Build the docs site locally and confirm the quickstart renders cleanly (admonitions, code blocks, tabs).
- [ ] Click-through every link in the changed section (compatibility matrix, internal cross-refs).
- [ ] Sanity-check the `bedrock/invoke/us.anthropic.claude-opus-4-7` config against a real Bedrock account with `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` set in `~/.claude/settings.json`.
- [ ] Verify `claude --model 'claude-opus-4-7[1m]'` example with current Claude Code release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates, though incorrect model IDs or env var guidance could mislead users configuring Bedrock/Claude Code.
> 
> **Overview**
> Updates the `Claude Code Quickstart` tutorial to use newer model examples (Opus 4.7 / Sonnet 4.6 / Haiku 4.5) across the `config.yaml`, `curl` verification, `claude --model`, default model env vars, and `[1m]` context snippets.
> 
> Modernizes the multi-provider section by switching Bedrock examples to `bedrock/invoke/<id>` (and updating regions/IDs), adds a link to the live Claude Code × LiteLLM compatibility matrix, and introduces a new Bedrock-specific subsection recommending Invoke and documenting how to set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` via `~/.claude/settings.json` (with restart and scoping notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79b5cfce27ebd341b05aa1f20763c4ed72ba9996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->