### PR TITLE
docs: add orphaned Token Counting page to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -735,6 +735,7 @@ const sidebars = {
             "anthropic_unified/messages_to_responses_mapping",
           ]
         },
+        "count_tokens",
         "anthropic_count_tokens",
         "moderation",
         "ocr",


### PR DESCRIPTION
## Summary

`docs/count_tokens.md` exists in the repo but is not referenced anywhere in `sidebars.js`, can only land on it via a direct URL.

This PR wires it into the **Supported Endpoints** section, right before the existing `anthropic_count_tokens` entry. The two pages are complementary, not duplicates:

| Page | Scope |
|------|-------|
| `count_tokens` (this PR) | General Token Counting feature: SDK `litellm.acount_tokens()` + both proxy endpoints (`/v1/messages/count_tokens`, `/v1/responses/input_tokens`), multi-provider (OpenAI, Anthropic, Vertex, Bedrock, Gemini) |
| `anthropic_count_tokens` (already in sidebar) | Endpoint-specific reference for `/v1/messages/count_tokens` (Anthropic format only) |
