### PR TITLE
docs(env-vars): document EXPERIMENTAL_UI_LOGIN_SESSION_DURATION (LIT-2394)

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -885,7 +885,8 @@ router_settings:
 | LITELLM_HOSTED_UI | URL of the hosted UI for LiteLLM
 | LITELLM_UI_API_DOC_BASE_URL | Optional override for the API Reference base URL (used in sample code/docs) when the admin UI runs on a different host than the proxy. Defaults to `PROXY_BASE_URL` when unset.
 | LITELLM_UI_PATH | Path to directory for Admin UI files. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/ui` in Docker.
-| LITELLM_UI_SESSION_DURATION | Duration for UI login session (username/password, SSO, invitation links). Format: "30s", "30m", "24h", "7d". Does not apply to EXPERIMENTAL_UI_LOGIN flow, which uses a fixed 10-minute expiry for security. Default is "24h"
+| LITELLM_UI_SESSION_DURATION | Duration for UI login session (username/password, SSO, invitation links). Format: "30s", "30m", "24h", "7d". Does not apply to EXPERIMENTAL_UI_LOGIN flow — that uses the separate `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION` env var. Default is "24h"
+| EXPERIMENTAL_UI_LOGIN_SESSION_DURATION | Duration for the EXPERIMENTAL_UI_LOGIN session (controls the JWT `expires` claim on tokens issued by `ExperimentalUIJWTToken`). Same `<number><unit>` format as `LITELLM_UI_SESSION_DURATION` ("10m", "1h", "2h", "12h", etc.). Malformed or non-positive values fall back to the default. Default is "10m".
 | LITELLM_EXPIRED_UI_SESSION_KEY_CLEANUP_BATCH_SIZE | Maximum number of expired LiteLLM dashboard session keys to delete per cleanup run. Default is 1000.
 | LITELLM_EXPIRED_UI_SESSION_KEY_CLEANUP_ENABLED | Set to `true` to enable the background cleanup job for expired LiteLLM dashboard session keys. Default is `false`.
 | LITELLM_EXPIRED_UI_SESSION_KEY_CLEANUP_INTERVAL_SECONDS | Interval in seconds for how often to run the expired LiteLLM dashboard session key cleanup job. Default is 86400 (24 hours).


### PR DESCRIPTION
Documents the new `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION` env var added in BerriAI/litellm#28954.

* New row added to the `### environment variables - Reference` table.
* Existing `LITELLM_UI_SESSION_DURATION` row updated — the experimental UI flow is no longer a hard-coded 10-min expiry; it now uses this separate env var.

Closes LIT-2394 documentation gap.