### PR TITLE
docs(mavvrik): add Mavvrik FOCUS export integration page

### DIFF
--- a/docs/observability/mavvrik.md
+++ b/docs/observability/mavvrik.md
@@ -8,7 +8,7 @@ LiteLLM can export proxy spend data to [Mavvrik](https://mavvrik.ai) as [FOCUS 1
 |----------|---------|
 | Destination | Export LiteLLM usage data to Mavvrik via signed URL upload |
 | Data format | FOCUS CSV (gzip-compressed, automatically transformed from LiteLLM spend data) |
-| Supported operations | Automatic scheduled export (daily by default) |
+| Supported operations | Automatic daily export |
 | Authentication | Mavvrik API key + connection ID |
 
 ## Prerequisites
@@ -28,9 +28,11 @@ You need the following from your Mavvrik account:
 | `MAVVRIK_API_KEY` | Yes | Mavvrik API key |
 | `MAVVRIK_API_ENDPOINT` | Yes | Tenant API endpoint, e.g. `https://api.mavvrik.ai/<tenant_id>` |
 | `MAVVRIK_CONNECTION_ID` | Yes | AI cost connection identifier |
-| `MAVVRIK_FOCUS_FREQUENCY` | No | Export cadence: `daily` (default), `hourly`, or `interval` |
-| `MAVVRIK_FOCUS_INTERVAL_SECONDS` | No | Seconds between exports when frequency is `interval` (default: 3600) |
-| `MAVVRIK_FOCUS_MAX_ROWS` | No | Maximum rows per export window (default: 500000). Increase for very high-traffic deployments. |
+| `MAVVRIK_FOCUS_MAX_ROWS` | No | Maximum rows per daily export (default: 500000). Increase for very high-traffic deployments. |
+
+:::info Daily export only
+Only `daily` frequency is supported. The Mavvrik ingestion protocol stores one file per calendar date (`metrics/YYYY-MM-DD`). Hourly or interval exports would overwrite each other within the same day, producing incomplete data.
+:::
 
 ### Proxy config
 
@@ -52,17 +54,17 @@ export MAVVRIK_CONNECTION_ID="<connection-id>"
 litellm --config /path/to/config.yaml
 ```
 
-The proxy registers a background job that exports FOCUS-formatted spend data on the configured schedule.
+The proxy registers a background job that exports FOCUS-formatted spend data once daily.
 
 ## How it works
 
-Each export cycle:
+Each daily export cycle:
 
 1. Registers the connector with the Mavvrik backend (`POST /metrics/agent/ai/{connection_id}`)
 2. Requests a GCS signed upload URL for the export date (`GET /metrics/agent/ai/{connection_id}/upload-url`)
 3. Uploads gzip-compressed FOCUS CSV to GCS via the signed URL
 
-Re-running an export for the same date overwrites the previous file for that day. Exports are capped at `MAVVRIK_FOCUS_MAX_ROWS` rows per window (default 500k) to bound memory usage.
+Re-running an export for the same date overwrites the previous file — exports are idempotent. Exports are capped at `MAVVRIK_FOCUS_MAX_ROWS` rows per day (default 500k) to bound memory usage.
 
 ## FOCUS Field Mapping
 

--- a/docs/observability/mavvrik.md
+++ b/docs/observability/mavvrik.md
@@ -1,0 +1,88 @@
+# Mavvrik Integration
+
+LiteLLM can export proxy spend data to [Mavvrik](https://mavvrik.ai) as [FOCUS 1.2](https://focus.finops.org/) formatted cost reports. This lets you track and analyse LLM spend within the Mavvrik cost management platform.
+
+## Overview
+
+| Property | Details |
+|----------|---------|
+| Destination | Export LiteLLM usage data to Mavvrik via signed URL upload |
+| Data format | FOCUS CSV (gzip-compressed, automatically transformed from LiteLLM spend data) |
+| Supported operations | Automatic scheduled export (daily by default) |
+| Authentication | Mavvrik API key + connection ID |
+
+## Prerequisites
+
+You need the following from your Mavvrik account:
+
+1. **API Key** — available in the Mavvrik dashboard under Settings.
+2. **API Endpoint** — your tenant-specific API URL, e.g. `https://api.mavvrik.ai/<tenant_id>`.
+3. **Connection ID** — the AI cost connection ID configured in your Mavvrik account.
+
+## Setup
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MAVVRIK_API_KEY` | Yes | Mavvrik API key |
+| `MAVVRIK_API_ENDPOINT` | Yes | Tenant API endpoint, e.g. `https://api.mavvrik.ai/<tenant_id>` |
+| `MAVVRIK_CONNECTION_ID` | Yes | AI cost connection identifier |
+| `MAVVRIK_FOCUS_FREQUENCY` | No | Export cadence: `daily` (default), `hourly`, or `interval` |
+| `MAVVRIK_FOCUS_INTERVAL_SECONDS` | No | Seconds between exports when frequency is `interval` (default: 3600) |
+| `MAVVRIK_FOCUS_MAX_ROWS` | No | Maximum rows per export window (default: 500000). Increase for very high-traffic deployments. |
+
+### Proxy config
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: sk-your-key
+
+litellm_settings:
+  callbacks: ["mavvrik"]
+```
+
+```bash
+export MAVVRIK_API_KEY="<your-api-key>"
+export MAVVRIK_API_ENDPOINT="https://api.mavvrik.ai/<tenant_id>"
+export MAVVRIK_CONNECTION_ID="<connection-id>"
+litellm --config /path/to/config.yaml
+```
+
+The proxy registers a background job that exports FOCUS-formatted spend data on the configured schedule.
+
+## How it works
+
+Each export cycle:
+
+1. Registers the connector with the Mavvrik backend (`POST /metrics/agent/ai/{connection_id}`)
+2. Requests a GCS signed upload URL for the export date (`GET /metrics/agent/ai/{connection_id}/upload-url`)
+3. Uploads gzip-compressed FOCUS CSV to GCS via the signed URL
+
+Re-running an export for the same date overwrites the previous file for that day. Exports are capped at `MAVVRIK_FOCUS_MAX_ROWS` rows per window (default 500k) to bound memory usage.
+
+## FOCUS Field Mapping
+
+LiteLLM spend data is transformed into the FOCUS 1.2 schema before upload:
+
+| LiteLLM Field | FOCUS Column | Description |
+|---------------|-------------|-------------|
+| `spend` | BilledCost, EffectiveCost | Cost of the usage |
+| `model` | ChargeDescription, ResourceId | Model identifier |
+| `model_group` | ServiceName | Model group / deployment |
+| `custom_llm_provider` | ProviderName, PublisherName | Provider (openai, anthropic, etc.) |
+| `api_key` | BillingAccountId | Hashed API key |
+| `api_key_alias` | BillingAccountName | Human-readable key alias |
+| `team_id` | SubAccountId | Team identifier |
+| `team_alias` | SubAccountName | Team name |
+
+Additional metadata (user_id, model_group, etc.) is included in the `Tags` column as JSON.
+
+## Related Links
+
+- [Mavvrik](https://mavvrik.ai)
+- [FOCUS Specification](https://focus.finops.org/)
+- [Focus Export (S3/GCS)](./focus.md)

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -737,6 +737,10 @@ router_settings:
 | FOCUS_S3_ACCESS_KEY | AWS access key ID used by the Focus export S3 client.
 | FOCUS_S3_SECRET_KEY | AWS secret access key used by the Focus export S3 client.
 | FOCUS_S3_SESSION_TOKEN | AWS session token used by the Focus export S3 client (optional).
+| MAVVRIK_API_KEY | API key for the Mavvrik FOCUS export integration.
+| MAVVRIK_API_ENDPOINT | Tenant API endpoint for the Mavvrik FOCUS export, e.g. `https://api.mavvrik.ai/<tenant_id>`.
+| MAVVRIK_CONNECTION_ID | AI cost connection ID for the Mavvrik FOCUS export.
+| MAVVRIK_FOCUS_MAX_ROWS | Maximum rows per export window for the Mavvrik FOCUS destination. Default is 500000.
 | FOCUS_GCS_BUCKET_NAME | GCS bucket to upload Focus export files when using the GCS destination.
 | FOCUS_GCS_PATH_SERVICE_ACCOUNT | Path to a service account JSON key file for the Focus export GCS client. Falls back to Application Default Credentials if unset.
 | FUNCTION_DEFINITION_TOKEN_COUNT | Token count for function definitions. Default is 9


### PR DESCRIPTION
Companion docs for BerriAI/litellm#29935 (feat(focus): add Mavvrik destination for FOCUS export).

**`docs/observability/mavvrik.md`** (new):
- Full integration page for the `mavvrik` callback
- Prerequisites, env vars table (including `MAVVRIK_FOCUS_MAX_ROWS`), proxy config, how it works, FOCUS field mapping
- Note: only `daily` frequency is supported

**`docs/proxy/config_settings.md`:**
- Adds `MAVVRIK_API_KEY`, `MAVVRIK_API_ENDPOINT`, `MAVVRIK_CONNECTION_ID`, `MAVVRIK_FOCUS_MAX_ROWS` to env vars reference table