### PR TITLE
docs(blog): fix Opus 4.6/4.7/4.8 thinking mode and effort guidance

### DIFF
--- a/blog/claude_opus_4_6/index.md
+++ b/blog/claude_opus_4_6/index.md
@@ -383,7 +383,7 @@ Compaction blocks are also supported in streaming mode. You'll receive:
 ### Adaptive Thinking
 
 :::note
-When using `reasoning_effort` with Claude Opus 4.6, all values (`low`, `medium`, `high`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets with `type: "enabled"`, pass the native `thinking` parameter directly (see "Native thinking param" tab below).
+When using `reasoning_effort` with Claude Opus 4.6, all values (`low`, `medium`, `high`, `max`) are mapped to `thinking: {type: "adaptive"}`. Explicit budgets via `thinking: {type: "enabled", budget_tokens: ...}` still work on Opus 4.6 but are deprecated and no longer recommended; prefer adaptive thinking with `output_config.effort` (see [Effort Levels](#effort-levels) below) to control thinking depth.
 :::
 
 <Tabs>

--- a/blog/claude_opus_4_7/index.md
+++ b/blog/claude_opus_4_7/index.md
@@ -221,7 +221,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 ### Adaptive Thinking
 
 :::note
-When using `reasoning_effort` with Claude Opus 4.7, all values (`low`, `medium`, `high`, `xhigh`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets with `type: "enabled"`, pass the native `thinking` parameter directly.
+When using `reasoning_effort` with Claude Opus 4.7, all values (`low`, `medium`, `high`, `xhigh`, `max`) are mapped to `thinking: {type: "adaptive"}`. Opus 4.7 only supports adaptive thinking; explicit budgets via `thinking: {type: "enabled", budget_tokens: ...}` are rejected by the Anthropic API with a 400 error. To control thinking depth, pair adaptive thinking with `output_config.effort` (see [Effort Levels](#effort-levels) below) rather than a fixed budget.
 :::
 
 <Tabs>
@@ -274,9 +274,9 @@ curl --location 'http://0.0.0.0:4000/v1/messages' \
 
 ### Effort Levels
 
-Claude Opus 4.7 supports four effort levels: `low`, `medium`, `high` (default), and `xhigh`. These give you finer-grained control over how much reasoning the model applies to a task. Pass the effort level via the `output_config` parameter.
+Claude Opus 4.7 supports five effort levels: `low`, `medium`, `high` (default), `xhigh`, and `max`. These give you finer-grained control over how much reasoning the model applies to a task. Pass the effort level via the `output_config` parameter.
 
-`xhigh` is a new effort level introduced with Opus 4.7 that sits above `high`. The `max` effort level is Claude Opus 4.6 only and is not available on 4.7.
+`xhigh` is a new effort level introduced with Opus 4.7 that sits above `high` and is the recommended starting point for coding and agentic work. `max` sits above `xhigh` for the absolute highest capability; reserve it for genuinely frontier problems, since on most workloads it adds significant token cost for relatively small quality gains.
 
 <Tabs>
 <TabItem value="completions" label="/chat/completions">

--- a/blog/claude_opus_4_8/index.md
+++ b/blog/claude_opus_4_8/index.md
@@ -237,7 +237,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 ### Adaptive Thinking
 
 :::note
-When using `reasoning_effort` with Claude Opus 4.8, all values (`low`, `medium`, `high`, `xhigh`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets with `type: "enabled"`, pass the native `thinking` parameter directly.
+When using `reasoning_effort` with Claude Opus 4.8, all values (`low`, `medium`, `high`, `xhigh`, `max`) are mapped to `thinking: {type: "adaptive"}`. Opus 4.8 only supports adaptive thinking; explicit budgets via `thinking: {type: "enabled", budget_tokens: ...}` are rejected by the Anthropic API with a 400 error. To control thinking depth, pair adaptive thinking with `output_config.effort` (see [Effort Levels](#effort-levels) below) rather than a fixed budget.
 :::
 
 <Tabs>
@@ -292,7 +292,7 @@ curl --location 'http://0.0.0.0:4000/v1/messages' \
 
 Claude Opus 4.8 supports five effort levels: `low`, `medium`, `high` (default), `xhigh`, and `max`. These give you finer-grained control over how much reasoning the model applies to a task. Pass the effort level via the `output_config` parameter.
 
-Opus 4.8 supports the full effort ladder. Both `xhigh` (introduced with Opus 4.7) and `max` (previously Opus 4.6 only) are available.
+Opus 4.8 supports the full effort ladder. Both `xhigh` (introduced with Opus 4.7) and `max` (also available on Opus 4.6 and 4.7) are available.
 
 <Tabs>
 <TabItem value="completions" label="/chat/completions">


### PR DESCRIPTION
## Summary

The day-0 blog posts for Claude Opus 4.6, 4.7, and 4.8 carried a copy-pasted "Adaptive Thinking" note that told readers to pass the native `thinking` parameter directly to use explicit thinking budgets with `type: "enabled"`. That guidance is wrong for Opus 4.7 and 4.8.

Per Anthropic's adaptive thinking and effort docs, adaptive thinking is the only supported mode on Opus 4.7 and 4.8, and a manual `thinking: {type: "enabled", budget_tokens: N}` is rejected with a 400 error. LiteLLM forwards the native `thinking` parameter unchanged on both `/chat/completions` and the `/v1/messages` passthrough, so following the old instructions just produces that 400. On Opus 4.6 the explicit budget still works but is deprecated and no longer recommended. Each note now states the actual behavior and points readers at `output_config.effort`, paired with adaptive thinking, as the way to control thinking depth.

## Effort ladder correction

While verifying the above, the 4.7 post claimed `max` effort was "Claude Opus 4.6 only and is not available on 4.7." Anthropic's effort docs list `max` as available on Opus 4.6, 4.7, and 4.8, and LiteLLM's `REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT` maps `max` to `max` with no per-model gating. So the 4.7 effort section now lists all five levels (`low`, `medium`, `high`, `xhigh`, `max`), the 4.8 "max (previously Opus 4.6 only)" parenthetical is corrected to "also available on Opus 4.6 and 4.7," and the `reasoning_effort` enumeration in each Adaptive Thinking note now includes `max` so it matches that model's own effort section. The 4.6 note gains `max` but not `xhigh`, since 4.6 never supported `xhigh`.

## Verification

Cross-checked against Anthropic's official docs (the adaptive thinking and effort pages) and the LiteLLM source. `_map_reasoning_effort` short-circuits every effort value to `thinking: {type: "adaptive"}` for adaptive-thinking models, the `thinking` parameter is passed through verbatim, and the effort mapping applies no per-model `max` restriction. These are prose-only changes to three blog markdown files, with no code or behavior changes.

## Type

Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation corrections with no code or configuration changes.
> 
> **Overview**
> Corrects **Adaptive Thinking** and **Effort Levels** guidance in the Opus 4.6, 4.7, and 4.8 day-0 blog posts so it matches Anthropic’s current API behavior and LiteLLM’s passthrough.
> 
> The shared note no longer tells readers to use native `thinking: {type: "enabled", budget_tokens: ...}` as the primary path. **Opus 4.7 and 4.8** are documented as **adaptive-only** (explicit budgets → **400**); depth should be tuned with **`output_config.effort`** alongside adaptive thinking. **Opus 4.6** keeps explicit budgets as still accepted but **deprecated**, with the same effort-based recommendation.
> 
> **Effort ladder** fixes: `reasoning_effort` lists now include **`max`** where appropriate (4.6 adds `max`, not `xhigh`; 4.7/4.8 include `max`). **4.7** drops the wrong claim that `max` is 4.6-only and documents five levels including **`max`**, with updated guidance on **`xhigh`** vs **`max`**. **4.8** fixes the parenthetical that `max` was “previously Opus 4.6 only.”
> 
> Prose-only; no runtime or gateway behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d5fb66fb3d407000b7affaf96a09b8692b3f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->