### PR TITLE
docs(release-notes): backfill v1.84.2 through v1.86.2

### DIFF
--- a/release_notes/v1.84.2/index.md
+++ b/release_notes/v1.84.2/index.md
@@ -1,0 +1,62 @@
+---
+title: "v1.84.2 - Path-Handling Hardening Backport"
+slug: "v1-84-2"
+date: 2026-05-27T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.2
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.2
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.2` is a patch release on top of [`v1.84.1`](/release_notes/v1.84.1/v1-84-1). It backports the path-handling hardening covered in the [host-header authentication bypass advisory](/blog/host-header-auth-bypass) and restores `npm` to the non-root Docker builder.
+
+Non-root deployments should pin [`v1.84.3`](/release_notes/v1.84.3/v1-84-3) instead; the `litellm-non_root:1.84.2` image failed to build because `npm` was missing from the builder, and `v1.84.3` ships the same application code with a fixed `Dockerfile.non_root`.
+
+### Bug Fixes
+
+- **Proxy auth / routing**
+    - Route the proxy's path-dependent call sites through `get_request_route()` so they all derive the request route from the ASGI scope rather than the `Host`-reconstructed URL - [PR #28547](https://github.com/BerriAI/litellm/pull/28547)
+
+### Infrastructure
+
+- **Docker**
+    - Restore `npm` to the `Dockerfile.non_root` builder stage so `prisma-python` no longer falls back to a `nodeenv`-bootstrapped Node runtime. Applies to `v1.84.3` and later; the `litellm-non_root:1.84.2` image did not build - [PR #28519](https://github.com/BerriAI/litellm/pull/28519)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.1...5560f35279

--- a/release_notes/v1.84.3/index.md
+++ b/release_notes/v1.84.3/index.md
@@ -1,0 +1,52 @@
+---
+title: "v1.84.3 - Dockerfile Re-cut for Non-Root Image"
+slug: "v1-84-3"
+date: 2026-05-27T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.3
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.3
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.3` is a Dockerfile-only re-cut of [`v1.84.2`](/release_notes/v1.84.2/v1-84-2); the application code is identical. It restores `npm` to the `Dockerfile.non_root` builder stage so the `litellm-non_root:1.84.3` image builds, which the `1.84.2` image did not.
+
+If you are upgrading from [`v1.84.1`](/release_notes/v1.84.1/v1-84-1), see the [`v1.84.2`](/release_notes/v1.84.2/v1-84-2) notes for the underlying code changes; in particular the path-handling hardening covered in the [host-header authentication bypass advisory](/blog/host-header-auth-bypass).
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/5560f35279...v1.84.3

