### PR TITLE
docs(enterprise): deprecate litellm-ee image, removal end of June 2026

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -96,6 +96,11 @@ Deploy our Docker image (or build from the pip package) on your own infrastructu
 LITELLM_LICENSE="eyJ..."
 ```
 
+:::warning `litellm-ee` image is deprecated — removal scheduled for end of June 2026
+
+Use the standard `ghcr.io/berriai/litellm` image (or `litellm-database` / `litellm-non_root`) and set `LITELLM_LICENSE` to unlock enterprise features. There is **no separate enterprise image** — `litellm-ee` is built from the same source and is functionally identical. The `litellm-ee` tag is deprecated and will stop being published at the **end of June 2026**.
+:::
+
 **No data leaves your environment.** [Procurement available via AWS and Azure Marketplace.](./data_security.md#legalcompliance-faqs)
 
 Pricing depends on your deployment size — [get in touch](https://enterprise.litellm.ai/demo) to scope it.

--- a/docs/proxy/docker_image_security.md
+++ b/docs/proxy/docker_image_security.md
@@ -15,8 +15,11 @@ All image variants published to `ghcr.io/berriai/` are signed with the same cosi
 
 The signing key was introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0) and the public key is checked into the repository at [`cosign.pub`](https://github.com/BerriAI/litellm/blob/main/cosign.pub).
 
-:::info Enterprise images
-Enterprise images (`litellm-ee`) follow the same signing process. Contact [support@berri.ai](mailto:support@berri.ai) to confirm coverage for your specific enterprise image tag.
+:::warning `litellm-ee` is deprecated — removal scheduled for end of June 2026
+
+There is **no separate enterprise image**. The `litellm-ee` tag is built from the same source as `ghcr.io/berriai/litellm` and is functionally identical — enterprise features are unlocked at runtime by your `LITELLM_LICENSE` key, not by the image you pull. The `litellm-ee` tag is deprecated and will stop being published at the **end of June 2026**.
+
+Migrate to `ghcr.io/berriai/litellm` (or `litellm-database` / `litellm-non_root`) and set `LITELLM_LICENSE` to enable enterprise features. These images follow the same cosign signing process described above.
 :::
 
 ## Verify image signatures


### PR DESCRIPTION
## Summary

Adds a deprecation notice for the `litellm-ee` Docker image. There is **no separate enterprise image** — `litellm-ee` is built from the same source as `ghcr.io/berriai/litellm` and is functionally identical. Enterprise features are unlocked at runtime by the `LITELLM_LICENSE` key, not by which image you pull. This has been confusing users, so we're clarifying it in docs and announcing that the `litellm-ee` tag will stop being published at the **end of June 2026**.

## Changes

- **`docs/enterprise.md`** — adds a deprecation warning to the Self-Hosted deployment section directing users to the standard image + license key.
- **`docs/proxy/docker_image_security.md`** — converts the existing `:::info Enterprise images` note (the only place the docs named `litellm-ee`) into a `:::warning` deprecation callout with the same migration guidance.

## Notes

- Docs-only change. The actual removal of the `litellm-ee` tag from the image-publish pipeline is a separate release-engineering task tracked outside this repo.