### PR TITLE
docs(proxy): document SMTP_USE_SSL env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1143,7 +1143,7 @@ router_settings:
 | SMTP_SENDER_EMAIL | Email address used as the sender in SMTP transactions
 | SMTP_SENDER_LOGO | Logo used in emails sent via SMTP
 | SMTP_TLS | Flag to enable or disable TLS for SMTP connections
-| SMTP_USE_SSL | Set to "True" to use implicit SSL (SMTP_SSL) on any port. Port 465 uses implicit SSL automatically. Default is False
+| SMTP_USE_SSL | Set to "True" to force implicit SSL (SMTP_SSL) on any port. Not needed for port 465, which uses implicit SSL automatically; other ports use STARTTLS by default (see SMTP_TLS)
 | SMTP_USERNAME | Username for SMTP authentication (do not set if SMTP does not require auth)
 | SENDGRID_API_KEY | API key for SendGrid email service
 | RESEND_API_KEY | API key for Resend email service

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1143,6 +1143,7 @@ router_settings:
 | SMTP_SENDER_EMAIL | Email address used as the sender in SMTP transactions
 | SMTP_SENDER_LOGO | Logo used in emails sent via SMTP
 | SMTP_TLS | Flag to enable or disable TLS for SMTP connections
+| SMTP_USE_SSL | Set to "True" to use implicit SSL (SMTP_SSL) on any port. Port 465 uses implicit SSL automatically. Default is False
 | SMTP_USERNAME | Username for SMTP authentication (do not set if SMTP does not require auth)
 | SENDGRID_API_KEY | API key for SendGrid email service
 | RESEND_API_KEY | API key for Resend email service


### PR DESCRIPTION
Adds SMTP_USE_SSL to the environment variables reference table. This env var is introduced by the SMTP over SSL support PR in the main repo (litellm_smtp_ssl_support branch); the documentation_test_env_keys CI check on that PR fails until this key is documented here. Set to "True" to force implicit SSL (SMTP_SSL) on any port; port 465 uses implicit SSL automatically