### PR TITLE
docs: document LITELLM_DEV_ENV_HOT_RELOAD env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -885,6 +885,7 @@ router_settings:
 | LITELLM_DD_AGENT_PORT | Port of DataDog agent for LiteLLM-specific log intake. Default is 10518
 | LITELLM_DD_LLM_OBS_PORT | Port for Datadog LLM Observability agent. Default is 8126
 | LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT | Default `encoding_format` for OpenAI-compatible embedding calls when it is not set on the request or in model `litellm_params` (e.g. `float`, `base64`). Fallback is `float`. See [Embeddings](./embedding.md#embedding-encoding-format).
+| LITELLM_DEV_ENV_HOT_RELOAD | Internal flag the proxy sets on itself when started with `--reload`, signalling reloaded workers to re-read `.env` with `override=True` so edits to existing keys take effect on reload. Not meant to be set by users
 | LITELLM_DONT_SHOW_FEEDBACK_BOX | Flag to hide feedback box in LiteLLM UI
 | LITELLM_DROP_PARAMS | Parameters to drop in LiteLLM requests
 | LITELLM_MODIFY_PARAMS | Parameters to modify in LiteLLM requests


### PR DESCRIPTION
Adds the LITELLM_DEV_ENV_HOT_RELOAD environment variable to the config settings reference. This internal flag is set by the proxy on itself when started with --reload and is read at import time to decide whether reloaded workers re-read .env with override=True. The litellm test_env_keys documentation check requires every os.getenv key in the litellm source to be documented here, so the BerriAI/litellm#29783 CI is red without this entry.