### PR TITLE
docs(a2a): document all supported JSON-RPC proxy methods

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -203,11 +203,41 @@ With header forwarding enabled, you'll see:
 
 ## API Reference
 
-### Endpoint
+### Endpoints
 
-```
-POST /a2a/{agent_name}/message/send
-```
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `POST /a2a/{agent_id}` | JSON-RPC 2.0 | **Primary** — all A2A methods (see table below) |
+| `POST /a2a/{agent_id}/message/send` | JSON-RPC | Alias for `message/send` only |
+| `POST /v1/a2a/{agent_id}/message/send` | JSON-RPC | Alias for `message/send` only |
+| `GET /a2a/{agent_id}/.well-known/agent.json` | Agent card | Discovery (proxy URL in `url` field) |
+| `GET /a2a/{agent_id}/.well-known/agent-card.json` | Agent card | Discovery (standard path) |
+
+`{agent_id}` may be the agent UUID or the registered agent name.
+
+### Supported JSON-RPC methods
+
+Send any of these in the `method` field of `POST /a2a/{agent_id}`:
+
+| Method | Description |
+|--------|-------------|
+| `message/send` | Send a message; returns a `task` or `message` (LiteLLM-integrated path) |
+| `message/stream` | Streaming variant (NDJSON/SSE) |
+| `tasks/get` | Get task status by `params.id` |
+| `tasks/list` | List tasks (optional `params.contextId`) |
+| `tasks/cancel` | Cancel task by `params.id` |
+| `tasks/resubscribe` | Subscribe to task updates (streaming) |
+| `tasks/pushNotificationConfig/set` | Register push notification config |
+| `tasks/pushNotificationConfig/get` | Get push config |
+| `tasks/pushNotificationConfig/list` | List push configs for a task |
+| `tasks/pushNotificationConfig/delete` | Delete push config |
+| `agent/getAuthenticatedExtendedCard` | Extended agent card |
+
+PascalCase SDK names (`GetTask`, `ListTasks`, …) are normalized to the slash form automatically.
+
+**Routing:** `message/send` and `message/stream` go through LiteLLM's A2A client (logging, guardrails, spend). All other methods are forwarded to the upstream URL in `agent_card_params.url`. Task APIs require that URL; completion-bridge-only agents support messaging methods only.
+
+See [Supported A2A methods](./a2a_agent_card#supported-a2a-methods) for examples, aliases, and limitations.
 
 ### Authentication
 
@@ -290,6 +320,22 @@ LiteLLM follows the [A2A JSON-RPC 2.0 specification](https://github.com/google/A
     ]
   }
 }
+```
+
+Agent JSON-RPC errors are returned in the `error` field with the same `id` as the request when possible. Poll long-running work with `tasks/get` after `message/send` returns a `submitted` task.
+
+### Example: `tasks/get`
+
+```bash title="Poll task after message/send"
+curl -X POST "http://localhost:4000/a2a/my-agent" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "req-2",
+    "method": "tasks/get",
+    "params": {"id": "task-id-from-send-response"}
+  }'
 ```
 
 ## Agent Registry

--- a/docs/a2a_agent_card.md
+++ b/docs/a2a_agent_card.md
@@ -105,23 +105,80 @@ When you register an A2A agent in LiteLLM:
     POST /a2a/{agent_id}
     ```
 
