### PR TITLE
chore(compat-matrix): refresh for v1.83.14-stable + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-21T06:19:19Z",
+  "generated_at": "2026-06-08T06:10:58Z",
   "litellm_version": "v1.83.14-stable",
   "claude_code_version": "2.1.126",
   "providers": [
@@ -16,70 +16,8 @@
       "name": "Basic messaging (non-streaming)",
       "providers": {
         "anthropic": {
-          "status": "pass"
-        },
-        "bedrock_invoke": {
-          "status": "pass"
-        },
-        "bedrock_converse": {
-          "status": "pass"
-        },
-        "vertex_ai": {
-          "status": "pass"
-        },
-        "azure": {
-          "status": "pass"
-        }
-      }
-    },
-    {
-      "id": "basic_messaging_streaming",
-      "name": "Basic messaging (streaming)",
-      "providers": {
-        "anthropic": {
-          "status": "pass"
-        },
-        "bedrock_invoke": {
-          "status": "pass"
-        },
-        "bedrock_converse": {
-          "status": "pass"
-        },
-        "vertex_ai": {
-          "status": "pass"
-        },
-        "azure": {
-          "status": "pass"
-        }
-      }
-    },
-    {
-      "id": "tool_use",
-      "name": "Tool use",
-      "providers": {
-        "anthropic": {
-          "status": "pass"
-        },
-        "bedrock_invoke": {
-          "status": "pass"
-        },
-        "bedrock_converse": {
-          "status": "pass"
-        },
-        "vertex_ai": {
-          "status": "pass"
-        },
-        "azure": {
-          "status": "pass"
-        }
-      }
-    },
-    {
-      "id": "prompt_caching_5m",
-      "name": "Prompt caching (5m TTL)",
-      "providers": {
-        "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -97,11 +35,59 @@
       }
     },
     {
-      "id": "vision",
-      "name": "Vision",
+      "id": "basic_messaging_streaming",
+      "name": "Basic messaging (streaming)",
       "providers": {
         "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+        },
+        "bedrock_invoke": {
           "status": "pass"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "pass"
+        },
+        "azure": {
+          "status": "pass"
+        }
+      }
+    },
+    {
+      "id": "tool_use",
+      "name": "Tool use",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+        },
+        "bedrock_invoke": {
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI timed out after 120.0s"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "pass"
+        },
+        "azure": {
+          "status": "pass"
+        }
+      }
+    },
+    {
+      "id": "prompt_caching_5m",
+      "name": "Prompt caching (5m TTL)",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -118,11 +104,35 @@
       }
     },
     {
+      "id": "vision",
+      "name": "Vision",
+      "providers": {
+        "anthropic": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+        },
+        "bedrock_invoke": {
+          "status": "pass"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "pass"
+        },
+        "azure": {
+          "status": "pass"
+        }
+      }
+    },
+    {
       "id": "thinking",
       "name": "Thinking",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "fail",
@@ -130,7 +140,7 @@
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "fail",
@@ -146,7 +156,8 @@
       "name": "Tool use (streaming / fine-grained)",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -168,7 +179,8 @@
       "name": "Extended thinking + tool use",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -190,7 +202,8 @@
       "name": "PDF document input",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -212,7 +225,8 @@
       "name": "Prompt caching (1h TTL)",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -234,7 +248,8 @@
       "name": "Web search (server tool)",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -256,7 +271,8 @@
       "name": "Structured outputs",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -299,7 +315,8 @@
       "name": "Tool search (MCP discovery)",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\\\"},\\\"request_id\\\":\\\"req_011CbqHnukJWqbzpJVsa3pYm\\\"}. Received Model Group=claude-haiku-4-5\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
         },
         "bedrock_invoke": {
           "status": "fail",
@@ -321,11 +338,12 @@
       "name": "Long context (1M)",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-sonnet-4-6] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; (no diagnostic output)"
+          "error": "[claude-opus-4-7-bedrock-invoke] claude CLI failed: exit=1; text=API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Try rephrasing the request or attempting a different approach. If you are seeing this refusal repeatedly, try running /model claude-sonnet-4-20250514 to switch models."
         },
         "bedrock_converse": {
           "status": "fail",


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

| Field | Value |
| --- | --- |
| litellm_version | `v1.83.14-stable` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-06-08T06:10:58Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=fail, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Vision**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=fail, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=fail, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=fail, azure=pass
- **Tool search (MCP discovery)**: anthropic=fail, bedrock_invoke=fail, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Long context (1M)**: anthropic=fail, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.