### PR TITLE
docs: clarify max-score behavior in semantic auto router

### DIFF
--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -215,9 +215,9 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 ## How It Works
 
 1. When a request comes in, LiteLLM generates embeddings for the input message
-2. It compares these embeddings against the utterances defined in your routes
-3. If a route's similarity score exceeds the threshold, the request is routed to that model
-4. If no route matches, the request goes to the default model
+2. It compares these embeddings against **all** utterances defined across **all** your routes simultaneously
+3. It identifies the route with the **highest similarity score**. If that score exceeds the route's defined threshold, the request is routed to that model. *(Because the router selects the global maximum score rather than stopping at the first match, the order of routes in your configuration does not affect which route is selected.)*
+4. If no route's maximum score meets its threshold, the request goes to the default model
 
 ---
 


### PR DESCRIPTION
## Summary

- The previous **How It Works** wording (step 3) implied a sequential, first-match check — making it seem like route order in the config matters.
- In practice, the semantic router evaluates **all routes simultaneously** and picks the one with the **globally highest similarity score**. Only if that score exceeds the route's threshold does it route there.
- Updated the four-step explanation to make this explicit, including a parenthetical note that route order is irrelevant.

## Why this matters

Developers were structuring their `router.json` by priority order, expecting earlier routes to "win" on a tie — which is not how the underlying semantic router works. This clarification prevents that confusion.

## Test plan

- [ ] Verify the rendered docs at `/docs/proxy/auto_routing` show the updated **How It Works** section
- [ ] Confirm no other sections reference route ordering as meaningful

🤖 Generated with [Claude Code](https://claude.com/claude-code)