### PR TITLE
docs: add repo contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to LiteLLM Docs
+
+Thanks for contributing to the LiteLLM documentation! This guide will help you run the docs site locally, make changes, and verify them before opening a PR.
+
+## 1. Clone the docs repo
+
+```bash
+git clone https://github.com/BerriAI/litellm-docs.git
+cd litellm-docs
+```
+
+## 2. Install dependencies
+
+```bash
+npm install
+```
+
+## 3. Start the docs site locally
+
+```bash
+npm start
+```
+
+Open http://localhost:3000.
+
+The site uses Docusaurus 3, so most docs and blog changes reload automatically while the dev server is running.
+
+## 4. Make your changes
+
+Most documentation pages live in `docs/`.
+
+Blog posts live in `blog/`.
+
+Custom standalone pages live in `src/pages/`.
+
+If you add, remove, or move docs pages, check whether `sidebars.js` needs to be updated.
+
+## 5. Verify your changes
+
+Before opening a PR, run:
+
+```bash
+npm run build
+```
+
+This catches broken links, invalid MDX, and other Docusaurus build issues.
+
+## 6. Submit a PR
+
+Create a branch:
+
+```bash
+git checkout -b docs/your-change-name
+```
+
+Commit your changes:
+
+```bash
+git add .
+git commit -m "docs: update contributing guide"
+```
+
+Push your branch and open a PR against `BerriAI/litellm-docs`.

--- a/docs/extras/contributing.md
+++ b/docs/extras/contributing.md
@@ -1,68 +1,41 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Contributing to Documentation
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
-Clone litellm 
-```
-git clone https://github.com/BerriAI/litellm.git
+Clone the docs repo:
+
+```bash
+git clone https://github.com/BerriAI/litellm-docs.git
+cd litellm-docs
 ```
 
 ### Local setup for locally running docs
 
-```
-cd docs/my-website
+Install dependencies:
+
+```bash
+npm install
 ```
 
+Run the docs site locally:
 
-<Tabs>
-
-<TabItem value="yarn" label="Yarn">
-
-Installation
-```
-npm install --global yarn
-```
-Install requirement
-```
-yarn
-```
-Run website
-```
-yarn start
+```bash
+npm start
 ```
 
-</TabItem>
-
-<TabItem value="pnpm" label="pnpm">
-
-Installation
-```
-npm install --global pnpm
-```
-Install requirement
-```
-pnpm install
-```
-Run website
-```
-pnpm start
-```
-
-</TabItem>
-
-</Tabs>
-
-
-Open docs here: [http://localhost:3000/](http://localhost:3000/)
-
-This command builds your Markdown files into HTML and starts a development server to browse your documentation. Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your web browser to see your documentation. You can make changes to your Markdown files and your docs will automatically rebuild.
-
-[Full tutorial here](https://docs.readthedocs.io/en/stable/intro/getting-started-with-mkdocs.html)
+Open docs here: [http://localhost:3000/](http://localhost:3000/).
 
 ### Making changes to Docs
 - All the docs are placed under the `docs` directory
-- If you are adding a new `.md` file or editing the hierarchy edit `mkdocs.yml` in the root of the project
-- After testing your changes, make a change/pull request to the `main` branch of [github.com/BerriAI/litellm](https://github.com/BerriAI/litellm)
+- Blog posts are placed under the `blog` directory
+- If you are adding a new `.md` file or editing the hierarchy, check whether `sidebars.js` needs to be updated
+
+### Verify your changes
+
+Before opening a PR, run:
+
+```bash
+npm run build
+```
+
+After testing your changes, open a pull request against [github.com/BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs).

--- a/src/pages/contributing.md
+++ b/src/pages/contributing.md
@@ -1,35 +1,41 @@
 # Contributing to Documentation
 
-Clone litellm 
-```
-git clone https://github.com/BerriAI/litellm.git
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
+
+Clone the docs repo:
+
+```bash
+git clone https://github.com/BerriAI/litellm-docs.git
+cd litellm-docs
 ```
 
 ### Local setup for locally running docs
 
-#### Installation
-```
-uv add mkdocs
+Install dependencies:
+
+```bash
+npm install
 ```
 
-#### Locally Serving Docs
-```
-mkdocs serve
-```
-If you see `command not found: mkdocs` try running the following
-```
-python3 -m mkdocs serve
+Run the docs site locally:
+
+```bash
+npm start
 ```
 
-This command builds your Markdown files into HTML and starts a development server to browse your documentation. Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your web browser to see your documentation. You can make changes to your Markdown files and your docs will automatically rebuild.
-
-[Full tutorial here](https://docs.readthedocs.io/en/stable/intro/getting-started-with-mkdocs.html)
+Open docs here: [http://localhost:3000/](http://localhost:3000/).
 
 ### Making changes to Docs
 - All the docs are placed under the `docs` directory
-- If you are adding a new `.md` file or editing the hierarchy edit `mkdocs.yml` in the root of the project
-- After testing your changes, make a change to the `main` branch of [github.com/BerriAI/litellm](https://github.com/BerriAI/litellm)
+- Blog posts are placed under the `blog` directory
+- If you are adding a new `.md` file or editing the hierarchy, check whether `sidebars.js` needs to be updated
 
+### Verify your changes
 
+Before opening a PR, run:
 
+```bash
+npm run build
+```
 
+After testing your changes, open a pull request against [github.com/BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs).


### PR DESCRIPTION
- Adds a root CONTRIBUTING.md for BerriAI/litellm-docs.
- Updates the existing documentation contribution pages to use the current Docusaurus 3 workflow.
- Replaces stale references to the main BerriAI/litellm repo, MkDocs, and mkdocs.yml.

GitHub was showing the existing docs/contributing.md page as the repository contributing guide. That page is for LiteLLM UI contribution in the main BerriAI/litellm repo, so it is misleading for contributors working on this docs repository.

Adding a root CONTRIBUTING.md makes the repository-level contribution flow explicit and points contributors to the correct docs setup commands.