### PR TITLE
docs(proxy): document GRACEFUL_SHUTDOWN_TIMEOUT env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -728,6 +728,7 @@ router_settings:
 | GALILEO_PROJECT_ID | Project ID for Galileo usage
 | GALILEO_USERNAME | Username for Galileo enterprise Observe authentication
 | GOOGLE_SECRET_MANAGER_PROJECT_ID | Project ID for Google Secret Manager
+| GRACEFUL_SHUTDOWN_TIMEOUT | Seconds the proxy waits for in-flight requests to drain on shutdown (SIGTERM or the `/health/drain` preStop hook) before proceeding with teardown. **Default is 30**
 | GCS_BUCKET_NAME | Name of the Google Cloud Storage bucket
 | GCS_MOCK | Enable mock mode for GCS integration testing. When set to true, intercepts GCS API calls and returns mock responses without making actual network calls. Default is false
 | GCS_MOCK_LATENCY_MS | Mock latency in milliseconds for GCS API calls when mock mode is enabled. Simulates network round-trip time. Default is 150ms


### PR DESCRIPTION
## Summary

Documents the new `GRACEFUL_SHUTDOWN_TIMEOUT` environment variable in the proxy config settings reference. It controls how long the proxy waits for in-flight requests to drain on shutdown (via SIGTERM or the new `/health/drain` preStop hook) before proceeding with teardown; default 30 seconds.

This is the docs companion to BerriAI/litellm#29439 (Resolves LIT-3307). The litellm `documentation` and `code-quality` CI checks scan the code for `os.getenv(...)` usages and require each one to be documented in `docs/proxy/config_settings.md`, so this needs to land for that PR's checks to pass.

## Related

BerriAI/litellm#29439

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGHvPLPUvkWZny7QkGaUDf)_