### PR TITLE
docs(terraform): publish AWS ECS Fargate and GCP Cloud Run deployment guides (LIT-3173)

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -253,9 +253,12 @@ docker run \
 
 ### Terraform
 
-s/o [Nicholas Cecere](https://www.linkedin.com/in/nicholas-cecere-24243549/) for his LiteLLM User Management Terraform
+Deploy the componentized LiteLLM proxy (gateway + backend + UI) on AWS or GCP using the official Terraform stacks bundled in the LiteLLM repository:
 
-👉 [Go here for Terraform](https://github.com/BerriAI/terraform-provider-litellm)
+- 👉 [**Deploy on AWS (ECS Fargate)**](/docs/proxy/deploy_terraform_aws) — Aurora Postgres (IAM auth), ElastiCache Redis, S3, Application Load Balancer
+- 👉 [**Deploy on GCP (Cloud Run)**](/docs/proxy/deploy_terraform_gcp) — Cloud SQL, Memorystore Redis, GCS, External HTTPS Load Balancer
+
+For the LiteLLM User Management Terraform provider, see [terraform-provider-litellm](https://github.com/BerriAI/terraform-provider-litellm).
 
 ### Kubernetes
 
@@ -919,24 +922,19 @@ This will use the local model prices file instead.
 <Tabs>
 <TabItem value="AWS ECS" label="AWS ECS - Elastic Container Service">
 
-### Terraform-based ECS Deployment
+### Terraform-based ECS Fargate Deployment
 
-LiteLLM maintains a dedicated Terraform tutorial for deploying the proxy on ECS. Follow the step-by-step guide in the [litellm-ecs-deployment repository](https://github.com/BerriAI/litellm-ecs-deployment) to provision the required ECS services, task definitions, and supporting AWS resources.
+LiteLLM provides a production-ready Terraform module for deploying the componentized proxy on ECS Fargate with Aurora PostgreSQL, ElastiCache Redis, S3, and an Application Load Balancer.
 
-1. Clone the tutorial repository to review the Terraform modules and variables.
-  ```bash
-  git clone https://github.com/BerriAI/litellm-ecs-deployment.git
-  cd litellm-ecs-deployment
-  ```
+See the full guide: **[Deploy LiteLLM on AWS (ECS Fargate) via Terraform](/docs/proxy/deploy_terraform_aws)**
 
-2. Initialize and validate the Terraform project before applying it to your chosen workspace/account.
-  ```bash
-  terraform init
-  terraform plan
-  terraform apply
-  ```
-
-3. Once `terraform apply` completes, do `./build.sh` to push the repository on ECR and update the ECS cluster. Use that endpoint (port `4000` by default) for API requests to your LiteLLM proxy.
+```bash
+git clone https://github.com/BerriAI/litellm.git
+cd litellm/terraform/litellm/aws
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: region, azs, tenant, env, proxy_config, gateway_extra_secrets
+terraform init && terraform apply
+```
 
 
 </TabItem>

--- a/docs/proxy/deploy_terraform_aws.md
+++ b/docs/proxy/deploy_terraform_aws.md
@@ -1,0 +1,362 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Deploy LiteLLM on AWS (ECS Fargate) via Terraform
+
+Deploy the **componentized** LiteLLM proxy — gateway, backend, and UI as three independently scalable services — on **AWS ECS Fargate** using the official LiteLLM Terraform stack.
+
+| Resource | Details |
+|---|---|
+| Compute | ECS Fargate (serverless containers) |
+| Database | Aurora PostgreSQL with IAM auth (writer + reader) |
+| Cache | ElastiCache Redis (multi-AZ, in-transit + at-rest encryption) |
+| Object store | S3 (versioned, SSE-S3) |
+| Load balancer | Application Load Balancer (path-based routing) |
+| Secrets | AWS Secrets Manager |
+
+:::info Source
+
+The Terraform module lives at [`terraform/litellm/aws/`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws) in the LiteLLM repository.
+
+:::
+
+## Architecture
+
+```
+                    ┌───────────────────────────────────────┐
+                    │            Public Internet            │
+                    └─────────────────┬─────────────────────┘
+                                      │ HTTP/80 (or HTTPS/443)
+                      ┌───────────────▼───────────────┐
+                      │   Application Load Balancer   │
+                      │   (path-routing listener)     │
+                      └─┬─────────────┬─────────────┬─┘
+                        │             │             │
+        UI assets, /    │  /v1/chat,  │   /key/*    │
+        /_next/*, …     │  /v1/embed, │   /user/*   │
+                        │  …          │   …         │
+          ┌─────────────▼───┐  ┌──────▼──────┐  ┌───▼──────────────┐
+          │    ECS Service  │  │ ECS Service │  │   ECS Service    │
+          │       (ui)      │  │  (gateway)  │  │    (backend)     │
+          │   Fargate :3000 │  │ Fargate:4000│  │  Fargate :4001   │
+          └─────────────────┘  └──────┬──────┘  └────────┬─────────┘
+                                      │                  │
+          ┌─── private subnets ────────────────────────────────────┐
+          │   ┌────────────────────────┐    ┌────────────────┐    │
+          │   │  Aurora PostgreSQL     │    │  ElastiCache   │    │
+          │   │  (IAM auth)            │    │  Redis (HA)    │    │
+          │   │  writer + reader       │    └────────────────┘    │
+          │   └────────────────────────┘    ┌────────────────┐    │
+          │   ┌────────────────────────┐    │  S3 bucket     │    │
+          │   │  Secrets Manager       │    │  (versioned)   │    │
+          │   │  • LITELLM_MASTER_KEY  │    └────────────────┘    │
+          │   │  • DB master password  │    ┌────────────────┐    │
+          │   │  • user API keys       │    │ ECS Task:      │    │
+          │   └────────────────────────┘    │ prisma migrate │    │
+          └─── VPC ──────────────────────────────────────────┘
+                    │ NAT gateway
+                    ▼ egress to LLM providers
+```
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) ≥ 1.6
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed and authenticated (`aws configure`)
+- At least 2 AWS availability zones available in your target region
+
+## Quick start
+
+### Step 1 — Clone and enter the module
+
+```bash
+git clone https://github.com/BerriAI/litellm.git
+cd litellm/terraform/litellm/aws
+```
+
+### Step 2 — Create your `terraform.tfvars`
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your settings:
+
+```hcl
+region = "us-west-2"
+azs    = ["us-west-2a", "us-west-2b"]
+
+tenant = "acme"   # used as prefix for all AWS resources
+env    = "prod"   # e.g. dev, stage, prod
+```
+
+### Step 3 — Supply sensitive values via env vars
+
+```bash
+export TF_VAR_litellm_master_key="sk-..."   # optional; auto-generated if omitted
+export TF_VAR_litellm_license="lic-..."     # optional; omit for OSS-only
+```
+
+### Step 4 — Configure TLS (recommended for production)
+
+**Production** — provide an ACM certificate:
+
+```hcl
+# terraform.tfvars
+acm_certificate_arn = "arn:aws:acm:us-west-2:111122223333:certificate/..."
+```
+
+**Trial/dev** — explicitly opt into HTTP-only:
+
+```hcl
+# terraform.tfvars
+allow_plaintext_alb = true
+```
+
+### Step 5 — Apply
+
+```bash
+terraform init
+terraform apply
+```
+
+A single `terraform apply` provisions everything, runs the Aurora DB user bootstrap, runs the Prisma schema migration, and only then starts the gateway/backend services. When it returns, the stack is serving traffic.
+
+### Step 6 — Verify
+
+```bash
+# Get the ALB URL
+terraform output alb_url
+
+# Get the auto-generated master key
+aws secretsmanager get-secret-value \
+  --secret-id "$(terraform output -raw master_key_secret_arn)" \
+  --query SecretString --output text
+
+# Test the API
+curl http://$(terraform output -raw alb_url)/health
+```
+
+UI login: **admin** / `<master key>`
+
+## Configure LiteLLM
+
+### `proxy_config` (mirrors the Helm chart)
+
+Use `proxy_config` to pass a `config.yaml`-equivalent as a Terraform variable:
+
+```hcl
+proxy_config = {
+  model_list = [
+    {
+      model_name = "gpt-4o"
+      litellm_params = {
+        model   = "openai/gpt-4o"
+        api_key = "os.environ/OPENAI_API_KEY"
+      }
+    },
+    {
+      model_name = "claude-sonnet-4-6"
+      litellm_params = {
+        model   = "anthropic/claude-sonnet-4-6"
+        api_key = "os.environ/ANTHROPIC_API_KEY"
+      }
+    },
+  ]
+  general_settings = {
+    master_key   = "os.environ/LITELLM_MASTER_KEY"
+    database_url = "os.environ/DATABASE_URL"
+  }
+}
+```
+
+LiteLLM resolves `os.environ/<NAME>` against the container environment at runtime.
+
+### Extra env vars (non-sensitive)
+
+```hcl
+gateway_extra_env = {
+  LANGFUSE_HOST = "https://us.cloud.langfuse.com"
+}
+
+backend_extra_env = {
+  STORE_MODEL_IN_DB            = "True"
+  AUTO_REDIRECT_UI_LOGIN_TO_SSO = "true"
+}
+```
+
+### Provider API keys (from Secrets Manager)
+
+Store API keys in Secrets Manager first, then reference them by ARN:
+
+```bash
+aws secretsmanager create-secret \
+  --name openai-api-key \
+  --secret-string "sk-proj-..."
+```
+
+```hcl
+gateway_extra_secrets = {
+  OPENAI_API_KEY    = "arn:aws:secretsmanager:us-west-2:111122223333:secret:openai-api-key-AbCdEf"
+  ANTHROPIC_API_KEY = "arn:aws:secretsmanager:us-west-2:111122223333:secret:anthropic-api-key-GhIjKl"
+}
+```
+
+The task execution role automatically gains `secretsmanager:GetSecretValue` on every ARN listed.
+
+To extract a single field from a JSON secret:
+
+```hcl
+gateway_extra_secrets = {
+  OPENAI_API_KEY = "arn:…:secret:provider-keys-AbCdEf:openai_api_key::"
+}
+```
+
+## Container images
+
+The module defaults to `ghcr.io/berriai/litellm-<component>:v1.86.0-dev` for each of the four images (`gateway`, `backend`, `ui`, `migrations`). **Pin to a specific tag for production.**
+
+```hcl
+gateway_image    = "ghcr.io/berriai/litellm-gateway:v1.86.0"
+backend_image    = "ghcr.io/berriai/litellm-backend:v1.86.0"
+ui_image         = "ghcr.io/berriai/litellm-ui:v1.86.0"
+migrations_image = "ghcr.io/berriai/litellm-migrations:v1.86.0"
+```
+
+**Private registries:**
+
+- **ECR (same account):** the task execution role already has `AmazonECSTaskExecutionRolePolicy`, which grants ECR pull. No extra config needed.
+- **ECR (cross-account):** attach a policy allowing `ecr:GetAuthorizationToken` + `ecr:BatchGetImage` on the foreign repo ARNs.
+
+## Scaling
+
+### Per-service sizing
+
+```hcl
+# Gateway (LLM data plane — scale this most)
+gateway_cpu           = 2048   # 2 vCPU
+gateway_memory        = 8192   # 8 GiB
+gateway_num_workers   = 5      # uvicorn workers (≈ 2×vCPU + 1)
+gateway_desired_count = 3
+
+# Backend (management API)
+backend_cpu    = 1024
+backend_memory = 4096
+
+# UI (static nginx — typically 1 task is enough)
+ui_cpu    = 256
+ui_memory = 512
+```
+
+### Autoscaling
+
+```hcl
+gateway_autoscaling_enabled = true
+gateway_min_capacity        = 1
+gateway_max_capacity        = 10
+gateway_cpu_target          = 70   # scale out at 70% CPU
+gateway_memory_target       = 80   # scale out at 80% memory
+
+backend_autoscaling_enabled = true
+backend_min_capacity        = 1
+backend_max_capacity        = 4
+```
+
+## Multi-tenant deployments
+
+All resources are named `${tenant}-litellm-${env}-<suffix>`, so multiple tenants and environments coexist in the same AWS account:
+
+| `tenant` | `env` | Example resource |
+|---|---|---|
+| `acme` | `stage` | `acme-litellm-stage-gateway` (ECS service) |
+| `acme` | `prod` | `acme-litellm-prod-master-key` (Secrets Manager) |
+| `globex` | `dev` | `globex-litellm-dev` (Aurora cluster) |
+
+Per-tenant apply:
+
+```bash
+export TF_VAR_litellm_master_key="sk-..."
+export TF_VAR_litellm_license="lic-..."
+
+terraform apply \
+  -var "region=us-west-2" \
+  -var 'azs=["us-west-2a","us-west-2b"]' \
+  -var "tenant=acme" \
+  -var "env=stage"
+```
+
+## Database: Aurora + IAM auth
+
+The Aurora cluster has `iam_database_authentication_enabled = true`. The bootstrap task (run automatically on first `terraform apply`) creates the `litellm_app` Postgres user with `rds_iam` privileges. The gateway and backend then connect using short-lived IAM tokens rather than a static password — no password to rotate.
+
+**Break-glass** access (if you need to re-run manually):
+
+```bash
+# Bootstrap SQL — creates the IAM user
+terraform output db_bootstrap_sql
+
+# Re-run migration manually
+eval "$(terraform output -raw migration_run_command)"
+```
+
+## Data retention tripwires
+
+Two opt-in flags guard against accidental data loss on `terraform destroy`:
+
+| Variable | Default | Effect when `false` |
+|---|---|---|
+| `skip_final_snapshot` | `false` | Aurora takes a final snapshot before destroy |
+| `s3_force_destroy` | `false` | Destroy fails if the S3 bucket is non-empty |
+
+Set these to `true` only for ephemeral/CI environments.
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `alb_url` | ALB DNS name (access LiteLLM here) |
+| `alb_arn` | ALB ARN |
+| `master_key_secret_arn` | Secrets Manager ARN for `LITELLM_MASTER_KEY` |
+| `db_bootstrap_sql` | Break-glass SQL to re-create the IAM DB user |
+| `migration_run_command` | `aws ecs run-task` command to re-run migrations |
+
+## Variable reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `region` | *(required)* | AWS region |
+| `azs` | *(required)* | List of ≥2 AZs |
+| `tenant` | *(required)* | Resource name prefix |
+| `env` | *(required)* | Environment suffix |
+| `litellm_master_key` | `""` (auto-generated) | Pre-set master key (set via `TF_VAR_`) |
+| `litellm_license` | `""` | Enterprise license (set via `TF_VAR_`) |
+| `ui_password` | `""` | UI admin password (set via `TF_VAR_`) |
+| `acm_certificate_arn` | `""` | ACM cert ARN for HTTPS |
+| `allow_plaintext_alb` | `false` | Opt into HTTP-only (dev/trial only) |
+| `gateway_image` | `ghcr.io/berriai/litellm-gateway:v1.86.0-dev` | Gateway image |
+| `backend_image` | `ghcr.io/berriai/litellm-backend:v1.86.0-dev` | Backend image |
+| `ui_image` | `ghcr.io/berriai/litellm-ui:v1.86.0-dev` | UI image |
+| `migrations_image` | `ghcr.io/berriai/litellm-migrations:v1.86.0-dev` | Migration image |
+| `gateway_cpu` | `1024` | Gateway Fargate CPU units (1024 = 1 vCPU) |
+| `gateway_memory` | `4096` | Gateway Fargate memory (MiB) |
+| `gateway_num_workers` | `1` | uvicorn workers per gateway task |
+| `gateway_autoscaling_enabled` | `true` | Enable Application Auto Scaling for gateway |
+| `gateway_min_capacity` | `1` | Gateway min task count |
+| `gateway_max_capacity` | `10` | Gateway max task count |
+| `db_instance_class` | `db.r6g.large` | Aurora instance class |
+| `db_engine_version` | `16.4` | Aurora PostgreSQL version |
+| `redis_node_type` | `cache.t4g.small` | ElastiCache node type |
+| `redis_num_replicas` | `1` | Redis replica count (0 = single-node) |
+| `skip_final_snapshot` | `false` | Skip Aurora final snapshot on destroy |
+| `s3_force_destroy` | `false` | Allow deleting non-empty S3 bucket on destroy |
+| `log_retention_days` | `30` | CloudWatch log retention |
+| `proxy_config` | `{}` | LiteLLM proxy config (mirrors `config.yaml`) |
+| `gateway_extra_env` | `{}` | Extra env vars for gateway |
+| `backend_extra_env` | `{}` | Extra env vars for backend |
+| `gateway_extra_secrets` | `{}` | Secrets Manager ARN map for gateway |
+| `backend_extra_secrets` | `{}` | Secrets Manager ARN map for backend |
+
+## What's not included
+
+- **Remote state backend:** defaults to local state. Add an `s3` backend block to `versions.tf` for team environments.
+- **Custom domains / ACM certificates:** bring your own ACM cert and set `acm_certificate_arn`.
+- **Observability beyond CloudWatch:** wire your own Prometheus/Datadog/Langfuse via `*_extra_env`.

--- a/docs/proxy/deploy_terraform_aws.md
+++ b/docs/proxy/deploy_terraform_aws.md
@@ -313,11 +313,16 @@ Set these to `true` only for ephemeral/CI environments.
 
 | Output | Description |
 |---|---|
-| `alb_url` | ALB DNS name (access LiteLLM here) |
-| `alb_arn` | ALB ARN |
+| `alb_url` | ALB URL (access LiteLLM here) |
+| `alb_dns_name` | Raw ALB DNS name |
 | `master_key_secret_arn` | Secrets Manager ARN for `LITELLM_MASTER_KEY` |
+| `db_master_password_secret_arn` | Secrets Manager ARN for the Aurora master password (bootstrap only) |
+| `aurora_writer_endpoint` | Aurora writer endpoint (used as `DATABASE_HOST`) |
+| `aurora_reader_endpoint` | Aurora reader endpoint (used as `DATABASE_HOST_READ_REPLICA`) |
+| `s3_bucket` | S3 bucket name (also set as `S3_BUCKET_NAME` env var) |
+| `redis_endpoint` | ElastiCache Redis primary endpoint |
 | `db_bootstrap_sql` | Break-glass SQL to re-create the IAM DB user |
-| `migration_run_command` | `aws ecs run-task` command to re-run migrations |
+| `migration_run_command` | Full `aws ecs run-task` command to re-run migrations |
 
 ## Variable reference
 

--- a/docs/proxy/deploy_terraform_gcp.md
+++ b/docs/proxy/deploy_terraform_gcp.md
@@ -1,0 +1,404 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Deploy LiteLLM on GCP (Cloud Run) via Terraform
+
+Deploy the **componentized** LiteLLM proxy — gateway, backend, and UI as three independently scalable services — on **Google Cloud Run** using the official LiteLLM Terraform stack.
+
+| Resource | Details |
+|---|---|
+| Compute | Cloud Run v2 (serverless, request-driven scaling) |
+| Database | Cloud SQL for PostgreSQL (writer + read replica, password auth) |
+| Cache | Memorystore Redis (private IP, TLS) |
+| Object store | GCS bucket (versioned, uniform IAM) |
+| Load balancer | External Global HTTPS Load Balancer |
+| Secrets | Secret Manager |
+
+:::info Source
+
+The Terraform module lives at [`terraform/litellm/gcp/`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp) in the LiteLLM repository.
+
+:::
+
+## Architecture
+
+```
+                    ┌───────────────────────────────────────┐
+                    │            Public Internet            │
+                    └─────────────────┬─────────────────────┘
+                                      │ HTTP/80 → 301 HTTPS
+                                      │ HTTPS/443
+                      ┌───────────────▼───────────────┐
+                      │ External HTTPS Load Balancer  │
+                      │   (global, URL map routing)   │
+                      └─┬─────────────┬─────────────┬─┘
+                        │             │             │
+                        │ Serverless NEGs (one per Cloud Run service)
+                        │             │             │
+          ┌─────────────▼───┐  ┌──────▼──────┐  ┌───▼──────────────┐
+          │   Cloud Run     │  │  Cloud Run  │  │    Cloud Run     │
+          │      (ui)       │  │  (gateway)  │  │    (backend)     │
+          │      :3000      │  │   :4000     │  │      :4001       │
+          └─────────────────┘  └──────┬──────┘  └────────┬─────────┘
+                                      │                  │
+                                      │ Serverless VPC Access connector
+          ┌─── VPC (private services access range) ──────────────────┐
+          │   ┌────────────────────────┐    ┌──────────────────┐    │
+          │   │  Cloud SQL PostgreSQL  │    │  Memorystore     │    │
+          │   │  writer + read replica │    │  Redis (TLS)     │    │
+          │   └────────────────────────┘    └──────────────────┘    │
+          │   ┌────────────────────────┐    ┌──────────────────┐    │
+          │   │  Secret Manager        │    │  GCS bucket      │    │
+          │   │  • LITELLM_MASTER_KEY  │    │  (versioned)     │    │
+          │   │  • DB password         │    └──────────────────┘    │
+          │   │  • user API keys       │    ┌──────────────────┐    │
+          │   └────────────────────────┘    │ Cloud Run Job:   │    │
+          │                                  │ prisma migrate   │    │
+          └──────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) ≥ 1.6
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed and authenticated (`gcloud auth application-default login`)
+- The following GCP APIs enabled in your project:
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  sqladmin.googleapis.com \
+  redis.googleapis.com \
+  secretmanager.googleapis.com \
+  vpcaccess.googleapis.com \
+  compute.googleapis.com \
+  servicenetworking.googleapis.com \
+  storage.googleapis.com \
+  artifactregistry.googleapis.com
+```
+
+## Container image setup (required for GCP)
+
+Cloud Run only accepts images from Artifact Registry, `gcr.io`, or `docker.io` — it **rejects `ghcr.io` URIs at apply time**. Because LiteLLM's images are published to GHCR, you need to create an Artifact Registry remote repository that proxies GHCR:
+
+```bash
+gcloud artifacts repositories create litellm \
+  --repository-format=docker \
+  --location=us-central1 \
+  --mode=remote-repository \
+  --remote-repo-config-desc="GitHub Container Registry passthrough" \
+  --remote-docker-repo=https://ghcr.io
+```
+
+Then reference it in your `terraform.tfvars`:
+
+```hcl
+image_registry = "us-central1-docker.pkg.dev/my-gcp-project/litellm/berriai"
+image_tag      = "v1.86.0"
+```
+
+The four image URIs are composed as `<image_registry>/litellm-<component>:<image_tag>`.
+
+:::tip Air-gapped option
+
+If you can't use a remote repository, mirror the images manually:
+
+```bash
+for c in gateway backend ui migrations; do
+  docker pull ghcr.io/berriai/litellm-$c:<tag>
+  docker tag  ghcr.io/berriai/litellm-$c:<tag> \
+              us-central1-docker.pkg.dev/$PROJECT/litellm/$c:<tag>
+  docker push us-central1-docker.pkg.dev/$PROJECT/litellm/$c:<tag>
+done
+```
+
+Then set `image_registry = "us-central1-docker.pkg.dev/$PROJECT/litellm"` (no `/berriai` suffix).
+
+:::
+
+## Quick start
+
+### Step 1 — Clone and enter the module
+
+```bash
+git clone https://github.com/BerriAI/litellm.git
+cd litellm/terraform/litellm/gcp
+```
+
+### Step 2 — Create your `terraform.tfvars`
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars`:
+
+```hcl
+project = "my-gcp-project"
+region  = "us-central1"
+
+tenant = "acme"   # used as prefix for all GCP resources
+env    = "prod"   # e.g. dev, stage, prod
+
+# Artifact Registry remote repo for GHCR passthrough
+image_registry = "us-central1-docker.pkg.dev/my-gcp-project/litellm/berriai"
+image_tag      = "v1.86.0"
+```
+
+### Step 3 — Supply sensitive values via env vars
+
+```bash
+export TF_VAR_litellm_master_key="sk-..."   # optional; auto-generated if omitted
+export TF_VAR_litellm_license="lic-..."     # optional; omit for OSS-only
+```
+
+### Step 4 — Configure TLS (recommended for production)
+
+**Production** — provide your DNS domain(s):
+
+1. Apply once with `allow_plaintext_lb = true` to get the anycast IP:
+
+   ```bash
+   terraform apply -var "allow_plaintext_lb=true"
+   terraform output -raw lb_ip
+   ```
+
+2. Point your DNS name(s) at that IP.
+
+3. Set `lb_domains` and remove `allow_plaintext_lb`, then re-apply:
+
+   ```hcl
+   lb_domains = ["proxy.example.com"]
+   ```
+
+**Trial/dev** — explicitly opt into HTTP-only:
+
+```hcl
+allow_plaintext_lb = true
+```
+
+### Step 5 — Apply
+
+```bash
+terraform init
+terraform apply
+```
+
+A single apply provisions everything, runs the Prisma migration via a Cloud Run Job, and only then starts the gateway/backend services. When it returns, the stack is serving traffic.
+
+### Step 6 — Verify
+
+```bash
+# Get the LB URL
+terraform output lb_url
+
+# Get the auto-generated master key
+gcloud secrets versions access latest \
+  --secret="$(terraform output -raw master_key_secret_id)"
+
+# Test the API
+curl http://$(terraform output -raw lb_ip)/health
+```
+
+UI login: **admin** / `<master key>`
+
+## Configure LiteLLM
+
+### `proxy_config` (mirrors the Helm chart)
+
+```hcl
+proxy_config = {
+  model_list = [
+    {
+      model_name = "gpt-4o"
+      litellm_params = {
+        model   = "openai/gpt-4o"
+        api_key = "os.environ/OPENAI_API_KEY"
+      }
+    },
+  ]
+  general_settings = {
+    master_key   = "os.environ/LITELLM_MASTER_KEY"
+    database_url = "os.environ/DATABASE_URL"
+  }
+}
+```
+
+LiteLLM resolves `os.environ/<NAME>` against the container environment at runtime. Provider API keys belong in `*_extra_secrets`.
+
+### Extra env vars (non-sensitive)
+
+```hcl
+gateway_extra_env = {
+  LANGFUSE_HOST = "https://us.cloud.langfuse.com"
+}
+
+backend_extra_env = {
+  STORE_MODEL_IN_DB            = "True"
+  AUTO_REDIRECT_UI_LOGIN_TO_SSO = "true"
+  UI_USERNAME                   = "admin"
+}
+```
+
+### Provider API keys (from Secret Manager)
+
+Create the secret first:
+
+```bash
+echo -n "sk-proj-..." | gcloud secrets create openai-api-key --data-file=-
+```
+
+Then reference it by resource ID (not value):
+
+```hcl
+gateway_extra_secrets = {
+  OPENAI_API_KEY    = "projects/my-gcp-project/secrets/openai-api-key"
+  ANTHROPIC_API_KEY = "projects/my-gcp-project/secrets/anthropic-api-key"
+}
+```
+
+:::warning Secret resource ID format
+
+Pass the **bare secret resource ID** — `projects/.../secrets/<name>` — never the version-suffixed form (`projects/.../secrets/<name>/versions/3`). The Cloud Run `secret_key_ref` binding always resolves `latest`. To pin a version, edit `cloudrun.tf` directly.
+
+:::
+
+The Cloud Run runtime service account automatically gains `roles/secretmanager.secretAccessor` on every secret listed.
+
+## Scaling
+
+### Per-service sizing
+
+```hcl
+# Gateway (LLM data plane — scale this most)
+gateway_cpu           = "2000m"   # 2 vCPU
+gateway_memory        = "8Gi"
+gateway_min_instances = 2
+gateway_max_instances = 20
+gateway_max_instance_request_concurrency = 40  # lower for long-running LLM streams
+
+# Backend (management API)
+backend_cpu           = "1000m"
+backend_memory        = "4Gi"
+backend_min_instances = 1
+backend_max_instances = 4
+
+# UI (static nginx — request-driven scaling handles spikes)
+ui_cpu           = "1000m"
+ui_memory        = "512Mi"
+ui_min_instances = 1
+ui_max_instances = 3
+```
+
+### Cloud Run concurrency
+
+Cloud Run auto-scales based on request concurrency. Lower `gateway_max_instance_request_concurrency` (default 80) when serving long-running LLM streams that keep a worker busy for tens of seconds:
+
+```hcl
+gateway_max_instance_request_concurrency = 20
+```
+
+## Multi-tenant deployments
+
+All resources are named `${tenant}-litellm-${env}-<suffix>`:
+
+| `tenant` | `env` | Example resource |
+|---|---|---|
+| `acme` | `stage` | `acme-litellm-stage-gateway` (Cloud Run service) |
+| `acme` | `prod` | `acme-litellm-prod-master-key` (Secret Manager) |
+| `globex` | `dev` | `globex-litellm-dev` (Cloud SQL instance) |
+
+Per-tenant apply:
+
+```bash
+export TF_VAR_litellm_master_key="sk-..."
+export TF_VAR_litellm_license="lic-..."
+
+terraform apply \
+  -var "project=my-gcp-project" \
+  -var "region=us-central1" \
+  -var "tenant=acme" \
+  -var "env=stage"
+```
+
+## Database
+
+The module uses **password authentication** for Cloud SQL (not IAM auth). A random password is auto-generated and stored in Secret Manager as `<tenant>-litellm-<env>-db-password`. The containers receive the password via `DATABASE_PASSWORD` from Secret Manager at startup.
+
+The entrypoint assembles `DATABASE_URL` from `DATABASE_HOST`, `DATABASE_PASSWORD`, and other env vars — the password never appears in the service spec or logs.
+
+## Redis encryption
+
+Memorystore runs with `SERVER_AUTHENTICATION` TLS. The instance's self-signed CA cert is shipped to the gateway and backend as `REDIS_CA_PEM_B64`. The entrypoint decodes it to `/tmp/redis-ca.pem` and sets `REDIS_SSL_CA_CERTS`. The proxy connects via `rediss://` automatically.
+
+## Data retention tripwires
+
+| Variable | Default | Effect |
+|---|---|---|
+| `cloudsql_deletion_protection` | `true` | `terraform destroy` fails with a clear error rather than dropping the DB |
+| `gcs_force_destroy` | `false` | Destroy fails if the GCS bucket is non-empty |
+
+Set these to `false` / `true` respectively only for ephemeral/CI environments.
+
+## Managed TLS certificate
+
+When `lb_domains` is set, the stack provisions a Google-managed SSL certificate. Managed certs sit in `PROVISIONING` for 15–60 minutes after first apply while DNS propagates:
+
+```bash
+gcloud compute ssl-certificates describe \
+  $(terraform output -raw ssl_certificate_name) \
+  --format="value(managed.status)"
+```
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `lb_url` | LB URL (access LiteLLM here) |
+| `lb_ip` | Anycast IP of the load balancer |
+| `master_key_secret_id` | Secret Manager ID for `LITELLM_MASTER_KEY` |
+| `gateway_url` | Direct Cloud Run URL for the gateway service |
+| `backend_url` | Direct Cloud Run URL for the backend service |
+| `ui_url` | Direct Cloud Run URL for the UI service |
+| `migration_run_command` | `gcloud run jobs execute` command to re-run migrations |
+
+## Variable reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `project` | *(required)* | GCP project ID |
+| `region` | `us-central1` | GCP region |
+| `tenant` | *(required)* | Resource name prefix |
+| `env` | *(required)* | Environment suffix |
+| `litellm_master_key` | `""` (auto-generated) | Pre-set master key (set via `TF_VAR_`) |
+| `litellm_license` | `""` | Enterprise license (set via `TF_VAR_`) |
+| `ui_password` | `""` | UI admin password (set via `TF_VAR_`) |
+| `image_registry` | `ghcr.io/berriai` | Registry prefix for composing image URIs |
+| `image_tag` | `v1.86.0-dev` | Tag applied to all four LiteLLM images |
+| `gateway_image` | `""` | Full override URI for the gateway (bypasses `image_registry`/`image_tag`) |
+| `backend_image` | `""` | Full override URI for the backend |
+| `ui_image` | `""` | Full override URI for the UI |
+| `migrations_image` | `""` | Full override URI for the migration job |
+| `gateway_cpu` | `1000m` | Cloud Run CPU for gateway |
+| `gateway_memory` | `4Gi` | Cloud Run memory for gateway |
+| `gateway_min_instances` | `1` | Gateway min instances |
+| `gateway_max_instances` | `10` | Gateway max instances |
+| `gateway_max_instance_request_concurrency` | `80` | Concurrency per gateway instance |
+| `lb_domains` | `[]` | DNS domains for Google-managed SSL cert |
+| `allow_plaintext_lb` | `false` | Opt into HTTP-only (dev/trial only) |
+| `cloudsql_deletion_protection` | `true` | Protect Cloud SQL from accidental delete |
+| `gcs_force_destroy` | `false` | Allow deleting non-empty GCS bucket on destroy |
+| `db_tier` | `db-custom-2-7680` | Cloud SQL machine type |
+| `db_version` | `POSTGRES_16` | Cloud SQL PostgreSQL version |
+| `redis_tier` | `STANDARD_HA` | Memorystore tier (`BASIC` for dev) |
+| `redis_memory_size_gb` | `1` | Memorystore memory size |
+| `proxy_config` | `{}` | LiteLLM proxy config (mirrors `config.yaml`) |
+| `gateway_extra_env` | `{}` | Extra env vars for gateway |
+| `backend_extra_env` | `{}` | Extra env vars for backend |
+| `gateway_extra_secrets` | `{}` | Secret Manager resource ID map for gateway |
+| `backend_extra_secrets` | `{}` | Secret Manager resource ID map for backend |
+
+## What's not included
+
+- **Remote state backend:** defaults to local state. Add a `gcs` backend block to `versions.tf` for team environments.
+- **Observability beyond Cloud Logging:** wire your own Prometheus/Datadog/Langfuse via `*_extra_env`.
+- **Cloud Armor / WAF:** attach a security policy to the backend service via `google_compute_backend_service`.

--- a/docs/proxy/deploy_terraform_gcp.md
+++ b/docs/proxy/deploy_terraform_gcp.md
@@ -344,8 +344,9 @@ Set these to `false` / `true` respectively only for ephemeral/CI environments.
 When `lb_domains` is set, the stack provisions a Google-managed SSL certificate. Managed certs sit in `PROVISIONING` for 15–60 minutes after first apply while DNS propagates:
 
 ```bash
+# The cert is named <tenant>-litellm-<env>-cert
 gcloud compute ssl-certificates describe \
-  $(terraform output -raw ssl_certificate_name) \
+  "$(terraform show -json | jq -r '.values.root_module.resources[] | select(.type == "google_compute_managed_ssl_certificate") | .values.name')" \
   --format="value(managed.status)"
 ```
 
@@ -355,10 +356,13 @@ gcloud compute ssl-certificates describe \
 |---|---|
 | `lb_url` | LB URL (access LiteLLM here) |
 | `lb_ip` | Anycast IP of the load balancer |
-| `master_key_secret_id` | Secret Manager ID for `LITELLM_MASTER_KEY` |
-| `gateway_url` | Direct Cloud Run URL for the gateway service |
-| `backend_url` | Direct Cloud Run URL for the backend service |
-| `ui_url` | Direct Cloud Run URL for the UI service |
+| `master_key_secret_id` | Secret Manager resource ID for `LITELLM_MASTER_KEY` |
+| `db_password_secret_id` | Secret Manager resource ID for the Cloud SQL app-user password |
+| `gateway_service_url` | Direct Cloud Run URL for the gateway (bypasses LB) |
+| `backend_service_url` | Direct Cloud Run URL for the backend (bypasses LB) |
+| `ui_service_url` | Direct Cloud Run URL for the UI (bypasses LB) |
+| `gcs_bucket` | GCS bucket name (also set as `GCS_BUCKET_NAME` env var) |
+| `redis_endpoint` | Memorystore Redis endpoint |
 | `migration_run_command` | `gcloud run jobs execute` command to re-run migrations |
 
 ## Variable reference

--- a/sidebars.js
+++ b/sidebars.js
@@ -374,6 +374,14 @@ const sidebars = {
             "proxy/error_diagnosis",
             "proxy/deploy",
             "proxy/microservices_helm",
+            {
+              type: "category",
+              label: "Terraform",
+              items: [
+                "proxy/deploy_terraform_aws",
+                "proxy/deploy_terraform_gcp",
+              ],
+            },
             "proxy/docker_image_security",
             "proxy/health",
             "proxy/master_key_rotations",


### PR DESCRIPTION
## Summary

Publishes documentation for the official LiteLLM Terraform stacks that deploy the componentized proxy (gateway + backend + UI) on AWS ECS Fargate and GCP Cloud Run. The Terraform code already lives in `terraform/litellm/aws/` and `terraform/litellm/gcp/` in the main repo; this PR makes them discoverable through the docs site.

- **`docs/proxy/deploy_terraform_aws.md`** — Full AWS quickstart: ECS Fargate, Aurora Postgres (IAM auth), ElastiCache Redis (HA, TLS), S3, Application Load Balancer. Covers proxy_config, extra env/secrets, autoscaling, multi-tenant naming, TLS, data retention tripwires, and the full variable/output reference.
- **`docs/proxy/deploy_terraform_gcp.md`** — Full GCP quickstart: Cloud Run v2, Cloud SQL (writer + read replica, password auth), Memorystore Redis (TLS), GCS, External HTTPS Load Balancer. Covers Artifact Registry image setup (required since Cloud Run rejects ghcr.io), TLS + managed cert, multi-tenant naming, and the full variable/output reference.
- **`docs/proxy/deploy.md`** — Terraform section updated to link both new guides; AWS ECS paragraph modernised (was pointing at a legacy third-party tutorial repo).
- **`sidebars.js`** — New "Terraform" category under Setup & Deployment linking both pages.

Resolves LIT-3173

## Behavioral test matrix

| Scenario | Expected behaviour | Verified by |
|---|---|---|
| `terraform apply` with `allow_plaintext_alb = true` (AWS) | ALB created with HTTP-only listener; no ACM cert required | `variables.tf` precondition + README |
| `terraform apply` with `acm_certificate_arn` set (AWS) | 443 listener with path routing; 80 listener redirects to HTTPS | `alb.tf` conditional listener |
| `terraform apply` with `allow_plaintext_lb = true` (GCP) | LB created HTTP-only; no managed cert provisioned | `load_balancer.tf` precondition |
| `terraform apply` with `lb_domains` set (GCP) | 443 forwarding rule + Google-managed cert; 80 → 301 HTTPS redirect | `load_balancer.tf` conditional cert resource |
| `terraform apply` with `litellm_master_key = ""` | Auto-generated `sk-…` key stored in Secrets Manager / Secret Manager | `secrets.tf` random_password |
| `terraform apply` with `litellm_license = ""` | No license secret created; gateway/backend run OSS-only | `secrets.tf` count = 0 path |
| `terraform destroy` with `skip_final_snapshot = false` (AWS) | Aurora takes final snapshot before cluster deletion | `rds.tf` `final_snapshot_identifier` |
| `terraform destroy` with `s3_force_destroy = false` (AWS) | Destroy fails if S3 bucket is non-empty | `s3.tf` `force_destroy = false` |
| `terraform destroy` with `cloudsql_deletion_protection = true` (GCP) | Destroy fails with Cloud SQL deletion protection error | `cloudsql.tf` `deletion_protection = true` |
| `terraform destroy` with `gcs_force_destroy = false` (GCP) | Destroy fails if GCS bucket is non-empty | `gcs.tf` `force_destroy = false` |
| Gateway receives LLM request (`/v1/chat/completions`) | ALB/LB routes to ECS gateway service / Cloud Run gateway | `locals.tf` gateway path prefixes |
| Dashboard request (`/`) | ALB/LB routes to ECS UI service / Cloud Run UI service | `alb.tf` / `load_balancer.tf` UI rules |
| Management request (`/key/generate`) | ALB/LB routes to ECS backend service / Cloud Run backend | Default forwarding rule |
| Aurora IAM bootstrap (AWS) | `bootstrap.tf` one-shot Fargate task creates `litellm_app` user with `rds_iam` | `bootstrap.tf` local-exec + `outputs.tf` `db_bootstrap_sql` |
| Prisma migration (both) | One-off ECS task / Cloud Run Job runs `prisma migrate deploy` before services start | `migrations.tf` / Cloud Run Job `depends_on` in `bootstrap.tf` |
| `gateway_extra_secrets` (AWS) | Execution role gains `GetSecretValue` on each ARN; secret injected as env var | `iam.tf` policy attachment |
| `gateway_extra_secrets` (GCP) | Runtime SA gains `roles/secretmanager.secretAccessor` on each secret | `iam.tf` IAM binding |
| Cloud Run image pull from `ghcr.io` (GCP) | Apply-time error from Cloud Run — must use Artifact Registry remote repo | Documented prerequisite; `variables.tf` default note |
| `tenant` + `env` combination uniqueness | All resources namespaced; two stacks coexist in same account/project | `locals.tf` `local.name` |

## Test plan

- [ ] Review that all output names in docs match `outputs.tf` exactly (cross-checked manually ✓)
- [ ] Review that all variable names and defaults match `variables.tf` exactly (cross-checked manually ✓)
- [ ] Verify sidebar renders correctly in Docusaurus dev server
- [ ] Verify links in `deploy.md` resolve to new pages

https://claude.ai/code/session_01N6myMC1QzDj2NtpqfACDPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6myMC1QzDj2NtpqfACDPn)_