### PR TITLE
docs(blog): announce LiteLLM-Rust launch

### DIFF
--- a/blog/litellm_rust_launch/diagrams.js
+++ b/blog/litellm_rust_launch/diagrams.js
@@ -1,0 +1,112 @@
+import React from 'react';
+
+const s = {
+  fig: {margin: '2.5rem 0', fontFamily: 'inherit'},
+  box: {borderRadius: 12, border: '1px solid #e5e7eb', background: '#fff', padding: '2rem 2.5rem'},
+  label: {fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.12em', color: '#9ca3af', textAlign: 'center', marginBottom: '1.5rem'},
+  caption: {textAlign: 'center', fontSize: 12, color: '#9ca3af', marginTop: 12},
+  node: (border='#d1d5db', bg='#f9fafb') => ({
+    border: `1px solid ${border}`, borderRadius: 6, padding: '8px 20px',
+    fontSize: 13, background: bg, display: 'inline-block',
+  }),
+};
+
+const SmallArrow = ({color='#9ca3af'}) => (
+  <svg width="2" height="28" style={{display:'block'}}>
+    <line x1="1" y1="0" x2="1" y2="22" stroke={color} strokeWidth="1.5"/>
+    <polygon points="1,28 -2,21 4,21" fill={color}/>
+  </svg>
+);
+
+export function LatencyCompare() {
+  const bar = (label, widthPct, valueText, color, textColor='#fff') => (
+    <div style={{display:'flex', alignItems:'center', gap:16, marginBottom:14}}>
+      <div style={{width:160, fontSize:13, color:'#4b5563', textAlign:'right'}}>{label}</div>
+      <div style={{flex:1, background:'#f3f4f6', borderRadius:6, height:32, position:'relative'}}>
+        <div style={{width:`${widthPct}%`, height:'100%', background:color, borderRadius:6, display:'flex', alignItems:'center', justifyContent:'flex-end', paddingRight:12}}>
+          <span style={{fontSize:12, color:textColor, fontWeight:600}}>{valueText}</span>
+        </div>
+      </div>
+    </div>
+  );
+  return (
+    <figure style={s.fig}>
+      <div style={s.box}>
+        <p style={s.label}>Gateway overhead per Claude Code call</p>
+        {bar('LiteLLM-Rust (target)', 4, '<1ms', '#7c6dff')}
+        {bar('Python (typical)', 60, 'ms-scale', '#9ca3af')}
+        <div style={{marginTop:16, paddingTop:16, borderTop:'1px solid #e5e7eb', fontSize:12, color:'#6b7280', textAlign:'center'}}>
+          Per-call overhead compounds across dozens of tool calls in a single agent run
+        </div>
+      </div>
+      <figcaption style={s.caption}>Sub-millisecond target on the hot path — Python removed from request forwarding</figcaption>
+    </figure>
+  );
+}
+
+export function DropInMigration() {
+  return (
+    <figure style={s.fig}>
+      <div style={s.box}>
+        <p style={s.label}>Drop-in migration — same config, same DB</p>
+        <div style={{display:'grid', gridTemplateColumns:'1fr auto 1fr', gap:24, alignItems:'center'}}>
+          <div style={{border:'1px solid #e5e7eb', borderRadius:8, padding:20, textAlign:'center'}}>
+            <p style={{fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.1em', color:'#9ca3af', marginBottom:12}}>Before</p>
+            <div style={{...s.node(), marginBottom:8, width:'80%'}}>litellm (Python)</div>
+            <div style={{fontSize:11, color:'#6b7280', marginTop:12}}>
+              <div>config.yaml</div>
+              <div>Postgres DB</div>
+              <div>Client SDKs</div>
+            </div>
+          </div>
+          <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:4}}>
+            <svg width="40" height="16"><polygon points="0,8 32,8 32,2 40,8 32,14 32,8" fill="#7c6dff"/></svg>
+            <span style={{fontSize:10, color:'#7c6dff', fontWeight:600}}>swap binary</span>
+          </div>
+          <div style={{border:'1px solid #7c6dff', borderRadius:8, padding:20, textAlign:'center', background:'#faf9ff'}}>
+            <p style={{fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.1em', color:'#7c6dff', marginBottom:12}}>After</p>
+            <div style={{...s.node('#7c6dff','#7c6dff'), color:'#fff', marginBottom:8, width:'80%', fontWeight:600}}>litellm-rust</div>
+            <div style={{fontSize:11, color:'#6b7280', marginTop:12}}>
+              <div>config.yaml <span style={{color:'#16a34a'}}>(unchanged)</span></div>
+              <div>Postgres DB <span style={{color:'#16a34a'}}>(unchanged)</span></div>
+              <div>Client SDKs <span style={{color:'#16a34a'}}>(unchanged)</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <figcaption style={s.caption}>Only the runtime changes — config, DB schema, and client contract are identical</figcaption>
+    </figure>
+  );
+}
+
+export function RemoteAgentsFlow() {
+  const pill = (text, dim=false) => (
+    <span style={{display:'inline-block', fontSize:11, padding:'3px 10px', borderRadius:999, border:`1px solid ${dim?'#e5e7eb':'#7c6dff'}`, color: dim?'#9ca3af':'#7c6dff', background: dim?'#f9fafb':'#faf9ff', marginRight:6, marginBottom:6}}>{text}</span>
+  );
+  return (
+    <figure style={s.fig}>
+      <div style={s.box}>
+        <p style={s.label}>Coding-agent runtime in the gateway</p>
+        <div style={{display:'flex', flexDirection:'column', alignItems:'center'}}>
+          <div style={s.node()}>Trigger (cron · webhook · API)</div>
+          <SmallArrow color="#7c6dff"/>
+          <div style={{...s.node('#7c6dff','#7c6dff'), color:'#fff', fontWeight:600}}>LiteLLM-Rust Gateway</div>
+          <SmallArrow />
+          <div style={{...s.node(), textAlign:'center', fontSize:13, padding:'12px 24px'}}>
+            <div style={{fontWeight:600, marginBottom:6}}>Sandbox</div>
+            <div>{pill('E2B')}{pill('Daytona')}</div>
+            <div style={{fontSize:11, color:'#9ca3af', marginTop:4}}>Claude Code runs isolated</div>
+          </div>
+          <SmallArrow />
+          <div style={{...s.node(), textAlign:'center', fontSize:13, padding:'12px 24px'}}>
+            <div style={{fontWeight:600, marginBottom:6, color:'#9ca3af'}}>Roadmap</div>
+            <div>{pill('durable sessions', true)}{pill('memory', true)}{pill('artifacts', true)}{pill('vault', true)}</div>
+          </div>
+          <SmallArrow />
+          <div style={{...s.node('#111827','#111827'), color:'#fff', fontWeight:600}}>Results streamed back to caller</div>
+        </div>
+      </div>
+      <figcaption style={s.caption}>One runtime: gateway, scheduler, sandbox — proxying LLM calls and running the agents that make them</figcaption>
+    </figure>
+  );
+}

--- a/blog/litellm_rust_launch/index.md
+++ b/blog/litellm_rust_launch/index.md
@@ -1,0 +1,99 @@
+---
+slug: litellm-rust-launch
+title: "Launching LiteLLM-Rust: A Minimal Rust AI Gateway for Coding Agents"
+date: 2026-06-01T22:34:00
+authors:
+  - krrish
+  - ishaan
+description: "Launching LiteLLM-Rust — a minimal, MIT-licensed Rust AI Gateway for coding agents. Drop-in compatible with your LiteLLM config.yaml + DB. Early, experimental, feedback welcome."
+tags: [launch, rust, coding-agents, ai-gateway]
+hide_table_of_contents: true
+---
+
+import { LatencyCompare, DropInMigration, RemoteAgentsFlow } from './diagrams';
+
+*Last Updated: June 2026*
+
+Today we're launching **LiteLLM-Rust** — a minimal Rust-based AI Gateway for coding agents.
+
+Repo: [github.com/LiteLLM-Labs/litellm-rust](https://github.com/LiteLLM-Labs/litellm-rust)
+
+It does three things:
+
+1. **LiteLLM-compatible** — your existing `config.yaml` and database work out of the box.
+2. **Fast** — targeting **`<1ms`** overhead latency on Claude Code calls.
+3. **Built for autonomous agents** — sandboxing via E2B and Daytona today, with durable sessions, memory, artifacts, and vault on the roadmap.
+
+{/* truncate */}
+
+## LiteLLM-compatible AI Gateway
+
+LiteLLM-Rust reads the same `config.yaml` format and the same database schema as the Python LiteLLM AI Gateway. Keys, virtual keys, teams, budgets, routing rules, and fallbacks carry over without changes. Client SDKs and admin workflows stay the same.
+
+<DropInMigration />
+
+```bash
+litellm-rust --config /etc/litellm/config.yaml --port 4000
+```
+
+Same interface contract — only the runtime changes.
+
+## Fast: `<1ms` overhead on Claude Code calls
+
+Coding agents like Claude Code fan out many LLM calls per task. Every millisecond of gateway overhead compounds across tool calls. Our goal with LiteLLM-Rust is **sub-millisecond overhead** on the hot path, by removing Python from request forwarding entirely.
+
+<LatencyCompare />
+
+## Built for autonomous agents
+
+A reliable AI Gateway for coding agents needs more than fast forwarding. It needs to schedule, sandbox, and persist state for long-running agent runs.
+
+LiteLLM-Rust ships today with:
+
+- **Sandboxing** via [E2B](https://e2b.dev/) and [Daytona](https://www.daytona.io/) — agents run in isolated environments, no host access
+- **Claude Code scheduling** — kick off agent runs on cron, webhook, or API trigger
+
+On the roadmap:
+
+- **Durable sessions** — resume long-running agents across restarts
+- **Memory** — persistent context across runs
+- **Artifacts** — store and retrieve agent outputs
+- **Vault** — secrets management for agent execution
+
+<RemoteAgentsFlow />
+
+## Key Takeaways
+
+- LiteLLM-Rust is a minimal, MIT-licensed Rust AI Gateway built for coding agents
+- Drop-in compatible with your existing LiteLLM `config.yaml` and database
+- Sub-millisecond overhead is the performance target on Claude Code calls
+- Sandboxing (E2B + Daytona) ships today; durable sessions, memory, artifacts, and vault on the roadmap
+- Early and experimental — feedback welcome on [Discord](https://discord.gg/wuPM9dRgDw)
+
+---
+
+## Frequently Asked Questions
+
+### Is it open-source?
+
+Yes. 100% open-source under the MIT license. Repo: [github.com/LiteLLM-Labs/litellm-rust](https://github.com/LiteLLM-Labs/litellm-rust).
+
+### Is it part of my existing LiteLLM deployment?
+
+No. LiteLLM-Rust is a separate repo. Goal is to explore the design space safely and bring the learnings back to the core LiteLLM project over time.
+
+### How mature is it?
+
+Early and experimental. We're shipping it to gather feedback from coding-agent teams running it against real workloads. Please join the [Discord](https://discord.gg/wuPM9dRgDw) and tell us what's working and what's missing.
+
+### How is this different from the existing Python LiteLLM AI Gateway?
+
+The Python LiteLLM AI Gateway is the production-grade, feature-complete AI Gateway used by enterprise deployments today — and remains the recommended choice. LiteLLM-Rust is a minimal, performance-focused exploration aimed at coding-agent workloads. For teams with strict uptime and compliance requirements, [LiteLLM Enterprise](https://litellm.ai/enterprise) on the Python AI Gateway provides SSO/SCIM, air-gapped deployment, 24/7 SLA support, and advanced guardrails.
+
+---
+
+## Recommended Reading
+
+- [LiteLLM AI Gateway — full feature overview](https://docs.litellm.ai/docs/simple_proxy)
+- [Achieving sub-millisecond proxy overhead](https://docs.litellm.ai/blog/sub-millisecond-proxy-overhead)
+- [Load balancing and routing across 100+ LLM providers](https://docs.litellm.ai/docs/routing)


### PR DESCRIPTION
## Summary

- New blog post announcing **LiteLLM-Rust** — a minimal, MIT-licensed Rust AI Gateway for coding agents
- Three React diagrams: latency target, drop-in migration, agent runtime
- Frames the launch around the three pillars: LiteLLM-compatible config/DB, `<1ms` overhead target on Claude Code calls, autonomous-agent runtime (E2B/Daytona today; durable sessions, memory, artifacts, vault on the roadmap)
- Honest framing: early/experimental, separate repo from core LiteLLM, feedback CTA to Discord

Repo announced: https://github.com/LiteLLM-Labs/litellm-rust

## Test plan

- [ ] `npm run start` renders `/blog/litellm-rust-launch` without MDX errors
- [ ] Three diagrams render: `LatencyCompare`, `DropInMigration`, `RemoteAgentsFlow`
- [ ] Post appears as the newest entry on the blog index (date set after host-header-auth-bypass)
- [ ] FAQ links + Discord/Repo links resolve correctly
- [ ] Hiring CTA auto-appends at bottom