### PR TITLE
docs: promote v1.87.0 release candidate to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,17 +10,7 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.86.0 — Weighted-Routing Failover, Native Web-Search Citations & OTel-Standard Tracing](/release_notes/v1.86.0/v1-86-0)
-
-_May 16, 2026_
-
-Weighted-Routing Failover (retry the same model group on a different deployment while still respecting configured weights), native `web_search_tool_result` blocks for Anthropic clients so Claude Desktop and Cowork render web-search citations correctly, OTel-standard server-span attributes (`http.response.status_code`, `http.route`, `url.path`, `litellm.preprocessing.duration_ms`) plus opt-in OTEL GenAI semconv support, an additive componentized deployment scaffold (`gateway` / `backend` / `ui` Dockerfiles + Helm chart + Terraform stacks), and a critical fix for the v3 rate limiter that was leaking internal reservation keys into upstream provider request bodies on every virtual key with a `tpm_limit` or `rpm_limit` set.
-
----
-
-## Latest Release Candidate
-
-### [v1.87.0rc1 — OCI Generative AI Provider, Gemini 3.5 Flash Day-0, MCP UI for OAuth Servers](/release_notes/v1.87.0rc1/v1-87-0-rc-1)
+### [v1.87.0 — OCI Generative AI Provider, Gemini 3.5 Flash Day-0, MCP UI for OAuth Servers](/release_notes/v1.87.0/v1-87-0)
 
 _May 23, 2026_
 
@@ -32,6 +22,7 @@ OCI Generative AI as a first-class provider (chat, embeddings, streaming, reason
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.87.0](/release_notes/v1.87.0/v1-87-0)   | May 23, 2026 | OCI Generative AI provider, Gemini 3.5 Flash day-0, MCP UI for OAuth servers |
 | [v1.86.0](/release_notes/v1.86.0/v1-86-0)   | May 16, 2026 | Weighted-Routing Failover, native Anthropic web-search citations, OTel-standard server spans |
 | [v1.85.1](/release_notes/v1.85.1/v1-85-1)   | May 20, 2026 | Patch — Gemini 3.5 Flash day-0 + cross-pod spend fix       |
 | [v1.84.1](/release_notes/v1.84.1/v1-84-1)   | May 20, 2026 | Patch — Gemini 3.5 Flash day-0 + cross-pod spend fix       |

--- a/release_notes/v1.87.0/index.md
+++ b/release_notes/v1.87.0/index.md
@@ -1,6 +1,6 @@
 ---
-title: "v1.87.0rc1 - OCI Generative AI Provider, Gemini 3.5 Flash Day-0, MCP UI for OAuth Servers"
-slug: "v1-87-0-rc-1"
+title: "v1.87.0 - OCI Generative AI Provider, Gemini 3.5 Flash Day-0, MCP UI for OAuth Servers"
+slug: "v1-87-0"
 date: 2026-05-23T16:35:00
 authors:
   - name: Krrish Dholakia
@@ -31,14 +31,14 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.87.0-rc.1
+docker.litellm.ai/berriai/litellm:1.87.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.87.0rc1
+pip install litellm==1.87.0
 ```
 
 </TabItem>
@@ -275,11 +275,11 @@ PRs by ownership area (total: 93)
 - @ro31337 made their first contribution in [#28280](https://github.com/BerriAI/litellm/pull/28280)
 - @withomasmicrosoft made their first contribution in [#28490](https://github.com/BerriAI/litellm/pull/28490)
 
-**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.86.0-rc.1...v1.87.0-rc.1
+**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.86.0...v1.87.0
 
 ---
 
-## 05/23/2026 (`v1.87.0rc1`)
+## 05/23/2026 (`v1.87.0`)
 
 * New Providers: 1
 * New Models / Updated Models: 17


### PR DESCRIPTION
## Summary

`v1.87.0` is promoted from release candidate to stable. This updates the release notes to drop the RC suffix and surfaces it as the latest stable release.

> **Note:** The repo only contained a `v1.87.0rc1` page (no `rc2` page exists). The request referenced "rc2", but the intent — promoting the 1.87 release candidate to stable `1.87.0` — is the same, so this applies to the existing rc1 page.

## Changes

**`release_notes/v1.87.0rc1/` → `release_notes/v1.87.0/`** (renamed)
- Title: `v1.87.0rc1 - …` → `v1.87.0 - …`
- Slug: `v1-87-0-rc-1` → `v1-87-0`
- Docker tag: `litellm:1.87.0-rc.1` → `litellm:1.87.0`
- Pip install: `litellm==1.87.0rc1` → `litellm==1.87.0`
- Bottom date header: `` (`v1.87.0rc1`) `` → `` (`v1.87.0`) ``
- Full Changelog compare link: `v1.86.0-rc.1...v1.87.0-rc.1` → `v1.86.0...v1.87.0` (matches the stable-page convention)

**`release_notes/index.md`** (changelog overview / main page)
- Promoted `v1.87.0` into the **Latest Release** slot
- Removed the now-empty **Latest Release Candidate** section
- Added `v1.87.0` as the top row of the **Recent Releases** table

No release content was changed — only the version labels and placement.


---
_Generated by [Claude Code](https://claude.ai/code/session_0168Z5FE9nrnezMrFACrc4Pt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-label updates only; no runtime, auth, or deployment logic changes.
> 
> **Overview**
> Promotes **v1.87.0** from release candidate to stable in the docs only—feature text and highlights are unchanged.
> 
> On `release_notes/index.md`, **v1.87.0** becomes the **Latest Release**, the **Latest Release Candidate** block is removed, and the recent-releases table gets a new top row for stable **v1.87.0** (links/slug `v1-87-0`).
> 
> The release page under `release_notes/v1.87.0/` updates labels and install pointers: title/slug, Docker `litellm:1.87.0`, pip `litellm==1.87.0`, the dated footer tag, and the changelog compare range `v1.86.0...v1.87.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef1eb5fb1c723780db6594ab33047b37ce38412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->