### PR TITLE
docs(mcp): pass guardrails via extra_body in OpenAI SDK example

### DIFF
--- a/docs/mcp_guardrail.md
+++ b/docs/mcp_guardrail.md
@@ -73,7 +73,7 @@ response = client.chat.completions.create(
         {"role": "user", "content": "Send an email to 555-123-4567 with my SSN 123-45-6789"}
     ],
     tools=[{"type": "mcp", "server_label": "litellm", "server_url": "litellm_proxy"}],
-    guardrails=["mcp-input-validation"]
+    extra_body={"guardrails": ["mcp-input-validation"]},
 )
 ```
 


### PR DESCRIPTION
## Summary
- Fix the MCP guardrails Python example to pass `guardrails` through `extra_body` instead of as a top-level OpenAI SDK argument
- Aligns with other LiteLLM guardrail docs (e.g. content filter) and prevents `TypeError: Completions.create() got an unexpected keyword argument 'guardrails'`
Fixes LIT-3066

## Test plan
- [x] Verified the updated example matches the working pattern used in other docs (`extra_body={"guardrails": [...]}`)
- [x] Confirmed curl examples are unchanged (raw JSON can still pass `guardrails` directly)

<img width="1197" height="692" alt="image" src="https://github.com/user-attachments/assets/4a4206f0-06aa-435b-833a-4266e8add237" />