### PR TITLE
docs: document LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -695,6 +695,7 @@ router_settings:
 | DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS | Default duration for video generation in seconds in google. Default is 8
 | DIRECT_URL | Direct URL for service endpoint
 | DISABLE_ADMIN_UI | Toggle to disable the admin UI
+| LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT | Flag to hide the "Default Credentials" info card on the admin UI login page (`/ui/login` and `/fallback/login`). Useful when UI credentials are managed via `UI_USERNAME` / `UI_PASSWORD` or SSO and the hardcoded hint about `admin` + `MASTER_KEY` becomes misleading or is flagged by security scanners. **Default is false**
 | DISABLE_AIOHTTP_TRANSPORT | Flag to disable aiohttp transport. When this is set to True, litellm will use httpx instead of aiohttp. **Default is False**
 | DISABLE_AIOHTTP_TRUST_ENV | Flag to disable aiohttp trust environment. When this is set to True, litellm will not trust the environment for aiohttp eg. `HTTP_PROXY` and `HTTPS_PROXY` environment variables will not be used when this is set to True. **Default is False**
 | DISABLE_SCHEMA_UPDATE | Toggle to disable schema updates


### PR DESCRIPTION
Companion to **BerriAI/litellm#30234** (closes BerriAI/litellm#30232).

Adds the new env var to `docs/proxy/config_settings.md` under the *environment variables - Reference* table so the documentation-validation CI (`tests/documentation_tests/test_env_keys.py`) passes once the code PR is merged.

The code PR gates the "Default Credentials" info card on `/ui/login` and `/fallback/login` behind `LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT=true` (or `general_settings.hide_default_credentials_hint: true`).