### PR TITLE
docs(custom-auth): document custom_auth_run_common_checks model enforcement

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -251,7 +251,7 @@ router_settings:
 | database_socket_timeout | float | Maps to the Prisma [`socket_timeout`](https://www.prisma.io/docs/orm/overview/databases/postgresql) URL param (seconds). When set, an idle or slow connection that has not produced data within this window is closed. **Use this to cap idle Prisma connections from LiteLLM.** |
 | database_extra_connection_params | object | Escape hatch — extra key/value pairs appended verbatim to the Prisma `DATABASE_URL` / `DIRECT_URL` query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets. |
 | allow_requests_on_db_unavailable | boolean | If true, allows requests to succeed even if DB is unreachable. **Only use this if running LiteLLM in your VPC** This will allow requests to work even when LiteLLM cannot connect to the DB to verify a Virtual Key [Doc on graceful db unavailability](prod#5-if-running-litellm-on-vpc-gracefully-handle-db-unavailability) |
-| custom_auth | string | Write your own custom authentication logic [Doc Custom Auth](virtual_keys#custom-auth) |
+| custom_auth | string | Write your own custom authentication logic [Doc Custom Auth](./custom_auth) |
 | max_parallel_requests | integer | The max parallel requests allowed per deployment |
 | global_max_parallel_requests | integer | The max parallel requests allowed on the proxy overall |
 | infer_model_from_keys | boolean | If true, infers the model from the provided keys |
@@ -310,7 +310,7 @@ router_settings:
 | always_include_stream_usage | boolean | If true, includes usage metrics in every streaming response chunk |
 | auto_redirect_ui_login_to_sso | boolean | If true, automatically redirects UI login page to SSO provider |
 | control_plane_url | string | URL of the control plane for cross-instance state sharing |
-| custom_auth_run_common_checks | boolean | If true, runs standard auth validation checks alongside custom auth handlers |
+| custom_auth_run_common_checks | boolean | If true, runs LiteLLM's standard auth validation alongside custom auth (key/team/user/project model allowlists, budgets, rate limits). Default is `false` — see [Custom Auth — Enforce model access](./custom_auth#enforce-model-access-budgets-and-teamproject-checks) |
 | custom_ui_sso_sign_in_handler | string | Custom handler for SSO sign-in logic in the UI |
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |
 | disable_error_logs | boolean | If true, suppresses error tracking and storage in the database |

--- a/docs/proxy/custom_auth.md
+++ b/docs/proxy/custom_auth.md
@@ -104,7 +104,7 @@ UserAPIKeyAuth(
 ```python
 UserAPIKeyAuth(
     # Model access control
-    models: List = [],                                # Allowed models list
+    models: List = [],                                # Allowed models list (enforced when custom_auth_run_common_checks: true)
     team_models: List = [],                           # Team's allowed models
     aliases: Dict = {},                               # Model aliases
     
@@ -234,6 +234,65 @@ general_settings:
 ```shell
 $ litellm --config /path/to/config.yaml 
 ```
+
+## Enforce model access, budgets, and team/project checks
+
+By default, LiteLLM **does not** run standard proxy auth checks (model allowlists, budgets, team/project restrictions) after your custom auth handler returns a `UserAPIKeyAuth` object. Setting `models=[...]` on the returned object only **records** the allowlist for logging — it does **not** block requests unless you opt in.
+
+To enforce LiteLLM's built-in checks alongside custom auth, set:
+
+```yaml
+general_settings:
+  custom_auth: custom_auth.user_api_key_auth
+  custom_auth_run_common_checks: true
+```
+
+When `custom_auth_run_common_checks: true`, LiteLLM runs the same validation used for virtual keys, including:
+
+- **Key-level model access** — the `models` list on your returned `UserAPIKeyAuth`
+- **Team / user / project model access** — loaded from LiteLLM's DB using `team_id`, `user_id`, and `project_id` on the token
+- **Budget and rate limits** — key, team, user, project, and end-user budgets where configured
+
+### Example: restrict models in custom auth
+
+```python
+async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
+    # ... validate api_key and load project_context from your system ...
+    return UserAPIKeyAuth(
+        api_key=api_key,
+        user_id=user_id,
+        team_id=project_context.team_id,
+        project_id=project_context.project_id,
+        models=project_context.models,  # e.g. ["gpt-4o-mini", "claude-3-haiku"]
+    )
+```
+
+```yaml
+general_settings:
+  custom_auth: my_auth.user_api_key_auth
+  custom_auth_run_common_checks: true
+```
+
+Without `custom_auth_run_common_checks: true`, a client can call any model the proxy has configured (for example `gpt-4o`) even if it is not in your `models` list.
+
+### Key `models` vs project `models`
+
+These are separate controls:
+
+| Field | Where it is enforced | Source of truth |
+| --- | --- | --- |
+| `models` on `UserAPIKeyAuth` | Key-level allowlist | Value you return from custom auth |
+| `project_id` on `UserAPIKeyAuth` | Project-level allowlist | `models` on the **project record in LiteLLM's DB** |
+
+If you set `project_id`, also create/update the project in LiteLLM (via `/project/new` or the UI) with the correct `models` list. See [Project Management](./project_management).
+
+**Notes:**
+
+- An empty `models` list (`[]`) means **no restriction** (all models allowed) for that scope.
+- Model names must match the model group name in your proxy config, or use wildcard patterns where supported.
+- Fallback models in the request body are also validated against the key allowlist when common checks are enabled.
+
+See also: [`custom_auth_run_common_checks` in Config Settings](./config_settings#all-settings).
 
 ## ✨ Support LiteLLM Virtual Keys + Custom Auth
 


### PR DESCRIPTION
## Summary
- Add a new **Enforce model access, budgets, and team/project checks** section to the Custom Auth docs explaining that `models=[...]` on `UserAPIKeyAuth` is not enforced by default
- Document `custom_auth_run_common_checks: true` as the opt-in to run LiteLLM's standard key/team/user/project model allowlists and budget checks alongside custom auth
- Clarify the difference between key-level `models` and project-level `models` (from the LiteLLM DB via `project_id`)
- Expand the `custom_auth_run_common_checks` entry in Config Settings and fix the broken `virtual_keys#custom-auth` link

## Test plan
- [ ] Preview Custom Auth page and verify the new section renders
- [ ] Confirm anchor links work between `custom_auth.md` and `config_settings.md`
- [ ] Verify Config Settings `custom_auth` link points to `./custom_auth`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or auth behavior changes.
> 
> **Overview**
> Documentation-only PR clarifies how **custom auth** interacts with LiteLLM’s built-in enforcement.
> 
> **`docs/proxy/custom_auth.md`** adds **Enforce model access, budgets, and team/project checks**, explaining that `models` on `UserAPIKeyAuth` is **not enforced by default** (logging only) and that **`custom_auth_run_common_checks: true`** opts into the same key/team/user/project model allowlists, budgets, and rate limits as virtual keys. It includes YAML/Python examples, contrasts key-level `models` vs DB-backed project `models` via `project_id`, and notes empty `models` means no restriction.
> 
> **`docs/proxy/config_settings.md`** expands the `custom_auth_run_common_checks` table entry, fixes the **`custom_auth`** doc link from `virtual_keys#custom-auth` to **`./custom_auth`**, and cross-links to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce938c9af847fe9d2d5c302f007a5c3e370eb488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->