--- a/release_notes/v1.84.4/index.md
+++ b/release_notes/v1.84.4/index.md
@@ -1,0 +1,61 @@
+---
+title: "v1.84.4 - Reset-Budget & Observability Fixes"
+slug: "v1-84-4"
+date: 2026-05-31T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.4` is a patch release on top of [`v1.84.3`](/release_notes/v1.84.3/v1-84-3). It fixes a `ResetBudgetJob` regression that affected UI-created keys on the `v1.84` line, removes duplicate observability exports for Claude Code streams, and tightens a Bearer-prefix edge case in the proxy auth metric labels.
+
+### Bug Fixes
+
+- **Spend Tracking, Budgets and Rate Limiting**
+    - `ResetBudgetJob` no longer pre-zeroes the spend counter and only writes `{spend, budget_reset_at}` on cycle rollover. On `v1.84.0+` this previously silently failed for every UI-created key, leaving spend frozen at the cycle boundary and opening a brief budget-enforcement bypass window on every scheduler tick - [PR #29358](https://github.com/BerriAI/litellm/pull/29358)
+
+- **Logging / Observability**
+    - Stop emitting duplicate Datadog logs and OTLP traces (Arize Phoenix, Langfuse, etc.) on completed streams by dispatching the success handler exactly once instead of running both `async_success_handler` and `success_handler` - [PR #29311](https://github.com/BerriAI/litellm/pull/29311) (originally [PR #29089](https://github.com/BerriAI/litellm/pull/29089))
+
+- **Proxy auth**
+    - Normalize the `Bearer ` prefix in the safe-hash helper so the failure-metric label is hashed identically whether or not the caller stripped the prefix - [PR #29343](https://github.com/BerriAI/litellm/pull/29343)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.3...v1.84.4

--- a/release_notes/v1.85.2/index.md
+++ b/release_notes/v1.85.2/index.md
@@ -1,0 +1,60 @@
+---
+title: "v1.85.2 - Path-Handling Hardening Backport"
+slug: "v1-85-2"
+date: 2026-05-27T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.2
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.2
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.2` is a patch release on top of [`v1.85.1`](/release_notes/v1.85.1/v1-85-1). It backports the path-handling hardening covered in the [host-header authentication bypass advisory](/blog/host-header-auth-bypass) and restores `npm` to the non-root Docker builder.
+
+### Bug Fixes
+
+- **Proxy auth / routing**
+    - Route the proxy's path-dependent call sites through `get_request_route()` so they all derive the request route from the ASGI scope rather than the `Host`-reconstructed URL - [PR #28547](https://github.com/BerriAI/litellm/pull/28547)
+
+### Infrastructure
+
+- **Docker**
+    - Restore `npm` to the `Dockerfile.non_root` builder stage so `prisma-python` no longer falls back to a `nodeenv`-bootstrapped Node runtime - [PR #28519](https://github.com/BerriAI/litellm/pull/28519)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.1...v1.85.2

--- a/release_notes/v1.86.1/index.md
+++ b/release_notes/v1.86.1/index.md
@@ -1,0 +1,55 @@
+---
+title: "v1.86.1 - Non-Root Docker Build Fix"
+slug: "v1-86-1"
+date: 2026-05-26T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.1` is a Dockerfile-only patch on top of [`v1.86.0`](/release_notes/v1.86.0/v1-86-0). The application code is unchanged.
+
+### Infrastructure
+
+- **Docker**
+    - Restore `npm` to the `Dockerfile.non_root` builder stage so `prisma-python` resolves Node and no longer falls back to a `nodeenv`-bootstrapped runtime - [PR #28519](https://github.com/BerriAI/litellm/pull/28519)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.0...v1.86.1

--- a/release_notes/v1.86.2/index.md
+++ b/release_notes/v1.86.2/index.md
@@ -1,0 +1,55 @@
+---
+title: "v1.86.2 - Path-Handling Hardening Backport"
+slug: "v1-86-2"
+date: 2026-05-27T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.2
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.2
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.2` is a patch release on top of [`v1.86.1`](/release_notes/v1.86.1/v1-86-1). It backports the path-handling hardening covered in the [host-header authentication bypass advisory](/blog/host-header-auth-bypass).
+
+### Bug Fixes
+
+- **Proxy auth / routing**
+    - Route the proxy's path-dependent call sites through `get_request_route()` so they all derive the request route from the ASGI scope rather than the `Host`-reconstructed URL - [PR #28547](https://github.com/BerriAI/litellm/pull/28547)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.1...v1.86.2


### PR DESCRIPTION
## Summary

Backfills the six missing release-notes pages on the `v1.84`, `v1.85`, and `v1.86` lines so users hitting those Docker tags have a changelog to read.

| Entry | Base | Scope |
| --- | --- | --- |
| `v1.84.2` | `v1.84.1` | #28547 path-handling backport + #28519 non-root npm restore; links to the host-header-auth-bypass advisory blog |
| `v1.84.3` | `v1.84.2` | Dockerfile-only re-cut to repair the `litellm-non_root:1.84.2` build (no application code changed) |
| `v1.84.4` | `v1.84.3` | #29358 reset_budget regression fix, #29311 duplicate Claude Code traces, #29343 Bearer-prefix safe-hash normalize |
| `v1.85.2` | `v1.85.1` | #28547 + #28519 |
| `v1.86.1` | `v1.86.0` | #28519 only (non-root npm restore) |
| `v1.86.2` | `v1.86.1` | #28547 |

Each `## Full Changelog` link is neighbor-to-neighbor. `v1.84.2`'s compare link points at SHA `5560f35279` because the `v1.84.2` git tag never landed in `BerriAI/litellm` (only the DockerHub image did). Worth retagging that SHA as `v1.84.2` upstream as a follow-up so the link is symmetric with the others; not blocking this PR.

`v1.83.10-stable.patch.{1,2,3}` were considered and explicitly deferred from this pass.

## Phrasing

The three advisory-related entries (`v1.84.2`, `v1.85.2`, `v1.86.2`) phrase the change as the route-resolution refactor it is and link to `/blog/host-header-auth-bypass` for the disclosure framing; the changelog itself stays matter-of-fact.

## Preview

`npm run start` and walk through:

- http://localhost:3000/release_notes/v1.84.2/v1-84-2
- http://localhost:3000/release_notes/v1.84.3/v1-84-3
- http://localhost:3000/release_notes/v1.84.4/v1-84-4
- http://localhost:3000/release_notes/v1.85.2/v1-85-2
- http://localhost:3000/release_notes/v1.86.1/v1-86-1
- http://localhost:3000/release_notes/v1.86.2/v1-86-2

Check that each page renders, the Deploy tabs work, and the `Full Changelog` link resolves on github.com.