### PR TITLE
docs(search): force Algolia DocSearch modal to autofocus its input on Cmd+K

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -206,6 +206,13 @@ const config = {
 
   // Algolia search comes from preset-classic when themeConfig.algolia is set.
   themes: ['@docusaurus/theme-mermaid'],
+
+  clientModules: [
+    // Ensures the Algolia DocSearch modal's input is focused when the modal
+    // opens (works around a race between React's autoFocus and other
+    // focus-stealing scripts after the modal portal is inserted).
+    require.resolve('./src/clientModules/algoliaSearchAutofocus.js'),
+  ],
   markdown: {
     mermaid: true,
   },

--- a/src/clientModules/algoliaSearchAutofocus.js
+++ b/src/clientModules/algoliaSearchAutofocus.js
@@ -1,0 +1,122 @@
+/**
+ * Force the Algolia DocSearch modal input to receive keyboard focus when the
+ * modal opens.
+ *
+ * Background
+ * ----------
+ * When a user hits Cmd+K (or Ctrl+K), Docusaurus's Algolia theme opens the
+ * DocSearch modal. The modal's `<input>` is marked with React's `autoFocus`
+ * prop, which *should* call `.focus()` after the modal mounts.
+ *
+ * In practice, this is racy:
+ *   - The DocSearchModal component is loaded via a dynamic `import()` on
+ *     first invocation, so the modal mounts asynchronously after the
+ *     keydown event.
+ *   - The modal is rendered into a portal that is prepended to
+ *     `document.body`. If anything else steals focus during that frame
+ *     (third-party widgets like the Crisp chat script, or the original
+ *     document.activeElement re-asserting focus when the modal portal is
+ *     inserted before it), the input is rendered but unfocused — exactly
+ *     the bug reported on the docs site: "the search popup opens but the
+ *     cursor isn't in the input, I have to click before I can type".
+ *
+ * Fix
+ * ---
+ * Run a `MutationObserver` on `document.body` for the lifetime of the page.
+ * Whenever a `.DocSearch-Container` element is inserted, schedule three
+ * focus attempts on its `.DocSearch-Input` (synchronous, next animation
+ * frame, and 60 ms later). Each attempt is idempotent — focusing an
+ * already-focused element is a no-op — so this never fights React's own
+ * autoFocus when it works on the first try.
+ *
+ * The observer also guards against future re-opens: every time the modal
+ * is re-added to the DOM, the input is focused again.
+ */
+
+const CONTAINER_SELECTOR = '.DocSearch-Container';
+const INPUT_SELECTOR = '.DocSearch-Input';
+
+function focusModalInput(container) {
+  if (!container) return false;
+  const input = container.querySelector(INPUT_SELECTOR);
+  if (!input) return false;
+  if (document.activeElement === input) return true;
+  try {
+    input.focus({preventScroll: true});
+  } catch (_e) {
+    input.focus();
+  }
+  // Place the caret at the end of any pre-filled query (Cmd+K with a prior
+  // search) so the user's first keystroke appends rather than replaces.
+  if (typeof input.value === 'string' && input.value.length > 0) {
+    try {
+      input.setSelectionRange(input.value.length, input.value.length);
+    } catch (_e) {
+      // not all input types support setSelectionRange — ignore.
+    }
+  }
+  return document.activeElement === input;
+}
+
+function scheduleFocusAttempts(container) {
+  // 1) Synchronous — covers the case where the input is already mounted.
+  focusModalInput(container);
+
+  // 2) Next animation frame — covers the case where the input was just
+  // inserted but React hasn't yet committed its autoFocus side effect.
+  if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+    window.requestAnimationFrame(() => {
+      focusModalInput(container);
+    });
+  }
+
+  // 3) Short timeout — covers the case where another script steals focus
+  // immediately after the modal opens (e.g. third-party widgets reacting
+  // to body mutations).
+  if (typeof window !== 'undefined') {
+    window.setTimeout(() => {
+      focusModalInput(container);
+    }, 60);
+  }
+}
+
+function handleNode(node) {
+  if (!(node instanceof Element)) return;
+  if (node.matches?.(CONTAINER_SELECTOR)) {
+    scheduleFocusAttempts(node);
+    return;
+  }
+  // The container might be added wrapped in an outer element on first paint.
+  const container = node.querySelector?.(CONTAINER_SELECTOR);
+  if (container) {
+    scheduleFocusAttempts(container);
+  }
+}
+
+function start() {
+  if (typeof document === 'undefined') return;
+  if (typeof MutationObserver === 'undefined') return;
+
+  // If a DocSearch container is already in the DOM at module-load time
+  // (highly unlikely, but cheap to check), focus it now.
+  const existing = document.querySelector(CONTAINER_SELECTOR);
+  if (existing) {
+    scheduleFocusAttempts(existing);
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      mutation.addedNodes?.forEach(handleNode);
+    }
+  });
+
+  observer.observe(document.body, {childList: true, subtree: true});
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, {once: true});
+  } else {
+    start();
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Per Mik's report on the eng channel after the Algolia migration: when a user hits `Cmd+K` on the docs site, the search modal opens but the cursor doesn't appear in the search box — the user has to click the input before they can start typing. The behavior is **intermittent**: sometimes the caret is in the right place, sometimes it isn't.

## Root cause

`@docusaurus/theme-search-algolia` renders the DocSearch modal like this:

```javascript
const openModal = useCallback(() => {
  prepareSearchContainer();
  importDocSearchModalIfNeeded().then(() => setIsOpen(true));
}, [prepareSearchContainer]);
```

Two things make autofocus racy:

1. The modal component is loaded via a **dynamic `import()`** on first invocation, so the modal mounts asynchronously after the keydown event.
2. The modal is rendered into a **portal that is prepended to `document.body`** (`document.body.insertBefore(divElement, document.body.firstChild)`).

The modal input has React's `autoFocus`, which schedules a `.focus()` call after mount. That call sometimes loses the race against:

- the previously focused element re-asserting focus when the portal is inserted before it, and
- third-party scripts reacting to body mutations (e.g. the Crisp chat widget we load via the `cripchat` plugin).

Result: the modal renders but the input is never focused, until the user clicks it.

## Fix

Add a small client module (`src/clientModules/algoliaSearchAutofocus.js`) that runs on every page and:

- Starts a `MutationObserver` on `document.body` for the lifetime of the page.
- When a `.DocSearch-Container` element is inserted, schedules **three idempotent focus attempts** on its `.DocSearch-Input` — synchronous, next animation frame, and 60 ms later — so the input ends up focused even if something else stole focus during the React commit phase.
- Places the caret at the end of any pre-filled query so typing appends instead of replaces.

Each attempt is a no-op if the input is already focused, so this never fights React's own `autoFocus` when it wins the race on the first try.

Wired up via the top-level `clientModules` array in `docusaurus.config.js` (see [Docusaurus client modules docs](https://docusaurus.io/docs/advanced/client#client-modules)).

## Verification

- `npm run build` succeeds (broken-anchor warnings on `release_notes/*` are pre-existing).
- The compiled main JS bundle contains both `MutationObserver` and the `.DocSearch-Container` / `.DocSearch-Input` selectors, confirming the module is wired up and ships to clients.
- The hook is purely additive — if Algolia's own `autoFocus` already worked, our `.focus()` calls are no-ops, so there is no risk of regressing the case where focus is already correct.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1779391286984769?thread_ts=1779391286.984769&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-76587a34-83e0-42b7-ba45-e4a3c84bb8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76587a34-83e0-42b7-ba45-e4a3c84bb8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

