### PR TITLE
docs(vantage): add organization fields to FOCUS field mapping

### DIFF
--- a/docs/observability/vantage.md
+++ b/docs/observability/vantage.md
@@ -129,8 +129,10 @@ LiteLLM spend data is transformed into the FOCUS 1.2 schema:
 | `api_key_alias` | BillingAccountName | Human-readable key alias |
 | `team_id` | SubAccountId | Team identifier |
 | `team_alias` | SubAccountName | Team name |
+| `organization_id` | Tags | Organization identifier (resolved from API key or team) |
+| `organization_alias` | Tags | Organization display name |
 
-Additional metadata (user_id, model_group, etc.) is included in the `Tags` column as JSON.
+Additional metadata (`user_id`, `user_email`, `model`, `model_group`, etc.) is also included in the `Tags` column as JSON.
 
 ## Upload Limits
 


### PR DESCRIPTION
## Summary

- Document `organization_id` and `organization_alias` in the Vantage FOCUS field mapping table
- Clarify these fields are exported in the `Tags` JSON column (resolved from API key or team)

Companion to code PR: https://github.com/BerriAI/litellm/pull/28184

## Test plan

- [x] Preview docs change locally (markdown table renders correctly)
- [ ] Verify on docs site after merge


Made with [Cursor](https://cursor.com)