### PR TITLE
docs(release_notes): add v1.84.1 and v1.85.1 patch release notes

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.85.0 — Realtime GA, MCP Gateway Expansion & Hardened Multi-Tenancy](/release_notes/v1.85.0/v1-85-0)
+### [v1.85.1 — Gemini 3.5 Flash & Reliability Fixes](/release_notes/v1.85.1/v1-85-1)
 
-_May 16, 2026_
+_May 20, 2026_
 
-OpenAI Realtime GA (with `gpt-realtime-2` pricing and `/openai/v1/realtime` logging), a broad multi-tenancy hardening sweep across keys, projects, batches, files, and MCP servers, MCP Gateway expansion (org-level permissions, OBO auth, `delegate_auth_to_upstream` PKCE passthrough), an observability overhaul (Prometheus label/cardinality fixes + OTEL handler isolation), and new models including xAI `grok-4.3`, OpenAI `gpt-realtime-2`, OpenRouter Qwen 3.6 Plus, SambaNova MiniMax-M2.7, and Bedrock Z.AI GLM-5.
+A patch release on top of [v1.85.0](/release_notes/v1.85.0/v1-85-0): day-0 support for Gemini 3.5 Flash on Google AI Studio and Vertex AI, a Vertex AI tool-calling fix that resolves Gemini 3.5+ HTTP 400 `Unknown name "id"` errors, and a cross-pod spend-counter fix that stops team budgets from double-counting after a Redis cache miss. The same fixes are also shipped for the 1.84 line as [v1.84.1](/release_notes/v1.84.1/v1-84-1).
 
 ---
 
@@ -22,6 +22,8 @@ OpenAI Realtime GA (with `gpt-realtime-2` pricing and `/openai/v1/realtime` logg
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.85.1](/release_notes/v1.85.1/v1-85-1)   | May 20, 2026 | Patch — Gemini 3.5 Flash day-0 + cross-pod spend fix       |
+| [v1.84.1](/release_notes/v1.84.1/v1-84-1)   | May 20, 2026 | Patch — Gemini 3.5 Flash day-0 + cross-pod spend fix       |
 | [v1.85.0](/release_notes/v1.85.0/v1-85-0)   | May 16, 2026 | Realtime GA, MCP Gateway expansion & hardened multi-tenancy |
 | [v1.84.0](/release_notes/v1.84.0/v1-84-0)   | May 14, 2026 | Reliability hardening + multi-pod budget accuracy          |
 | [v1.83.14](/release_notes/v1.83.14/v1-83-14) | Apr 27, 2026 | GPT-5.5, Prompt Compression & Memory API                   |

