### PR TITLE
docs: fix Skills Marketplace release note links

### DIFF
--- a/release_notes/v1.83.3/index.md
+++ b/release_notes/v1.83.3/index.md
@@ -54,7 +54,7 @@ pip install litellm==1.83.3
 ## Key Highlights
 
 - **MCP Toolsets** — [Create curated tool subsets from one or more MCP servers with scoped permissions, and manage them from the UI or API](../../docs/mcp)
-- **Skills Marketplace** — [Browse, install, and publish Claude Code skills from a self-hosted marketplace — works across Anthropic, Vertex AI, Azure, and Bedrock](../../docs/proxy/skills)
+- **Skills Marketplace** — [Browse, install, and publish Claude Code skills from a self-hosted marketplace — works across Anthropic, Vertex AI, Azure, and Bedrock](../../docs/skills_gateway)
 - **Guardrail Fallbacks** — [Configure `on_error` behavior so guardrail failures degrade gracefully instead of blocking the request](../../docs/proxy/guardrails)
 - **Team Bring Your Own Guardrails** — [Teams can now attach and manage their own guardrails directly from team settings in the UI](../../docs/proxy/guardrails)
 
@@ -67,7 +67,7 @@ The Skills Marketplace gives teams a self-hosted catalog for discovering, instal
 
 ![Skills Marketplace](../../img/release_notes/skills_marketplace.png)
 
-[Get Started](../../docs/proxy/skills)
+[Get Started](../../docs/skills_gateway)
 
 ### Guardrail Fallbacks
 


### PR DESCRIPTION
## Problem
The v1.83.3 release notes link the Skills Marketplace entries to `../../docs/proxy/skills`, which resolves to a missing docs page. This matches BerriAI/litellm#26035.

## Solution
Update both Skills Marketplace links in `release_notes/v1.83.3/index.md` to point at the existing `../../docs/skills_gateway` page, which is already present in the docs sidebar.

## Validation
- Verified `docs/skills_gateway.md` exists locally.
- Verified `release_notes/v1.83.3/index.md` no longer contains `docs/proxy/skills`.
- Ran `git diff --check`.

## Confidence
85/100 — docs/broken-link fix. Small, directly verifiable link target update with an open issue and no overlapping open PR found in `BerriAI/litellm-docs`.

Related: BerriAI/litellm#26035
