### PR TITLE
docs: document CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY for /model picker

### DIFF
--- a/docs/tutorials/claude_responses_api.md
+++ b/docs/tutorials/claude_responses_api.md
@@ -143,6 +143,52 @@ export ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5-20251001
 claude
 ```
 
+### Show your LiteLLM models in Claude Code's `/model` picker
+
+By default, the `/model` picker inside Claude Code only lists Anthropic's built-in models — your LiteLLM proxy models won't appear, even after you point `ANTHROPIC_BASE_URL` at the gateway. To populate the picker with the models from your LiteLLM `config.yaml`, set:
+
+```bash
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+```
+
+With this flag enabled, on startup Claude Code calls `GET {ANTHROPIC_BASE_URL}/v1/models` (using the same `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` as inference requests) and adds the returned models to `/model`. Each entry is labeled **"From gateway"** and uses the model's `display_name` when one is provided. Results are cached at `~/.claude/cache/gateway-models.json` and refreshed on each startup.
+
+```bash
+# Launch Claude Code against your LiteLLM proxy with discovery enabled
+export ANTHROPIC_BASE_URL="http://0.0.0.0:4000"
+export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+claude
+# then inside the session:
+/model
+```
+
+**Requirements and caveats:**
+
+- Claude Code **v2.1.129 or later**.
+- Only works when `ANTHROPIC_BASE_URL` points at a gateway exposing the Anthropic Messages format. Discovery does **not** run for Bedrock or Vertex pass-through endpoints, nor when `ANTHROPIC_BASE_URL` is unset or points at `api.anthropic.com`.
+- Only models whose `id` begins with `claude` or `anthropic` are added to the picker. Name your entries in `config.yaml` accordingly (e.g. `claude-opus-4-7`, `claude-bedrock-opus`) so they pass the filter.
+- Discovery is **off by default** so that gateways backed by a shared API key don't surface every model the key can access to every user. Set the flag explicitly per user / shell to opt in.
+- If your gateway uses model names that don't match the filter, fall back to selecting them explicitly via `--model <name>` or the `ANTHROPIC_DEFAULT_*_MODEL` environment variables shown above.
+
+:::tip Persist the setting
+
+To make this stick across sessions, add it to your global Claude Code settings at `~/.claude/settings.json`:
+
+```json title="~/.claude/settings.json"
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1"
+  }
+}
+```
+
+Fully quit and reopen Claude Code (or restart your IDE for plugin users) so the new setting is picked up.
+
+:::
+
+For more detail on how Claude Code discovers gateway models, see Anthropic's [LLM gateway configuration docs](https://docs.anthropic.com/en/docs/claude-code/llm-gateway#model-selection).
+
 ### Using 1M Context Window
 
 Claude Code supports extended context (1 million tokens) using the `[1m]` suffix:


### PR DESCRIPTION
## Summary

Adds a new section to the **Claude Code Quickstart** (`docs/tutorials/claude_responses_api.md`) covering `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, which is required for LiteLLM-proxy models to show up inside Claude Code's `/model` picker.

Without this env var, the picker only lists Anthropic's built-in models even after `ANTHROPIC_BASE_URL` is pointed at the LiteLLM gateway — discovery is off by default upstream so that gateways backed by a shared API key don't surface every accessible model to every user.

The new section explains:

- What the flag does (Claude Code calls `GET {ANTHROPIC_BASE_URL}/v1/models` at startup and adds returned models to `/model`, labeled "From gateway")
- Minimum Claude Code version (**v2.1.129**)
- The `claude` / `anthropic` id-prefix filter that determines which models appear (and the implication for naming entries in `config.yaml`)
- Auth model (re-uses `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`) and cache location (`~/.claude/cache/gateway-models.json`)
- When discovery does **not** run (Bedrock / Vertex pass-through, unset / `api.anthropic.com` base URL)
- How to persist the setting via `~/.claude/settings.json`
- Link to Anthropic's upstream [LLM gateway docs](https://docs.anthropic.com/en/docs/claude-code/llm-gateway#model-selection)

## Test plan

- [ ] `npm run build` renders the Quickstart page cleanly
- [ ] Section anchors / sidebar entry under **AI Tools → Claude Code** still resolve
- [ ] Code blocks and `:::tip` admonition render correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change describing how to enable gateway model discovery in Claude Code; no runtime or API behavior in this repo is modified.
> 
> **Overview**
> Adds a new **Claude Code Quickstart** section explaining how to make LiteLLM gateway models appear in Claude Code’s `/model` picker via `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`.
> 
> Documents how discovery works (startup `GET {ANTHROPIC_BASE_URL}/v1/models`, auth reuse, cache location), plus version requirements, filtering/limitations (gateway-only, `claude`/`anthropic` id prefix), and how to persist the setting in `~/.claude/settings.json` with a link to upstream Anthropic docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaeeea9a2cf4635ee462eb489e34e7a5ef40d54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->