### PR TITLE
blog(lite-harness): add env var setup to AI Gateway example

### DIFF
--- a/blog/lite-harness-sdk/index.md
+++ b/blog/lite-harness-sdk/index.md
@@ -4,6 +4,7 @@ title: "LiteLLM Labs: Announcing Lite-Harness SDK — Unified API for Claude Cod
 date: 2026-06-02T09:00:00
 authors:
   - krrish
+  - ishaan-alt
 description: "One SDK. Swap between Claude Code, Codex, and Pi AI by changing a string. Pairs with the LiteLLM AI Gateway for keys, budgets, logs, and fallbacks."
 tags: [litellm-labs, product, agents, sdk, ai-gateway]
 hide_table_of_contents: true
@@ -66,7 +67,16 @@ async for message in query(
 
 ## LiteLLM AI Gateway
 
-Lite-Harness supports proxy'ing harnesses via LiteLLM AI Gateway. This enables easy model swapping, cost controls and logging. 
+Lite-Harness supports proxy'ing harnesses via LiteLLM AI Gateway. This enables easy model swapping, cost controls and logging.
+
+Point Lite-Harness at your gateway by setting two environment variables:
+
+```bash
+export LITELLM_API_BASE=https://litellm.your-company.com/v1
+export LITELLM_API_KEY=sk-litellm-...
+```
+
+Then call as usual — every underlying model request routes through the gateway:
 
 ```python
 from lite_harness import query, AgentOptions


### PR DESCRIPTION
## Summary
- Adds `LITELLM_API_BASE` and `LITELLM_API_KEY` bash export snippet before the Python AI Gateway code example
- Reader now sees how to point Lite-Harness at the gateway before the call example

Follow-up to #288.

## Test plan
- [ ] `/blog/lite-harness-sdk` renders new bash block above Python example

🤖 Generated with [Claude Code](https://claude.com/claude-code)