### PR TITLE
fix(blog): correct lite-harness repo link

### DIFF
--- a/blog/lap_internal_agent_30pct/index.md
+++ b/blog/lap_internal_agent_30pct/index.md
@@ -64,7 +64,7 @@ We started with agent frameworks: Pydantic AI, LangGraph, the PI SDK. Each one m
 
 We landed on **OpenCode**. The Claude Agents SDK spawns a CLI session per run and OOM'd for us at ~1 RPM. OpenCode hits the same fundamental bottleneck (long-running sessions held in memory), but its memory usage grew more slowly, making it the better fit for now.
 
-That choice stays flexible because we also wrote a harness unification layer, [`BerriAI/lite-harness`](https://github.com/BerriAI/lite-harness), which adapts OpenCode, Claude Code, Codex, and others to a single HTTP contract:
+That choice stays flexible because we also wrote a harness unification layer, [`LiteLLM-Labs/lite-harness`](https://github.com/LiteLLM-Labs/lite-harness), which adapts OpenCode, Claude Code, Codex, and others to a single HTTP contract:
 
 ```
 lite-harness/


### PR DESCRIPTION
## Summary
- Fix wrong repo link for `lite-harness` in the [lap-internal-agent-30-percent](https://docs.litellm.ai/blog/lap-internal-agent-30-percent) blog post
- Line 67 pointed to `BerriAI/lite-harness`; corrected to `LiteLLM-Labs/lite-harness` (link + display text)

## Test plan
- [ ] Verify link resolves to https://github.com/LiteLLM-Labs/lite-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)