### PR TITLE
docs(deploy): document first-party AWS & GCP Terraform stacks

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -253,6 +253,70 @@ docker run \
 
 ### Terraform
 
+#### Cloud infrastructure stacks (AWS & GCP)
+
+LiteLLM ships first-party Terraform stacks that provision the full proxy
+deployment — networking, database, Redis, object storage, secrets, the
+gateway/backend/ui services, a load balancer, and a one-off schema-migration
+task — on either AWS (ECS Fargate) or GCP (Cloud Run):
+
+- **AWS:** [`terraform/litellm/aws`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws)
+- **GCP:** [`terraform/litellm/gcp`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp)
+
+Each stack is a **reusable module** (it declares no `provider` block), with a
+thin `examples/default/` root that wires the provider and gives you a
+one-command deploy:
+
+```bash
+# AWS (ECS Fargate)
+cd terraform/litellm/aws/examples/default
+cp terraform.tfvars.example terraform.tfvars   # edit: region, tenant, env, azs, proxy_config, ...
+terraform init
+terraform apply
+```
+
+```bash
+# GCP (Cloud Run)
+cd terraform/litellm/gcp/examples/default
+cp terraform.tfvars.example terraform.tfvars   # edit: project, region, tenant, env, image_registry, ...
+terraform init
+terraform apply
+```
+
+Because the stack is a module with no embedded provider, you can also call it
+directly from your own config with `count`, `for_each` (many tenants from one
+config), `depends_on`, or an assume-role / impersonated-SA provider:
+
+```hcl
+module "litellm" {
+  for_each = toset(["acme", "globex"])
+  source   = "github.com/BerriAI/litellm//terraform/litellm/aws?ref=<tag>"
+
+  tenant = each.key
+  env    = "prod"
+  region = "us-west-2"
+  azs    = ["us-west-2a", "us-west-2b"]
+}
+```
+
+:::warning Upgrading an existing deployment
+
+If you first deployed by running terraform from the stack root directly (before
+the module-first layout), the new `examples/default/` entry point shifts every
+resource address under a `module.litellm.` prefix. Run `terraform state mv` to
+re-key your state **before** applying — otherwise terraform plans a full
+destroy-and-recreate of the stack. See the migration section in the
+[AWS](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws#migrating-an-existing-deployment)
+/ [GCP](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp#migrating-an-existing-deployment)
+README.
+
+:::
+
+See each stack's README for the full variable surface, TLS setup, multi-tenant
+patterns, and image-pull configuration.
+
+#### User management
+
 s/o [Nicholas Cecere](https://www.linkedin.com/in/nicholas-cecere-24243549/) for his LiteLLM User Management Terraform
 
 👉 [Go here for Terraform](https://github.com/BerriAI/terraform-provider-litellm)

--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -299,19 +299,6 @@ module "litellm" {
 }
 ```
 
-:::warning Upgrading an existing deployment
-
-If you first deployed by running terraform from the stack root directly (before
-the module-first layout), the new `examples/default/` entry point shifts every
-resource address under a `module.litellm.` prefix. Run `terraform state mv` to
-re-key your state **before** applying — otherwise terraform plans a full
-destroy-and-recreate of the stack. See the migration section in the
-[AWS](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws#migrating-an-existing-deployment)
-/ [GCP](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp#migrating-an-existing-deployment)
-README.
-
-:::
-
 See each stack's README for the full variable surface, TLS setup, multi-tenant
 patterns, and image-pull configuration.
 

--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -299,8 +299,41 @@ module "litellm" {
 }
 ```
 
-See each stack's README for the full variable surface, TLS setup, multi-tenant
-patterns, and image-pull configuration.
+The GCP stack also ships a Cloud Shell one-click installer via
+DeployStack; the "Open in Cloud Shell" button in
+[`terraform/litellm/gcp/README.md`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp)
+opens a guided tutorial that runs `terraform apply` against your selected
+project.
+
+Both stacks expose the same conceptual surface; concrete inputs differ only
+where the cloud forces it.
+
+| Capability                       | AWS input(s)                                            | GCP input(s)                                              |
+| -------------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| Per-deployment tags / labels     | `tags` (`map(string)`)                                  | `labels` (`map(string)`)                                  |
+| TLS posture                      | `acm_certificate_arn`, `allow_plaintext_alb`            | `lb_domains`, `allow_plaintext_lb`                        |
+| Force destroy of object store    | `s3_force_destroy`                                      | `gcs_force_destroy`                                       |
+| Database deletion protection     | `skip_final_snapshot`                                   | `cloudsql_deletion_protection`                            |
+| Typed `proxy_config` YAML map    | `proxy_config`                                          | `proxy_config`                                            |
+| Extra plain env per component    | `gateway_extra_env`, `backend_extra_env`                | `gateway_extra_env`, `backend_extra_env`                  |
+| Extra secret-backed env          | `gateway_extra_secrets`, `backend_extra_secrets` (ARNs) | `gateway_extra_secrets`, `backend_extra_secrets` (resource IDs) |
+| Uvicorn `--workers` on gateway   | `gateway_num_workers`                                   | `gateway_num_workers`                                     |
+| OpenTelemetry v2 (opt-in)        | `otel_endpoint`, `otel_exporter`, `otel_environment_name`, `otel_capture_message_content`, `otel_headers_secret_arn` | `otel_endpoint`, `otel_exporter`, `otel_environment_name`, `otel_capture_message_content`, `otel_headers_secret` |
+
+OTel v2 is opt-in: leave `otel_endpoint` empty and nothing OTel-related is
+added to the container env; set it and both gateway and backend get
+`LITELLM_OTEL_V2=true` plus the full `OTEL_*` block, with
+`OTEL_SERVICE_NAME` stamped per component
+(`<tenant>-litellm-<env>-gateway` / `-backend`). Any `OTEL_*` key set in
+`gateway_extra_env` / `backend_extra_env` wins for that service.
+
+Both stacks stamp their own `litellm:stack` (AWS) / `litellm-stack` (GCP)
+plus `managed-by = "terraform"` tag/label onto every taggable resource and
+merge `var.tags` / `var.labels` on top. AWS provider `default_tags` merge
+on top of those.
+
+See each stack's README for the full variable surface, TLS setup,
+multi-tenant patterns, and image-pull configuration.
 
 #### User management
 


### PR DESCRIPTION
## Summary

Adds a **Terraform infrastructure-stacks** section to `docs/proxy/deploy.md`, documenting the first-party AWS (ECS Fargate) and GCP (Cloud Run) Terraform stacks introduced in BerriAI/litellm#28103.

Covers:
- The reusable-module + `examples/default/` one-command deploy path for both clouds
- Calling the module directly with `for_each` for multi-tenant deployments
- A side-by-side input mapping covering tags/labels, TLS posture, `proxy_config`, extra env / secrets, `gateway_num_workers`, and OpenTelemetry v2; spelling out what works the same on each cloud after the AWS/GCP consistency pass in the code PR
- A pointer to the GCP-only DeployStack one-click Cloud Shell installer for trial flows

The existing User Management Terraform link is preserved under a `#### User management` subheading.

## Related
- Code PR: BerriAI/litellm#28103
- Linear: LIT-3504
