### PR TITLE
docs: move LiteLLM Agent Platform navbar link to end

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -279,11 +279,6 @@ const config = {
             label: 'Docs',
           },
           {
-            href: 'https://docs.litellm-agent-platform.ai/',
-            label: 'LiteLLM Agent Platform',
-            position: 'left',
-          },
-          {
             type: 'docSidebar',
             sidebarId: 'learnSidebar',
             position: 'left',
@@ -302,6 +297,11 @@ const config = {
           },
           { to: '/release_notes', label: 'Changelog', position: 'left' },
           { to: '/blog', label: 'Blog', position: 'left' },
+          {
+            href: 'https://docs.litellm-agent-platform.ai/',
+            label: 'LiteLLM Agent Platform',
+            position: 'left',
+          },
           {
             href: 'https://github.com/BerriAI/litellm',
             position: 'right',


### PR DESCRIPTION
Follow-up to #136.

Moves the **LiteLLM Agent Platform** navbar link from position 2 (between Docs and Learn) to the end of the left navbar group (after Blog), so it sits as the last text link before the right-side icons.

Before: \`Docs   LiteLLM Agent Platform   Learn   Integrations   Enterprise   Changelog   Blog\`

After: \`Docs   Learn   Integrations   Enterprise   Changelog   Blog   LiteLLM Agent Platform\`