### PR TITLE
docs: reschedule May Town Hall (May 18 → May 19)

### DIFF
--- a/blog/may_townhall_announcement/index.md
+++ b/blog/may_townhall_announcement/index.md
@@ -1,18 +1,24 @@
 ---
 slug: may-townhall-announcement
 title: "May Townhall: Product + Roadmap Updates"
-date: 2026-05-18T07:30:00
+date: 2026-05-19T07:30:00
 authors:
   - krrish
   - ishaan-alt
-description: "Join the LiteLLM May townhall on Monday, 18 May at 7:30 AM PST to learn about LiteLLM's product updates and roadmap."
+description: "Join the LiteLLM May townhall on Tuesday, 19 May at 7:30 AM PST to learn about LiteLLM's product updates and roadmap."
 tags: [announcement, townhall]
 hide_table_of_contents: true
 ---
 
 import Image from '@theme/IdealImage';
 
-We are hosting our May townhall on **Monday, 18 May at 7:30 AM PST**.
+:::note Rescheduled
+
+Apologies — due to technical difficulties, the May townhall has been moved from Monday, 18 May to **Tuesday, 19 May at 7:30 AM PST**. Thanks for your patience!
+
+:::
+
+We are hosting our May townhall on **Tuesday, 19 May at 7:30 AM PST**.
 
 <Image
   img={require('../../img/may_townhall_banner.png')}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -260,9 +260,9 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       announcementBar: {
-        id: 'may_townhall_2026',
+        id: 'may_townhall_2026_rescheduled',
         content:
-          '📅 <strong>LiteLLM May Town Hall</strong> — Monday, May 18 at 7:30 AM PST. Hear product updates, roadmap, and Q&A. <a href="https://forms.gle/rVeiTtpY96EKLT9i9" target="_blank" rel="noopener noreferrer">Register now →</a>',
+          '📅 <strong>LiteLLM May Town Hall — rescheduled.</strong> Apologies, due to technical difficulties the Town Hall has moved from Monday, May 18 to <strong>Tuesday, May 19 at 7:30 AM PST</strong>. Thanks for your patience! <a href="https://forms.gle/rVeiTtpY96EKLT9i9" target="_blank" rel="noopener noreferrer">Register now →</a>',
         backgroundColor: '#0078d4',
         textColor: '#ffffff',
         isCloseable: false,


### PR DESCRIPTION
## Summary

The LiteLLM May Town Hall has been moved from **Monday, May 18** to **Tuesday, May 19 at 7:30 AM PST** due to technical difficulties.

## Changes

- **Announcement banner** (`docusaurus.config.js`): updated copy to apologize and announce the new date; bumped the banner `id` to `may_townhall_2026_rescheduled` so the new message shows for everyone (Docusaurus tracks dismissals by `id`).
- **May Town Hall blog post** (`blog/may_townhall_announcement/index.md`): updated frontmatter `date`, `description`, and body to May 19; added a "Rescheduled" admonition with an apology.