### PR TITLE
docs: rename litellm-proxy CLI command to lite

### DIFF
--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -103,20 +103,19 @@ Example poll response (after SSO completes):
 
 1. **Install the CLI**
 
-   If you have [uv](https://github.com/astral-sh/uv) installed, you can try this:
+   The one-line installer needs only `curl`; it installs a Python runtime for you if you don't already have one:
+
+   ```shell
+   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
+   ```
+
+   Or, if you already have [uv](https://github.com/astral-sh/uv):
 
    ```shell
    uv tool install 'litellm[proxy]'
    ```
 
-   If that works, you'll see something like this:
-
-   ```shell
-   ...
-   Installed 2 executables: litellm, lite
-   ```
-
-   and now you can use the tool by just typing `lite` in your terminal:
+   Either way the `lite` command is now available, so you can use the tool by just typing `lite` in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -103,19 +103,19 @@ Example poll response (after SSO completes):
 
 1. **Install the CLI**
 
-   The one-line installer needs only `curl`; it installs a Python runtime for you if you don't already have one:
+   The one-line installer needs only `curl`. It bootstraps everything else: it installs [uv](https://github.com/astral-sh/uv) when it's missing, then uses uv to provision a Python runtime if you don't already have one:
 
    ```shell
    curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
    ```
 
-   Or, if you already have [uv](https://github.com/astral-sh/uv):
+   Already have uv and prefer to drive it yourself? Install the package directly instead:
 
    ```shell
    uv tool install 'litellm[proxy]'
    ```
 
-   Either way the `lite` command is now available, so you can use the tool by just typing `lite` in your terminal:
+   Either way you get the full `litellm[proxy]` package: the proxy server plus the `lite` management CLI. The `lite` command is now available, so start by typing it in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -59,7 +59,7 @@ When `EXPERIMENTAL_UI_LOGIN` is enabled, the **browser UI login** session uses a
 :::tip
 You can check your current token's age and expiration status using:
 ```bash
-litellm-proxy whoami
+lite whoami
 ```
 :::
 
@@ -113,13 +113,13 @@ Example poll response (after SSO completes):
 
    ```shell
    ...
-   Installed 2 executables: litellm, litellm-proxy
+   Installed 2 executables: litellm, lite
    ```
 
-   and now you can use the tool by just typing `litellm-proxy` in your terminal:
+   and now you can use the tool by just typing `lite` in your terminal:
 
    ```shell
-   litellm-proxy
+   lite
    ```
 
 2. **Set up environment variables**
@@ -135,7 +135,7 @@ Example poll response (after SSO completes):
 3. **Login**
 
    ```shell
-   litellm-proxy login
+   lite login
    ```
 
    This will open a browser window to authenticate. If you have connected LiteLLM Proxy to your SSO provider, you should be able to login with your SSO credentials. Once logged in, you can use the CLI to make requests to the LiteLLM Gateway.
@@ -143,7 +143,7 @@ Example poll response (after SSO completes):
 4. **Make a test request to view models**
 
    ```shell
-   litellm-proxy models list
+   lite models list
    ```
 
    This will list all the models available to you.

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -103,19 +103,25 @@ Example poll response (after SSO completes):
 
 1. **Install the CLI**
 
-   The one-line installer needs only `curl`. It bootstraps everything else: it installs [uv](https://github.com/astral-sh/uv) when it's missing, then uses uv to provision a Python runtime if you don't already have one:
+   The `lite` client is a thin laptop install: it points at a LiteLLM proxy and runs your coding agents through it, with none of the proxy server runtime pulled in. The one-line installer needs only `curl`; it bootstraps [uv](https://github.com/astral-sh/uv) when it's missing and lets uv provision a compatible Python for you:
 
    ```shell
-   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
+   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install-cli.sh | sh
    ```
 
-   Already have uv and prefer to drive it yourself? Install the package directly instead:
+   On macOS you can install it with Homebrew instead:
 
    ```shell
-   uv tool install 'litellm[proxy]'
+   brew install BerriAI/litellm/lite
    ```
 
-   Either way you get the full `litellm[proxy]` package: the proxy server plus the `lite` management CLI. The `lite` command is now available, so start by typing it in your terminal:
+   Already have uv and prefer to drive it yourself? Install the package directly:
+
+   ```shell
+   uv tool install 'litellm[cli]'
+   ```
+
+   Any of these gives you the `lite` command; if you already run a proxy server from `litellm[proxy]`, it ships there too. Start by typing it in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -17,19 +17,25 @@ and more, as well as making chat and HTTP requests to the proxy server.
 
 1. **Install the CLI**
 
-   The one-line installer needs only `curl`. It bootstraps everything else: it installs [uv](https://github.com/astral-sh/uv) when it's missing, then uses uv to provision a Python runtime if you don't already have one:
+   The `lite` client is a thin laptop install: it points at a LiteLLM proxy and runs your coding agents through it, with none of the proxy server runtime pulled in. The one-line installer needs only `curl`; it bootstraps [uv](https://github.com/astral-sh/uv) when it's missing and lets uv provision a compatible Python for you:
 
    ```shell
-   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
+   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install-cli.sh | sh
    ```
 
-   Already have uv and prefer to drive it yourself? Install the package directly instead:
+   On macOS you can install it with Homebrew instead:
 
    ```shell
-   uv tool install 'litellm[proxy]'
+   brew install BerriAI/litellm/lite
    ```
 
-   Either way you get the full `litellm[proxy]` package: the proxy server plus the `lite` management CLI. The `lite` command is now available, so start by typing it in your terminal:
+   Already have uv and prefer to drive it yourself? Install the package directly:
+
+   ```shell
+   uv tool install 'litellm[cli]'
+   ```
+
+   Any of these gives you the `lite` command; if you already run a proxy server from `litellm[proxy]`, it ships there too. Start by typing it in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -1,6 +1,6 @@
 # LiteLLM Proxy CLI
 
-The `litellm-proxy` CLI is a command-line tool for managing your LiteLLM proxy
+The `lite` CLI is a command-line tool for managing your LiteLLM proxy
 server. It provides commands for managing models, credentials, API keys, users,
 and more, as well as making chat and HTTP requests to the proxy server.
 
@@ -27,13 +27,13 @@ and more, as well as making chat and HTTP requests to the proxy server.
 
    ```shell
    ...
-   Installed 2 executables: litellm, litellm-proxy
+   Installed 2 executables: litellm, lite
    ```
 
-   and now you can use the tool by just typing `litellm-proxy` in your terminal:
+   and now you can use the tool by just typing `lite` in your terminal:
 
    ```shell
-   litellm-proxy
+   lite
    ```
 
 2. **Set up environment variables**
@@ -48,7 +48,7 @@ and more, as well as making chat and HTTP requests to the proxy server.
 3. **Make your first request (list models)**
 
    ```bash
-   litellm-proxy models list
+   lite models list
    ```
 
    If the CLI is set up correctly, you should see a list of available models or a table output.
@@ -99,7 +99,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 2. **Login**
 
    ```bash
-   litellm-proxy login
+   lite login
    ```
 
    This will open a browser window to authenticate. If you have connected LiteLLM Proxy to your SSO provider, you can login with your SSO credentials. Once logged in, you can use the CLI to make requests to the LiteLLM Gateway.
@@ -107,7 +107,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 3. **Test your authentication**
 
    ```bash
-   litellm-proxy models list
+   lite models list
    ```
 
    This will list all the models available to you.
@@ -120,12 +120,12 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy models list
-  litellm-proxy models add gpt-4 \
+  lite models list
+  lite models add gpt-4 \
     --param api_key=sk-123 \
     --param max_tokens=2048
-  litellm-proxy models update <model-id> -p temperature=0.7
-  litellm-proxy models delete <model-id>
+  lite models update <model-id> -p temperature=0.7
+  lite models delete <model-id>
   ```
 
   [API used (OpenAPI)](https://litellm-api.up.railway.app/#/model%20management)
@@ -136,12 +136,12 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy credentials list
-  litellm-proxy credentials create azure-prod \
+  lite credentials list
+  lite credentials create azure-prod \
     --info='{"custom_llm_provider": "azure"}' \
     --values='{"api_key": "sk-123", "api_base": "https://prod.azure.openai.com"}'
-  litellm-proxy credentials get azure-cred
-  litellm-proxy credentials delete azure-cred
+  lite credentials get azure-cred
+  lite credentials delete azure-cred
   ```
 
   [API used (OpenAPI)](https://litellm-api.up.railway.app/#/credential%20management)
@@ -152,14 +152,14 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy keys list
-  litellm-proxy keys generate \
+  lite keys list
+  lite keys generate \
     --models=gpt-4 \
     --spend=100 \
     --duration=24h \
     --key-alias=my-key
-  litellm-proxy keys info --key sk-key1
-  litellm-proxy keys delete --keys sk-key1,sk-key2 --key-aliases alias1,alias2
+  lite keys info --key sk-key1
+  lite keys delete --keys sk-key1,sk-key2 --key-aliases alias1,alias2
   ```
 
   [API used (OpenAPI)](https://litellm-api.up.railway.app/#/key%20management)
@@ -170,15 +170,15 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy users list
-  litellm-proxy users create \
+  lite users list
+  lite users create \
     --email=user@example.com \
     --role=internal_user \
     --alias="Alice" \
     --team=team1 \
     --max-budget=100.0
-  litellm-proxy users get --id <user-id>
-  litellm-proxy users delete <user-id>
+  lite users get --id <user-id>
+  lite users delete <user-id>
   ```
 
   [API used (OpenAPI)](https://litellm-api.up.railway.app/#/Internal%20User%20management)
@@ -189,7 +189,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy chat completions gpt-4 -m "user:Hello, how are you?"
+  lite chat completions gpt-4 -m "user:Hello, how are you?"
   ```
 
   [API used (OpenAPI)](https://litellm-api.up.railway.app/#/chat%2Fcompletions)
@@ -200,7 +200,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 - Example:
 
   ```bash
-  litellm-proxy http request \
+  lite http request \
     POST /chat/completions \
     --json '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}'
   ```
@@ -217,13 +217,13 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 1. **List all models:**
 
    ```bash
-   litellm-proxy models list
+   lite models list
    ```
 
 2. **Add a new model:**
 
    ```bash
-   litellm-proxy models add gpt-4 \
+   lite models add gpt-4 \
      --param api_key=sk-123 \
      --param max_tokens=2048
    ```
@@ -231,7 +231,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 3. **Create a credential:**
 
    ```bash
-   litellm-proxy credentials create azure-prod \
+   lite credentials create azure-prod \
      --info='{"custom_llm_provider": "azure"}' \
      --values='{"api_key": "sk-123", "api_base": "https://prod.azure.openai.com"}'
    ```
@@ -239,7 +239,7 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 4. **Generate an API key:**
 
    ```bash
-   litellm-proxy keys generate \
+   lite keys generate \
      --models=gpt-4 \
      --spend=100 \
      --duration=24h \
@@ -249,14 +249,14 @@ EXPERIMENTAL_UI_LOGIN="True" litellm --config config.yaml
 5. **Chat completion:**
 
    ```bash
-   litellm-proxy chat completions gpt-4 \
+   lite chat completions gpt-4 \
      -m "user:Write a story"
    ```
 
 6. **Custom HTTP request:**
 
    ```bash
-   litellm-proxy http request \
+   lite http request \
      POST /chat/completions \
      --json '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}'
    ```

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -17,19 +17,19 @@ and more, as well as making chat and HTTP requests to the proxy server.
 
 1. **Install the CLI**
 
-   The one-line installer needs only `curl`; it installs a Python runtime for you if you don't already have one:
+   The one-line installer needs only `curl`. It bootstraps everything else: it installs [uv](https://github.com/astral-sh/uv) when it's missing, then uses uv to provision a Python runtime if you don't already have one:
 
    ```shell
    curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
    ```
 
-   Or, if you already have [uv](https://github.com/astral-sh/uv):
+   Already have uv and prefer to drive it yourself? Install the package directly instead:
 
    ```shell
    uv tool install 'litellm[proxy]'
    ```
 
-   Either way the `lite` command is now available, so you can use the tool by just typing `lite` in your terminal:
+   Either way you get the full `litellm[proxy]` package: the proxy server plus the `lite` management CLI. The `lite` command is now available, so start by typing it in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -17,20 +17,19 @@ and more, as well as making chat and HTTP requests to the proxy server.
 
 1. **Install the CLI**
 
-   If you have [uv](https://github.com/astral-sh/uv) installed, you can try this:
+   The one-line installer needs only `curl`; it installs a Python runtime for you if you don't already have one:
+
+   ```shell
+   curl -fsSL https://raw.githubusercontent.com/BerriAI/litellm/main/scripts/install.sh | sh
+   ```
+
+   Or, if you already have [uv](https://github.com/astral-sh/uv):
 
    ```shell
    uv tool install 'litellm[proxy]'
    ```
 
-   If that works, you'll see something like this:
-
-   ```shell
-   ...
-   Installed 2 executables: litellm, lite
-   ```
-
-   and now you can use the tool by just typing `lite` in your terminal:
+   Either way the `lite` command is now available, so you can use the tool by just typing `lite` in your terminal:
 
    ```shell
    lite


### PR DESCRIPTION
## What

`lite` is the new recommended short command for the proxy CLI (BerriAI/litellm#29850); the existing `litellm-proxy` name stays as an alias for the same CLI. These two living docs pages now teach `lite` as the primary command.

[management_cli.md](docs/proxy/management_cli.md) and [cli_sso.md](docs/proxy/cli_sso.md) use `lite ...` for every invocation (`lite login`, `lite models list`, `lite keys generate`, `lite whoami`, and so on).

The install steps now point at the thin `lite` client instead of the full proxy package: the one-line `scripts/install-cli.sh` installer (needs only curl, and lets uv provision a compatible Python), a Homebrew option (`brew install BerriAI/litellm/lite`), and `uv tool install 'litellm[cli]'`. Anyone already running a proxy from `litellm[proxy]` gets `lite` bundled with it, so for them this is just a rename

## Scope

Only the CLI command examples and the install step were changed. Environment variables (`LITELLM_PROXY_URL`, `LITELLM_PROXY_API_KEY`), placeholder URLs like `<your-litellm-proxy-base-url>`, k8s/docker resource names, JWT audiences/scopes, and bucket/service names are unrelated identifiers that merely share the string and were left untouched. Historical release notes that reference `litellm-proxy` are point-in-time records and were not rewritten

## Merge ordering

The thin-install paths only resolve once BerriAI/litellm#29850 ships: `scripts/install-cli.sh` has to be on `main`, `litellm[cli]` has to be published to PyPI, and the Homebrew formula has to be pushed to the `BerriAI/homebrew-litellm` tap. Merge this docs PR after that release so the commands work when a reader copies them
