### PR TITLE
docs(release-notes): group changelog sidebar by minor version within each year

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,7 +168,6 @@ const config = {
 
           const docItems = flattenDocs(items);
 
-          // Group by year
           const byYear = {};
           for (const item of docItems) {
             const year = docYearMap[item.id] || 'Other';
@@ -176,23 +175,34 @@ const config = {
             byYear[year].push(item);
           }
 
-          // Sort each year's items by version descending
-          for (const year of Object.keys(byYear)) {
-            byYear[year].sort(compareVersionsDesc);
+          function buildMinorCategories(yearItems, expandNewest) {
+            const byMinor = {};
+            for (const item of yearItems) {
+              const [maj, min] = parseVersion(item.label || item.id || '');
+              const key = `v${maj}.${min}.x`;
+              if (!byMinor[key]) byMinor[key] = {maj, min, items: []};
+              byMinor[key].items.push(item);
+            }
+            const keys = Object.keys(byMinor);
+            for (const key of keys) byMinor[key].items.sort(compareVersionsDesc);
+            keys.sort((a, b) =>
+              (byMinor[b].maj - byMinor[a].maj) || (byMinor[b].min - byMinor[a].min));
+            return keys.map((key, idx) => ({
+              type: 'category',
+              label: key,
+              collapsed: !(expandNewest && idx === 0),
+              items: byMinor[key].items,
+            }));
           }
 
-          // Build categories sorted by year descending
-          const years = Object.keys(byYear).sort((a, b) => {
-            // Object.keys() returns strings; avoid numeric subtraction type errors.
-            const na = Number.parseInt(a, 10);
-            const nb = Number.parseInt(b, 10);
-            return nb - na;
-          });
-          return years.map(year => ({
+          const years = Object.keys(byYear).sort(
+            (a, b) => Number.parseInt(b, 10) - Number.parseInt(a, 10),
+          );
+          return years.map((year, idx) => ({
             type: 'category',
             label: String(year),
             collapsed: year !== String(years[0]),
-            items: byYear[year],
+            items: buildMinorCategories(byYear[year], idx === 0),
           }));
         },
       },


### PR DESCRIPTION
## What

The changelog sidebar (the autogenerated release-notes nav) listed every release as a flat list under its year. With 80+ releases that column has gotten long. This nests the releases by minor version inside each year, so the tree now reads Year -> minor line -> patch releases, for example 2026 -> v1.84.x -> v1.84.4 ... v1.84.0

The year stays the top level so the outermost list stays short and bounded (one entry per year). The newest year is expanded on load and its newest minor line is expanded too, so the latest release is still visible without an extra click, matching the previous behavior

## How

This is a contained change to the existing `sidebarItemsGenerator` in the `release-notes` docs plugin in `docusaurus.config.js`. It already grouped items by year; the patch-sorting step is replaced with a `buildMinorCategories` helper that buckets a year's releases by `major.minor`, labels each group `vX.Y.x`, sorts the minor lines newest-first, and sorts the patches inside each line newest-first. The 80+ version folders on disk are untouched and public URLs are unaffected since each release carries an explicit `slug`

## Note on year boundaries

Grouping is year-first then minor, so a release line that crosses New Year's appears under both years. The 1.80 line is the current example: the 2025 patches sit under 2025 -> v1.80.x and v1.80.15 sits under 2026 -> v1.80.x. The releases inside are distinct and correctly dated; only the group label repeats. This is intentional; the alternative (pinning a whole minor line to one year) would place some releases under a year that does not match their own ship date

## Proof

Run the dev server and open the Changelog:

\`\`\`
cd litellm-docs && npm run start
\`\`\`

Sidebar renders Year -> vX.Y.x -> patch releases, newest-first, with 2026 and its top minor line expanded