### PR TITLE
blog: Harnesses Are the New LLMs

### DIFF
--- a/blog/harnesses-are-the-new-llms/diagrams.js
+++ b/blog/harnesses-are-the-new-llms/diagrams.js
@@ -1,5 +1,63 @@
 import React from 'react';
 
+// ── Hero ──────────────────────────────────────────────────────────────────
+// Two-focal bundle: many curves fan in from the left, pass through two focal
+// nodes (registry + invocation), fan out on the right. Reads as: many agent
+// runtimes routed through one unified control plane to many consumers.
+export function ConvergenceHero() {
+  const W = 1200;
+  const H = 500;
+  const N = 40;
+  const f1 = { x: W * 0.25, y: H * 0.5 };
+  const f2 = { x: W * 0.75, y: H * 0.5 };
+  const curves = Array.from({ length: N }, (_, i) => {
+    const t = (i - N / 2) / (N / 2);
+    const yIn = H * 0.5 + t * H * 0.45;
+    const yOut = H * 0.5 - t * H * 0.45;
+    const d = `M 0 ${yIn} Q ${f1.x} ${f1.y}, ${(f1.x + f2.x) / 2} ${H / 2} Q ${f2.x} ${f2.y}, ${W} ${yOut}`;
+    return { d, o: 0.18 + 0.35 * (1 - Math.abs(t)) };
+  });
+
+  return (
+    <figure style={{ margin: '0 0 2rem 0' }}>
+      <div
+        style={{
+          background: '#3a3a2e',
+          borderRadius: 12,
+          overflow: 'hidden',
+          aspectRatio: `${W} / ${H}`,
+          width: '100%',
+        }}
+      >
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          width="100%"
+          height="100%"
+          preserveAspectRatio="xMidYMid meet"
+          style={{ display: 'block' }}
+          role="img"
+          aria-label="Abstract curve bundle fanning in from the left, passing through two focal points, and fanning out on the right — representing many agent runtimes routed through a unified control plane to many consumers."
+        >
+          {curves.map((c, i) => (
+            <path
+              key={i}
+              d={c.d}
+              fill="none"
+              stroke="#faf9f5"
+              strokeWidth={0.9}
+              strokeOpacity={c.o}
+              strokeLinecap="round"
+            />
+          ))}
+          <circle cx={f1.x} cy={f1.y} r={4} fill="#faf9f5" opacity={0.95} />
+          <circle cx={f2.x} cy={f2.y} r={4} fill="#faf9f5" opacity={0.95} />
+        </svg>
+      </div>
+    </figure>
+  );
+}
+
+
 const ROWS = [
   {
     label: 'Unified API',

--- a/blog/harnesses-are-the-new-llms/diagrams.js
+++ b/blog/harnesses-are-the-new-llms/diagrams.js
@@ -1,0 +1,162 @@
+import React from 'react';
+
+const ROWS = [
+  {
+    label: 'Unified API',
+    sub: 'one interface, many backends',
+    model: { name: 'LiteLLM', desc: 'one API across 100+ models', open: false },
+    agent: { name: '?', desc: 'one API across agent runtimes', open: true },
+  },
+  {
+    label: 'Managed cloud service',
+    sub: 'fully hosted, pay-per-use',
+    model: { name: 'Bedrock', desc: 'cloud model inference', open: false },
+    agent: { name: 'Claude Managed Agents', desc: 'cloud model + harness API', open: false },
+  },
+  {
+    label: 'Deployment platform',
+    sub: 'run open-source yourself',
+    model: { name: 'SageMaker', desc: 'deploy OSS models', open: false },
+    agent: { name: 'AgentCore · Vertex Agents', desc: 'deploy OSS harnesses', open: false },
+  },
+  {
+    label: 'High-perf serving',
+    sub: 'throughput & latency engine',
+    model: { name: 'vLLM', desc: 'fast model serving', open: false },
+    agent: { name: '?', desc: 'fast harness serving', open: true },
+  },
+];
+
+const BLUE = '#3b82f6';
+
+const s = {
+  fig: { margin: '2.5rem 0', fontFamily: 'inherit' },
+  wrap: {
+    display: 'grid',
+    gridTemplateColumns: '180px 1fr 24px 1fr',
+    gap: '12px 12px',
+    alignItems: 'center',
+  },
+  colHeader: {
+    fontSize: 14,
+    fontWeight: 700,
+    textAlign: 'center',
+    paddingBottom: 4,
+  },
+  colSub: {
+    fontSize: 11,
+    opacity: 0.6,
+    textAlign: 'center',
+    paddingBottom: 12,
+  },
+  rowLabel: {
+    fontSize: 13,
+    fontWeight: 600,
+    paddingRight: 12,
+  },
+  rowSub: {
+    fontSize: 11,
+    opacity: 0.6,
+    marginTop: 2,
+  },
+  box: (open) => ({
+    border: open ? `1.5px dashed ${BLUE}` : '1px solid var(--ifm-color-emphasis-300)',
+    background: open ? 'rgba(59,130,246,0.08)' : 'transparent',
+    borderRadius: 8,
+    padding: '14px 18px',
+    minHeight: 56,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+  }),
+  boxName: (open) => ({
+    fontSize: 14,
+    fontWeight: 700,
+    color: open ? BLUE : 'inherit',
+  }),
+  boxDesc: {
+    fontSize: 12,
+    opacity: 0.7,
+    marginTop: 3,
+  },
+  arrow: {
+    fontSize: 16,
+    opacity: 0.5,
+    textAlign: 'center',
+  },
+  legend: {
+    display: 'flex',
+    gap: 24,
+    justifyContent: 'center',
+    marginTop: 24,
+    fontSize: 12,
+    opacity: 0.7,
+    flexWrap: 'wrap',
+  },
+  legendItem: { display: 'flex', alignItems: 'center', gap: 8 },
+  legendSwatch: (open) => ({
+    width: 24,
+    height: 14,
+    borderRadius: 4,
+    border: open ? `1.5px dashed ${BLUE}` : '1px solid var(--ifm-color-emphasis-300)',
+    background: open ? 'rgba(59,130,246,0.08)' : 'transparent',
+  }),
+  caption: {
+    textAlign: 'center',
+    fontSize: 12,
+    opacity: 0.6,
+    marginTop: 14,
+  },
+};
+
+export function StackComparison() {
+  return (
+    <figure style={s.fig}>
+      <div style={s.wrap}>
+        <div />
+        <div>
+          <div style={s.colHeader}>Model stack — today</div>
+          <div style={s.colSub}>calling models</div>
+        </div>
+        <div />
+        <div>
+          <div style={s.colHeader}>Agent stack — future</div>
+          <div style={s.colSub}>calling harnesses</div>
+        </div>
+
+        {ROWS.map((row, i) => (
+          <React.Fragment key={i}>
+            <div style={s.rowLabel}>
+              {row.label}
+              <div style={s.rowSub}>{row.sub}</div>
+            </div>
+            <div style={s.box(row.model.open)}>
+              <div style={s.boxName(row.model.open)}>{row.model.name}</div>
+              <div style={s.boxDesc}>{row.model.desc}</div>
+            </div>
+            <div style={s.arrow}>→</div>
+            <div style={s.box(row.agent.open)}>
+              <div style={s.boxName(row.agent.open)}>{row.agent.name}</div>
+              <div style={s.boxDesc}>{row.agent.desc}</div>
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      <div style={s.legend}>
+        <div style={s.legendItem}>
+          <div style={s.legendSwatch(true)} />
+          <span>open gap — no clear winner yet</span>
+        </div>
+        <div style={s.legendItem}>
+          <div style={s.legendSwatch(false)} />
+          <span>established / announced player</span>
+        </div>
+      </div>
+
+      <figcaption style={s.caption}>
+        Each model-stack layer has a mirror in the agent stack. Dashed boxes mark open opportunities.
+      </figcaption>
+    </figure>
+  );
+}

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -1,64 +1,87 @@
 ---
-
-slug:  harnesses-are-the-new-llms
-
-title:  "Harnesses Are the New LLMs"
-
-date:  2026-06-10T09:00:00
-
+slug: agents-are-the-new-llms
+title: "A Unified Agent Control Plane"
+date: 2026-06-10T09:00:00
 authors:
-
--  krrish
-
-description:  "The same deployment pattern that emerged with LLMs — routing, fallbacks, observability, central billing — is now emerging with harnesses. Here's why the AI Gateway layer is moving up the stack."
-
+- krrish
+description: "The AI Gateway is moving up the stack: from routing model calls to routing agent work."
 tags: [ideas, harnesses, ai-gateway, agents, thesis]
-
 hide_table_of_contents: true
-
 ---
 
 import { StackComparison } from './diagrams';
 
-*Last Updated: June 2026*
+*Last updated: June 2026*
 
-When we see harnesses today, we see the same stack being built, as the ones we saw for LLM's. This blog walks through some emerging patterns, and open problems that we see in the space. 
+Agent infrastructure is already separating into three layers: models, harnesses, and runtimes. Our thesis is that a fourth layer will emerge: the unified agent control plane. This will allow calling agents living in different agent runtimes, all from 1 place. 
 
-## What's new? 
+The reason is that companies will not run every agent on one runtime. Coding agents may run on Bedrock AgentCore or Claude Managed Agents. Data agents may run inside Elastic, Databricks, or Snowflake. Internal workflow agents may run on custom infrastructure. The control plane emerges because companies want one place where all of these agents can be used, regardless of where they were built or run.
 
-Building agents today is no longer about just wrapping an LLM API call in a tool loop and pushing it to production. Claude Code and OpenClaw changed user expectations for how powerful AI could be, and how we'd want to interact with it ("I don't want to go to code, I just want to tell it what to do, and have it do the thing."). This has given rise to several coding harnesses which wrap the LLM API call with a tool loop, and handle scenarios like sub-agent spawning, memory, compaction, etc. increasing the robustness of agents and making them more useful for tasks. 
+But a registry alone is not enough. Anyone can build a list of agents.
 
-## What does this change?
+The harder problem is invocation. Agent runtimes expose similar primitives — agents, sessions, events, tools — but they do not expose them through the same APIs. So if you want one place to actually use these agents, not just list them, the control plane has to manage agent runtimes, schedules, memory, and sessions.
 
-The agents we're focusing on, our autonomous, long-running coding agents - the kind you can ask to file a PR to fix an issue. To run this agent, you pick a model + harness and deploy it somewhere. The harness also needs a sandbox, to check out the code, make changes and file a fix. Making harnesses reliable in production is hard. It involves sandbox orchestration, and optimizing the harness to handle concurrent requests (what happens if the container goes down mid-way through a request? how to hand off sessions? etc.). 
-
-We're already seeing solutions ("Agent Runtimes") crop up that help simplify this - AgentCore, Gemini Agent Platform, Claude Managed Agents. Over time, similar to LLM's, we expect there to be a wide range of providers offering 'harness-as-a-service' API's (either proprietary - e.g. Claude Managed Agents, or wrapping open-source - e.g. [Bedrock Agent Core wrapping OpenCode](https://aws.amazon.com/blogs/machine-learning/its-safe-to-close-your-laptop-now-hosting-coding-agents-on-amazon-bedrock-agentcore/).
+This is the same pattern LiteLLM saw with models. Companies did not just need a catalog of models. They needed one interface to call them. The only change, is that the primitive is now the agent session, not the model call.
 
 ## The Stack of the Future
 
 <StackComparison />
 
-## Open Questions
+The important shift is that the gateway is no longer just routing model calls. It is routing agent work.
 
-This stack has 2 open questions:
+With LLMs, the stack became:
 
-- What does the VLLM of this world look like? 
-- When will users want to go across multiple Agent Runtimes?
+* **Models:** GPT, Claude, Gemini, Llama
+* **Inference providers:** OpenAI, Anthropic, Bedrock, Vertex, Azure, vLLM
+* **Gateway:** routing, fallbacks, logging, spend tracking, auth, billing
+* **Applications:** copilots, workflows, internal tools, products
 
-For #1, We think there's room for someone to build a high-throughput inference server, which works across the open-source coding harnesses, and optimizes them to achieve high scale (1k+ RPS). We've already published templates, for OpenCode, DeepAgents, and Hermes, for what that server needs to look like (ideally mapped to the Claude Managed Agents API spec). 
+With agents, we think the stack becomes:
 
-For #2, we see this control plane above the runtimes being very similar to how LiteLLM works today, and are building this as an experimental project with [LAP](https://github.com/LiteLLM-Labs/litellm-agent-platform). This is a Rust-based AI Gateway + Agent Control Plane, that allows users to build, register and invoke agents across multiple Agent Runtimes. 
+* **Models:** Claude, GPT, Gemini, open-source models
+* **Harnesses:** Claude Code, Codex, OpenCode, Hermes, DeepAgents
+* **Agent runtimes:** Claude Managed Agents, Bedrock AgentCore, Gemini Enterprise Agent Platform, self-hosted runtimes
+* **Agent control plane:** multi-runtime platform where teams manage agent runtimes, schedules, memory, and sessions.
+* **Applications:** coding agents, support agents, data agents, security agents
 
-We're already starting to see some users resonate with this problem - trying to use LAP as a control plane for agents being built in their company in different runtimes (e.g. Exposing an agent built on Elastic's Runtime, for analyzing Kibana logs to everyone via LAP). 
+## Why companies will need this
 
-If you're company is facing similar problems, we'd love your feedback on LiteLLM Agent Platform - https://github.com/LiteLLM-Labs/litellm-agent-platform. 
+At LiteLLM, we are already seeing our team work across multiple agent runtimes. Some people are building on Claude Managed Agents, others are on N8N or Cursor. 
 
-## Frequently Asked Questions 
+This fragmentation makes it hard for agents built on these platforms to be shareable, and everyone to benefit from the work done so far. 
 
-1. Is LiteLLM building a 2nd product? 
+By having the agents live in 1 place, everyone can leverage these agents - even if the PR Babysitter Agent was written in Claude Managed Agents, which not everyone has direct access to. 
 
-No. Our goal is to roll these learnings into the core LiteLLM offering over time. Building it separately, allows us to move quickly without impacting existing users. 
+That is the control plane problem.
 
-2. Is LAP ready for production? 
+This is also why we think the AI Gateway moves up the stack. The gateway starts by managing model calls. But as agents become the dominant use-case for AI, the gateway has to manage agent sessions too.
 
-No. This is a pre-v0 project. The API's might change unexpectedly, as we work with users on this. If you want to contribute to this project, file an [issue](https://github.com/LiteLLM-Labs/litellm-agent-platform/issues) OR join our discord [here](https://discord.gg/Nkxw3rm3EE). 
+## What we are building
+
+[LiteLLM Agent Platform](https://github.com/LiteLLM-Labs/litellm-agent-platform) is our experiment in this direction.
+
+LiteLLM Agent Platform is a Rust-based AI Gateway and Agent Control Plane. The goal is to let teams register, invoke, observe, and govern agents across multiple runtimes.
+
+We are starting with coding agents because the need is obvious. They are long-running, stateful, tool-heavy, and expensive enough to require real infrastructure.
+
+We are already seeing early users resonate with this pattern. Some companies want LAP to act as a central control plane for agents built by different teams on different runtimes. For example, one team might build an agent on Elastic’s runtime to analyze Kibana logs, but the company may want to expose that agent internally through a common gateway.
+
+This is the architecture we believe is coming: models become interchangeable, harnesses become specialized, runtimes become managed, and the gateway becomes the control plane for agent work.
+
+If this matches what you are seeing, we would love feedback on LiteLLM Agent Platform:
+
+https://github.com/LiteLLM-Labs/litellm-agent-platform
+
+## Frequently Asked Questions
+
+### Is LiteLLM building a second product?
+
+No. LAP is an experimental project. The goal is to learn quickly and bring the right pieces into LiteLLM over time.
+
+### Is LAP production-ready?
+
+No. LAP is pre-v0. APIs may change as we work with early users and contributors.
+
+If you want to contribute, file an issue or join our Discord:
+
+https://discord.gg/Nkxw3rm3EE

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -1,165 +1,64 @@
 ---
-slug: harnesses-are-the-new-llms
-title: "Harnesses Are the New LLMs"
-date: 2026-06-10T09:00:00
+
+slug:  harnesses-are-the-new-llms
+
+title:  "Harnesses Are the New LLMs"
+
+date:  2026-06-10T09:00:00
+
 authors:
-  - krrish
-description: "The same deployment pattern that emerged with LLMs — routing, fallbacks, observability, central billing — is now emerging with harnesses. Here's why the AI Gateway layer is moving up the stack."
+
+-  krrish
+
+description:  "The same deployment pattern that emerged with LLMs — routing, fallbacks, observability, central billing — is now emerging with harnesses. Here's why the AI Gateway layer is moving up the stack."
+
 tags: [harnesses, ai-gateway, agents, thesis, infrastructure]
+
 hide_table_of_contents: true
+
 ---
+
+import { StackComparison } from './diagrams';
 
 *Last Updated: June 2026*
 
-Three years ago, every team picked one LLM. Then they picked two. Then they hit the same wall: how do you route between them, fall back when one is down, track spend across both, and audit who called what? That wall is what an AI Gateway solves.
+When we see harnesses today, we see the same stack being built, as the ones we saw for LLM's. This blog walks through some emerging patterns, and open problems that we see in the space. 
 
-The same wall is forming one layer up. Teams started with one harness — Claude Code, Codex, or Cursor. They're already running two. By next quarter they'll run three. The deployment pattern that emerged for LLMs is repeating, exactly, for harnesses.
+## What's new? 
 
-{/* truncate */}
+Building agents today is no longer about just wrapping an LLM API call in a tool loop and pushing it to production. Claude Code and OpenClaw changed user expectations for how powerful AI could be, and how we'd want to interact with it ("I don't want to go to code, I just want to tell it what to do, and have it do the thing."). This has given rise to several coding harnesses which wrap the LLM API call with a tool loop, and handle scenarios like sub-agent spawning, memory, compaction, etc. increasing the robustness of agents and making them more useful for tasks. 
 
-## The pattern from LLMs
+## What does this change?
 
-The LLM pattern took about 18 months to play out, and every team went through the same four stages:
+The agents we're focusing on, our autonomous, long-running coding agents - the kind you can ask to file a PR to fix an issue. To run this agent, you pick a model + harness and deploy it somewhere. The harness also needs a sandbox, to check out the code, make changes and file a fix. Making harnesses reliable in production is hard. It involves sandbox orchestration, and optimizing the harness to handle concurrent requests (what happens if the container goes down mid-way through a request? how to hand off sessions? etc.). 
 
-1. **Single provider.** Pick OpenAI. Ship the feature. Done.
-2. **Second provider.** Anthropic releases Claude. Eval shows it wins on a critical task. Now you're maintaining two SDKs, two key sets, two billing dashboards, two retry policies.
-3. **Routing pressure.** One provider has an outage. The other is rate-limiting. Cost spikes on one model. You need to route traffic dynamically — by latency, by error rate, by budget.
-4. **Gateway.** Central place to manage keys, route requests, fall back on failure, track spend per team, audit every call. The AI Gateway becomes the seam between application code and provider APIs.
+We're already seeing solutions ("Agent Runtimes") crop up that help simplify this - AgentCore, Gemini Agent Platform, Claude Managed Agents. Over time, similar to LLM's, we expect there to be a wide range of providers offering 'harness-as-a-service' API's (either proprietary - e.g. Claude Managed Agents, or wrapping open-source - e.g. [Bedrock Agent Core wrapping OpenCode](https://aws.amazon.com/blogs/machine-learning/its-safe-to-close-your-laptop-now-hosting-coding-agents-on-amazon-bedrock-agentcore/).
 
-The endpoint of this pattern wasn't optional. Every Enterprise AI Gateway deployment we've seen converged on it because the alternative — N integrations, N retry policies, N audit logs — does not scale across teams.
+## The Stack of the Future
 
-## Why harnesses follow the same path
+<StackComparison />
 
-A harness is the loop around a model: tool-calling, context management, file edits, agent state. Claude Code, Codex, Aider, Cursor, OpenCode, Pi AI — different harnesses, different strengths, different prompt formats, different tool semantics.
+## Open Questions
 
-Right now, most teams are at stage 1 with harnesses. One team standardized on Claude Code. Another team picked Codex. A platform team is evaluating Aider for batch refactors.
+This stack has 2 open questions:
 
-Stage 2 is already here. Vendors are releasing harnesses faster than teams can pick winners. The same eval pressure that drove LLM-shopping — "this one is 12% better on our task" — applies one layer up. You don't pick *the* harness any more than you picked *the* LLM.
+- What does the VLLM of this world look like? 
+- When will users want to go across multiple Agent Runtimes?
 
-Stage 3 follows mechanically:
+For #1, We think there's room for someone to build a high-throughput inference server, which works across the open-source coding harnesses, and optimizes them to achieve high scale (1k+ RPS). We've already published templates, for OpenCode, DeepAgents, and Hermes, for what that server needs to look like (ideally mapped to the Claude Managed Agents API spec). 
 
-- A harness vendor has an outage. Your batch agent stops.
-- One harness costs 3x more per task than another on the same model. Budget owners want routing.
-- Different harnesses win on different task types. Refactors → harness A. Test writing → harness B.
-- Security teams want one audit log across every harness invocation, not N.
+For #2, we see this control plane above the runtimes being very similar to how LiteLLM works today, and are building this as an experimental project with [LAP](https://github.com/LiteLLM-Labs/litellm-agent-platform). This is a Rust-based AI Gateway + Agent Control Plane, that allows users to build, register and invoke agents across multiple Agent Runtimes. 
 
-Stage 4 is the AI Gateway, but for harnesses.
+We're already starting to see some users resonate with this problem - trying to use LAP as a control plane for agents being built in their company in different runtimes (e.g. Exposing an agent built on Elastic's Runtime, for analyzing Kibana logs to everyone via LAP). 
 
-## The harness stack maps onto the model stack
+If you're company is facing similar problems, we'd love your feedback on LiteLLM Agent Platform - https://github.com/LiteLLM-Labs/litellm-agent-platform. 
 
-The model stack settled into three layers. Each layer is now reappearing one level up, for harnesses:
+## Frequently Asked Questions 
 
-| Layer | Models | Harnesses |
-|---|---|---|
-| Unified API | **LiteLLM** — one API across 100+ models | **Lite-Harness SDK** — one API across Claude Code, Codex, Pi AI |
-| Deployment platform (OSS) | **SageMaker**, **Vertex** — deploy OSS models | **AWS AgentCore**, **Google Agent Platform** — deploy OSS harnesses (OpenCode, Hermes) |
-| Cloud inference (managed) | **Bedrock**, **Azure OpenAI** — managed model APIs | **Claude Managed Agents** — managed harness API |
-| High-performance server | **vLLM**, **TGI** — high-throughput inference | *Open slot* — high-throughput harness server |
+1. Is LiteLLM building a 2nd product? 
 
-Two cells fill themselves in. One is still open: a high-performance server for harnesses — batching agent runs, sharing context across runs, packing tool calls. The model layer needed vLLM to make OSS models economical at scale. Harnesses will need the same thing once batch agents move to production.
+No. Our goal is to roll these learnings into the core LiteLLM offering over time. Building it separately, allows us to move quickly without impacting existing users. 
 
-## What an AI Gateway for harnesses looks like
+2. Is LAP ready for production? 
 
-The gateway responsibilities map almost one-to-one from LLMs to harnesses:
-
-| LLM gateway | Harness gateway |
-|---|---|
-| Route by model name | Route by harness + model |
-| Fall back to backup provider | Fall back to backup harness |
-| Per-team budgets, per-key spend | Per-team agent budgets, per-key task spend |
-| Audit log of every LLM call | Audit log of every agent run |
-| Standardized request/response shape | Standardized agent invocation shape |
-| Provider-side key management | Harness-side key management |
-
-The shape of the seam is the same. What changes is *what* flows through it: instead of a single completion call, an agent run with tool invocations, file edits, and streamed messages.
-
-LiteLLM's AI Gateway already sits at the LLM seam for thousands of deployments. The harness layer is the natural extension — same gateway, one layer up.
-
-## The unified harness API
-
-Last week we shipped [Lite-Harness SDK](https://docs.litellm.ai/blog/lite-harness-sdk) — a unified TypeScript and Python API across Claude Code, Codex, and Pi AI. Swap harnesses by changing a string, same way you swap models in LiteLLM today.
-
-```python
-from lite_harness import query, AgentOptions
-
-prompt = "Fix the failing test"
-
-# Claude Code harness
-async for message in query(
-    prompt=prompt,
-    options=AgentOptions(harness="claude-code", model="claude-opus-4-8"),
-):
-    print(message)
-
-# Codex harness — same prompt, same code shape
-async for message in query(
-    prompt=prompt,
-    options=AgentOptions(harness="codex", model="gpt-5.5"),
-):
-    print(message)
-```
-
-Point it at the LiteLLM AI Gateway with two environment variables and every underlying model call routes through the gateway — keys, budgets, fallbacks, audit log:
-
-```bash
-export LITELLM_API_BASE=https://litellm.your-company.com/v1
-export LITELLM_API_KEY=sk-litellm-...
-```
-
-This is the same deployment shape teams already run for LLMs. Application code targets a uniform interface. The gateway handles the messy parts — keys, routing, spend tracking, fallback policy — without leaking into every call site.
-
-## What changes at scale
-
-Three things change when harnesses become the unit of routing instead of models:
-
-**Failure modes get bigger.** An LLM failure costs one request. A harness failure costs an entire agent run — minutes of tool calls, partial file edits, half-finished state. Fallback policy has to account for resumable runs and idempotent tool use, not just retries.
-
-**Spend tracking gets coarser and finer at the same time.** Coarser because a single agent run can burn 50+ model calls. Finer because teams want to attribute spend per task, per agent, per harness — not per token. The gateway needs to roll up correctly at every layer.
-
-**Audit gets more interesting.** "Who called GPT-5?" is a one-line answer. "Which agent edited this file, using which harness, running which tools, on whose budget?" is a join across harness, model, tool calls, and identity. The gateway is the only place that sees all of it.
-
-These are the kinds of failure modes a production-grade AI Gateway is designed for before they appear. The work LiteLLM has done at the LLM layer — circuit breakers, fallback policies, per-key budgets, central audit — is exactly the work the harness layer needs next.
-
-## Key Takeaways
-
-- The LLM deployment pattern — multi-provider, gateway-fronted — is repeating at the harness layer
-- Every layer of the model stack has a harness equivalent: unified API, OSS deployment platform, managed cloud, high-perf server
-- Lite-Harness SDK fills the unified-API slot; AWS AgentCore and Claude Managed Agents fill the deployment/managed slots; the high-perf harness server slot is still open
-- An AI Gateway for harnesses solves the same problems: routing, fallback, spend, audit — one layer up
-- Harness-level failures are bigger than model-level failures, which makes resilient gateway behavior more important, not less
-
----
-
-### Frequently Asked Questions
-
-### Isn't this just an SDK abstraction? Why does the gateway matter?
-
-The SDK gives you uniform invocation. The gateway gives you uniform *operation* — keys, budgets, fallbacks, audit, rate limiting, observability. At one harness those are nice-to-haves. At three, they're how you keep production reliable.
-
-### Won't harnesses converge on one winner?
-
-LLMs haven't, after four years. Harnesses won't either. Each one wins on a different task profile — refactors vs. test writing vs. batch agents vs. interactive editing. Multi-harness is the steady state, not a transition phase.
-
-### How is harness routing different from model routing?
-
-Model routing picks an endpoint. Harness routing picks a *loop* — what tools the agent has, how context is managed, how tool calls are structured. Routing decisions can compose: "use harness A with model X for refactors, harness B with model Y for tests."
-
-### Is this available in LiteLLM OSS?
-
-Yes. [Lite-Harness SDK](https://github.com/LiteLLM-Labs/lite-harness) is MIT-licensed. LiteLLM AI Gateway is Apache 2.0. [LiteLLM Enterprise](https://litellm.ai/enterprise) adds SSO/SCIM, air-gapped deployment, 24/7 SLA support, and advanced guardrails on top.
-
----
-
-## Conclusion
-
-The seam moves up the stack. The job stays the same: route reliably, fall back gracefully, track spend, audit every call. A production-grade AI Gateway is the layer where all of that lives — first for LLMs, now for harnesses.
-
-The right failure mode looks the same in both layers: one component degrades, the gateway routes around it, the audit log records what happened, and the team keeps shipping. This is how AI Gateway infrastructure should behave under pressure.
-
-For teams with strict uptime and compliance requirements, [LiteLLM Enterprise](https://litellm.ai/enterprise) provides the additional controls needed for regulated production environments.
-
-## Recommended Reading
-
-- [Lite-Harness SDK — Unified API for Claude Code, Codex, and Pi AI](https://docs.litellm.ai/blog/lite-harness-sdk)
-- [LiteLLM AI Gateway — full feature overview](https://docs.litellm.ai/docs/simple_proxy)
-- [Load balancing and routing across 100+ LLM providers](https://docs.litellm.ai/docs/routing)
+No. This is a pre-v0 project. The API's might change unexpectedly, as we work with users on this. If you want to contribute to this project, file an [issue](https://github.com/LiteLLM-Labs/litellm-agent-platform/issues) OR join our discord [here](https://discord.gg/Nkxw3rm3EE). 

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -1,0 +1,165 @@
+---
+slug: harnesses-are-the-new-llms
+title: "Harnesses Are the New LLMs"
+date: 2026-06-10T09:00:00
+authors:
+  - krrish
+description: "The same deployment pattern that emerged with LLMs — routing, fallbacks, observability, central billing — is now emerging with harnesses. Here's why the AI Gateway layer is moving up the stack."
+tags: [harnesses, ai-gateway, agents, thesis, infrastructure]
+hide_table_of_contents: true
+---
+
+*Last Updated: June 2026*
+
+Three years ago, every team picked one LLM. Then they picked two. Then they hit the same wall: how do you route between them, fall back when one is down, track spend across both, and audit who called what? That wall is what an AI Gateway solves.
+
+The same wall is forming one layer up. Teams started with one harness — Claude Code, Codex, or Cursor. They're already running two. By next quarter they'll run three. The deployment pattern that emerged for LLMs is repeating, exactly, for harnesses.
+
+{/* truncate */}
+
+## The pattern from LLMs
+
+The LLM pattern took about 18 months to play out, and every team went through the same four stages:
+
+1. **Single provider.** Pick OpenAI. Ship the feature. Done.
+2. **Second provider.** Anthropic releases Claude. Eval shows it wins on a critical task. Now you're maintaining two SDKs, two key sets, two billing dashboards, two retry policies.
+3. **Routing pressure.** One provider has an outage. The other is rate-limiting. Cost spikes on one model. You need to route traffic dynamically — by latency, by error rate, by budget.
+4. **Gateway.** Central place to manage keys, route requests, fall back on failure, track spend per team, audit every call. The AI Gateway becomes the seam between application code and provider APIs.
+
+The endpoint of this pattern wasn't optional. Every Enterprise AI Gateway deployment we've seen converged on it because the alternative — N integrations, N retry policies, N audit logs — does not scale across teams.
+
+## Why harnesses follow the same path
+
+A harness is the loop around a model: tool-calling, context management, file edits, agent state. Claude Code, Codex, Aider, Cursor, OpenCode, Pi AI — different harnesses, different strengths, different prompt formats, different tool semantics.
+
+Right now, most teams are at stage 1 with harnesses. One team standardized on Claude Code. Another team picked Codex. A platform team is evaluating Aider for batch refactors.
+
+Stage 2 is already here. Vendors are releasing harnesses faster than teams can pick winners. The same eval pressure that drove LLM-shopping — "this one is 12% better on our task" — applies one layer up. You don't pick *the* harness any more than you picked *the* LLM.
+
+Stage 3 follows mechanically:
+
+- A harness vendor has an outage. Your batch agent stops.
+- One harness costs 3x more per task than another on the same model. Budget owners want routing.
+- Different harnesses win on different task types. Refactors → harness A. Test writing → harness B.
+- Security teams want one audit log across every harness invocation, not N.
+
+Stage 4 is the AI Gateway, but for harnesses.
+
+## The harness stack maps onto the model stack
+
+The model stack settled into three layers. Each layer is now reappearing one level up, for harnesses:
+
+| Layer | Models | Harnesses |
+|---|---|---|
+| Unified API | **LiteLLM** — one API across 100+ models | **Lite-Harness SDK** — one API across Claude Code, Codex, Pi AI |
+| Deployment platform (OSS) | **SageMaker**, **Vertex** — deploy OSS models | **AWS AgentCore**, **Google Agent Platform** — deploy OSS harnesses (OpenCode, Hermes) |
+| Cloud inference (managed) | **Bedrock**, **Azure OpenAI** — managed model APIs | **Claude Managed Agents** — managed harness API |
+| High-performance server | **vLLM**, **TGI** — high-throughput inference | *Open slot* — high-throughput harness server |
+
+Two cells fill themselves in. One is still open: a high-performance server for harnesses — batching agent runs, sharing context across runs, packing tool calls. The model layer needed vLLM to make OSS models economical at scale. Harnesses will need the same thing once batch agents move to production.
+
+## What an AI Gateway for harnesses looks like
+
+The gateway responsibilities map almost one-to-one from LLMs to harnesses:
+
+| LLM gateway | Harness gateway |
+|---|---|
+| Route by model name | Route by harness + model |
+| Fall back to backup provider | Fall back to backup harness |
+| Per-team budgets, per-key spend | Per-team agent budgets, per-key task spend |
+| Audit log of every LLM call | Audit log of every agent run |
+| Standardized request/response shape | Standardized agent invocation shape |
+| Provider-side key management | Harness-side key management |
+
+The shape of the seam is the same. What changes is *what* flows through it: instead of a single completion call, an agent run with tool invocations, file edits, and streamed messages.
+
+LiteLLM's AI Gateway already sits at the LLM seam for thousands of deployments. The harness layer is the natural extension — same gateway, one layer up.
+
+## The unified harness API
+
+Last week we shipped [Lite-Harness SDK](https://docs.litellm.ai/blog/lite-harness-sdk) — a unified TypeScript and Python API across Claude Code, Codex, and Pi AI. Swap harnesses by changing a string, same way you swap models in LiteLLM today.
+
+```python
+from lite_harness import query, AgentOptions
+
+prompt = "Fix the failing test"
+
+# Claude Code harness
+async for message in query(
+    prompt=prompt,
+    options=AgentOptions(harness="claude-code", model="claude-opus-4-8"),
+):
+    print(message)
+
+# Codex harness — same prompt, same code shape
+async for message in query(
+    prompt=prompt,
+    options=AgentOptions(harness="codex", model="gpt-5.5"),
+):
+    print(message)
+```
+
+Point it at the LiteLLM AI Gateway with two environment variables and every underlying model call routes through the gateway — keys, budgets, fallbacks, audit log:
+
+```bash
+export LITELLM_API_BASE=https://litellm.your-company.com/v1
+export LITELLM_API_KEY=sk-litellm-...
+```
+
+This is the same deployment shape teams already run for LLMs. Application code targets a uniform interface. The gateway handles the messy parts — keys, routing, spend tracking, fallback policy — without leaking into every call site.
+
+## What changes at scale
+
+Three things change when harnesses become the unit of routing instead of models:
+
+**Failure modes get bigger.** An LLM failure costs one request. A harness failure costs an entire agent run — minutes of tool calls, partial file edits, half-finished state. Fallback policy has to account for resumable runs and idempotent tool use, not just retries.
+
+**Spend tracking gets coarser and finer at the same time.** Coarser because a single agent run can burn 50+ model calls. Finer because teams want to attribute spend per task, per agent, per harness — not per token. The gateway needs to roll up correctly at every layer.
+
+**Audit gets more interesting.** "Who called GPT-5?" is a one-line answer. "Which agent edited this file, using which harness, running which tools, on whose budget?" is a join across harness, model, tool calls, and identity. The gateway is the only place that sees all of it.
+
+These are the kinds of failure modes a production-grade AI Gateway is designed for before they appear. The work LiteLLM has done at the LLM layer — circuit breakers, fallback policies, per-key budgets, central audit — is exactly the work the harness layer needs next.
+
+## Key Takeaways
+
+- The LLM deployment pattern — multi-provider, gateway-fronted — is repeating at the harness layer
+- Every layer of the model stack has a harness equivalent: unified API, OSS deployment platform, managed cloud, high-perf server
+- Lite-Harness SDK fills the unified-API slot; AWS AgentCore and Claude Managed Agents fill the deployment/managed slots; the high-perf harness server slot is still open
+- An AI Gateway for harnesses solves the same problems: routing, fallback, spend, audit — one layer up
+- Harness-level failures are bigger than model-level failures, which makes resilient gateway behavior more important, not less
+
+---
+
+### Frequently Asked Questions
+
+### Isn't this just an SDK abstraction? Why does the gateway matter?
+
+The SDK gives you uniform invocation. The gateway gives you uniform *operation* — keys, budgets, fallbacks, audit, rate limiting, observability. At one harness those are nice-to-haves. At three, they're how you keep production reliable.
+
+### Won't harnesses converge on one winner?
+
+LLMs haven't, after four years. Harnesses won't either. Each one wins on a different task profile — refactors vs. test writing vs. batch agents vs. interactive editing. Multi-harness is the steady state, not a transition phase.
+
+### How is harness routing different from model routing?
+
+Model routing picks an endpoint. Harness routing picks a *loop* — what tools the agent has, how context is managed, how tool calls are structured. Routing decisions can compose: "use harness A with model X for refactors, harness B with model Y for tests."
+
+### Is this available in LiteLLM OSS?
+
+Yes. [Lite-Harness SDK](https://github.com/LiteLLM-Labs/lite-harness) is MIT-licensed. LiteLLM AI Gateway is Apache 2.0. [LiteLLM Enterprise](https://litellm.ai/enterprise) adds SSO/SCIM, air-gapped deployment, 24/7 SLA support, and advanced guardrails on top.
+
+---
+
+## Conclusion
+
+The seam moves up the stack. The job stays the same: route reliably, fall back gracefully, track spend, audit every call. A production-grade AI Gateway is the layer where all of that lives — first for LLMs, now for harnesses.
+
+The right failure mode looks the same in both layers: one component degrades, the gateway routes around it, the audit log records what happened, and the team keeps shipping. This is how AI Gateway infrastructure should behave under pressure.
+
+For teams with strict uptime and compliance requirements, [LiteLLM Enterprise](https://litellm.ai/enterprise) provides the additional controls needed for regulated production environments.
+
+## Recommended Reading
+
+- [Lite-Harness SDK — Unified API for Claude Code, Codex, and Pi AI](https://docs.litellm.ai/blog/lite-harness-sdk)
+- [LiteLLM AI Gateway — full feature overview](https://docs.litellm.ai/docs/simple_proxy)
+- [Load balancing and routing across 100+ LLM providers](https://docs.litellm.ai/docs/routing)

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -12,7 +12,7 @@ authors:
 
 description:  "The same deployment pattern that emerged with LLMs — routing, fallbacks, observability, central billing — is now emerging with harnesses. Here's why the AI Gateway layer is moving up the stack."
 
-tags: [harnesses, ai-gateway, agents, thesis, infrastructure]
+tags: [ideas, harnesses, ai-gateway, agents, thesis]
 
 hide_table_of_contents: true
 

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -9,7 +9,9 @@ tags: [ideas, harnesses, ai-gateway, agents, thesis]
 hide_table_of_contents: true
 ---
 
-import { StackComparison } from './diagrams';
+import { StackComparison, ConvergenceHero } from './diagrams';
+
+<ConvergenceHero />
 
 *Last updated: June 2026*
 

--- a/blog/harnesses-are-the-new-llms/index.md
+++ b/blog/harnesses-are-the-new-llms/index.md
@@ -5,7 +5,7 @@ date: 2026-06-10T09:00:00
 authors:
 - krrish
 description: "The AI Gateway is moving up the stack: from routing model calls to routing agent work."
-tags: [ideas, harnesses, ai-gateway, agents, thesis]
+tags: [ideas, harnesses, ai-gateway, agents]
 hide_table_of_contents: true
 ---
 
@@ -15,7 +15,7 @@ import { StackComparison, ConvergenceHero } from './diagrams';
 
 *Last updated: June 2026*
 
-Agent infrastructure is already separating into three layers: models, harnesses, and runtimes. Our thesis is that a fourth layer will emerge: the unified agent control plane. This will allow calling agents living in different agent runtimes, all from 1 place. 
+Agent infrastructure is already separating into three layers: models, harnesses, and runtimes. We believe a fourth layer will emerge: the unified agent control plane. This will allow calling agents living in different agent runtimes, all from 1 place. 
 
 The reason is that companies will not run every agent on one runtime. Coding agents may run on Bedrock AgentCore or Claude Managed Agents. Data agents may run inside Elastic, Databricks, or Snowflake. Internal workflow agents may run on custom infrastructure. The control plane emerges because companies want one place where all of these agents can be used, regardless of where they were built or run.
 

--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -7,12 +7,14 @@ import styles from './styles.module.css';
 const TABS = [
   {id: 'all', label: 'All'},
   {id: 'engineering', label: 'Engineering'},
+  {id: 'ideas', label: 'Ideas'},
   {id: 'security', label: 'Security'},
   {id: 'infrastructure', label: 'Performance / Reliability'},
 ];
 
 const SECURITY_TAGS = ['security', 'incident-report'];
 const INFRA_TAGS = ['performance', 'reliability', 'infrastructure'];
+const IDEAS_TAGS = ['ideas', 'thesis'];
 
 function hasTag(item, tagSet) {
   const tags = item.content?.metadata?.tags || [];
@@ -23,7 +25,12 @@ function filterItems(items, tab) {
   if (tab === 'all') return items;
   if (tab === 'security') return items.filter(i => hasTag(i, SECURITY_TAGS));
   if (tab === 'infrastructure') return items.filter(i => hasTag(i, INFRA_TAGS));
-  return items.filter(i => !hasTag(i, SECURITY_TAGS) && !hasTag(i, INFRA_TAGS));
+  if (tab === 'ideas') return items.filter(i => hasTag(i, IDEAS_TAGS));
+  return items.filter(i =>
+    !hasTag(i, SECURITY_TAGS) &&
+    !hasTag(i, INFRA_TAGS) &&
+    !hasTag(i, IDEAS_TAGS)
+  );
 }
 
 // ── Provider marquee ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Thesis blog post: same deployment pattern that emerged for LLMs (unified API → OSS deploy platform → managed cloud → high-perf server) is repeating one layer up for harnesses
- Maps the model stack onto the harness stack: LiteLLM ↔ Lite-Harness SDK, SageMaker ↔ AgentCore/Google Agent Platform, Bedrock ↔ Claude Managed Agents, vLLM ↔ open slot
- Positions LiteLLM AI Gateway as the natural seam for harnesses; links back to the Lite-Harness SDK launch post

## Test plan
- [ ] Local Docusaurus preview at http://localhost:3457/blog/harnesses-are-the-new-llms renders cleanly
- [ ] Truncate marker shows correct fold on /blog index
- [ ] Stack-mapping table renders
- [ ] Recommended Reading links resolve