### PR TITLE
docs(release-notes): backfill 1.84-1.88 patches, promote 1.88.0 stable, add 1.89.0

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,21 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.87.0 — OCI Generative AI Provider, Gemini 3.5 Flash Day-0, MCP UI for OAuth Servers](/release_notes/v1.87.0/v1-87-0)
+### [v1.89.0 — Claude Fable 5, A2A Agent Providers & MCP Per-Server Controls](/release_notes/v1.89.0/v1-89-0)
 
-_May 23, 2026_
+_June 10, 2026_
 
-OCI Generative AI as a first-class provider (chat, embeddings, streaming, reasoning, tool use across Cohere, Llama, Grok, Gemini, and GPT-5 on OCI with full pricing catalog), Gemini 3.5 Flash and Gemini 3.1 Flash-Lite day-0 on Vertex AI / Google AI Studio / OpenRouter, MCP UI for OAuth-protected tool calls plus Cursor MCP OAuth, Codex CLI JWT team-alias and SSO form-URL auth hardening, and a hot-path Anthropic `/v1/messages` streaming rewrite with byte-identical wire output and ~90% lower TTFT overhead measured on a real 4-pod deployment.
-
----
-
-## Latest Release Candidate
-
-### [v1.88.0rc3 — Claude Opus 4.8, MCP Access-Group Authorization & Typed OpenTelemetry](/release_notes/v1.88.0rc3/v1-88-0-rc-3)
-
-_June 4, 2026_
-
-Claude Opus 4.8 across Anthropic, Bedrock (with `global` / `us` / `eu` / `au` regional routes), Azure AI, and Vertex at 1M context with adaptive thinking and `output_config` goal mode, a full rework of MCP access-group authorization (key and team access groups resolve to MCP servers, additive opt-in grants, stateful/stateless session routing), typed semconv-aligned OpenTelemetry spans carrying `team_metadata` and `http.route` on inference spans, and a ~30% cheaper per-chunk Anthropic/Bedrock streaming path.
+Claude Fable 5 across Anthropic, Bedrock, Azure AI, and Vertex at 1M context with adaptive thinking and computer use, two new A2A agent providers (watsonx Orchestrate and LangFlow with session bridging) plus OAuth M2M for Databricks Apps agents, MCP per-server environment variables and RPM rate limiting with OAuth passthrough and issuer-scoped JWT auth, OpenInference rendering parity for Arize/Phoenix, and three new search and transcription providers (APISerpent, You.com, Soniox).
 
 ---
 
@@ -32,6 +22,8 @@ Claude Opus 4.8 across Anthropic, Bedrock (with `global` / `us` / `eu` / `au` re
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.89.0](/release_notes/v1.89.0/v1-89-0)   | Jun 10, 2026 | Claude Fable 5, A2A agent providers, MCP per-server controls |
+| [v1.88.0](/release_notes/v1.88.0/v1-88-0)   | Jun 4, 2026  | Claude Opus 4.8, MCP access-group authorization, typed OpenTelemetry |
 | [v1.87.0](/release_notes/v1.87.0/v1-87-0)   | May 23, 2026 | OCI Generative AI provider, Gemini 3.5 Flash day-0, MCP UI for OAuth servers |
 | [v1.86.0](/release_notes/v1.86.0/v1-86-0)   | May 16, 2026 | Weighted-Routing Failover, native Anthropic web-search citations, OTel-standard server spans |
 | [v1.85.1](/release_notes/v1.85.1/v1-85-1)   | May 20, 2026 | Patch — Gemini 3.5 Flash day-0 + cross-pod spend fix       |

