### PR TITLE
docs(proxy): CLI SSO attribution metadata from OIDC claims

### DIFF
--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -274,6 +274,8 @@ Nested attribute paths are supported (e.g., `claims.role` or `attributes.litellm
 
 Use `GENERIC_USER_EXTRA_ATTRIBUTES` to extract additional fields from the SSO provider response beyond the standard user attributes (id, email, name, etc.). This is useful when you need to access custom organization-specific data (e.g., department, employee ID, groups) in your [custom SSO handler](./custom_sso.md).
 
+For **CLI SSO**, you can map the same (or other) claims into user `metadata` and return scalars to the CLI via `CLI_SSO_CLAIM_MAP` — see [CLI Authentication](./cli_sso.md#attribution-metadata-oidc-claims).
+
 ```shell
 # Comma-separated list of field names to extract
 GENERIC_USER_EXTRA_ATTRIBUTES="department,employee_id,manager,groups"

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -63,6 +63,42 @@ litellm-proxy whoami
 ```
 :::
 
+#### Attribution metadata (OIDC claims)
+
+Map allowlisted OIDC claims into the LiteLLM user's `metadata` and return them to the CLI in `/sso/cli/poll` as `attribution_metadata`. Use this for stable attribution fields (for example employment type or cost center) without parsing large group lists in the client.
+
+Set on the **proxy** before startup:
+
+```bash
+export CLI_SSO_CLAIM_MAP="employment_type->acme_employment_type,org_info.department->department"
+export GENERIC_USER_EXTRA_ATTRIBUTES="employment_type,org_info.department"
+```
+
+`CLI_SSO_CLAIM_MAP` and `LITELLM_CLI_SSO_CLAIM_MAP` are equivalent. Format: comma-separated `source_claim->metadata_key` pairs. The optional `metadata.` prefix on the destination is stripped; values are stored on the user's `metadata` JSON column.
+
+| Part | Meaning |
+|------|---------|
+| `source_claim` | OIDC claim path (dot notation), including fields from `GENERIC_USER_EXTRA_ATTRIBUTES` |
+| `metadata_key` | Key under LiteLLM user `metadata` (supports nested keys via dots) |
+
+Only non-secret scalar values (`string`, `int`, `float`, `bool`) are persisted and returned. Lists, objects, and destination keys containing fragments like `token` or `secret` are dropped.
+
+Example poll response (after SSO completes):
+
+```json
+{
+  "status": "ready",
+  "key": "eyJ...",
+  "user_id": "user@company.com",
+  "attribution_metadata": {
+    "acme_employment_type": "full_time",
+    "department": "Engineering"
+  }
+}
+```
+
+**Local testing without a real IdP:** run `python scripts/mock_oidc_server_for_cli_sso.py` from the LiteLLM repo, point Generic SSO env vars at `http://127.0.0.1:8765`, then run `python scripts/test_cli_sso_claims_e2e.py`.
+
 ### Steps
 
 1. **Install the CLI**

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -543,6 +543,7 @@ router_settings:
 | CIRCLE_OIDC_TOKEN | OpenID Connect token for CircleCI
 | CIRCLE_OIDC_TOKEN_V2 | Version 2 of the OpenID Connect token for CircleCI
 | CLI_JWT_EXPIRATION_HOURS | Expiration time in hours for CLI-generated JWT tokens. Default is 24 hours. Can also be set via LITELLM_CLI_JWT_EXPIRATION_HOURS
+| CLI_SSO_CLAIM_MAP | Comma-separated allowlist mapping OIDC claim paths to LiteLLM user `metadata` keys for CLI SSO (e.g. `employment_type->acme_employment_type,org_info.department->department`). Scalar values are also returned in `/sso/cli/poll` as `attribution_metadata`. Alias: `LITELLM_CLI_SSO_CLAIM_MAP`
 | CLOUDZERO_API_KEY | CloudZero API key for authentication
 | CLOUDZERO_CONNECTION_ID | CloudZero connection ID for data submission
 | CLOUDZERO_EXPORT_INTERVAL_MINUTES | Interval in minutes for CloudZero data export operations
@@ -858,6 +859,7 @@ router_settings:
 | LITELLM_ASSETS_PATH | Path to directory for UI assets and logos. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/assets` in Docker.
 | LITELLM_BLOG_POSTS_URL | Custom URL for fetching LiteLLM blog posts JSON. Default is the GitHub main branch URL
 | LITELLM_CLI_JWT_EXPIRATION_HOURS | Expiration time in hours for CLI-generated JWT tokens. Default is 24 hours
+| LITELLM_CLI_SSO_CLAIM_MAP | Alias for `CLI_SSO_CLAIM_MAP` — allowlisted OIDC claims for CLI SSO attribution metadata
 | LITELLM_CORS_ALLOW_CREDENTIALS | Set to `true` to explicitly allow credentials in CORS responses. When not set, credentials are disabled automatically if `LITELLM_CORS_ORIGINS` is `*` (wildcard) to prevent the browser security misconfiguration of reflecting any origin with credentials
 | LITELLM_CORS_ORIGINS | Comma-separated list of allowed CORS origins (e.g. `https://app.example.com,https://admin.example.com`). Defaults to `*` (all origins) when not set
 | LITELLM_DD_AGENT_HOST | Hostname or IP of DataDog agent for LiteLLM-specific logging. When set, logs are sent to agent instead of direct API


### PR DESCRIPTION
## Summary
- Document `CLI_SSO_CLAIM_MAP` / `LITELLM_CLI_SSO_CLAIM_MAP` on the CLI SSO page
- Add env var entries to `config_settings.md`
- Note local mock IdP testing via LiteLLM repo scripts

Companion to https://github.com/BerriAI/litellm/pull/28463

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates describing new/aliased env vars and their behavior; no runtime code changes.
> 
> **Overview**
> Adds docs for CLI SSO *attribution metadata* by introducing `CLI_SSO_CLAIM_MAP`/`LITELLM_CLI_SSO_CLAIM_MAP`, including mapping syntax, allowlisting/scalar filtering rules, and an example `/sso/cli/poll` response.
> 
> Updates the env var reference in `config_settings.md` to include the new setting and alias, and cross-links the Admin UI SSO docs to the new CLI claim-mapping section (with notes on local mock-IdP testing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271ed986fd2c9dc592abd8d3e58749146039b456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->