### PR TITLE
chore(docs): remove May 2026 Town Hall announcement banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -259,14 +259,6 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      announcementBar: {
-        id: 'may_townhall_2026_rescheduled',
-        content:
-          '📅 <strong>LiteLLM May Town Hall — rescheduled.</strong> Apologies, due to technical difficulties the Town Hall has moved from Monday, May 18 to <strong>Tuesday, May 19 at 7:30 AM PST</strong>. Thanks for your patience! <a href="https://forms.gle/rVeiTtpY96EKLT9i9" target="_blank" rel="noopener noreferrer">Register now →</a>',
-        backgroundColor: '#0078d4',
-        textColor: '#ffffff',
-        isCloseable: false,
-      },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.png',
       navbar: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the site-wide announcement banner advertising the rescheduled LiteLLM May Town Hall (May 19, 2026), as the event has passed.

### Changes
- Drop the `announcementBar` block (id `may_townhall_2026_rescheduled`) from `docusaurus.config.js`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1779289926190729?thread_ts=1779289926.190729&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-fb0a8228-efb9-57b1-ba45-20f06e524643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0a8228-efb9-57b1-ba45-20f06e524643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

