### PR TITLE
Stretch sidebar search bar full-width and align colors with site theme

### DIFF
--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -48,6 +48,92 @@
   width: 100%;
 }
 
+/* Make the Algolia DocSearch button fill the sidebar column instead of
+   sitting as a short fixed-width pill. The button is the visible trigger
+   that opens the search modal. */
+.searchBarContainer :global(.DocSearch-Button) {
+  width: 100%;
+  margin: 0;
+  height: 2.5rem;
+  padding: 0 0.75rem;
+  border-radius: var(--ifm-border-radius);
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.searchBarContainer :global(.DocSearch-Button:hover),
+.searchBarContainer :global(.DocSearch-Button:focus),
+.searchBarContainer :global(.DocSearch-Button:active) {
+  background-color: #ffffff;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px rgba(46, 133, 85, 0.12);
+}
+
+.searchBarContainer :global(.DocSearch-Button .DocSearch-Search-Icon) {
+  color: #6b7280;
+  width: 16px;
+  height: 16px;
+}
+
+.searchBarContainer :global(.DocSearch-Button-Placeholder) {
+  flex: 1;
+  text-align: left;
+  padding: 0 0.75rem 0 0.5rem;
+  font-size: 14px;
+  color: #6b7280;
+  font-family: var(--ifm-font-family-base);
+  font-weight: 400;
+}
+
+.searchBarContainer :global(.DocSearch-Button-Keys) {
+  min-width: auto;
+  gap: 2px;
+}
+
+.searchBarContainer :global(.DocSearch-Button-Key) {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  box-shadow: none;
+  color: #6b7280;
+  padding: 0 4px;
+  margin-right: 0;
+  font-size: 11px;
+  font-family: var(--ifm-font-family-base);
+  font-weight: 500;
+  top: 0;
+}
+
+/* Dark mode */
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button) {
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid #21262d;
+  box-shadow: none;
+}
+
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button:hover),
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button:focus),
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button:active) {
+  background-color: var(--ifm-background-surface-color);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 194, 160, 0.18);
+}
+
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button .DocSearch-Search-Icon) {
+  color: #9ca3af;
+}
+
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button-Placeholder) {
+  color: #9ca3af;
+}
+
+:global([data-theme='dark']) .searchBarContainer :global(.DocSearch-Button-Key) {
+  background: #21262d;
+  border-color: #30363d;
+  color: #c9d1d9;
+}
+
 /* Remove the default top padding from the sidebar content that follows */
 .searchBarContainer + div {
   padding-top: 0 !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Restyles the Algolia DocSearch button rendered in the docs sidebar so that it:

- Stretches the full width of the sidebar column (previously rendered as a short pill that only filled a portion of the available space).
- Adopts the same neutral / surface colors used elsewhere on the site, replacing the default purple shortcut keys / blue-tinted background with palette-matched tones for both light and dark mode.
- Picks up the brand primary color on hover/focus (green in light, teal in dark) with a soft focus ring, consistent with other interactive elements.

Only the sidebar search trigger is affected — the mobile navbar trigger and the open DocSearch modal use the default styling. Scoping is done via the `searchBarContainer` CSS module class so global DocSearch consumers aren't touched.

## Where

`src/theme/DocSidebar/styles.module.css` — adds overrides targeting `:global(.DocSearch-Button)` and its inner parts (`-Container`, `-Placeholder`, `-Keys`, `-Key`) for both light and `[data-theme='dark']`.

## Screenshots

Light mode:

[Sidebar search — light mode](https://cursor.com/agents/bc-7e52d554-603c-41ef-bc78-af8708305996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar-light.png)

Dark mode:

[Sidebar search — dark mode](https://cursor.com/agents/bc-7e52d554-603c-41ef-bc78-af8708305996/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar-dark.png)

## Verification

- `npm run build` succeeds.
- Built CSS contains the scoped overrides (`.searchBarContainer_<hash> .DocSearch-Button …`).
- Headless Chrome screenshots in light and dark mode confirm the search bar fills the sidebar and matches the site palette.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1779555479057899?thread_ts=1779555479.057899&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-7e52d554-603c-41ef-bc78-af8708305996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e52d554-603c-41ef-bc78-af8708305996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

