### PR TITLE
docs(config_settings): document DD_BATCH_SIZE env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -596,6 +596,7 @@ router_settings:
 | DD_AGENT_PORT | Port of DataDog agent for log intake. Default is 10518
 | DD_API_KEY | API key for Datadog integration
 | DD_APP_KEY | Application key for Datadog Cost Management integration. Required along with DD_API_KEY for cost metrics
+| DD_BATCH_SIZE | Number of log events buffered before flushing to Datadog. Clamped to [1, 1000]; defaults to 1000. Lower it (e.g. 50) if batches exceed Datadog's 5MB request limit
 | DD_SITE | Site URL for Datadog (e.g., datadoghq.com)
 | DD_SOURCE | Source identifier for Datadog logs
 | DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE | Resource name for Datadog tracing of streaming chunk yields. Default is "streaming.chunk.yield"


### PR DESCRIPTION
Documents the `DD_BATCH_SIZE` environment variable in the environment variables reference.

`DD_BATCH_SIZE` is wired up in litellm to control the Datadog logger batch size (see BerriAI/litellm#29444). The `test_env_keys` documentation gate validates every `os.getenv()` in the litellm source against this file, so the new variable has to be documented here for that gate to pass on the litellm PR. This docs PR therefore needs to merge alongside (or before) BerriAI/litellm#29444.

https://claude.ai/code/session_01R5srSidjGmPtEKuAnRqPXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5srSidjGmPtEKuAnRqPXw)_