### PR TITLE
chore(compat-matrix): refresh for v1.83.14-stable + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-21T06:19:19Z",
+  "generated_at": "2026-06-03T06:41:58Z",
   "litellm_version": "v1.83.14-stable",
   "claude_code_version": "2.1.126",
   "providers": [
@@ -19,10 +19,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -40,10 +42,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -61,10 +65,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -82,7 +88,8 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
@@ -104,10 +111,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -126,11 +135,11 @@
         },
         "bedrock_invoke": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-invoke] no `thinking` content block observed in stream-json events"
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events"
+          "error": "[claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "fail",
@@ -149,7 +158,8 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
@@ -171,7 +181,8 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
@@ -193,7 +204,8 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
@@ -215,11 +227,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-opus-4-7-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -237,7 +250,8 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
@@ -259,10 +273,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -306,7 +322,8 @@
           "error": "[claude-haiku-4-5-bedrock-invoke] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"message\\\":\\\"tools.0: Input tag 'tool_search_tool_regex_20251119' found using 'type' does not match any of the expected tags: 'bash_20250124', 'custom', 'memory_20250818', 'text_editor_20250124', 'text_editor_20250429', 'text_editor_20250728', 'web_search_20250305'\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\""
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-converse] tool_search probe failed: status 500: {\"error\":{\"message\":\"litellm.APIConnectionError: BedrockException - {\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-converse\\nAvailable Model Group Fallbacks=None\","
         },
         "vertex_ai": {
           "status": "pass"
@@ -325,11 +342,11 @@
         },
         "bedrock_invoke": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; (no diagnostic output)"
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"error\":{\"message\":\"{\\\"message\\\":\\\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\\\"}. Received Model Group=claude-opus-4-7-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-converse] claude returned empty assistant text"
+          "error": "[claude-opus-4-7-bedrock-converse] claude CLI failed: exit=1; api_status=500; text=API Error: 500 litellm.APIConnectionError: BedrockException - {\"message\":\"anthropic.claude-opus-4-7 is not available for this account. You can explore other available models on Amazon Bedrock. For additional access options, contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/\"}. Received Model Group=claude-opus-4-7-bedrock-converse\nAvailable Model Group Fallbacks=None. This is a server-side issue, usually temporary \u2014 try again in a moment. If it persists, check status.claude.com."
         },
         "vertex_ai": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

| Field | Value |
| --- | --- |
| litellm_version | `v1.83.14-stable` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-06-03T06:41:58Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=fail, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=fail, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Long context (1M)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.