### PR TITLE
docs(claude-code): document CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY for /model switching

### DIFF
--- a/docs/tutorials/claude_non_anthropic_models.md
+++ b/docs/tutorials/claude_non_anthropic_models.md
@@ -237,6 +237,40 @@ claude --model anthropic-vertex
 claude --model azure-gpt-4
 ```
 
+### 6. Switch Models at Runtime with `/model`
+
+Once Claude Code is running, you can switch between any of the models exposed by your LiteLLM proxy using the built-in `/model` command. By default the picker only shows Anthropic's hardcoded models, so to populate it with the models from your LiteLLM proxy you must opt in to **gateway model discovery**.
+
+Set the following environment variable before launching Claude Code:
+
+```bash
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+```
+
+On startup, Claude Code will call `GET /v1/models` against your `ANTHROPIC_BASE_URL` (your LiteLLM proxy) and add each returned model to the `/model` picker, labeled **From gateway**. Inside Claude Code, run:
+
+```
+/model
+```
+
+and select any LiteLLM-managed model (`gpt-4o`, `gemini-3.0-flash-exp`, `anthropic-vertex`, etc.) to switch without restarting the session.
+
+:::info Requirements
+
+- Claude Code **v2.1.129** or later.
+- `ANTHROPIC_BASE_URL` must point at a gateway that serves the Anthropic Messages API format — LiteLLM does this on `/v1/messages`.
+- Discovery is opt-in. Without `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, Claude Code will not query your proxy's `/v1/models`.
+
+:::
+
+:::tip Surface only specific models
+
+If you only want a subset of your LiteLLM models to show up in the `/model` picker, issue a [virtual key](../proxy/virtual_keys) scoped to those models and use that key as `ANTHROPIC_AUTH_TOKEN`. `/v1/models` will only return models the key can access.
+
+You can also add individual model entries manually via `ANTHROPIC_CUSTOM_MODEL_OPTION` instead of (or in addition to) enabling discovery.
+
+:::
+
 ## How It Works
 
 LiteLLM acts as a unified interface that:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds documentation for using Claude Code's `/model` command to switch between LiteLLM-managed models at runtime, which requires the opt-in `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` environment variable.

## Context

From #eng on Slack — users hit a Claude Code quirk where the `/model` picker only lists Anthropic's hardcoded models even when pointed at a LiteLLM proxy serving many providers. Claude Code v2.1.129+ ships an opt-in gateway-discovery flag that makes it query the gateway's `/v1/models` and populate the picker, but we had no docs covering it.

## Changes

- `docs/tutorials/claude_non_anthropic_models.md`: new "Switch Models at Runtime with `/model`" section under the existing non-Anthropic-models tutorial, since that is where users already learn to point Claude Code at LiteLLM. Covers:
  - Setting `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`.
  - How discovery uses `GET /v1/models` against `ANTHROPIC_BASE_URL`.
  - Minimum Claude Code version (v2.1.129).
  - Scoping the picker via a LiteLLM virtual key, plus the `ANTHROPIC_CUSTOM_MODEL_OPTION` fallback for manual entries.

No other files touched; no sidebar changes needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1779233419469089?thread_ts=1779233419.469089&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-ea234597-a600-4dd8-ac8d-e54501ca84c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea234597-a600-4dd8-ac8d-e54501ca84c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

