### PR TITLE
docs: add LiteLLM Agent Platform link to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -279,6 +279,11 @@ const config = {
             label: 'Docs',
           },
           {
+            href: 'https://docs.litellm-agent-platform.ai/',
+            label: 'LiteLLM Agent Platform',
+            position: 'left',
+          },
+          {
             type: 'docSidebar',
             sidebarId: 'learnSidebar',
             position: 'left',


### PR DESCRIPTION
Adds a navbar link to the LiteLLM Agent Platform docs.

Placement: between **Docs** and **Learn** in the left navbar group.

Link: https://docs.litellm-agent-platform.ai/