### PR TITLE
docs(proxy): add disable_daily_spend_aggregation config flag

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -119,6 +119,7 @@ general_settings:
   store_prompts_in_spend_logs: boolean
   forward_client_headers_to_llm_api: boolean
   disable_spend_logs: boolean  # turn off writing each transaction to the db
+  disable_daily_spend_aggregation: boolean  # skip DailyUser/Team/Tag/Org/EndUser/Agent aggregation tables (prevents Redis OOM when Usage dashboard is not needed)
   disable_master_key_return: boolean  # turn off returning master key on UI (checked on '/user/info' endpoint)
   disable_retry_on_max_parallel_request_limit_error: boolean  # turn off retries when max parallel request limit is reached
   disable_reset_budget: boolean  # turn off reset budget scheduled task
@@ -232,6 +233,7 @@ router_settings:
 |------|------|-------------|
 | completion_model | string | The model to use for all completions, overriding any `model` specified in the request |
 | disable_spend_logs | boolean | If true, turns off writing each transaction to the database |
+| disable_daily_spend_aggregation | boolean | If true, skips writing to the DailyUser/Team/Tag/Org/EndUser/Agent spend aggregation tables. Prevents Redis buffer key (`litellm_daily_*_spend_update_buffer`) growth when the Usage dashboard is not needed. Key/user/team balance updates continue to work normally. |
 | disable_spend_updates | boolean | If true, turns off all spend updates to the DB. Including key/user/team spend updates. |
 | disable_master_key_return | boolean | If true, turns off returning master key on UI. (checked on '/user/info' endpoint) |
 | disable_retry_on_max_parallel_request_limit_error | boolean | If true, turns off retries when max parallel request limit is reached |

--- a/docs/proxy/db_info.md
+++ b/docs/proxy/db_info.md
@@ -70,6 +70,33 @@ When disabling error logs (`disable_error_logs: True`):
 - You **will** continue seeing error logs in your application logs and any other logging integrations you are using
 
 
+## Disable Daily Spend Aggregation
+
+If you do **not** use the LiteLLM Usage dashboard (DailyUser/Team/Tag/Org/EndUser/Agent spend tables) and are hitting Redis OOM errors due to growing `litellm_daily_*_spend_update_buffer` keys, you can set `disable_daily_spend_aggregation: true` to stop all daily aggregation writes.
+
+```yaml
+general_settings:
+  disable_daily_spend_aggregation: true   # Skip DailyUser/Team/Tag/Org/EndUser/Agent spend tables
+```
+
+### What is the impact?
+
+When `disable_daily_spend_aggregation: true`:
+- The six Redis buffer keys (`litellm_daily_user_spend_update_buffer`, `litellm_daily_team_spend_update_buffer`, `litellm_daily_tag_spend_update_buffer`, `litellm_daily_org_spend_update_buffer`, `litellm_daily_end_user_spend_update_buffer`, `litellm_daily_agent_spend_update_buffer`) are **never written** — preventing Redis OOM.
+- The `update_daily_tag_spend_job` background scheduler is **not registered** at startup.
+- Key, user, and team **balance updates** (budget enforcement) continue to work normally.
+- You **will not** be able to view the Usage analytics dashboard (daily breakdowns by user/team/tag/org).
+- `disable_spend_logs: true` and `disable_daily_spend_aggregation: true` can be combined for maximum write reduction.
+
+:::tip When to use this
+
+Use `disable_daily_spend_aggregation: true` when:
+- You have `disable_spend_logs: true` set (suppresses per-request rows) but still see Redis buffer growth.
+- You do not use the LiteLLM Usage/Analytics dashboard.
+- Your deployment processes high request volumes and the daily aggregation Redis buffers are causing memory pressure.
+
+:::
+
 ## Migrating Databases 
 
 If you need to migrate Databases the following Tables should be copied to ensure continuation of services and no downtime


### PR DESCRIPTION
## Summary

Documents the new `disable_daily_spend_aggregation` general_settings flag introduced in [BerriAI/litellm#28802](https://github.com/BerriAI/litellm/pull/28802).

- **`docs/proxy/config_settings.md`**: Added `disable_daily_spend_aggregation` to both the YAML reference block and the settings table (next to `disable_spend_logs` / `disable_spend_updates`)
- **`docs/proxy/db_info.md`**: Added a new "Disable Daily Spend Aggregation" section explaining the flag, the Redis buffer keys it suppresses, and when to use it

## Context

Resolves LIT-3332. Customers with `disable_spend_logs: true` were still seeing Redis OOM because the six daily aggregation buffer keys (`litellm_daily_user/team/tag/org/end_user/agent_spend_update_buffer`) ran unconditionally. The new flag skips all daily aggregation writes while keeping key/user/team balance updates working.

## Test plan

- [ ] Verify YAML snippet renders correctly in the docs site
- [ ] Verify the settings table row appears between `disable_spend_logs` and `disable_spend_updates`
- [ ] Verify the new "Disable Daily Spend Aggregation" section in `db_info.md` renders the tip admonition correctly

https://claude.ai/code/session_01VSh9vug6wHMkBWZ76MjdTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSh9vug6wHMkBWZ76MjdTt)_