### PR TITLE
chore(compat-matrix): refresh for v1.83.14-stable + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-16T18:32:19Z",
+  "generated_at": "2026-05-16T19:21:06Z",
   "litellm_version": "v1.83.14-stable",
   "claude_code_version": "2.1.126",
   "providers": [
@@ -88,8 +88,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -222,7 +221,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

| Field | Value |
| --- | --- |
| litellm_version | `v1.83.14-stable` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-05-16T19:21:06Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=fail, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.