### PR TITLE
Remove security update notice from documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,6 @@ import TabItem from '@theme/TabItem';
 import NavigationCards from '@site/src/components/NavigationCards';
 import Image from '@theme/IdealImage';
 
-:::note Security Update
-The Trivy supply-chain compromise has been contained :tada: . All affected packages have been deleted and current releases are free of the compromised code/component. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
-:::
-
 <Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />
 
 **LiteLLM** is an open-source library that gives you a single, unified interface to call 100+ LLMs — OpenAI, Anthropic, Vertex AI, Bedrock, and more — using the OpenAI format.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,10 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::note Security Update
-The Trivy supply-chain compromise has been contained :tada: . All affected packages have been deleted and current releases are free of the compromised code/component. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
-:::
-
 # LiteLLM - Getting Started
 
 https://github.com/BerriAI/litellm


### PR DESCRIPTION
## Summary
This PR removes the security update notice regarding the Trivy supply-chain compromise from the documentation homepage and getting started page. The notice has been removed as the incident has been resolved and is no longer relevant for current users.

## Changes
- Removed the security update notice block from `docs/index.md`
- Removed the security update notice block from `src/pages/index.md`

## Details
The security notice that referenced the contained Trivy supply-chain compromise and directed users to the Security Townhall and CI/CD v2 blog posts has been removed from both documentation entry points. This cleanup reflects that the incident is resolved and the notice is no longer necessary for users visiting the documentation.

https://claude.ai/code/session_01JP57ugB7LUHbsN2iFRJDPy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an informational callout; no runtime code or APIs are affected.
> 
> **Overview**
> Removes the *Security Update* callout about the Trivy supply-chain compromise from both documentation entry points (`docs/index.md` and `src/pages/index.md`), leaving the rest of the Getting Started content unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc080b93debb154771041f4c8ea92c936065f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->