### PR TITLE
docs: remove redundant Docker Compose image pull

### DIFF
--- a/docs/proxy/docker_quick_start.md
+++ b/docs/proxy/docker_quick_start.md
@@ -104,23 +104,11 @@ $ uv tool install 'litellm[proxy]'
 
 Docker Compose bundles LiteLLM with a Postgres database. Follow the steps below — the proxy will be fully running by the end.
 
-### Step 1 — Pull the LiteLLM database image
-
-LiteLLM provides a dedicated `litellm-database` image for proxy deployments that connect to Postgres.
-
-```bash
-docker pull ghcr.io/berriai/litellm-database:main-latest
-```
-
-See all available tags on the [GitHub Container Registry](https://github.com/BerriAI/litellm/pkgs/container/litellm-database).
-
----
-
-### Step 2 — Set up a database
+### Step 1 — Set up a database
 
 Complete all three config files **before** running `docker compose up`. The proxy server will not start correctly if any of these are missing.
 
-#### 2.1 — Get `docker-compose.yml` and create `.env`
+#### 1.1 — Get `docker-compose.yml` and create `.env`
 
 ```bash
 # Get the docker compose file
@@ -139,7 +127,7 @@ echo 'AZURE_API_BASE="https://openai-***********/"' >> .env
 echo 'AZURE_API_KEY="your-azure-api-key"' >> .env
 ```
 
-#### 2.2 — Create `config.yaml`
+#### 1.2 — Create `config.yaml`
 
 The default `docker-compose.yml` starts a Postgres container at `db:5432`. Your `config.yaml` must include `database_url` pointing to it:
 
@@ -161,7 +149,7 @@ general_settings:
 `database_url` enables virtual keys, spend tracking, and the UI. Replace it with your [Supabase](https://supabase.com/) or [Neon](https://neon.tech/) connection string if you prefer a managed database.
 :::
 
-#### 2.3 — Create `prometheus.yml`
+#### 1.3 — Create `prometheus.yml`
 
 This file **must exist as a file** before `docker compose up`. If it is missing, Docker auto-creates it as an empty directory and the Prometheus container fails to start.
 
@@ -193,7 +181,7 @@ All three files (`.env`, `config.yaml`, `prometheus.yml`) must be present before
 
 ---
 
-### Step 3 — Start the proxy server and test it
+### Step 2 — Start the proxy server and test it
 
 After `config.yaml`, `prometheus.yml`, and `.env` are complete, start the proxy:
 
@@ -768,13 +756,12 @@ Error: cannot create subdirectories in ".../prometheus.yml": not a directory
 
 Docker created `prometheus.yml` as an **empty directory** instead of a file. This happens when the file is missing at `docker compose up` time.
 
-Fix it:
-Then create the file (see [Step 2.3 — Create `prometheus.yml`](#23--create-prometheusyml)) and run `docker compose up` again.
+Fix it by removing the directory Docker created:
 ```bash
 rm -rf prometheus.yml
 ```
 
-Then create the file (see [Step 2.4](#step-24--create-prometheusyml)) and run `docker compose up` again.
+Then create the file (see [Step 1.3 — Create `prometheus.yml`](#13--create-prometheusyml)) and run `docker compose up` again.
 
 ### Non-root docker image?
 


### PR DESCRIPTION
## Problem
The Docker Compose quickstart tells users to pull `ghcr.io/berriai/litellm-database:main-latest` before downloading `docker-compose.yml`, but the Compose file used by the guide runs `docker.litellm.ai/berriai/litellm:main-stable` with `postgres:16`. The extra pull is not used by the setup and matches the docs inaccuracy reported in BerriAI/litellm#26235.

## Solution
- Remove the redundant Docker Compose image-pull step.
- Renumber the remaining Docker Compose quickstart steps and substeps.
- Fix the troubleshooting link for creating `prometheus.yml` after Docker accidentally creates it as a directory.

## Validation
- `git diff --check`
- Verified the current upstream `docker-compose.yml` references `docker.litellm.ai/berriai/litellm:main-stable` and `postgres:16`, not `ghcr.io/berriai/litellm-database:main-latest`.
- Verified no stale `Step 2.3`, `Step 2.4`, or `Step 3 — Start` references remain in `docs/proxy/docker_quick_start.md`.

Confidence: 82/100 (docs)
Related: BerriAI/litellm#26235