### PR TITLE
docs(proxy): document Prisma idle/connect timeout + extra DB URL params

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -138,6 +138,9 @@ general_settings:
   database_url: string
   database_connection_pool_limit: 0  # default 10
   database_connection_timeout: 0  # default 60s
+  database_connect_timeout: 0  # Prisma `connect_timeout` URL param (seconds). Unset => Prisma default.
+  database_socket_timeout: 0  # Prisma `socket_timeout` URL param (seconds). Idle/slow connections beyond this are closed.
+  database_extra_connection_params: {}  # Extra key/value pairs appended to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. sslmode, pgbouncer, statement_cache_size). Overrides LiteLLM defaults.
   allow_requests_on_db_unavailable: boolean  # if true, will allow requests that can not connect to the DB to verify Virtual Key to still work 
 
   custom_auth: string
@@ -244,6 +247,9 @@ router_settings:
 | database_url | string | The URL for the database connection [Set up Virtual Keys](virtual_keys) |
 | database_connection_pool_limit | integer | The limit for database connection pool [Setting DB Connection Pool limit](#configure-db-pool-limits--connection-timeouts) |
 | database_connection_timeout | integer | The timeout for database connections in seconds [Setting DB Connection Pool limit, timeout](#configure-db-pool-limits--connection-timeouts) |
+| database_connect_timeout | float | Maps to the Prisma [`connect_timeout`](https://www.prisma.io/docs/orm/overview/databases/postgresql) URL param (seconds). Bounds how long the engine waits to establish a new connection before failing. Defaults to Prisma's built-in value when unset. |
+| database_socket_timeout | float | Maps to the Prisma [`socket_timeout`](https://www.prisma.io/docs/orm/overview/databases/postgresql) URL param (seconds). When set, an idle or slow connection that has not produced data within this window is closed. **Use this to cap idle Prisma connections from LiteLLM.** |
+| database_extra_connection_params | object | Escape hatch — extra key/value pairs appended verbatim to the Prisma `DATABASE_URL` / `DIRECT_URL` query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets. |
 | allow_requests_on_db_unavailable | boolean | If true, allows requests to succeed even if DB is unreachable. **Only use this if running LiteLLM in your VPC** This will allow requests to work even when LiteLLM cannot connect to the DB to verify a Virtual Key [Doc on graceful db unavailability](prod#5-if-running-litellm-on-vpc-gracefully-handle-db-unavailability) |
 | custom_auth | string | Write your own custom authentication logic [Doc Custom Auth](virtual_keys#custom-auth) |
 | max_parallel_requests | integer | The max parallel requests allowed per deployment |

--- a/docs/proxy/configs.md
+++ b/docs/proxy/configs.md
@@ -602,6 +602,28 @@ Since you shouldn't use 12.5, round down to **10** to leave a safety buffer. Thi
 - Total maximum connections: 8 workers × 10 connections = 80 connections
 - This stays safely under your database's 100 connection limit
 
+### Cap Idle DB Connections + Pass Extra Prisma URL Params
+
+If you're seeing a large number of idle Prisma connections that never close, set `database_socket_timeout` so Prisma closes any connection that's been silent past the threshold. You can also bound how long Prisma waits to open a new connection with `database_connect_timeout`, and pass arbitrary extra query-string params through to Prisma via `database_extra_connection_params`.
+
+These map to the Prisma [PostgreSQL connection URL params](https://www.prisma.io/docs/orm/overview/databases/postgresql) of the same name (minus the `database_` prefix), and LiteLLM appends them to both `DATABASE_URL` and `DIRECT_URL`.
+
+```yaml
+general_settings:
+  database_connection_pool_limit: 20
+  database_socket_timeout: 300   # close any connection idle/slow for >5 min
+  database_connect_timeout: 15   # fail fast if a new connection can't be established within 15s
+  database_extra_connection_params:
+    pgbouncer: "true"            # set if running behind PgBouncer
+    statement_cache_size: 0
+    sslmode: "require"
+```
+
+**Notes:**
+- `database_socket_timeout` is the main knob for capping idle DB connections from LiteLLM.
+- `database_connect_timeout` and `database_socket_timeout` are omitted from the URL when unset, so Prisma's defaults apply.
+- `database_extra_connection_params` is an untyped passthrough — any key you set here **overrides** the LiteLLM-set defaults for that key (e.g. you can override `pool_timeout` from this dict). Use it for `sslmode`, `pgbouncer`, `statement_cache_size`, or any other Prisma URL param.
+
 ## LiteLLM License Key (Enterprise)
 
 To enable [LiteLLM Enterprise features](https://docs.litellm.ai/docs/enterprise), set your license key as an environment variable:


### PR DESCRIPTION
## Summary

Documents the three new `general_settings` keys added in [BerriAI/litellm#28395](https://github.com/BerriAI/litellm/pull/28395):

- `database_connect_timeout` → Prisma `connect_timeout` URL param
- `database_socket_timeout` → Prisma `socket_timeout` URL param (the main knob for capping idle DB connections from LiteLLM)
- `database_extra_connection_params` → escape-hatch dict appended verbatim to `DATABASE_URL` / `DIRECT_URL` (e.g. `pgbouncer`, `sslmode`, `statement_cache_size`)

Changes:
- `docs/proxy/config_settings.md` — adds the three keys to the YAML reference block and the `general_settings` reference table, with links to Prisma's PostgreSQL connection URL docs.
- `docs/proxy/configs.md` — new "Cap Idle DB Connections + Pass Extra Prisma URL Params" subsection under General Settings, with the example config from the upstream PR (`pgbouncer` + `statement_cache_size`) and notes on the override semantics of `database_extra_connection_params`.

No release-notes entry — upstream PR is still open.

## Test plan
- [ ] Render docs locally and visually check the new section / table rows
- [ ] Confirm anchors and markdown links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)