### PR TITLE
docs: AgentCOGS integration (env vars + observability page)

### DIFF
--- a/docs/observability/agentcogs.md
+++ b/docs/observability/agentcogs.md
@@ -1,0 +1,72 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# AgentCOGS - Per-customer margin
+
+[AgentCOGS](https://github.com/vaibhav11123/agentcogs) tracks per-customer LLM cost and gross margin for B2B SaaS (cost + revenue), alongside your existing proxy and observability stack.
+
+## Quick Start
+
+Use one line to send successful completion cost to AgentCOGS:
+
+Get your AgentCOGS [API key and workspace id](https://github.com/vaibhav11123/agentcogs/blob/main/docs/quickstart.md).
+
+```python
+litellm.success_callback = ["agentcogs"]
+```
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import litellm
+import os
+
+os.environ["AGENTCOGS_API_KEY"] = ""
+os.environ["AGENTCOGS_WORKSPACE_ID"] = ""
+os.environ["AGENTCOGS_ENDPOINT"] = "https://api.agentcogs.dev"  # optional
+
+litellm.success_callback = ["agentcogs"]
+
+response = litellm.completion(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hi"}],
+    user="your_customer_id",  # B2B tenant id → AgentCOGS customer_id
+    metadata={"agentcogs_workflow_id": "support_bot"},
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+litellm_settings:
+  callbacks: ["agentcogs"]
+```
+
+Set `AGENTCOGS_API_KEY`, `AGENTCOGS_WORKSPACE_ID`, and optionally `AGENTCOGS_ENDPOINT` in the proxy environment.
+
+</TabItem>
+</Tabs>
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AGENTCOGS_API_KEY` | Yes | Workspace API key (`acg_live_...`) |
+| `AGENTCOGS_WORKSPACE_ID` | Yes | Workspace UUID |
+| `AGENTCOGS_ENDPOINT` | No | API base URL (default `https://api.agentcogs.dev`) |
+| `AGENTCOGS_CHARGE_BY` | No | Proxy attribution: `end_user_id` (default), `user_id`, `team_id` — same as [Lago](./lago.md) |
+
+## Tenant attribution
+
+**Proxy:** Uses `AGENTCOGS_CHARGE_BY` (default `end_user_id` from request `user` in proxy body). Client `metadata.agentcogs_customer_id` is not trusted on proxy traffic.
+
+**SDK / direct:** Pass `user=` on each completion, or `metadata.agentcogs_customer_id`.
+
+Completions without a resolvable customer id are skipped (non-blocking).
+
+## Learn more
+
+- [AgentCOGS quickstart](https://github.com/vaibhav11123/agentcogs/blob/main/docs/quickstart.md)
+- [User-landed callback](https://github.com/vaibhav11123/agentcogs/blob/main/docs/integrations/litellm.md)

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -433,6 +433,10 @@ router_settings:
 | AGENTOPS_ENVIRONMENT | Environment for AgentOps logging integration
 | AGENTOPS_API_KEY | API Key for AgentOps logging integration
 | AGENTOPS_SERVICE_NAME | Service Name for AgentOps logging integration
+| AGENTCOGS_API_KEY | API key for [AgentCOGS](../observability/agentcogs.md) per-customer margin tracking
+| AGENTCOGS_CHARGE_BY | Proxy tenant attribution for AgentCOGS (`end_user_id`, `user_id`, or `team_id`). Default is `end_user_id`
+| AGENTCOGS_ENDPOINT | Base URL for AgentCOGS ingest API. Default is `https://api.agentcogs.dev`
+| AGENTCOGS_WORKSPACE_ID | Workspace UUID for AgentCOGS
 | AISPEND_ACCOUNT_ID | Account ID for AI Spend
 | AISPEND_API_KEY | API Key for AI Spend
 | AIOHTTP_CONNECTOR_LIMIT | Connection limit for aiohttp connector. When set to 0, no limit is applied. **Default is 0**


### PR DESCRIPTION
## Summary

Documents the AgentCOGS community callback for [BerriAI/litellm#28255](https://github.com/BerriAI/litellm/pull/28255).

## Changes

- `docs/observability/agentcogs.md` — quickstart (SDK + proxy), env vars, tenant attribution
- `docs/proxy/config_settings.md` — `AGENTCOGS_API_KEY`, `AGENTCOGS_WORKSPACE_ID`, `AGENTCOGS_ENDPOINT`, `AGENTCOGS_CHARGE_BY`

## Why separate PR

LiteLLM main repo policy: integration docs and env reference live in **litellm-docs** only (required for CI `test_env_keys`).

## Test plan

- [ ] Docs build locally (if applicable)
- [ ] Merge before or with litellm#28255 so documentation CI passes


Made with [Cursor](https://cursor.com)