-    using standard A2A JSON-RPC (`message/send`, `message/stream`).
+    using A2A JSON-RPC 2.0 (see [Supported A2A methods](#supported-a2a-methods) below).
 
 ## Supported A2A methods
 
-| Method | Supported |
+All methods below are accepted on `POST /a2a/{agent_id}` (and `POST /a2a/{agent_id}/message/send` for `message/send`). LiteLLM also accepts the PascalCase aliases from the A2A SDK (for example `GetTask` → `tasks/get`).
+
+| Method | Supported | How LiteLLM handles it |
+|---|---|---|
+| `message/send` | ✅ | Routed through LiteLLM A2A SDK (`asend_message`) — logging, guardrails, cost tracking |
+| `message/stream` | ✅ | Routed through LiteLLM streaming handler — NDJSON/SSE response |
+| `tasks/get` | ✅ | JSON-RPC forwarded to the agent's `agent_card_params.url` |
+| `tasks/list` | ✅ | JSON-RPC forwarded to upstream |
+| `tasks/cancel` | ✅ | JSON-RPC forwarded to upstream |
+| `tasks/resubscribe` | ✅ | JSON-RPC forwarded to upstream (streaming/SSE) |
+| `tasks/pushNotificationConfig/set` | ✅ | JSON-RPC forwarded to upstream |
+| `tasks/pushNotificationConfig/get` | ✅ | JSON-RPC forwarded to upstream |
+| `tasks/pushNotificationConfig/list` | ✅ | JSON-RPC forwarded to upstream |
+| `tasks/pushNotificationConfig/delete` | ✅ | JSON-RPC forwarded to upstream |
+| `agent/getAuthenticatedExtendedCard` | ✅ | JSON-RPC forwarded to upstream; `result.url` rewritten to the proxy |
+
+### PascalCase aliases (SDK)
+
+| SDK / alias name | Wire method |
 |---|---|
-| `message/send` | ✅ |
-| `message/stream` | ✅ |
-| `tasks/get` | ❌ |
-| `tasks/cancel` | ❌ |
-| `tasks/list` | ❌ |
-| `tasks/resubscribe` | ❌ |
-| `tasks/pushNotificationConfig/set` | ❌ |
-| `tasks/pushNotificationConfig/get` | ❌ |
-| `tasks/pushNotificationConfig/list` | ❌ |
-| `tasks/pushNotificationConfig/delete` | ❌ |
-| `agent/getAuthenticatedExtendedCard` | ❌ |
+| `GetTask` | `tasks/get` |
+| `ListTasks` | `tasks/list` |
+| `CancelTask` | `tasks/cancel` |
+| `SubscribeToTask` | `tasks/resubscribe` |
+| `CreateTaskPushNotificationConfig` | `tasks/pushNotificationConfig/set` |
+| `GetTaskPushNotificationConfig` | `tasks/pushNotificationConfig/get` |
+| `ListTaskPushNotificationConfigs` | `tasks/pushNotificationConfig/list` |
+| `DeleteTaskPushNotificationConfig` | `tasks/pushNotificationConfig/delete` |
+| `GetExtendedAgentCard` | `agent/getAuthenticatedExtendedCard` |
+
+### Requirements
+
+- **Task and push-notification methods** require `agent_card_params.url` pointing at a real A2A JSON-RPC server. LiteLLM forwards the request body unchanged (aside from auth headers).
+- **Completion-bridge-only agents** (for example LangGraph/Bedrock AgentCore with `custom_llm_provider` and no `url`) support `message/send` and `message/stream` only. Task APIs return an error if no upstream URL is configured.
+- **`message/send` / `message/stream` only:** LiteLLM may strip LiteLLM-specific keys from `params` (for example `guardrails`). Task method `params` are forwarded as-is so A2A fields like `id` are preserved.
+
+### Example: two-step task flow
+
+```bash title="1. Send a message"
+curl -X POST "http://localhost:4000/a2a/my-agent" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "r1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "kind": "message",
+        "role": "user",
+        "messageId": "m1",
+        "parts": [{"kind": "text", "text": "Hello"}]
+      }
+    }
+  }'
+```
+
+Use `result.id` from the response as the task id:
+
+```bash title="2. Poll task status"
+curl -X POST "http://localhost:4000/a2a/my-agent" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "r2",
+    "method": "tasks/get",
+    "params": {"id": "<task-id-from-step-1>"}
+  }'
+```
 
 ---
 

--- a/docs/a2a_invoking_agents.md
+++ b/docs/a2a_invoking_agents.md
@@ -266,6 +266,24 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
+## Task APIs (`tasks/get`, `tasks/list`, …)
+
+Agents that return a `submitted` task from `message/send` expect clients to poll with `tasks/get`. Call the same LiteLLM base URL with JSON-RPC:
+
+```bash showLineNumbers title="tasks_get.sh"
+curl -X POST "http://localhost:4000/a2a/${AGENT_ID}" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "req-2",
+    "method": "tasks/get",
+    "params": {"id": "TASK_ID_FROM_SEND_RESPONSE"}
+  }'
+```
+
+LiteLLM forwards `tasks/get`, `tasks/list`, `tasks/cancel`, push-notification methods, and `agent/getAuthenticatedExtendedCard` to the upstream agent URL. See the full method list in [Supported A2A methods](./a2a_agent_card#supported-a2a-methods).
+
 ## Key Differences
 
 | Method | Use Case | Advantages |


### PR DESCRIPTION
## Summary
- Updates the A2A agent card page to mark all proxy-routed JSON-RPC methods as supported (`tasks/get`, `tasks/list`, `tasks/cancel`, push notification CRUD, `agent/getAuthenticatedExtendedCard`, etc.).
- Documents how LiteLLM routes each method (SDK-integrated vs transparent forward to upstream `agent_card_params.url`).
- Adds PascalCase SDK alias mapping, completion-bridge limitations, and a `message/send` → `tasks/get` example.
- Expands the A2A overview API reference and adds a task polling section to the invoking agents guide.

## Test plan
- [ ] Preview docs site locally (`npm run start` in litellm-docs) and verify `/docs/a2a`, `/docs/a2a_agent_card`, and `/docs/a2a_invoking_agents` render correctly.
- [ ] Confirm method tables and anchor links work in the agent card page.


Made with [Cursor](https://cursor.com)