### PR TITLE
docs: document LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -932,6 +932,7 @@ router_settings:
 | LITELLM_MAX_BUDGET_PER_SESSION_TTL | TTL in seconds for session budget counters used by the max-budget-per-session limiter. Default is 3600 (1 hour)
 | LITELLM_MAX_ITERATIONS_TTL | TTL in seconds for session iteration counters used by the max-iterations limiter. Default is 3600 (1 hour)
 | LITELLM_MAX_STREAMING_DURATION_SECONDS | Maximum duration in seconds allowed for a streaming response. Streams exceeding this duration are terminated with a Timeout error. Default is None (no limit)
+| LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS | Maximum seconds to wait for the next chunk from an async streaming provider before raising a Timeout. Guards against a provider that keeps the connection warm with keepalive bytes but stops sending content. Default is None (disabled)
 | LITELLM_MODE | Operating mode for LiteLLM (e.g., production, development)
 | LITELLM_NON_ROOT | Flag to run LiteLLM in non-root mode for enhanced security in Docker containers
 | LITELLM_RATE_LIMIT_WINDOW_SIZE | Rate limit window size for LiteLLM. Default is 60


### PR DESCRIPTION
Documents the new `LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS` environment variable in the env-vars reference table.

Companion to BerriAI/litellm#29767, which adds an opt-in inactivity timeout that raises `litellm.Timeout` when an async streaming provider keeps the socket warm (keepalive bytes) but stops sending content. The litellm repo's documentation env-keys test requires every env var to appear here, so this entry is needed for that PR's docs CI to pass.
