### PR TITLE
docs(config): document DEFAULT_OCI_CHAT_MAX_TOKENS

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -666,6 +666,7 @@ router_settings:
 | DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT | Default token count for mock response prompts. Default is 10
 | DEFAULT_MODEL_CREATED_AT_TIME | Default creation timestamp for models. Default is 1677610602
 | DEFAULT_NUM_WORKERS_LITELLM_PROXY | Default number of workers for LiteLLM proxy when `NUM_WORKERS` is not set. Default is 1. **We strongly recommend setting NUM_WORKERS to the number of vCPUs available** (e.g. `NUM_WORKERS=8` or `--num_workers 8`).
+| DEFAULT_OCI_CHAT_MAX_TOKENS | Default maximum output tokens injected for OCI GenAI chat completions when the caller omits max_tokens, preventing truncation by OCI's low server-side default. Default is 4096
 | DEFAULT_PROMPT_INJECTION_SIMILARITY_THRESHOLD | Default threshold for prompt injection similarity. Default is 0.7
 | DEFAULT_POLLING_INTERVAL | Default polling interval for schedulers in seconds. Default is 0.03
 | DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET | Default reasoning effort disable thinking budget. Default is 0


### PR DESCRIPTION
Documents the DEFAULT_OCI_CHAT_MAX_TOKENS environment variable in the config settings reference. It pairs with BerriAI/litellm#30018, which injects a default maxTokens for OCI GenAI chat when the caller omits max_tokens (OCI's server-side default truncates responses at ~20 tokens). The litellm test_env_keys.py documentation check validates every env var referenced in code against this table, so the new var has to be listed here for that check to pass