### PR TITLE
docs(gemini): document web search for image generation

### DIFF
--- a/docs/completion/web_search.md
+++ b/docs/completion/web_search.md
@@ -7,7 +7,7 @@ Use web search with litellm
 
 | Feature | Details |
 |---------|---------|
-| Supported Endpoints | - `/chat/completions` <br/> - `/responses` |
+| Supported Endpoints | - `/chat/completions` <br/> - `/responses` <br/> - `/images/generations` (Gemini image models only) |
 | Supported Providers | `openai`, `xai`, `vertex_ai`, `anthropic`, `gemini`, `perplexity` |
 | LiteLLM Cost Tracking | ✅ Supported |
 | LiteLLM Version | `v1.71.0+` |
@@ -247,6 +247,20 @@ response = completion(
     }
 )
 ```
+
+**Gemini image generation (using web_search_options on `/images/generations`)**
+
+```python showLineNumbers
+from litellm import image_generation
+
+response = image_generation(
+    model="gemini/gemini-3.1-flash-image-preview",
+    prompt="Generate an image of the latest iPhone design",
+    web_search_options={},
+)
+```
+
+Works with `vertex_ai/gemini-3.1-flash-image-preview` and other Gemini image models. See [Vertex AI Image Generation](../providers/vertex_image.md) and [Google AI Studio Image Generation](../providers/google_ai_studio/image_gen.md).
 </TabItem>
 <TabItem value="proxy" label="PROXY">
 

--- a/docs/providers/google_ai_studio/image_gen.md
+++ b/docs/providers/google_ai_studio/image_gen.md
@@ -191,6 +191,38 @@ curl --location 'http://localhost:4000/v1/images/generations' \
 </TabItem>
 </Tabs>
 
+## Gemini Image Models
+
+Gemini image models (e.g. `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`) use the `generateContent` API and return base64 images. They also support **Google Search grounding** on `/v1/images/generations`.
+
+```python showLineNumbers title="Gemini image generation with Google Search"
+import litellm
+import os
+
+os.environ["GEMINI_API_KEY"] = "your-api-key-here"
+
+response = litellm.image_generation(
+    model="gemini/gemini-3.1-flash-image-preview",
+    prompt="Generate an image of the latest iPhone design",
+    web_search_options={},
+)
+
+print(response.data[0].b64_json)
+```
+
+```bash showLineNumbers title="Proxy request with web_search_options"
+curl --location 'http://localhost:4000/v1/images/generations' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer sk-1234' \
+--data '{
+    "model": "gemini-3.1-flash-image-preview",
+    "prompt": "Generate an image of the latest iPhone design",
+    "web_search_options": {}
+}'
+```
+
+You can also pass `tools=[{"type": "web_search"}]` or native `tools=[{"googleSearch": {}}]`.
+
 ## Supported Parameters
 
 Google AI Studio Image Generation supports the following OpenAI-compatible parameters:
@@ -201,6 +233,8 @@ Google AI Studio Image Generation supports the following OpenAI-compatible param
 | `model` | string | The model to use for generation | Required | `"gemini/imagen-4.0-generate-001"` |
 | `n` | integer | Number of images to generate (1-4) | `1` | `2` |
 | `size` | string | Image dimensions | `"1024x1024"` | `"512x512"`, `"1024x1024"` |
+| `web_search_options` | object | Enable Google Search grounding (Gemini image models only) | - | `{}` |
+| `tools` | array | Pass `{"type": "web_search"}` or `{"googleSearch": {}}` (Gemini image models only) | - | `[{"type": "web_search"}]` |
 
 1. Create an account at [Google AI Studio](https://aistudio.google.com/)
 2. Generate an API key from [API Keys section](https://aistudio.google.com/app/apikey)

--- a/docs/providers/vertex_image.md
+++ b/docs/providers/vertex_image.md
@@ -57,6 +57,49 @@ response = await litellm.aimage_generation(
 print(response.data[0].b64_json)
 ```
 
+### Google Search Grounding
+
+Gemini image models (e.g. `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`) support Google Search on `/v1/images/generations`. LiteLLM maps `web_search_options` or OpenAI-style `web_search` tools to Gemini's `googleSearch` tool on the underlying `generateContent` request.
+
+```python showLineNumbers title="Image generation with Google Search"
+import litellm
+
+response = await litellm.aimage_generation(
+    prompt="Generate an image of the latest iPhone design",
+    model="vertex_ai/gemini-3.1-flash-image-preview",
+    vertex_ai_project="your-project-id",
+    vertex_ai_location="us-central1",
+    web_search_options={},
+)
+
+print(response.data[0].b64_json)
+```
+
+```python showLineNumbers title="Using OpenAI-style web_search tool"
+import litellm
+
+response = await litellm.aimage_generation(
+    prompt="Generate an image of the latest iPhone design",
+    model="vertex_ai/gemini-3.1-flash-image-preview",
+    vertex_ai_project="your-project-id",
+    vertex_ai_location="us-central1",
+    tools=[{"type": "web_search"}],
+)
+```
+
+Via LiteLLM Proxy (`/v1/images/generations`):
+
+```bash showLineNumbers title="Proxy request with web_search_options"
+curl -X POST 'http://localhost:4000/v1/images/generations' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+    "model": "gemini-3.1-flash-image-preview",
+    "prompt": "Generate an image of the latest iPhone design",
+    "web_search_options": {}
+}'
+```
+
 ### Imagen Models
 
 ```python showLineNumbers title="Imagen Image Generation"
@@ -122,6 +165,7 @@ print(response.data[0].url)
 ### Gemini Image Generation Models
 
 - `vertex_ai/gemini-2.5-flash-image` - Fast, efficient image generation (1024px resolution)
+- `vertex_ai/gemini-3.1-flash-image-preview` - Fast image generation with Google Search grounding
 - `vertex_ai/gemini-3-pro-image-preview` - Advanced model with 4K output, Google Search grounding, and thinking mode
 - `vertex_ai/gemini-2.0-flash-preview-image` - Preview model
 - `vertex_ai/gemini-2.5-flash-image-preview` - Preview model


### PR DESCRIPTION
## Summary
- Document `web_search_options` and `tools` support on `/v1/images/generations` for Gemini image models
- Add Google Search grounding examples for Google AI Studio and Vertex AI
- Update web search docs to list `/images/generations` as a supported endpoint for Gemini image models

Related code PR: https://github.com/BerriAI/litellm/pull/30119

## Test plan
- [x] Reviewed markdown rendering for new sections in `vertex_image.md`, `google_ai_studio/image_gen.md`, and `completion/web_search.md`