### PR TITLE
docs(proxy): document pass-through request timeouts

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -310,6 +310,7 @@ router_settings:
 | litellm_license | str | The license key for the proxy. [Docs](../enterprise.md#how-does-deployment-with-enterprise-license-work) |
 | oauth2_config_mappings | Dict[str, str] | Define the OAuth2 config mappings | 
 | pass_through_endpoints | List[Dict[str, Any]] | Define the pass through endpoints. [Docs](./pass_through) |
+| pass_through_request_timeout | float | Upstream request timeout in seconds for pass-through routes (custom endpoints and native provider passthrough). Default: `600`. Per-endpoint `timeout` overrides this. [Docs](./pass_through#request-timeouts) |
 | enable_oauth2_proxy_auth | boolean | (Enterprise Feature) If true, enables oauth2.0 authentication |
 | forward_openai_org_id | boolean | If true, forwards the OpenAI Organization ID to the backend LLM call (if it's OpenAI). |
 | forward_client_headers_to_llm_api | boolean | If true, forwards the client headers (any `x-` headers and `anthropic-beta` headers) to the backend LLM call |

--- a/docs/proxy/pass_through.md
+++ b/docs/proxy/pass_through.md
@@ -174,12 +174,14 @@ general_settings:
 
 ```yaml
 general_settings:
+  pass_through_request_timeout: 600   # Optional: upstream timeout (seconds) for all pass-through routes. Default: 600
   pass_through_endpoints:
     - path: string                    # Route on LiteLLM Proxy Server
       target: string                  # Target URL for forwarding
       auth: boolean                   # Enable LiteLLM authentication (Enterprise)
       forward_headers: boolean        # Forward all incoming headers
       include_subpath: boolean        # If true, forwards requests to sub-paths (default: false)
+      timeout: float                  # Optional: per-endpoint upstream timeout (seconds). Overrides pass_through_request_timeout
       methods: list[string]           # Optional: HTTP methods (e.g., ["GET", "POST"]). If not specified, all methods are supported.
       default_query_params:           # Optional: Default query parameters sent with every request
         <param-name>: string          # Key-value pairs (e.g., version: "v1", format: "json")
@@ -191,6 +193,10 @@ general_settings:
         LANGFUSE_SECRET_KEY: string  # For Langfuse endpoints
         <custom-header>: string      # Any custom header
 ```
+
+### Request timeouts
+
+Pass-through routes default to a **600 second** upstream timeout. Set `general_settings.pass_through_request_timeout` for a global override, or `timeout` on a custom endpoint (per-endpoint wins). Applies to custom pass-through endpoints and native provider passthrough routes (e.g. Bedrock `/converse`).
 
 ### Header Options
 - **Authorization**: Authentication for the target API


### PR DESCRIPTION
## Summary
- Document `general_settings.pass_through_request_timeout` in the config settings reference
- Add `timeout` and global timeout notes to the pass-through endpoints configuration reference

Companion to BerriAI/litellm#30266.

## Test plan
- [ ] Verify pass-through docs page renders the new Request timeouts section
- [ ] Verify config settings table includes `pass_through_request_timeout`