--- a/release_notes/v1.84.1/index.md
+++ b/release_notes/v1.84.1/index.md
@@ -1,0 +1,72 @@
+---
+title: "v1.84.1 - Gemini 3.5 Flash & Reliability Fixes"
+slug: "v1-84-1"
+date: 2026-05-20T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.1` is a patch release on top of [`v1.84.0`](/release_notes/v1.84.0/v1-84-0). It adds day-0 support for Gemini 3.5 Flash and ships two reliability fixes — cross-pod spend accuracy and Vertex AI tool calling.
+
+## New Models / Updated Models
+
+#### New Model Support (1 new model)
+
+| Provider | Model | Context Window | Input ($/1M tokens) | Output ($/1M tokens) | Features |
+| --- | --- | --- | --- | --- | --- |
+| Gemini / Vertex AI | `gemini/gemini-3.5-flash`, `vertex_ai/gemini-3.5-flash` | 1M | $1.50 | $9.00 | Reasoning, vision, audio input, PDF input, prompt caching, web search, function calling, response schema |
+
+#### Features
+
+- **[Gemini](../../docs/providers/gemini)** / **[Vertex AI](../../docs/providers/vertex)**
+    - Day-0 support for Gemini 3.5 Flash on both Google AI Studio and Vertex AI - [PR #28268](https://github.com/BerriAI/litellm/pull/28268)
+
+### Bug Fixes
+
+- **[Vertex AI](../../docs/providers/vertex)**
+    - Omit the `function_call` / `function_response` `id` on Vertex Gemini 3.5+ tool turns, fixing HTTP 400 `Unknown name "id"` errors. Google AI Studio (`gemini` provider) still forwards the `id` on Gemini 3.5+ for strict tool-call matching - [PR #28324](https://github.com/BerriAI/litellm/pull/28324)
+
+## Spend Tracking, Budgets and Rate Limiting
+
+- Seed the Redis spend counter via `SET NX` instead of `INCRBYFLOAT` to prevent cross-pod double-seeding. On multi-pod deployments this previously caused team `spend` to jump to ~Nx the pod count after a Redis cache miss / TTL expiry, triggering false "Budget Crossed" alerts - [PR #27854](https://github.com/BerriAI/litellm/pull/27854)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.0...v1.84.1

--- a/release_notes/v1.85.1/index.md
+++ b/release_notes/v1.85.1/index.md
@@ -1,0 +1,72 @@
+---
+title: "v1.85.1 - Gemini 3.5 Flash & Reliability Fixes"
+slug: "v1-85-1"
+date: 2026-05-20T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.1` is a patch release on top of [`v1.85.0`](/release_notes/v1.85.0/v1-85-0). It adds day-0 support for Gemini 3.5 Flash and ships two reliability fixes — cross-pod spend accuracy and Vertex AI tool calling.
+
+## New Models / Updated Models
+
+#### New Model Support (1 new model)
+
+| Provider | Model | Context Window | Input ($/1M tokens) | Output ($/1M tokens) | Features |
+| --- | --- | --- | --- | --- | --- |
+| Gemini / Vertex AI | `gemini/gemini-3.5-flash`, `vertex_ai/gemini-3.5-flash` | 1M | $1.50 | $9.00 | Reasoning, vision, audio input, PDF input, prompt caching, web search, function calling, response schema |
+
+#### Features
+
+- **[Gemini](../../docs/providers/gemini)** / **[Vertex AI](../../docs/providers/vertex)**
+    - Day-0 support for Gemini 3.5 Flash on both Google AI Studio and Vertex AI - [PR #28268](https://github.com/BerriAI/litellm/pull/28268)
+
+### Bug Fixes
+
+- **[Vertex AI](../../docs/providers/vertex)**
+    - Omit the `function_call` / `function_response` `id` on Vertex Gemini 3.5+ tool turns, fixing HTTP 400 `Unknown name "id"` errors. Google AI Studio (`gemini` provider) still forwards the `id` on Gemini 3.5+ for strict tool-call matching - [PR #28324](https://github.com/BerriAI/litellm/pull/28324)
+
+## Spend Tracking, Budgets and Rate Limiting
+
+- Seed the Redis spend counter via `SET NX` instead of `INCRBYFLOAT` to prevent cross-pod double-seeding. On multi-pod deployments this previously caused team `spend` to jump to ~Nx the pod count after a Redis cache miss / TTL expiry, triggering false "Budget Crossed" alerts - [PR #27854](https://github.com/BerriAI/litellm/pull/27854)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.0...v1.85.1


### PR DESCRIPTION
## Summary

Adds changelog entries for the `v1.84.1` and `v1.85.1` patch releases (released May 20, 2026).

Both are hotfix patches on top of `v1.84.0` / `v1.85.0` and ship the **same three PRs**:

- **Gemini 3.5 Flash** day-0 support on Google AI Studio + Vertex AI — [#28268](https://github.com/BerriAI/litellm/pull/28268)
- **Vertex AI tool-calling fix** — omit `function_call` `id` on Gemini 3.5+ tool turns, resolving HTTP 400 `Unknown name "id"` errors — [#28324](https://github.com/BerriAI/litellm/pull/28324)
- **Cross-pod spend fix** — seed the Redis spend counter via `SET NX` to stop team budgets double-counting after a Redis cache miss — [#27854](https://github.com/BerriAI/litellm/pull/27854)

## Changes

- New `release_notes/v1.84.1/index.md` and `release_notes/v1.85.1/index.md` patch pages
- `release_notes/index.md` — Latest Release block now points at `v1.85.1`, plus two new rows in the Recent Releases table

## Verification

- Ancestry confirmed: `v1.84.0`→`v1.84.1`, `v1.85.0`→`v1.85.1`
- Docker tags `1.84.1` / `1.85.1` confirmed live on GHCR
- Doc links (`docs/providers/gemini`, `docs/providers/vertex`) resolve