### PR TITLE
docs(proxy): add batch input-file pre-read controls

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -127,6 +127,9 @@ general_settings:
   enable_jwt_auth: boolean  # allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims
   enforce_user_param: boolean  # requires all openai endpoint requests to have a 'user' param
   reject_clientside_metadata_tags: boolean  # if true, rejects requests with client-side 'metadata.tags' to prevent users from influencing budgets
+  disable_batch_input_file_rate_limiting: boolean  # if true, skip pre-reading batch input files for rate-limit/model checks
+  skip_batch_input_file_rate_limiting_for_providers: ["hosted_vllm"]  # provider allowlist for skipping batch input-file pre-read
+  skip_batch_input_file_rate_limiting_for_models: ["my-batch-model-prefix"]  # model/prefix allowlist for skipping batch input-file pre-read
   allowed_routes: ["route1", "route2"]  # list of allowed proxy API routes - a user can access. (currently JWT-Auth only)
   key_management_system: google_kms  # either google_kms or azure_kms
   master_key: string
@@ -241,6 +244,9 @@ router_settings:
 | enable_jwt_auth | boolean | allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims. [Doc on JWT Tokens](token_auth) |
 | enforce_user_param | boolean | If true, requires all OpenAI endpoint requests to have a 'user' param. [Doc on call hooks](call_hooks)|
 | reject_clientside_metadata_tags | boolean | If true, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata. |
+| disable_batch_input_file_rate_limiting | boolean | If true, skips pre-reading batch input files during `POST /batches` pre-checks. |
+| skip_batch_input_file_rate_limiting_for_providers | array of strings | Skip batch input-file pre-read for specific providers (for example `["hosted_vllm"]`). |
+| skip_batch_input_file_rate_limiting_for_models | array of strings | Skip batch input-file pre-read for specific model names or prefixes. |
 | allowed_routes | array of strings | List of allowed proxy API routes a user can access [Doc on controlling allowed routes](enterprise#control-available-public-private-routes)|
 | key_management_system | string | Specifies the key management system. [Doc Secret Managers](../secret) |
 | master_key | string | The master key for the proxy [Set up Virtual Keys](virtual_keys) |

--- a/docs/proxy/managed_batches.md
+++ b/docs/proxy/managed_batches.md
@@ -31,6 +31,7 @@ Here's how to give developers access to your Batch models.
 ### 1. Setup config.yaml
 
 - specify `mode: batch` for each model: Allows developers to know this is a batch model.
+- optionally skip pre-read of batch input files for specific batch providers/models (useful for large files on custom vLLM batch deployments).
 
 ```yaml showLineNumbers title="litellm_config.yaml"
 model_list:
@@ -48,6 +49,18 @@ model_list:
       api_key: os.environ/AZURE_API_KEY_2
     model_info: 
       mode: batch # 👈 SPECIFY MODE AS BATCH, to tell user this is a batch model
+
+general_settings:
+  # Optional: disable batch input-file pre-read globally
+  # disable_batch_input_file_rate_limiting: true
+
+  # Optional: skip only for selected providers (example: custom vLLM)
+  skip_batch_input_file_rate_limiting_for_providers:
+    - hosted_vllm
+
+  # Optional: skip only for selected model names / prefixes
+  # skip_batch_input_file_rate_limiting_for_models:
+  #   - my-vllm-batch-model
 
 ```
 
@@ -129,6 +142,17 @@ batch_response = client.batches.retrieve(
     batch_id
 )
 status = batch_response.status
+```
+
+You can also skip input-file pre-read per request:
+
+```python showLineNumbers title="create_batch.py"
+batch = client.batches.create(
+    input_file_id=batch_input_file.id,
+    endpoint="/v1/chat/completions",
+    completion_window="24h",
+    metadata={"skip_batch_input_file_rate_limiting": True},
+)
 ```
 
 ### 4. Retrieve Batch Content 


### PR DESCRIPTION
## Summary
- document `disable_batch_input_file_rate_limiting` in proxy config settings
- document provider/model skip-list settings for batch input-file pre-read
- add managed batches examples for global/provider/model and per-request controls

## Test plan
- [x] docs-only changes reviewed in preview/editor

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or config parsing changes in this PR.
> 
> **Overview**
> Documents how to **skip pre-reading batch input files** during `POST /batches` pre-checks (rate-limit/model validation), which matters for large inputs on custom deployments (e.g. hosted vLLM).
> 
> **`docs/proxy/config_settings.md`** adds three `general_settings` entries: global `disable_batch_input_file_rate_limiting`, plus provider and model/prefix allowlists `skip_batch_input_file_rate_limiting_for_providers` and `skip_batch_input_file_rate_limiting_for_models`, in both the sample YAML and the reference table.
> 
> **`docs/proxy/managed_batches.md`** extends the admin `config.yaml` example with those optional settings and shows per-request opt-out via `metadata.skip_batch_input_file_rate_limiting` on `client.batches.create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34abc0dc53e4c21a81740d2d2df2bba279222eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->