### PR TITLE
Document FAROS_* environment variables

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -714,6 +714,12 @@ router_settings:
 | EMAIL_BUDGET_ALERT_TTL | Time-to-live for budget alert deduplication in seconds. Default is 86400 (24 hours)
 | ENKRYPTAI_API_BASE | Base URL for EnkryptAI Guardrails API. **Default is https://api.enkryptai.com**
 | ENKRYPTAI_API_KEY | API key for EnkryptAI Guardrails service
+| FAROS_API_KEY | API key for sending LLM usage data to Faros AI
+| FAROS_API_URL | Base URL for the Faros AI API. Default is https://prod.api.faros.ai
+| FAROS_GRAPH | Faros graph that LiteLLM usage data is written to. Default is "default"
+| FAROS_ORIGIN | Origin recorded on rows written to Faros by LiteLLM. Default is "litellm"
+| FAROS_TOOL_CATEGORY | Tool category recorded on Faros vcs_UserTool rows. Default is "LiteLLM"
+| FAROS_USER_SOURCE | Source recorded on Faros vcs_User rows for LiteLLM users. Default is "LiteLLM"
 | FIREWORKS_AI_4_B | Size parameter for Fireworks AI 4B model. Default is 4
 | FIREWORKS_AI_16_B | Size parameter for Fireworks AI 16B model. Default is 16
 | FIREWORKS_AI_56_B_MOE | Size parameter for Fireworks AI 56B MOE model. Default is 56


### PR DESCRIPTION
Adds the six FAROS_* environment variables to the environment variables reference table in docs/proxy/config_settings.md. These are introduced by the Faros usage logging callback in BerriAI/litellm#30152; the env keys documentation check (test_env_keys.py) on that PR fails until these keys are documented here, since CI checks out this repo's main branch.

Verified locally by running tests/documentation_tests/test_env_keys.py against this updated file; it passes with these rows added