### PR TITLE
docs: document PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1058,6 +1058,7 @@ router_settings:
 | PRISMA_RECONNECT_COOLDOWN_SECONDS | Cooldown in seconds between Prisma reconnection attempts. Default is 15
 | PRISMA_RECONNECT_ESCALATION_THRESHOLD | Number of consecutive reconnect failures before escalating the reconnection strategy. Default is 3
 | PRISMA_WATCHDOG_RECONNECT_TIMEOUT_SECONDS | Timeout in seconds for Prisma watchdog-initiated reconnection. Default is 30.0
+| PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT | Number of consecutive probe failures required before the watchdog triggers a reconnect. Default is 1 |
 | PREDIBASE_API_BASE | Base URL for Predibase API
 | PRESIDIO_ANALYZER_API_BASE | Base URL for Presidio Analyzer service
 | PRESIDIO_ANONYMIZER_API_BASE | Base URL for Presidio Anonymizer service


### PR DESCRIPTION
Documents the `PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT` environment variable introduced in BerriAI/litellm#29502.

The variable controls how many consecutive health probe failures are required before the watchdog triggers a reconnect. Default is 1, which preserves existing behavior. Added alongside the other `PRISMA_WATCHDOG_*` entries in the environment variables reference table.