### PR TITLE
docs(mcp): document PROXY_BASE_URL for OAuth invalid_request fix

### DIFF
--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -90,6 +90,64 @@ sequenceDiagram
 
 See the official [MCP Authorization Flow](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-flow-steps) for additional reference.
 
+### Reverse proxy and ingress configuration {#reverse-proxy-and-ingress-configuration}
+
+If LiteLLM runs behind a TLS-terminating ingress (Kubernetes, ALB, nginx, Cloudflare, etc.), the proxy needs to know its public origin so the OAuth `authorize` endpoint can compare the browser-supplied `redirect_uri` (e.g. `https://llm.example.com/ui/mcp/oauth/callback`) against its own scheme + host + port. If the proxy resolves to its internal address (`http://<pod-ip>:4000`) the same-origin check fails and the **Connect** button on the MCP server page returns `400 Bad Request` with `{"detail":"invalid_request"}`.
+
+The simplest and recommended fix is to set `PROXY_BASE_URL` to the exact origin users see in the address bar:
+
+```bash
+PROXY_BASE_URL=https://llm.example.com
+```
+
+Rules for the value:
+
+- Full origin only: scheme + host (+ port if non-default).
+- No trailing slash, no path component.
+- Must match the address bar exactly. `https://llm.example.com` and `https://llm.example.com:443` are accepted as the same origin (the default port is normalized away), but `https://llm.example.com` will not match a browser running against `https://llm.example.com:8443`.
+
+When `PROXY_BASE_URL` is set, LiteLLM uses it directly and skips the `X-Forwarded-*` trust path described below.
+
+#### Origin resolution order
+
+For MCP OAuth endpoints, LiteLLM resolves the proxy's public origin in this order:
+
+1. **`PROXY_BASE_URL` env var** — used verbatim if set to a valid `http(s)` URL. Invalid values are ignored with a warning.
+2. **`X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Port`** — only honored when **both** [`use_x_forwarded_for`](./proxy/config_settings#general_settings---reference) is `true` **and** the request peer's IP falls inside [`mcp_trusted_proxy_ranges`](./proxy/config_settings#general_settings---reference). If `use_x_forwarded_for` is enabled without `mcp_trusted_proxy_ranges`, the headers are not trusted (there is no way to distinguish a trusted reverse proxy from a direct attacker).
+3. **`request.base_url`** — the literal URL FastAPI sees on the request. For ingressed deployments this is typically `http://<internal-host>:4000` and will not match the browser origin.
+
+If you cannot or do not want to set `PROXY_BASE_URL`, configure the X-Forwarded path explicitly:
+
+```yaml title="config.yaml" showLineNumbers
+general_settings:
+  use_x_forwarded_for: true
+  mcp_trusted_proxy_ranges:
+    - "10.0.0.0/8"      # your ingress / load-balancer CIDR(s)
+```
+
+and verify your ingress sends `X-Forwarded-Proto`, `X-Forwarded-Host`, and (if non-default) `X-Forwarded-Port`. See [MCP OAuth troubleshooting](./mcp_troubleshoot#mcp-oauth-invalid-request) for the diagnostic curl.
+
+#### Allowing additional first-party redirect_uri origins {#allowing-additional-first-party-redirect_uri-origins}
+
+If a first-party OAuth client lives on a sister domain (for example, an internal web app on `app.example.com` registering against the MCP proxy on `llm.example.com`), set `MCP_TRUSTED_REDIRECT_ORIGINS` to allowlist its origin in addition to the proxy's own:
+
+```bash
+MCP_TRUSTED_REDIRECT_ORIGINS=app.example.com,*.tools.example.com
+```
+
+- Comma-separated list of `host` or `host:port` entries.
+- HTTPS only. The allowlist path rejects any non-`https` `redirect_uri`.
+- A `*.suffix` entry matches any strictly-deeper subdomain of `suffix` (`*.tools.example.com` matches `a.tools.example.com` but not `tools.example.com`).
+- Loopback (`localhost`, `127.0.0.0/8`, `::1`) is always accepted regardless of this setting.
+
+This is for first-party OAuth clients you control. For the standard ingress case, prefer `PROXY_BASE_URL`.
+
+#### Why the same-origin check exists
+
+The MCP proxy's `/v1/mcp/server/oauth/<server_id>/authorize` endpoint validates that the caller's `redirect_uri` shares scheme + host + port with the proxy's own public origin (or with one of the loopback / allowlisted entries above). The check exists to stop an attacker from phishing a logged-in admin into a link that bounces an authorization code — for an upstream OAuth-protected MCP server such as GitHub or Slack — through an attacker-controlled host. Same-origin (plus an explicit ops allowlist) is the threat-model-safe equivalent of the loopback-only rule used for native MCP clients.
+
+`PROXY_BASE_URL` is the right escape hatch for ingressed deployments because the operator is declaring the proxy's true public origin out of band, rather than asking the proxy to infer it from headers an attacker might be able to set. The check itself is not relaxed.
+
 ## Machine-to-Machine (M2M) Auth
 
 LiteLLM automatically fetches, caches, and refreshes OAuth2 tokens using the `client_credentials` grant. No manual token management required.

--- a/docs/mcp_troubleshoot.md
+++ b/docs/mcp_troubleshoot.md
@@ -92,6 +92,52 @@ LiteLLM performs metadata discovery per the MCP spec ([section 2.3](https://mode
 
 For detailed OAuth2 debugging — including debug header reference, common misconfigurations, and example output — see [Debugging OAuth](./mcp_oauth#debugging-oauth).
 
+### MCP OAuth: Connect returns `{"detail":"invalid_request"}` {#mcp-oauth-invalid-request}
+
+**Symptom.** Clicking **Connect** on an MCP OAuth server in the LiteLLM UI returns:
+
+```
+HTTP/1.1 400 Bad Request
+{"detail":"invalid_request"}
+```
+
+The proxy logs (with verbose logging) show a line like `MCP OAuth: rejecting redirect_uri ... as invalid_request. Computed proxy base=...`.
+
+**Cause.** The `/v1/mcp/server/oauth/{server_id}/authorize` endpoint validates that the browser-supplied `redirect_uri` (`https://llm.example.com/ui/mcp/oauth/callback`) shares scheme + host + port with the proxy's own public origin. Behind a TLS-terminating ingress (Kubernetes, ALB, nginx, Cloudflare, etc.) the proxy resolves to its internal address (`http://<pod-ip>:4000`) by default, so the same-origin check rejects.
+
+**Diagnostic.** Compare what the proxy advertises as its origin to what the browser sees:
+
+```bash
+curl -sS https://llm.example.com/.well-known/oauth-authorization-server | jq .issuer
+```
+
+The `issuer` value should equal the origin the user types into their browser (`https://llm.example.com`). If it returns an internal hostname or `http://...`, the proxy's resolved origin is wrong.
+
+**Fixes**, in order of preference:
+
+1. **Set `PROXY_BASE_URL`** (recommended). Operator declares the proxy's true public origin out of band, no header trust required:
+
+   ```bash
+   PROXY_BASE_URL=https://llm.example.com
+   ```
+
+   Full origin only: scheme + host (+ port if non-default), no trailing slash, no path. See [Reverse proxy and ingress configuration](./mcp_oauth#reverse-proxy-and-ingress-configuration).
+
+2. **Trust `X-Forwarded-*` from your ingress.** Set both keys in `general_settings`:
+
+   ```yaml title="config.yaml" showLineNumbers
+   general_settings:
+     use_x_forwarded_for: true
+     mcp_trusted_proxy_ranges:
+       - "10.0.0.0/8"      # your ingress / load-balancer CIDR(s)
+   ```
+
+   `use_x_forwarded_for` alone is not enough — without `mcp_trusted_proxy_ranges`, the proxy refuses to honor `X-Forwarded-*` because it cannot tell a trusted reverse proxy from a direct attacker. Verify that your ingress sends `X-Forwarded-Proto`, `X-Forwarded-Host`, and (when running on a non-default port) `X-Forwarded-Port`.
+
+3. **Fix the ingress.** If the ingress is stripping or rewriting `X-Forwarded-*`, no proxy setting will help — restore the headers at the ingress layer.
+
+If the `redirect_uri` legitimately lives on a sister domain you control (e.g. an internal web app registering as an OAuth client of the MCP proxy), allowlist its origin via `MCP_TRUSTED_REDIRECT_ORIGINS`. See [Allowing additional first-party redirect_uri origins](./mcp_oauth#allowing-additional-first-party-redirect_uri-origins).
+
 ## Verify Connectivity
 
 Run lightweight validations before impacting production traffic.

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -259,7 +259,7 @@ router_settings:
 | alert_types | List[str] | Control list of alert types to send to slack (Doc on alert types)[./alerting.md] |
 | enforced_params | List[str] | (Enterprise Feature) List of params that must be included in all requests to the proxy |
 | enable_oauth2_auth | boolean | (Enterprise Feature) If true, enables oauth2.0 authentication on LLM + info routes |
-| use_x_forwarded_for | str | If true, uses the X-Forwarded-For header to get the client IP address |
+| use_x_forwarded_for | str | If true, uses the `X-Forwarded-For` header to derive the client IP and (for MCP OAuth) the proxy's public origin from `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Port`. For MCP OAuth, headers are honored only when `mcp_trusted_proxy_ranges` is also set and the request peer's IP falls inside one of those CIDRs. For ingressed deployments, prefer [`PROXY_BASE_URL`](#environment-variables---reference). See [MCP OAuth — Reverse proxy and ingress configuration](../mcp_oauth#reverse-proxy-and-ingress-configuration). |
 | service_account_settings | List[Dict[str, Any]] | Set `service_account_settings` if you want to create settings that only apply to service account keys (Doc on service accounts)[./service_accounts.md] | 
 | image_generation_model | str | The default model to use for image generation - ignores model set in request |
 | store_model_in_db | boolean | If true, enables storing model + credential information in the DB. |
@@ -320,7 +320,7 @@ router_settings:
 | mcp_client_side_auth_header_name | string | HTTP header name for client-side MCP server credentials |
 | mcp_internal_ip_ranges | list | CIDR ranges considered internal for non-public MCP server access control |
 | mcp_required_fields | list | List of required field names for MCP server submissions |
-| mcp_trusted_proxy_ranges | list | CIDR ranges of proxies trusted to forward X-Forwarded-For headers for MCP |
+| mcp_trusted_proxy_ranges | list | CIDR ranges of proxies trusted to forward `X-Forwarded-*` headers for MCP. Required (in addition to `use_x_forwarded_for: true`) for the MCP OAuth `authorize` endpoint to derive its public origin from those headers. Without this, headers are ignored and the proxy falls back to the request's literal base URL. For ingressed deployments, prefer [`PROXY_BASE_URL`](#environment-variables---reference). See [MCP OAuth — Reverse proxy and ingress configuration](../mcp_oauth#reverse-proxy-and-ingress-configuration). |
 | require_end_user_mcp_access_defined | boolean | If true, requires end users to have explicit MCP access permissions defined |
 | role_permissions | list | List of role-based permission configurations |
 | search_tools | list | List of search tool configurations for enabling web search capabilities |
@@ -642,6 +642,7 @@ router_settings:
 | MCP_PER_USER_TOKEN_DEFAULT_TTL | Default TTL in seconds for per-user MCP OAuth tokens stored in Redis. Default is 43200 (12 hours)
 | MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS | Seconds to subtract from per-user MCP OAuth token expiry when computing Redis TTL. Default is 60
 | MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE | Maximum number of entries in the MCP OAuth2 token exchange cache. Default is 500
+| MCP_TRUSTED_REDIRECT_ORIGINS | Comma-separated allowlist of additional `redirect_uri` origins accepted by the MCP OAuth `authorize` endpoint, beyond same-origin and loopback. Each entry is `host` or `host:port`; a `*.suffix` prefix matches any strictly-deeper subdomain. HTTPS only. Use this for first-party OAuth clients on sister domains (e.g. `app.example.com`). For ingressed deployments where the proxy's own origin is wrong, set [`PROXY_BASE_URL`](#environment-variables---reference) instead. See [MCP OAuth — Reverse proxy and ingress configuration](../mcp_oauth#reverse-proxy-and-ingress-configuration).
 | DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT | Default token count for mock response completions. Default is 20
 | DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT | Default token count for mock response prompts. Default is 10
 | DEFAULT_MODEL_CREATED_AT_TIME | Default creation timestamp for models. Default is 1677610602
@@ -1035,7 +1036,7 @@ router_settings:
 | PROMETHEUS_URL | URL for Prometheus service
 | PROMPTLAYER_API_KEY | API key for PromptLayer integration
 | PROXY_ADMIN_ID | Admin identifier for proxy server
-| PROXY_BASE_URL | Base URL for proxy service
+| PROXY_BASE_URL | Base URL for proxy service. Also used by the MCP OAuth `authorize` endpoint as the proxy's public origin when validating browser-supplied `redirect_uri` values — set this to the exact origin users see in their address bar (e.g. `https://llm.example.com`) when LiteLLM runs behind a TLS-terminating ingress. Full origin only: scheme + host (+ port if non-default), no trailing slash, no path. When set, it takes precedence over `X-Forwarded-*` headers (which only apply when [`use_x_forwarded_for`](#general_settings---reference) is `true` AND the request peer is in [`mcp_trusted_proxy_ranges`](#general_settings---reference)). See [MCP OAuth — Reverse proxy and ingress configuration](../mcp_oauth#reverse-proxy-and-ingress-configuration).
 | PROXY_BATCH_WRITE_AT | Time in seconds to wait before batch writing spend logs to the database. Default is 10
 | PROXY_BATCH_POLLING_INTERVAL | Time in seconds to wait before polling a batch, to check if it's completed. Default is 6000s (1 hour)
 | PROXY_BATCH_POLLING_ENABLED | Set to `false` to disable the `CheckBatchCost` and `CheckResponsesCost` background polling jobs entirely. Useful for emergency mitigation on installs with large numbers of stale managed objects. Default is `true`


### PR DESCRIPTION
## Summary

Documents the new optional `PROXY_BASE_URL` env var added in [BerriAI/litellm#28086](https://github.com/BerriAI/litellm/pull/28086), which lets operators behind a TLS-terminating ingress (Kubernetes, ALB, nginx, Cloudflare, etc.) bypass the `X-Forwarded-*` trust dance for MCP OAuth same-origin redirect_uri validation.

The bug being documented: customers on `v1.83.14-stable.patch.3`, `v1.84.x`, and `v1.85.0-rc.x` see `400 Bad Request {"detail":"invalid_request"}` when clicking **Connect** on an MCP OAuth server in the UI, because the proxy resolves its own origin to the internal pod address (`http://<pod-ip>:4000`) and that fails the same-origin check against the browser's `https://llm.example.com/ui/mcp/oauth/callback` redirect_uri. `PROXY_BASE_URL` lets operators declare the public origin directly.

## What's documented

- **`docs/mcp_oauth.md`** — new **Reverse proxy and ingress configuration** section under Interactive OAuth, covering:
  - `PROXY_BASE_URL` as the recommended fix (full origin, no trailing slash, no path).
  - The full origin-resolution order: `PROXY_BASE_URL` → `X-Forwarded-*` (gated by `use_x_forwarded_for: true` AND `mcp_trusted_proxy_ranges`) → `request.base_url`.
  - The `MCP_TRUSTED_REDIRECT_ORIGINS` env var for first-party OAuth clients on sister domains (HTTPS-only, comma-separated `host[:port]`, `*.suffix` wildcards).
  - "Why this check exists" sidebar explaining the phishing/code-theft threat that motivates same-origin enforcement, and why `PROXY_BASE_URL` is the right escape hatch (operator declares truth) rather than relaxing the check.
- **`docs/mcp_troubleshoot.md`** — new entry containing the literal string `{"detail":"invalid_request"}` (so it's findable by Google), with the `/.well-known/oauth-authorization-server` diagnostic and three fixes in order of preference (`PROXY_BASE_URL`; `use_x_forwarded_for` + `mcp_trusted_proxy_ranges`; fix the ingress).
- **`docs/proxy/config_settings.md`** — expanded `PROXY_BASE_URL`, `use_x_forwarded_for`, and `mcp_trusted_proxy_ranges` entries to call out the new MCP OAuth interaction; added `MCP_TRUSTED_REDIRECT_ORIGINS` to the env-var reference. All cross-linked to the new MCP OAuth section.

## Reviewer-runnable diagnostic

The `curl` from the troubleshooting entry — for any deployment behind an ingress, the `issuer` should equal what users type in their address bar:

```bash
curl -sS https://llm.example.com/.well-known/oauth-authorization-server | jq .issuer
```

If it returns the internal hostname or `http://...`, set `PROXY_BASE_URL` and re-run.

## Verification

- `npm run build` succeeds locally with Docusaurus 3.8.1; broken-link/anchor count is unchanged from `main` (166 pre-existing → 166 post-change), and none of the pre-existing warnings touch the three pages this PR modifies.
- All new cross-references resolve: `mcp_oauth#reverse-proxy-and-ingress-configuration`, `mcp_oauth#allowing-additional-first-party-redirect_uri-origins`, `mcp_troubleshoot#mcp-oauth-invalid-request`, and the `config_settings.md` intra-page anchors using the existing auto-generated slugs (`#general_settings---reference`, `#environment-variables---reference`).

## Not included

- **Release-notes line.** The fix lands in a release after `v1.84.0` (already published) — likely `v1.85.0`. Since that release-notes page does not exist yet in this repo, I have not added a changelog entry. The release author should add a one-liner under "Bug Fixes" or "Improvements" referencing PR #28086 and pointing at the new MCP OAuth section when cutting `v1.85.0`.

## Test plan

- [ ] Run `npm run build` and confirm zero net-new broken anchors/links.
- [ ] Spot-check the rendered pages: `/docs/mcp_oauth#reverse-proxy-and-ingress-configuration`, `/docs/mcp_troubleshoot#mcp-oauth-invalid-request`, the three updated rows in `/docs/proxy/config_settings`.
- [ ] Confirm the troubleshooting entry's literal `{"detail":"invalid_request"}` appears in the rendered HTML so search engines pick it up.
- [ ] Confirm cross-links between the three pages resolve in the rendered site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify configuration for MCP OAuth behind TLS-terminating ingresses; no runtime behavior is modified.
> 
> **Overview**
> Adds a new **Reverse proxy and ingress configuration** section to `docs/mcp_oauth.md` explaining how MCP OAuth `redirect_uri` same-origin validation can fail behind TLS-terminating ingresses, and documents `PROXY_BASE_URL` as the recommended fix (with origin resolution precedence and required `X-Forwarded-*` + `mcp_trusted_proxy_ranges` conditions).
> 
> Extends troubleshooting docs with a new entry for the `400 {"detail":"invalid_request"}` **Connect** failure, including an `/.well-known/oauth-authorization-server` `issuer` diagnostic and ordered remediation steps, plus documents `MCP_TRUSTED_REDIRECT_ORIGINS` for first-party sister-domain redirect allowlisting.
> 
> Updates `docs/proxy/config_settings.md` reference text to reflect these MCP OAuth interactions, expanding `use_x_forwarded_for`, `mcp_trusted_proxy_ranges`, and `PROXY_BASE_URL`, and adding `MCP_TRUSTED_REDIRECT_ORIGINS` to the env-var table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb06d0d333a34e28c02db7c99c4850dc19068f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->