### PR TITLE
docs(galileo): document GALILEO_API_KEY and GALILEO_LOG_STREAM_ID

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -721,10 +721,12 @@ router_settings:
 | FOCUS_S3_SECRET_KEY | AWS secret access key used by the Focus export S3 client.
 | FOCUS_S3_SESSION_TOKEN | AWS session token used by the Focus export S3 client (optional).
 | FUNCTION_DEFINITION_TOKEN_COUNT | Token count for function definitions. Default is 9
-| GALILEO_BASE_URL | Base URL for Galileo platform
-| GALILEO_PASSWORD | Password for Galileo authentication
+| GALILEO_API_KEY | API key for Galileo Cloud (hosted). Used with the v2 spans API when `success_callback` includes `galileo`.
+| GALILEO_BASE_URL | Base URL for Galileo platform. For Galileo Cloud, use `https://api.galileo.ai`. For enterprise/self-hosted, replace `console` with `api` in your console URL.
+| GALILEO_LOG_STREAM_ID | Log stream ID for Galileo Cloud v2 spans logging (optional).
+| GALILEO_PASSWORD | Password for Galileo enterprise Observe authentication
 | GALILEO_PROJECT_ID | Project ID for Galileo usage
-| GALILEO_USERNAME | Username for Galileo authentication
+| GALILEO_USERNAME | Username for Galileo enterprise Observe authentication
 | GOOGLE_SECRET_MANAGER_PROJECT_ID | Project ID for Google Secret Manager
 | GCS_BUCKET_NAME | Name of the Google Cloud Storage bucket
 | GCS_MOCK | Enable mock mode for GCS integration testing. When set to true, intercepts GCS API calls and returns mock responses without making actual network calls. Default is false
@@ -760,10 +762,12 @@ router_settings:
 | GENERIC_ROLE_MAPPINGS_ROLES | Python dict string mapping LiteLLM roles to SSO group names. Example: `{"proxy_admin": ["admin-group"], "internal_user": ["users"]}`
 | GENERIC_USER_ROLE_MAPPINGS | Alternative to GENERIC_ROLE_MAPPINGS_ROLES for configuring user role mappings from SSO
 | GEMINI_API_BASE | Base URL for Gemini API. Default is https://generativelanguage.googleapis.com
-| GALILEO_BASE_URL | Base URL for Galileo platform
-| GALILEO_PASSWORD | Password for Galileo authentication
+| GALILEO_API_KEY | API key for Galileo Cloud (hosted). Used with the v2 spans API when `success_callback` includes `galileo`.
+| GALILEO_BASE_URL | Base URL for Galileo platform. For Galileo Cloud, use `https://api.galileo.ai`. For enterprise/self-hosted, replace `console` with `api` in your console URL.
+| GALILEO_LOG_STREAM_ID | Log stream ID for Galileo Cloud v2 spans logging (optional).
+| GALILEO_PASSWORD | Password for Galileo enterprise Observe authentication
 | GALILEO_PROJECT_ID | Project ID for Galileo usage
-| GALILEO_USERNAME | Username for Galileo authentication
+| GALILEO_USERNAME | Username for Galileo enterprise Observe authentication
 | GITHUB_COPILOT_TOKEN_DIR | Directory to store GitHub Copilot token for `github_copilot` llm provider
 | GITHUB_COPILOT_API_KEY_FILE | File to store GitHub Copilot API key for `github_copilot` llm provider
 | GITHUB_COPILOT_ACCESS_TOKEN_FILE | File to store GitHub Copilot access token for `github_copilot` llm provider

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -2288,8 +2288,19 @@ Beta Integration
 
 **Required Env Variables**
 
+Galileo Cloud (app.galileo.ai):
+
 ```bash
-export GALILEO_BASE_URL=""  # For most users, this is the same as their console URL except with the word 'console' replaced by 'api' (e.g. http://www.console.galileo.myenterprise.com -> http://www.api.galileo.myenterprise.com)
+export GALILEO_API_KEY=""
+export GALILEO_PROJECT_ID=""
+export GALILEO_LOG_STREAM_ID=""  # optional
+export GALILEO_BASE_URL="https://api.galileo.ai"  # optional, defaults when GALILEO_API_KEY is set
+```
+
+Enterprise / self-hosted Observe:
+
+```bash
+export GALILEO_BASE_URL=""  # Replace 'console' with 'api' in your console URL (e.g. https://api.galileo.myenterprise.com)
 export GALILEO_PROJECT_ID=""
 export GALILEO_USERNAME=""
 export GALILEO_PASSWORD=""
@@ -2306,6 +2317,11 @@ model_list:
     api_key: my-fake-key
     model: openai/my-fake-model
   model_name: fake-openai-endpoint
+
+environment_variables:
+  GALILEO_API_KEY: "os.environ/GALILEO_API_KEY"
+  GALILEO_PROJECT_ID: "your-project-id"
+  GALILEO_LOG_STREAM_ID: "your-log-stream-id"  # optional
 
 litellm_settings:
   success_callback: ["galileo"] # 👈 KEY CHANGE


### PR DESCRIPTION
## Summary
- Document `GALILEO_API_KEY` and `GALILEO_LOG_STREAM_ID` in `config_settings.md` (fixes litellm `test_env_keys.py` CI)
- Update Galileo logging guide for hosted Cloud (API key) vs enterprise Observe (username/password)

## Related
- https://github.com/BerriAI/litellm/pull/28771

## Test plan
- [x] Verified locally: `python ./tests/documentation_tests/test_env_keys.py` passes when docs are checked out to `docs/my-website`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Documents **Galileo Cloud** vs **enterprise Observe** setup so proxy users can configure the `galileo` success callback correctly.
> 
> **`config_settings.md`** adds **`GALILEO_API_KEY`** and **`GALILEO_LOG_STREAM_ID`**, and clarifies **`GALILEO_BASE_URL`**, **`GALILEO_USERNAME`**, and **`GALILEO_PASSWORD`** (Cloud API key + v2 spans vs enterprise username/password). This aligns the env reference with code so **`test_env_keys.py`** CI can pass.
> 
> **`logging.md`** splits required env vars into two paths (hosted Cloud with optional log stream and `https://api.galileo.ai`, vs self-hosted Observe), and adds a **`environment_variables`** block in the Galileo quick-start **`config.yaml`** example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7edea3804c12cf7aaa21ec06b5fa0bf6f7417e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->