### PR TITLE
docs(release-notes): add New Contributors section to v1.89.0

### DIFF
--- a/release_notes/v1.89.0/index.md
+++ b/release_notes/v1.89.0/index.md
@@ -226,6 +226,41 @@ PRs by ownership area (visible, non-vehicle set; total: 101)
   - Guardrails: 1
 ```
 
+## New Contributors
+
+* @someswar177 made their first contribution in https://github.com/BerriAI/litellm/pull/26585
+* @trexinc made their first contribution in https://github.com/BerriAI/litellm/pull/26597
+* @navnitshukla made their first contribution in https://github.com/BerriAI/litellm/pull/26609
+* @tanmay958 made their first contribution in https://github.com/BerriAI/litellm/pull/27580
+* @samagana made their first contribution in https://github.com/BerriAI/litellm/pull/27810
+* @DrishnaTrivedi made their first contribution in https://github.com/BerriAI/litellm/pull/28330
+* @brainsparker made their first contribution in https://github.com/BerriAI/litellm/pull/28370
+* @icep87 made their first contribution in https://github.com/BerriAI/litellm/pull/28846
+* @adriangomez24 made their first contribution in https://github.com/BerriAI/litellm/pull/29097
+* @zzw-math made their first contribution in https://github.com/BerriAI/litellm/pull/29325
+* @BeginnerRudy made their first contribution in https://github.com/BerriAI/litellm/pull/29392
+* @danisalvaa made their first contribution in https://github.com/BerriAI/litellm/pull/29394
+* @kapelame made their first contribution in https://github.com/BerriAI/litellm/pull/29412
+* @Zhao73 made their first contribution in https://github.com/BerriAI/litellm/pull/29419
+* @suleimanelkhoury made their first contribution in https://github.com/BerriAI/litellm/pull/29420
+* @aneeshsangvikar made their first contribution in https://github.com/BerriAI/litellm/pull/29427
+* @Ar-maan05 made their first contribution in https://github.com/BerriAI/litellm/pull/29483
+* @kingdoooo made their first contribution in https://github.com/BerriAI/litellm/pull/29490
+* @dan2k3k4 made their first contribution in https://github.com/BerriAI/litellm/pull/29508
+* @yanismiraoui made their first contribution in https://github.com/BerriAI/litellm/pull/29522
+* @josx made their first contribution in https://github.com/BerriAI/litellm/pull/29532
+* @1qh made their first contribution in https://github.com/BerriAI/litellm/pull/29561
+* @tin-berri made their first contribution in https://github.com/BerriAI/litellm/pull/29605
+* @mak2508 made their first contribution in https://github.com/BerriAI/litellm/pull/29606
+* @VANDRANKI made their first contribution in https://github.com/BerriAI/litellm/pull/29620
+* @andrey-dubnik made their first contribution in https://github.com/BerriAI/litellm/pull/29621
+* @ErRickow made their first contribution in https://github.com/BerriAI/litellm/pull/29646
+* @saswatds made their first contribution in https://github.com/BerriAI/litellm/pull/29650
+* @Dinesh-Girbide made their first contribution in https://github.com/BerriAI/litellm/pull/29655
+* @BWAAEEEK made their first contribution in https://github.com/BerriAI/litellm/pull/29660
+* @hectorc98 made their first contribution in https://github.com/BerriAI/litellm/pull/29672
+* @abhay23-AI made their first contribution in https://github.com/BerriAI/litellm/pull/29779
+
 ## Full Changelog
 
 https://github.com/BerriAI/litellm/compare/v1.88.0...v1.89.0


### PR DESCRIPTION
## What this does

Adds the New Contributors section to the v1.89.0 release notes. The section was deliberately left out of the original backfill (#347) because the per-author first-PR verification had not been run; this is that follow-up.

## How the list was derived

The list is the 32 people whose first-ever merged litellm PR first shipped in v1.89.0. Two standard sources both come up short here, so neither was trusted on its own. GitHub's auto-generated contributor list returns nothing for the v1.88.0 to v1.89.0 range, and a plain commit-author reachability diff (authors present in v1.89.0 history but not v1.88.0) surfaces only one name. Both miss the same group: most of these contributors arrived through the squashed OSS-staging sync (#29161), which collapses each underlying commit's authorship onto the person who cut the sync, so the original authors never appear as first-parent PR authors or as distinct commit authors in the mainline history.

To recover them, each candidate author's earliest merged PR was checked against the actual release histories: a contributor counts as new only when that earliest PR is present in v1.89.0 and absent from every one of v1.84.0, v1.85.0, v1.86.0, v1.87.0, and v1.88.0. Checking against v1.88.0 alone is not enough, since v1.88.0 is a separate release-branch fork that predates the sync and so legitimately lacks these PRs. The check keys on the PR reference in commit messages, which survives squashing, and was validated against controls (Claude Opus 4.8 #29238 resolves to both lines; Claude Fable 5 #30064 resolves to v1.89.0 only).

## Type

Documentation