### PR TITLE
docs(bedrock): document search_results citations and annotations

### DIFF
--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -655,6 +655,88 @@ Same as [Anthropic API response](../providers/anthropic#usage---thinking--reason
 
 Same as [Anthropic API response](../providers/anthropic#usage---thinking--reasoning_content).
 
+## Usage - Bedrock search citations in `/chat/completions`
+
+If your tool returns search sources and you want citation metadata in the final assistant response, pass `search_results` on the `role: "tool"` message.
+
+### Request shape
+
+```json
+{
+  "model": "bedrock-claude-3-7",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is XX?"
+    },
+    {
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "id": "tooluse_a4rBqeZNRTKj2lTskvaO4H",
+          "type": "function",
+          "function": {
+            "name": "RAGRequest",
+            "arguments": "{\"query\":\"What is Apptio?\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "tooluse_a4rBqeZNRTKj2lTskvaO4H",
+      "content": "XX is a company that makes calls to Bedrock using passthrough APIs via LiteLLM",
+      "search_results": [
+        {
+          "source": "https://www.xx.com/about",
+          "title": "About XX",
+          "content": [
+            {
+              "text": "XX is a company that makes calls to Bedrock using passthrough APIs via LiteLLM"
+            }
+          ],
+          "citations": {
+            "enabled": true
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### What you get back
+
+LiteLLM returns regular assistant text in `message.content` and citation metadata in `message.annotations`:
+
+```json
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "XX is a technology business management company...",
+        "annotations": [
+          {
+            "type": "url_citation",
+            "url_citation": {
+              "start_index": 0,
+              "end_index": 42,
+              "title": "About XX",
+              "url": "https://www.xx.com/about"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+:::note
+If you only send plain `tool.content` text (without `search_results`), you will still get a normal answer, but no structured citation annotations.
+:::
+
 
 ## Usage - Anthropic Beta Features
 


### PR DESCRIPTION
## Summary
- add a user-facing guide for passing `search_results` on tool messages in `/chat/completions`
- document the expected response shape with `message.annotations` for citation metadata
- include concise request/response examples focused on integration usage

## Validation
- docs-only update in `docs/providers/bedrock.md`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds a new **Usage - Bedrock search citations in `/chat/completions`** section to `docs/providers/bedrock.md`, placed after the thinking/reasoning docs and before Anthropic beta features.
> 
> The guide explains how to attach **`search_results`** on `role: "tool"` messages (with `source`, `title`, `content`, and optional `citations.enabled`) so RAG/tool flows can surface **structured citation metadata** in the assistant reply. It includes a full multi-turn example (user → assistant `tool_calls` → tool message with `search_results`) and documents the response shape: normal text in **`message.content`** plus **`message.annotations`** entries of type **`url_citation`** (title, URL, character span indices). A note clarifies that plain `tool.content` without `search_results` still answers but omits citation annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7451fed01ad543f46a1050b699b9b758dfbb6c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->