--- a/release_notes/v1.84.5/index.md
+++ b/release_notes/v1.84.5/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.84.5 - Azure AD, Batch Auth & Passthrough Backports"
+slug: "v1-84-5"
+date: 2026-06-03T20:44:41
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.5
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.5
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.5` is a patch release on top of [`v1.84.4`](/release_notes/v1.84.4/v1-84-4). It backports six staged fixes covering Azure AD token refresh, batch and video model routing, org-scoped team key creation, Vertex Claude effort handling, and duplicate passthrough cost callbacks.
+
+### What's Changed
+
+- fix(azure): preserve AD token refresh in the v1 OpenAI client path - [PR #28627](https://github.com/BerriAI/litellm/pull/28627)
+- fix(proxy): map a stripped batch `body.model` back to the proxy alias so key access checks pass - [PR #29264](https://github.com/BerriAI/litellm/pull/29264)
+- fix(proxy): resolve managed video model ids through the router before auth, budget, and key checks - [PR #29545](https://github.com/BerriAI/litellm/pull/29545)
+- fix(key_generate): let team members create keys on org-scoped teams (regression since v1.84.0-rc.1) - [PR #29310](https://github.com/BerriAI/litellm/pull/29310)
+- fix(vertex): strip `output_config.effort` for Vertex Claude models that reject it, such as Haiku 4.5 - [PR #29585](https://github.com/BerriAI/litellm/pull/29585)
+- fix(passthrough): stop duplicate cost callbacks for Anthropic streaming pass-through - [PR #29598](https://github.com/BerriAI/litellm/pull/29598)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.4...v1.84.5

--- a/release_notes/v1.84.6/index.md
+++ b/release_notes/v1.84.6/index.md
@@ -1,0 +1,55 @@
+---
+title: "v1.84.6 - CrowdStrike AIDR Identity Capture"
+slug: "v1-84-6"
+date: 2026-06-08T18:25:32
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.6
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.6
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.6` is a patch release on top of [`v1.84.5`](/release_notes/v1.84.5/v1-84-5). It backports CrowdStrike AIDR user and model metadata capture, plus a follow-up fix so identity is read from both metadata bags rather than being dropped when a request carries `litellm_metadata`.
+
+### What's Changed
+
+- feat(guardrails): capture CrowdStrike AIDR user and model metadata - [PR #29517](https://github.com/BerriAI/litellm/pull/29517)
+- fix(guardrails): read CrowdStrike AIDR identity from both metadata bags - [PR #29991](https://github.com/BerriAI/litellm/pull/29991)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.5...v1.84.6

--- a/release_notes/v1.84.7/index.md
+++ b/release_notes/v1.84.7/index.md
@@ -1,0 +1,55 @@
+---
+title: "v1.84.7 - Claude Fable 5 & Batch File Authorization"
+slug: "v1-84-7"
+date: 2026-06-10T18:11:13
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.7
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.7
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.7` is a patch release on top of [`v1.84.6`](/release_notes/v1.84.6/v1-84-6). It adds Claude Fable 5 across Anthropic, Bedrock, Vertex AI, and Azure AI, and authorizes batch files using the upload `target_model_names`.
+
+### What's Changed
+
+- feat: add Claude Fable 5 across Anthropic, Bedrock, Vertex AI, and Azure AI - [PR #30064](https://github.com/BerriAI/litellm/pull/30064)
+- fix(proxy): authorize batch files using upload `target_model_names` (LIT-3593) - [PR #30009](https://github.com/BerriAI/litellm/pull/30009)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.6...v1.84.7

--- a/release_notes/v1.84.8/index.md
+++ b/release_notes/v1.84.8/index.md
@@ -1,0 +1,62 @@
+---
+title: "v1.84.8 - Database Resilience & Grace-Period Key Rotation"
+slug: "v1-84-8"
+date: 2026-06-12T18:20:57
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.8
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.8
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.8` is a patch release on top of [`v1.84.7`](/release_notes/v1.84.7/v1-84-7). It backports a database-resilience set (Prisma reconnection, prepared-statement and timeout controls, 5xx on DB infra errors during auth) together with the complete grace-period key rotation fix, plus routing and streaming corrections.
+
+### What's Changed
+
+- fix(anthropic): correct streaming reasoning token usage - [PR #27319](https://github.com/BerriAI/litellm/pull/27319)
+- fix(proxy): grace-period key rotation deprecated-key lookup - [PR #27756](https://github.com/BerriAI/litellm/pull/27756)
+- fix(router): use forwarded model_id for native Azure container IDs - [PR #27921](https://github.com/BerriAI/litellm/pull/27921)
+- fix(proxy): recover from cached-plan errors by reconnecting the Prisma client - [PR #29983](https://github.com/BerriAI/litellm/pull/29983)
+- fix(proxy): expose Prisma idle/connect timeout and extra DB URL params - [PR #28395](https://github.com/BerriAI/litellm/pull/28395)
+- feat(proxy): add option to disable server-side prepared statements for DB lookups - [PR #29984](https://github.com/BerriAI/litellm/pull/29984)
+- fix(proxy): return 5xx on DB infra errors during auth - [PR #29986](https://github.com/BerriAI/litellm/pull/29986)
+- fix(passthrough): resolve costing model when body model is unknown - [PR #30160](https://github.com/BerriAI/litellm/pull/30160)
+- fix(proxy): return deprecated-key lookup result directly in get_data combined view - [PR #30327](https://github.com/BerriAI/litellm/pull/30327)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.7...v1.84.8

--- a/release_notes/v1.85.3/index.md
+++ b/release_notes/v1.85.3/index.md
@@ -1,0 +1,58 @@
+---
+title: "v1.85.3 - Observability, Budget & Rate-Limit Fixes"
+slug: "v1-85-3"
+date: 2026-06-01T19:02:53
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.3
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.3
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.3` is a patch release on top of [`v1.85.2`](/release_notes/v1.85.2/v1-85-2). It cherry-picks fixes for duplicate Claude Code traces, Bearer-prefix hashing, budget-reset writes, and two flag-leak corrections in the rate limiter and the provider request body.
+
+### What's Changed
+
+- fix(logging): stop duplicate Claude Code traces (internal copy of #29089) - [PR #29311](https://github.com/BerriAI/litellm/pull/29311)
+- fix(proxy): normalize the Bearer prefix in the safe-hash helper - [PR #29343](https://github.com/BerriAI/litellm/pull/29343)
+- fix(budget): reset_budget writes only `{spend, budget_reset_at}` and no longer pre-zeroes the counter - [PR #29358](https://github.com/BerriAI/litellm/pull/29358)
+- fix(rate-limit): stop the v3 limiter from leaking internal stash to the provider body - [PR #27913](https://github.com/BerriAI/litellm/pull/27913)
+- fix(proxy): stop the `use_chat_completions_api` flag from leaking into the provider request body - [PR #29447](https://github.com/BerriAI/litellm/pull/29447)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.2...v1.85.3

--- a/release_notes/v1.85.4/index.md
+++ b/release_notes/v1.85.4/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.85.4 - Azure AD, Batch Auth & Passthrough Backports"
+slug: "v1-85-4"
+date: 2026-06-03T16:25:32
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.4` is a patch release on top of [`v1.85.3`](/release_notes/v1.85.3/v1-85-3). It backports the same six staged fixes shipped on the 1.84 line: Azure AD token refresh, batch and video model routing, org-scoped team key creation, Vertex Claude effort handling, and duplicate passthrough cost callbacks.
+
+### What's Changed
+
+- fix(azure): preserve AD token refresh in the v1 OpenAI client path - [PR #28627](https://github.com/BerriAI/litellm/pull/28627)
+- fix(proxy): map a stripped batch `body.model` back to the proxy alias so key access checks pass - [PR #29264](https://github.com/BerriAI/litellm/pull/29264)
+- fix(proxy): resolve managed video model ids through the router before auth, budget, and key checks - [PR #29545](https://github.com/BerriAI/litellm/pull/29545)
+- fix(key_generate): let team members create keys on org-scoped teams (regression since v1.84.0-rc.1) - [PR #29310](https://github.com/BerriAI/litellm/pull/29310)
+- fix(vertex): strip `output_config.effort` for Vertex Claude models that reject it, such as Haiku 4.5 - [PR #29585](https://github.com/BerriAI/litellm/pull/29585)
+- fix(passthrough): stop duplicate cost callbacks for Anthropic streaming pass-through - [PR #29598](https://github.com/BerriAI/litellm/pull/29598)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.3...v1.85.4

--- a/release_notes/v1.85.5/index.md
+++ b/release_notes/v1.85.5/index.md
@@ -1,0 +1,57 @@
+---
+title: "v1.85.5 - Claude Fable 5, CrowdStrike AIDR & Batch File Auth"
+slug: "v1-85-5"
+date: 2026-06-10T18:31:24
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.5
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.5
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.5` is a patch release on top of [`v1.85.4`](/release_notes/v1.85.4/v1-85-4). It adds Claude Fable 5, backports the CrowdStrike AIDR identity capture and follow-up fix, and authorizes batch files using the upload `target_model_names`.
+
+### What's Changed
+
+- feat: add Claude Fable 5 across Anthropic, Bedrock, Vertex AI, and Azure AI - [PR #30064](https://github.com/BerriAI/litellm/pull/30064)
+- feat(guardrails): capture CrowdStrike AIDR user and model metadata - [PR #29517](https://github.com/BerriAI/litellm/pull/29517)
+- fix(guardrails): read CrowdStrike AIDR identity from both metadata bags - [PR #29991](https://github.com/BerriAI/litellm/pull/29991)
+- fix(proxy): authorize batch files using upload `target_model_names` (LIT-3593) - [PR #30009](https://github.com/BerriAI/litellm/pull/30009)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.4...v1.85.5

--- a/release_notes/v1.86.3/index.md
+++ b/release_notes/v1.86.3/index.md
@@ -1,0 +1,60 @@
+---
+title: "v1.86.3 - Gemini 3.5 Flash Day-0 & Pending Line Backports"
+slug: "v1-86-3"
+date: 2026-06-02T17:31:21
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.3
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.3
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.3` is a patch release on top of [`v1.86.2`](/release_notes/v1.86.2/v1-86-2). It closes the gap with the 1.84 and 1.85 lines: day-0 Gemini 3.5 Flash on Vertex AI and Google AI Studio with its paired Vertex tool-call fix, Redis spend-counter seeding, and the observability, budget, and flag-leak fixes.
+
+### What's Changed
+
+- feat: day-0 support for Gemini 3.5 Flash on Vertex AI and Google AI Studio - [PR #28268](https://github.com/BerriAI/litellm/pull/28268)
+- fix(vertex): omit the function_call `id` on Gemini 3.5+ tool turns (pairs with #28268) - [PR #28324](https://github.com/BerriAI/litellm/pull/28324)
+- fix(spend): seed the Redis spend counter with `SET NX` so concurrent pods no longer double-seed - [PR #27854](https://github.com/BerriAI/litellm/pull/27854)
+- fix(logging): stop duplicate Claude Code traces, plus the `_build_passthrough_logging_result` helper - [PR #29311](https://github.com/BerriAI/litellm/pull/29311)
+- fix(proxy): normalize the Bearer prefix in the safe-hash helper - [PR #29343](https://github.com/BerriAI/litellm/pull/29343)
+- fix(budget): reset_budget writes only `{spend, budget_reset_at}` - [PR #29358](https://github.com/BerriAI/litellm/pull/29358)
+- fix(proxy): stop the `use_chat_completions_api` flag from leaking into the provider request body - [PR #29447](https://github.com/BerriAI/litellm/pull/29447)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.2...v1.86.3

--- a/release_notes/v1.86.4/index.md
+++ b/release_notes/v1.86.4/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.86.4 - Azure AD, Batch Auth & Passthrough Backports"
+slug: "v1-86-4"
+date: 2026-06-03T20:10:47
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.4` is a patch release on top of [`v1.86.3`](/release_notes/v1.86.3/v1-86-3). It backports the same six staged fixes shipped on the 1.84 and 1.85 lines: Azure AD token refresh, batch and video model routing, org-scoped team key creation, Vertex Claude effort handling, and duplicate passthrough cost callbacks.
+
+### What's Changed
+
+- fix(azure): preserve AD token refresh in the v1 OpenAI client path - [PR #28627](https://github.com/BerriAI/litellm/pull/28627)
+- fix(proxy): map a stripped batch `body.model` back to the proxy alias so key access checks pass - [PR #29264](https://github.com/BerriAI/litellm/pull/29264)
+- fix(proxy): resolve managed video model ids through the router before auth, budget, and key checks - [PR #29545](https://github.com/BerriAI/litellm/pull/29545)
+- fix(key_generate): let team members create keys on org-scoped teams (regression since v1.84.0-rc.1) - [PR #29310](https://github.com/BerriAI/litellm/pull/29310)
+- fix(vertex): strip `output_config.effort` for Vertex Claude models that reject it, such as Haiku 4.5 - [PR #29585](https://github.com/BerriAI/litellm/pull/29585)
+- fix(passthrough): stop duplicate cost callbacks for Anthropic streaming pass-through - [PR #29598](https://github.com/BerriAI/litellm/pull/29598)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.3...v1.86.4

--- a/release_notes/v1.86.5/index.md
+++ b/release_notes/v1.86.5/index.md
@@ -1,0 +1,57 @@
+---
+title: "v1.86.5 - Claude Fable 5, CrowdStrike AIDR & Batch File Auth"
+slug: "v1-86-5"
+date: 2026-06-10T19:46:17
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.5
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.5
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.5` is a patch release on top of [`v1.86.4`](/release_notes/v1.86.4/v1-86-4). It adds Claude Fable 5, backports the CrowdStrike AIDR identity capture and follow-up fix (an upgrade-monotonicity backport so the 1.86 line keeps AIDR identity attribution), and authorizes batch files using the upload `target_model_names`.
+
+### What's Changed
+
+- feat: add Claude Fable 5 across Anthropic, Bedrock, Vertex AI, and Azure AI - [PR #30064](https://github.com/BerriAI/litellm/pull/30064)
+- feat(guardrails): capture CrowdStrike AIDR user and model metadata - [PR #29517](https://github.com/BerriAI/litellm/pull/29517)
+- fix(guardrails): read CrowdStrike AIDR identity from both metadata bags - [PR #29991](https://github.com/BerriAI/litellm/pull/29991)
+- fix(proxy): authorize batch files using upload `target_model_names` (LIT-3593) - [PR #30009](https://github.com/BerriAI/litellm/pull/30009)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.4...v1.86.5

--- a/release_notes/v1.86.6/index.md
+++ b/release_notes/v1.86.6/index.md
@@ -1,0 +1,63 @@
+---
+title: "v1.86.6 - DB Resilience, Passthrough & Dependency Backports"
+slug: "v1-86-6"
+date: 2026-06-13T17:37:03
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.6
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.6
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.6` is a patch release on top of [`v1.86.5`](/release_notes/v1.86.5/v1-86-5). It brings the 1.84.8 database-resilience and passthrough set onto the 1.86 line, adds the budget-reservation toggle, hardens Anthropic streaming logging, and refreshes dependencies.
+
+### What's Changed
+
+- fix(router): use forwarded model_id for native Azure container IDs - [PR #27921](https://github.com/BerriAI/litellm/pull/27921)
+- fix(proxy): expose Prisma idle/connect timeout and extra DB URL params - [PR #28395](https://github.com/BerriAI/litellm/pull/28395)
+- feat(proxy): add `disable_budget_reservation` general setting - [PR #29493](https://github.com/BerriAI/litellm/pull/29493)
+- fix(proxy): recover from cached-plan errors by reconnecting the Prisma client - [PR #29983](https://github.com/BerriAI/litellm/pull/29983)
+- feat(proxy): add option to disable server-side prepared statements for DB lookups - [PR #29984](https://github.com/BerriAI/litellm/pull/29984)
+- fix(proxy): return 5xx on DB infra errors during auth; reserve 401 for genuine auth failures - [PR #29986](https://github.com/BerriAI/litellm/pull/29986)
+- fix(passthrough): resolve costing model when body model is unknown - [PR #30160](https://github.com/BerriAI/litellm/pull/30160)
+- fix(passthrough): skip `[DONE]` sentinels and non-JSON SSE frames in Anthropic streaming logging - [PR #30202](https://github.com/BerriAI/litellm/pull/30202)
+- fix(proxy): return deprecated-key lookup result directly in get_data combined view - [PR #30327](https://github.com/BerriAI/litellm/pull/30327)
+- chore(deps): bump pypdf, tornado, the aiohttp constraint, vitest, and brace-expansion - [PR #30220](https://github.com/BerriAI/litellm/pull/30220)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.5...v1.86.6

--- a/release_notes/v1.87.1/index.md
+++ b/release_notes/v1.87.1/index.md
@@ -1,0 +1,58 @@
+---
+title: "v1.87.1 - Azure AD, Batch Auth & Key Access Backports"
+slug: "v1-87-1"
+date: 2026-06-03T21:54:19
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.87.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.87.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.87.1` is a patch release on top of [`v1.87.0`](/release_notes/v1.87.0/v1-87-0). It backports five staged fixes: Azure AD token refresh, batch and video model routing, org-scoped team key creation, and Vertex Claude effort handling. The duplicate passthrough cost-callback fix the other lines received is deliberately held back here, since 1.87.x branched separately and carries a different passthrough logging path where that guard does not exist.
+
+### What's Changed
+
+- fix(azure): preserve AD token refresh in the v1 OpenAI client path - [PR #28627](https://github.com/BerriAI/litellm/pull/28627)
+- fix(proxy): map a stripped batch `body.model` back to the proxy alias so key access checks pass - [PR #29264](https://github.com/BerriAI/litellm/pull/29264)
+- fix(proxy): resolve managed video model ids through the router before auth, budget, and key checks - [PR #29545](https://github.com/BerriAI/litellm/pull/29545)
+- fix(key_generate): let team members create keys on org-scoped teams (regression since v1.84.0-rc.1) - [PR #29310](https://github.com/BerriAI/litellm/pull/29310)
+- fix(vertex): strip `output_config.effort` for Vertex Claude models that reject it, such as Haiku 4.5 - [PR #29585](https://github.com/BerriAI/litellm/pull/29585)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.87.0...v1.87.1

--- a/release_notes/v1.87.2/index.md
+++ b/release_notes/v1.87.2/index.md
@@ -1,0 +1,58 @@
+---
+title: "v1.87.2 - Claude Fable 5, Batch Auth, CrowdStrike & Mantle SigV4"
+slug: "v1-87-2"
+date: 2026-06-10T21:47:54
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.87.2
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.87.2
+```
+
+</TabItem>
+</Tabs>
+
+`v1.87.2` is a patch release on top of [`v1.87.1`](/release_notes/v1.87.1/v1-87-1). It adds Claude Fable 5, batch-file authorization, the CrowdStrike AIDR identity pair, and SigV4/IAM auth for the Bedrock Mantle Responses API route.
+
+### What's Changed
+
+- feat: add Claude Fable 5 across Anthropic, Bedrock, Vertex AI, and Azure AI - [PR #30064](https://github.com/BerriAI/litellm/pull/30064)
+- fix(proxy): authorize batch files using upload `target_model_names` (LIT-3593) - [PR #30009](https://github.com/BerriAI/litellm/pull/30009)
+- feat(guardrails): capture CrowdStrike AIDR user and model metadata - [PR #29517](https://github.com/BerriAI/litellm/pull/29517)
+- fix(guardrails): read CrowdStrike AIDR identity from both metadata bags - [PR #29991](https://github.com/BerriAI/litellm/pull/29991)
+- feat(bedrock_mantle): add SigV4/IAM auth to the Responses API route, with its prerequisite Mantle Responses route (#29490) - [PR #29788](https://github.com/BerriAI/litellm/pull/29788)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.87.1...v1.87.2

--- a/release_notes/v1.87.3/index.md
+++ b/release_notes/v1.87.3/index.md
@@ -1,0 +1,61 @@
+---
+title: "v1.87.3 - DB Resilience & Passthrough Hardening"
+slug: "v1-87-3"
+date: 2026-06-13T17:37:18
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.87.3
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.87.3
+```
+
+</TabItem>
+</Tabs>
+
+`v1.87.3` is a patch release on top of [`v1.87.2`](/release_notes/v1.87.2/v1-87-2). It brings the 1.84.8 database-resilience set onto the 1.87 line, adds the budget-reservation toggle, hardens Anthropic streaming logging, and refreshes dependencies.
+
+### What's Changed
+
+- feat(proxy): add `disable_budget_reservation` general setting - [PR #29493](https://github.com/BerriAI/litellm/pull/29493)
+- fix(proxy): recover from cached-plan errors by reconnecting the Prisma client - [PR #29983](https://github.com/BerriAI/litellm/pull/29983)
+- feat(proxy): add option to disable server-side prepared statements for DB lookups - [PR #29984](https://github.com/BerriAI/litellm/pull/29984)
+- fix(proxy): return 5xx on DB infra errors during auth; reserve 401 for genuine auth failures - [PR #29986](https://github.com/BerriAI/litellm/pull/29986)
+- fix(passthrough): resolve costing model when body model is unknown - [PR #30160](https://github.com/BerriAI/litellm/pull/30160)
+- fix(passthrough): skip `[DONE]` sentinels and non-JSON SSE frames in Anthropic streaming logging - [PR #30202](https://github.com/BerriAI/litellm/pull/30202)
+- fix(proxy): return deprecated-key lookup result directly in get_data combined view - [PR #30327](https://github.com/BerriAI/litellm/pull/30327)
+- chore(deps): bump pypdf, tornado, the aiohttp constraint, vitest, and brace-expansion - [PR #30220](https://github.com/BerriAI/litellm/pull/30220)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.87.2...v1.87.3

--- a/release_notes/v1.88.0/index.md
+++ b/release_notes/v1.88.0/index.md
@@ -1,6 +1,6 @@
 ---
-title: "v1.88.0rc3 - Claude Opus 4.8, MCP Access-Group Authorization & Typed OpenTelemetry"
-slug: "v1-88-0-rc-3"
+title: "v1.88.0 - Claude Opus 4.8, MCP Access-Group Authorization & Typed OpenTelemetry"
+slug: "v1-88-0"
 date: 2026-06-04T18:45:10
 authors:
   - name: Krrish Dholakia
@@ -31,14 +31,14 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.88.0-rc.3
+docker.litellm.ai/berriai/litellm:1.88.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.88.0rc3
+pip install litellm==1.88.0
 ```
 
 </TabItem>
@@ -46,7 +46,7 @@ pip install litellm==1.88.0rc3
 
 ## Key Highlights
 
-`v1.88.0rc3` is the current release candidate for 1.88.0.
+`v1.88.0` is the stable release, graduated from the `v1.88.0` release candidates.
 
 - **Claude Opus 4.8** is supported across Anthropic, Bedrock (including `global` / `us` / `eu` / `au` regional routes), Azure AI, and Vertex, at 1M-token context with adaptive thinking and `output_config` goal mode.
 - **MCP access-group authorization** was reworked end to end: key and team access groups now resolve to MCP servers, grants are additive with opt-in member assignment, and clients can route through stateful or stateless sessions by session id.
@@ -256,11 +256,11 @@ Almost everything above shipped in **rc.1**. The later candidates are small, tar
 
 No new contributors this release; all 11 authors are returning contributors.
 
-**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.87.0-rc.1...v1.88.0-rc.3
+**Full Changelog**: https://github.com/BerriAI/litellm/compare/v1.87.0...v1.88.0
 
 ---
 
-## 06/04/2026 (`v1.88.0rc3`)
+## 06/04/2026 (`v1.88.0`)
 
 * New Models / Updated Models: 9
 * LLM API Endpoints: 15

--- a/release_notes/v1.88.1/index.md
+++ b/release_notes/v1.88.1/index.md
@@ -1,0 +1,54 @@
+---
+title: "v1.88.1 - Dependency Bumps"
+slug: "v1-88-1"
+date: 2026-06-08T17:23:56
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.88.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.88.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.88.1` is a patch release on top of [`v1.88.0`](/release_notes/v1.88.0/v1-88-0). It bumps PyJWT and the `ws` override to clear dependency advisories on the 1.88 line.
+
+### What's Changed
+
+- build(deps): bump PyJWT to 2.13.0 and the `ws` override to 8.20.1 - [PR #29987](https://github.com/BerriAI/litellm/pull/29987)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.88.0...v1.88.1

--- a/release_notes/v1.88.2/index.md
+++ b/release_notes/v1.88.2/index.md
@@ -1,0 +1,64 @@
+---
+title: "v1.88.2 - DB Resilience, Passthrough, Model-Info & Budget"
+slug: "v1-88-2"
+date: 2026-06-13T19:29:53
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.88.2
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.88.2
+```
+
+</TabItem>
+</Tabs>
+
+`v1.88.2` is a patch release on top of [`v1.88.1`](/release_notes/v1.88.1/v1-88-1). It backports an already-merged set: the database-resilience fixes, passthrough corrections, the `/v1/model/info` team-access chain, the budget-reservation toggle, and dependency bumps.
+
+### What's Changed
+
+- feat(proxy): add `disable_budget_reservation` general setting - [PR #29493](https://github.com/BerriAI/litellm/pull/29493)
+- fix(proxy): recover from cached-plan errors by reconnecting the Prisma client - [PR #29983](https://github.com/BerriAI/litellm/pull/29983)
+- feat(proxy): add option to disable server-side prepared statements for DB lookups - [PR #29984](https://github.com/BerriAI/litellm/pull/29984)
+- fix(proxy): return 5xx on DB infra errors during auth; reserve 401 for genuine auth failures - [PR #29986](https://github.com/BerriAI/litellm/pull/29986)
+- fix(passthrough): resolve costing model when body model is unknown - [PR #30160](https://github.com/BerriAI/litellm/pull/30160)
+- fix(passthrough): skip `[DONE]` sentinels and non-JSON SSE frames in Anthropic streaming logging - [PR #30202](https://github.com/BerriAI/litellm/pull/30202)
+- fix(proxy): return deprecated-key lookup result directly in get_data combined view - [PR #30327](https://github.com/BerriAI/litellm/pull/30327)
+- fix(proxy): stop team BYOK model name corruption on model edit - [PR #29731](https://github.com/BerriAI/litellm/pull/29731)
+- fix(proxy): align `/v1/model/info` with router deployments - [PR #30025](https://github.com/BerriAI/litellm/pull/30025)
+- fix(proxy): populate `access_via_team_ids` on `/v1/model/info` - [PR #30274](https://github.com/BerriAI/litellm/pull/30274)
+- chore(deps): bump vitest, brace-expansion, pypdf, and tornado - [PR #30220](https://github.com/BerriAI/litellm/pull/30220)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.88.1...v1.88.2

--- a/release_notes/v1.89.0/index.md
+++ b/release_notes/v1.89.0/index.md
@@ -1,0 +1,249 @@
+---
+title: "v1.89.0 - Claude Fable 5, A2A Agent Providers & MCP Per-Server Controls"
+slug: "v1-89-0"
+date: 2026-06-10T11:04:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:v1.89.0
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.89.0
+```
+
+</TabItem>
+</Tabs>
+
+## Key Highlights
+
+`v1.89.0` builds on [`v1.88.0`](/release_notes/v1.88.0/v1-88-0).
+
+- **Claude Fable 5** is supported across Anthropic, Bedrock, Azure AI, and Vertex at 1M-token context with adaptive thinking and computer use.
+- **Agent-to-agent (A2A)** gains two new agent providers - watsonx Orchestrate and LangFlow (with A2A session bridging) - plus OAuth M2M for Databricks Apps agents.
+- **MCP gateway** adds per-server environment variables with global and per-user scopes, per-server RPM rate limiting for keys and teams, OAuth passthrough with issuer-scoped JWT auth, and `oauth2_flow` persistence on server registration.
+- **Observability** lands OpenInference rendering parity for Arize/Phoenix (tool calls, cost, passthrough I/O, sessions, multimodal, cache tokens), MCP semantic conventions on the typed OTel v2 spans, and a Galileo logger that uses the ingest-traces API.
+- **New search and transcription providers** - APISerpent, You.com, and Soniox - join the gateway, alongside the dashboard's migration to fully typed, OpenAPI-generated API clients.
+
+## New Providers and Endpoints
+
+### New Providers (3 new providers)
+
+| Provider | Supported LiteLLM Endpoints | Description |
+| --- | --- | --- |
+| APISerpent (`apiserpent`) | Search | Web search and deep-search API |
+| You.com (`you_com`) | Search | You.com web search API |
+| Soniox (`soniox`) | Audio Transcription | Async speech-to-text (`stt-async-v4`) |
+
+## New Models / Updated Models
+
+#### New Model Support (selected)
+
+| Provider | Model | Context Window | Input ($/1M tokens) | Output ($/1M tokens) | Features |
+| --- | --- | --- | --- | --- | --- |
+| Anthropic | `claude-fable-5` | 1,000,000 | $10.00 | $50.00 | Adaptive thinking, computer use, function calling, prompt caching, vision |
+| Vertex AI | `vertex_ai/claude-fable-5` | 1,000,000 | $10.00 | $50.00 | Same as Anthropic direct |
+| Azure AI | `azure_ai/claude-fable-5` | 1,000,000 | $10.00 | $50.00 | Same as Anthropic direct |
+| Bedrock | `anthropic.claude-fable-5` (+ `global.` / `us.` / `eu.` routes) | 1,000,000 | $10.00 | $50.00 | Same as Anthropic direct |
+| Bedrock Mantle | `bedrock_mantle/openai.gpt-5.5` | 272,000 | $5.50 | $33.00 | Responses API, reasoning, function calling, prompt caching |
+| Bedrock Mantle | `bedrock_mantle/openai.gpt-5.4` | 272,000 | $2.75 | $16.50 | Responses API, reasoning, function calling, prompt caching |
+| Azure AI | `azure_ai/kimi-k2.6` | 262,144 | $0.95 | $4.00 | Reasoning, vision, function calling, tool choice |
+| MiniMax | `minimax/MiniMax-M3` | 512,000 | $0.60 | $2.40 | Reasoning, prompt caching, function calling |
+| Inception | `inception/mercury-2` (+ `mercury-edit-2`) | 128,000 | $0.25 | $0.75 | Function calling, prompt caching, response schema |
+
+Additional model-map additions: fal.ai Nano Banana and Gemini 2.5 Flash Image generation - [PR #29798](https://github.com/BerriAI/litellm/pull/29798); `mistral/ministral-8b-latest` - [PR #29453](https://github.com/BerriAI/litellm/pull/29453); a batch of new Snowflake Cortex model entries (Claude, GPT, Llama, embeddings); `vertex_ai/google/gemma-4-26b-a4b-it-maas`; APISerpent, You.com, and Soniox catalog entries; and a `jp.` regional route for Claude Opus 4.7.
+
+#### Features
+
+- **[Anthropic](../../docs/providers/anthropic)**
+    - Route future Claude models to the Anthropic provider via pattern matching - [PR #29239](https://github.com/BerriAI/litellm/pull/29239)
+    - Route Claude Opus 4.8 through adaptive thinking - [PR #29702](https://github.com/BerriAI/litellm/pull/29702)
+    - Emit a thinking block for `reasoning_content`-only streaming chunks in the Anthropic adapter - [PR #29600](https://github.com/BerriAI/litellm/pull/29600)
+    - Inline legacy `$ref` defs in tool schemas (Anthropic and Fireworks) - [PR #28646](https://github.com/BerriAI/litellm/pull/28646)
+- **[Gemini](../../docs/providers/gemini)**
+    - Support `googleSearch` with server-side tools and `googleMaps` JSON schema - [PR #29582](https://github.com/BerriAI/litellm/pull/29582)
+    - Use GA event names for Pipecat 1.3.x compatibility on Gemini realtime - [PR #29662](https://github.com/BerriAI/litellm/pull/29662)
+- **[Vertex AI](../../docs/providers/vertex)**
+    - Use a user-supplied `api_base` as-is for the Model Garden OpenAI-compatible path - [PR #29530](https://github.com/BerriAI/litellm/pull/29530)
+    - Handle namespace tools and strip `client_metadata` for Codex compatibility on Vertex/Anthropic - [PR #29489](https://github.com/BerriAI/litellm/pull/29489)
+- **[Azure AI](../../docs/providers/azure_ai)**
+    - Strip tool-level extra fields on a 400 and retry - [PR #29479](https://github.com/BerriAI/litellm/pull/29479)
+
+#### Bug Fixes
+
+- **General**
+    - Return a 400 (not 500) on Anthropic context overflow, and seed identity on failed auth - [PR #29848](https://github.com/BerriAI/litellm/pull/29848)
+    - Omit the OpenAI `[DONE]` sentinel on google-genai `streamGenerateContent` - [PR #29426](https://github.com/BerriAI/litellm/pull/29426)
+
+## LLM API Endpoints
+
+#### Features
+
+- **[Batches](../../docs/batches)**
+    - Skip unnecessary batch input-file reads - [PR #29114](https://github.com/BerriAI/litellm/pull/29114)
+    - Resolve credentials correctly when cancelling a managed batch - [PR #29734](https://github.com/BerriAI/litellm/pull/29734)
+- **Vector Stores**
+    - Resolve vector-store file-list credentials from team deployments - [PR #29739](https://github.com/BerriAI/litellm/pull/29739)
+    - Support an engines URL for Vertex AI Search - [PR #27885](https://github.com/BerriAI/litellm/pull/27885)
+    - Forward per-request params to Vertex AI Search - [PR #29459](https://github.com/BerriAI/litellm/pull/29459)
+- **Realtime**
+    - Track realtime audio token cost - [PR #29722](https://github.com/BerriAI/litellm/pull/29722)
+    - Allow null transcripts in stream logging payloads - [PR #29625](https://github.com/BerriAI/litellm/pull/29625)
+    - WebSocket connection improvements - [PR #29563](https://github.com/BerriAI/litellm/pull/29563)
+
+#### Agents (A2A)
+
+- watsonx Orchestrate agent provider - [PR #29410](https://github.com/BerriAI/litellm/pull/29410)
+- LangFlow agent provider with A2A session bridging - [PR #28963](https://github.com/BerriAI/litellm/pull/28963)
+- OAuth M2M for Databricks Apps A2A agents - [PR #29586](https://github.com/BerriAI/litellm/pull/29586)
+- A2A bug fixes - [PR #29566](https://github.com/BerriAI/litellm/pull/29566)
+
+## Management Endpoints / UI
+
+#### Features
+
+- **Virtual Keys & Auth**
+    - JWT-to-virtual-key mapping - [PR #28510](https://github.com/BerriAI/litellm/pull/28510)
+    - Let internal users view search tools - [PR #29542](https://github.com/BerriAI/litellm/pull/29542)
+    - Expand the all-team-models sentinel in `can_key_call_model` for batch validation - [PR #29746](https://github.com/BerriAI/litellm/pull/29746)
+- **Dashboard**
+    - Generate dashboard API types from the proxy OpenAPI spec - [PR #29816](https://github.com/BerriAI/litellm/pull/29816)
+    - Centralize proxy base-URL resolution into a tested resolver - [PR #29793](https://github.com/BerriAI/litellm/pull/29793)
+    - Route networking calls through a shared, location-pinned `apiClient` - [PR #29723](https://github.com/BerriAI/litellm/pull/29723), [PR #29806](https://github.com/BerriAI/litellm/pull/29806), [PR #29815](https://github.com/BerriAI/litellm/pull/29815)
+    - Migrate ESLint to flat config and bump `eslint-config-next` to 16 - [PR #29626](https://github.com/BerriAI/litellm/pull/29626)
+
+#### Bug Fixes
+
+- Use the resolved DB `user_id` for spend on legacy email match (JWT) - [PR #29217](https://github.com/BerriAI/litellm/pull/29217)
+- Preserve the 401 status for expired JWTs in OTel traces - [PR #29510](https://github.com/BerriAI/litellm/pull/29510)
+- Stop team BYOK model-name corruption on model edit - [PR #29731](https://github.com/BerriAI/litellm/pull/29731)
+- Drop a deleted team BYOK model name from `team.models` - [PR #29820](https://github.com/BerriAI/litellm/pull/29820)
+- Add `default=None` to `LiteLLM_TeamMembership.litellm_budget_table` - [PR #29684](https://github.com/BerriAI/litellm/pull/29684)
+- Require a new expiration when regenerating an expired key - [PR #29838](https://github.com/BerriAI/litellm/pull/29838)
+- Render caller-supplied filter options in caller order (LIT-3151) - [PR #29462](https://github.com/BerriAI/litellm/pull/29462)
+- Make A2A skill tags enterable and validated - [PR #29512](https://github.com/BerriAI/litellm/pull/29512)
+- Persist the Tools-tab MCP OAuth token to the DB - [PR #29809](https://github.com/BerriAI/litellm/pull/29809)
+- Route MCP playground auth by OAuth2 mode instead of `token_url` - [PR #29714](https://github.com/BerriAI/litellm/pull/29714)
+- Stop MCP playground tool calls from sending twice - [PR #29821](https://github.com/BerriAI/litellm/pull/29821)
+
+## AI Integrations
+
+### Logging
+
+- **[Arize / Phoenix](../../docs/proxy/logging)**
+    - OpenInference rendering parity: tool calls, cost, passthrough I/O, session/user, multimodal, and cache tokens - [PR #28800](https://github.com/BerriAI/litellm/pull/28800)
+- **[Datadog](../../docs/proxy/logging#datadog)**
+    - Split oversized batches on a 413 instead of re-queueing forever - [PR #29444](https://github.com/BerriAI/litellm/pull/29444)
+- **Galileo**
+    - Use the ingest-traces API and the standard logging payload - [PR #29651](https://github.com/BerriAI/litellm/pull/29651)
+- **OpenTelemetry**
+    - Allowlist `team_metadata` sub-keys promoted to baggage - [PR #29442](https://github.com/BerriAI/litellm/pull/29442)
+    - Add MCP semantic conventions to OTel v2 - [PR #29468](https://github.com/BerriAI/litellm/pull/29468)
+    - Capture 401 error details in management-endpoint spans - [PR #29535](https://github.com/BerriAI/litellm/pull/29535)
+    - Emit the missing MCP span attributes - [PR #29554](https://github.com/BerriAI/litellm/pull/29554)
+    - Emit a guardrail span on passthrough, including when a guardrail blocks - [PR #29552](https://github.com/BerriAI/litellm/pull/29552), [PR #29470](https://github.com/BerriAI/litellm/pull/29470)
+
+### Guardrails
+
+- **[Sensitive Data Routing](../../docs/proxy/guardrails/quick_start)**
+    - Route sensitive data to on-premise models - [PR #29531](https://github.com/BerriAI/litellm/pull/29531)
+
+## Spend Tracking, Budgets and Rate Limiting
+
+- Strip NUL bytes from spend-log payloads to prevent PostgreSQL `22P05` errors - [PR #29515](https://github.com/BerriAI/litellm/pull/29515)
+- Scope the session-token team-key budget exemption to a caller-supplied `team_id` - [PR #29641](https://github.com/BerriAI/litellm/pull/29641)
+
+## MCP Gateway
+
+- Per-server environment variables with global and per-user scopes - [PR #28917](https://github.com/BerriAI/litellm/pull/28917)
+- Per-MCP-server RPM rate limiting for keys and teams - [PR #29482](https://github.com/BerriAI/litellm/pull/29482)
+- Support MCP OAuth passthrough and issuer-scoped JWT auth - [PR #28356](https://github.com/BerriAI/litellm/pull/28356)
+- Persist `oauth2_flow` on MCP server registration - [PR #29690](https://github.com/BerriAI/litellm/pull/29690)
+- Clear `allowed_tools` and tool overrides on MCP server edit - [PR #29411](https://github.com/BerriAI/litellm/pull/29411)
+- Gate `/public/mcp_hub` strictly on `litellm.public_mcp_servers` - [PR #27764](https://github.com/BerriAI/litellm/pull/27764)
+
+## Performance / Loadbalancing / Reliability improvements
+
+- Native `/health/drain` preStop hook for graceful shutdown - [PR #29439](https://github.com/BerriAI/litellm/pull/29439)
+- Disable proxy buffering on streaming SSE responses - [PR #29557](https://github.com/BerriAI/litellm/pull/29557)
+- Populate `llm_provider` on internal rate-limit errors - [PR #27707](https://github.com/BerriAI/litellm/pull/27707)
+- Hot-reload `.env` in dev when running with `--reload` - [PR #29783](https://github.com/BerriAI/litellm/pull/29783)
+- Enable the Helm backend deployment to mount the gateway `config.yaml` - [PR #29605](https://github.com/BerriAI/litellm/pull/29605)
+- Convert the AWS and GCP Terraform stacks into reusable modules - [PR #28103](https://github.com/BerriAI/litellm/pull/28103)
+- Terraform GCP: abandon the SQL user on destroy - [PR #29855](https://github.com/BerriAI/litellm/pull/29855); prompt for `image_registry` in the DeployStack one-click - [PR #29852](https://github.com/BerriAI/litellm/pull/29852)
+- Dependency bumps - [PR #29860](https://github.com/BerriAI/litellm/pull/29860)
+
+## Documentation Updates
+
+- Clarify when to create new test files - [PR #29472](https://github.com/BerriAI/litellm/pull/29472)
+- Remove fixed dimensions from the README hero image - [PR #29496](https://github.com/BerriAI/litellm/pull/29496)
+- CLAUDE.md nits - [PR #29504](https://github.com/BerriAI/litellm/pull/29504), [PR #29749](https://github.com/BerriAI/litellm/pull/29749)
+
+### PR roll-up by ownership area
+
+```
+PRs by ownership area (visible, non-vehicle set; total: 101)
+  - UI / Dashboard: 22
+  - General Proxy (testing / CI / build): 22
+  - Models & Providers: 13
+  - Performance / Reliability: 10
+  - Logging: 9
+  - LLM API Endpoints: 8
+  - MCP: 6
+  - Auth & Management: 5
+  - Agents (A2A): 4
+  - Docs: 4
+  - Spend / Budgets / Rate Limits: 2
+  - Models & Providers (new providers): 3
+  - Guardrails: 1
+```
+
+## New Contributors
+
+New-contributor verification was not run for this release; see the changelog link below for the full author list.
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.88.0...v1.89.0
+
+---
+
+## 06/10/2026
+
+* New Models / Updated Models: 16
+* LLM API Endpoints: 12
+* Management Endpoints / UI: 22
+* AI Integrations (Logging / Guardrails): 10
+* Spend Tracking, Budgets and Rate Limiting: 2
+* MCP Gateway: 6
+* Performance / Loadbalancing / Reliability improvements: 10
+* General Proxy Improvements (testing / CI / build): 22
+* Documentation Updates: 4

--- a/release_notes/v1.89.0/index.md
+++ b/release_notes/v1.89.0/index.md
@@ -226,10 +226,6 @@ PRs by ownership area (visible, non-vehicle set; total: 101)
   - Guardrails: 1
 ```
 
-## New Contributors
-
-New-contributor verification was not run for this release; see the changelog link below for the full author list.
-
 ## Full Changelog
 
 https://github.com/BerriAI/litellm/compare/v1.88.0...v1.89.0


### PR DESCRIPTION
## What this does

Brings the release notes current with everything shipped over the past week and a half. The changelog had drifted well behind the releases going out across the active stable lines, so this catches all of them up in one pass.

For each active stable line it adds a patch changelog for every release since the last one that was documented, and each of those lists the PRs that went into the release rather than a hand-written narrative; that keeps the backfill honest and quick to scan. The lines covered are 1.84.5 through 1.84.8, 1.85.3 through 1.85.5, 1.86.3 through 1.86.6, 1.87.1 through 1.87.3, and 1.88.1 plus 1.88.2. The PR lists were pulled from each release's backport "what's included" section rather than a raw commit-range diff, since the patches are cut on separate release branches where a SHA-range diff misreports what shipped.

It also promotes the old v1.88.0rc3 doc to the v1.88.0 stable release (directory, slug, title, deploy version, and changelog link all moved to the stable form), matching how earlier lines retired their release candidates.

Finally it adds full release notes for the v1.89.0 stable release. Predecessor was resolved to v1.88.0; the two lines fork on the shared history, so the delta was cross-checked against the 1.88.0 PR set to avoid re-counting 1.88.0's own features. A few new models and providers that arrived through squashed staging-aggregator PRs (Snowflake Cortex entries, APISerpent, You.com, Soniox) are captured from the model-price diff rather than attributed to an individual PR.

The overview page now shows v1.89.0 as the latest release and the recent-releases table is refreshed.

## Verification

Ran `docusaurus build` locally and it generated successfully. The only broken-link warning touching a new page was the site-wide `../../docs/proxy/guardrails` path (already warning on older release notes); the one occurrence here points to `../../docs/proxy/guardrails/quick_start` instead so it resolves.

## Type

Documentation