### PR TITLE
docs(proxy): recommend plain vX.Y.Z tags; flag main-stable as deprecated

### DIFF
--- a/docs/proxy/docker_image_security.md
+++ b/docs/proxy/docker_image_security.md
@@ -171,12 +171,12 @@ cosign verify \
 
 If digest pinning is too rigid for your workflow, use plain semver / PEP 440 release tags (e.g. `v1.86.2`). These are immutable release tags that will not be overwritten.
 
-:::warning `main-stable` is deprecated
+:::warning `main-stable` and `main-latest` are deprecated
 
-LiteLLM has moved to PEP 440 / semver versioning, so stable releases are now published as plain `vX.Y.Z` tags (e.g. `v1.86.2`) instead of the older `vX.Y.Z-stable` form. The rolling `main-stable` tag is still being updated for backwards compatibility, but it is deprecated; pin to a specific `vX.Y.Z` tag (or a digest) instead.
+LiteLLM has moved to PEP 440 / semver versioning, so stable releases are now published as plain `vX.Y.Z` tags (e.g. `v1.86.2`) instead of the older `vX.Y.Z-stable` form. The rolling `main-stable` tag is still being updated for backwards compatibility but is deprecated; pin to a specific `vX.Y.Z` tag (or a digest) instead. The rolling `main-latest` tag is deprecated and is no longer being updated; use `latest` instead.
 :::
 
-Avoid `main-latest` in production. This rolling tag points to the most recent build and can change between deployments.
+Avoid `latest` in production. This rolling tag points to the most recent build and can change between deployments.
 
 ### Safe upgrade checklist
 

--- a/docs/proxy/docker_image_security.md
+++ b/docs/proxy/docker_image_security.md
@@ -169,9 +169,14 @@ cosign verify \
 
 ### Use stable release tags
 
-If digest pinning is too rigid for your workflow, use `-stable` release tags (e.g. `v1.83.0-stable`). These are immutable release tags that will not be overwritten.
+If digest pinning is too rigid for your workflow, use plain semver / PEP 440 release tags (e.g. `v1.86.2`). These are immutable release tags that will not be overwritten.
 
-Avoid `main-latest` or `main-stable` in production — these rolling tags point to the most recent build and can change between deployments.
+:::warning `main-stable` is deprecated
+
+LiteLLM has moved to PEP 440 / semver versioning, so stable releases are now published as plain `vX.Y.Z` tags (e.g. `v1.86.2`) instead of the older `vX.Y.Z-stable` form. The rolling `main-stable` tag is still being updated for backwards compatibility, but it is deprecated; pin to a specific `vX.Y.Z` tag (or a digest) instead.
+:::
+
+Avoid `main-latest` in production. This rolling tag points to the most recent build and can change between deployments.
 
 ### Safe upgrade checklist
 


### PR DESCRIPTION
## Summary

Updates the "Use stable release tags" section of `docs/proxy/docker_image_security.md` to reflect the move to PEP 440 / semver versioning.

Stable releases are now published as plain `vX.Y.Z` tags (e.g. `v1.86.2`) instead of the older `vX.Y.Z-stable` form. Adds a `:::warning` admonition noting that the rolling `main-stable` tag is still being updated for backwards compatibility but is deprecated; readers should pin to a specific `vX.Y.Z` tag or a digest instead. Also drops the `main-stable` mention from the "avoid in production" line since the deprecation admonition above now covers it.

## Screenshots / Proof of Fix

Rendered preview locally via `npm run start`; the "Use stable release tags" section reads as the updated prose with the warning admonition immediately under the recommendation, and "Avoid `main-latest` in production." follows as a standalone line.