### PR TITLE
docs: document LITELLM_USE_LEGACY_INTERACTIONS_SCHEMA env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -912,6 +912,7 @@ router_settings:
 | LITELLM_TOKEN | Access token for LiteLLM integration
 | LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES | When set to "true", routes OpenAI /v1/messages requests through chat/completions instead of the Responses API for Anthropic models. Can also be set via `litellm_settings.use_chat_completions_url_for_anthropic_messages`
 | LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES | When set to "true", routes all OpenAI /chat/completions requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via `litellm_settings.route_all_chat_openai_to_responses`
+| LITELLM_USE_LEGACY_INTERACTIONS_SCHEMA | When set to "true", sends `Api-Revision: 2026-05-07` to Google so the Interactions API returns the legacy `outputs` schema instead of the new `steps` schema. Can also be set via `general_settings.use_legacy_interactions_schema`. Default is "false". Remove this flag after June 8, 2026.
 | LITELLM_USER_AGENT | Custom user agent string for LiteLLM API requests. Used for partner telemetry attribution
 | LITELLM_WORKER_STARTUP_HOOKS | Comma-separated list of `module.path:function_name` callables to run in each worker process during startup. Runs early in the worker lifecycle (before config/DB loading). Useful for re-initializing per-process state like [gflags](https://github.com/google/python-gflags). See [Worker Startup Hooks](/proxy/worker_startup_hooks) for details
 | LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD | If true, prints the standard logging payload to the console - useful for debugging


### PR DESCRIPTION
Adds the `LITELLM_USE_LEGACY_INTERACTIONS_SCHEMA` env var (introduced in BerriAI/litellm#28153) to the environment variables reference, unblocking the documentation validation CI check on that PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change adding a new environment variable entry; no runtime or configuration logic is modified.
> 
> **Overview**
> Documents the new `LITELLM_USE_LEGACY_INTERACTIONS_SCHEMA` environment variable in `docs/proxy/config_settings.md`, explaining that it forces Google Interactions API to return the legacy `outputs` schema (via `Api-Revision: 2026-05-07`) and noting the corresponding `general_settings.use_legacy_interactions_schema` toggle and planned removal date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479e54c72fa4fc03f8d13b17db18254469116fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->