### PR TITLE
docs(blog): pin managed agents and Gemini 3.5 Flash to v1.87.0-dev.1

### DIFF
--- a/blog/gemini_3_5_flash/index.md
+++ b/blog/gemini_3_5_flash/index.md
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 LiteLLM now supports `gemini-3.5-flash` with full day 0 support!
 
 :::note
-If you only want cost tracking, you need no change in your current LiteLLM version. But if you want support for new features introduced with this release — thinking levels, strict function-call IDs, and thought signatures — upgrade to the latest LiteLLM release.
+If you only want cost tracking, you need no change in your current LiteLLM version. But if you want support for new features introduced with this release — thinking levels, strict function-call IDs, and thought signatures — use `v1.87.0-dev.1` or above.
 :::
 
 {/* truncate */}
@@ -34,7 +34,7 @@ If you only want cost tracking, you need no change in your current LiteLLM versi
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-ghcr.io/berriai/litellm:main-stable
+ghcr.io/berriai/litellm:v1.87.0-dev.1
 ```
 
 </TabItem>
@@ -42,7 +42,7 @@ ghcr.io/berriai/litellm:main-stable
 <TabItem value="pip" label="Pip">
 
 ``` showLineNumbers title="pip install litellm"
-pip install litellm --upgrade
+pip install litellm==1.87.0.dev1
 ```
 
 </TabItem>

--- a/blog/google_ai_studio_managed_agents/index.md
+++ b/blog/google_ai_studio_managed_agents/index.md
@@ -17,6 +17,35 @@ import TabItem from '@theme/TabItem';
 
 LiteLLM now supports the [Google AI Studio Managed Agents API](https://ai.google.dev/gemini-api/docs/agents). Create, manage, and run custom agents through LiteLLM.
 
+:::note
+Available from LiteLLM `v1.87.0-dev.1` or above.
+:::
+
+{/* truncate */}
+
+## Deploy this version
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+``` showLineNumbers title="docker run litellm"
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+ghcr.io/berriai/litellm:v1.87.0-dev.1
+```
+
+</TabItem>
+
+<TabItem value="pip" label="Pip">
+
+``` showLineNumbers title="pip install litellm"
+pip install litellm==1.87.0.dev1
+```
+
+</TabItem>
+</Tabs>
+
 ## Overview
 
 There are two distinct steps:


### PR DESCRIPTION
## Summary
- Pin **Google AI Studio Managed Agents** blog to `v1.87.0-dev.1` with deploy instructions (Docker + pip)
- Pin **Gemini 3.5 Flash** blog note and deploy section to `v1.87.0-dev.1` / `1.87.0.dev1` instead of generic `main-stable` / `--upgrade`

## Test plan
- [ ] Verify blog pages render on docs preview
- [ ] Confirm Docker tag `ghcr.io/berriai/litellm:v1.87.0-dev.1` and pip `1.87.0.dev1` are correct for this release


Made with [Cursor](https://cursor.com)