### PR TITLE
docs(blog): deprecate main-stable in cleaner-release-versions (cutover Jun 30 2026)

### DIFF
--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -9,6 +9,16 @@ tags: [release, packaging, docker]
 hide_table_of_contents: false
 ---
 
+*Last Updated: May 2026*
+
+:::info The rolling `main-stable` Docker tag is still being updated — that's intentional
+`main-stable` is a **moving pointer** tag (like `:latest`, but for stable releases). It advances to the newest stable image each week and exists for users who want "always the latest stable" without re-pinning — that's why you continue to see it updated.
+
+It is unrelated to the per-release `-stable` *suffix* on immutable tags (e.g. `v1.83.3-stable`) being dropped from new version names below. Existing deployments that pull `ghcr.io/berriai/litellm:main-stable` (and the equivalent `docker.litellm.ai/berriai/litellm:main-stable`) keep working unchanged.
+
+For reproducible production deploys, pin to a content tag like `ghcr.io/berriai/litellm:1.84.0` instead of the rolling pointer.
+:::
+
 LiteLLM release version names are changing. Two pain points have been driving this:
 
 **1. The `-stable` and `-nightly` suffixes aren't standard.**

--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -11,12 +11,18 @@ hide_table_of_contents: false
 
 *Last Updated: May 2026*
 
-:::info The rolling `main-stable` Docker tag is still being updated — that's intentional
-`main-stable` is a **moving pointer** tag (like `:latest`, but for stable releases). It advances to the newest stable image each week and exists for users who want "always the latest stable" without re-pinning — that's why you continue to see it updated.
+:::warning `main-stable` is deprecated — migrate to `:latest` by June 30, 2026
+The legacy `main-stable` Docker tag still advances each week so existing deployments keep working, but **we plan to stop publishing it on June 30, 2026 (end of Q2)**. Going forward, **`:latest`** is the canonical rolling pointer to the newest stable image — it advances automatically when each stable ships and matches the standard Docker convention.
 
-It is unrelated to the per-release `-stable` *suffix* on immutable tags (e.g. `v1.83.3-stable`) being dropped from new version names below. Existing deployments that pull `ghcr.io/berriai/litellm:main-stable` (and the equivalent `docker.litellm.ai/berriai/litellm:main-stable`) keep working unchanged.
+`main-stable` carries over from the previous naming scheme and doesn't fit modern conventions: it mixes "main" (typically a development branch) with "stable" (a release channel), and has no PyPI counterpart.
 
-For reproducible production deploys, pin to a content tag like `ghcr.io/berriai/litellm:1.84.0` instead of the rolling pointer.
+**Migration:**
+
+- **Rolling stable (Docker)** → `ghcr.io/berriai/litellm:latest`
+- **Reproducible pin (Docker)** → `ghcr.io/berriai/litellm:1.84.0`
+- **Reproducible pin (PyPI)** → `pip install litellm==1.84.0`
+
+This banner will be updated with reminders as the cutover approaches.
 :::
 
 LiteLLM release version names are changing. Two pain points have been driving this:


### PR DESCRIPTION
## Summary

Adds a deprecation banner + last-updated stamp to the [Cleaner Release Versions](https://docs.litellm.ai/blog/cleaner-release-versions) blog post.

The legacy `main-stable` Docker tag has been a recurring source of confusion since the cleaner-release-versions cutover: users see it still advancing each week and assume the version-naming change in this post didn't actually ship. `main-stable` is in fact a separate concept — a rolling-pointer alias to the newest stable image — but it predates the new naming scheme and conflicts with the standard Docker convention for that role (`:latest`).

This PR commits to deprecating `main-stable` and points users at the replacement:

- **Cutover date:** June 30, 2026 (end of Q2).
- **Replacement rolling pointer:** `ghcr.io/berriai/litellm:latest` (already published per the lower section of this same post).
- **Recommended for production:** pin to a content tag (`:1.84.0`, etc.) — the post already calls this out.

The banner is placed above `<!-- truncate -->` so it shows up in the blog index preview, and the closing line promises in-banner reminders as the cutover approaches (rather than a post-cutover follow-up, which would be too late). The `*Last Updated: May 2026*` line matches the style already used by `redis_circuit_breaker` and `componentized_deployment`.

## Follow-ups (separate PRs)

- Update the in-repo `main-stable` references in the litellm proxy repo (`render.yaml`, `docker-compose.yml`, `terraform/litellm/README.md`, `docker/README.md`) to `:latest` before the cutover, so the deployment recipes don't contradict this banner.

## Test plan

- [ ] Local \`npm run start\` renders the \`:::warning\` admonition correctly above the post intro
- [ ] Banner appears in the blog index preview (placed above \`<!-- truncate -->\`)