### PR TITLE
docs(router_settings): document ttft_timeout and stream_idle_timeout

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -413,6 +413,8 @@ router_settings:
 | default_litellm_params | Optional[dict] | The default litellm parameters to add to all requests (e.g. `temperature`, `max_tokens`). |
 | timeout | Optional[float] | The default timeout for a request. Default is 10 minutes. |
 | stream_timeout | Optional[float] | The default timeout for a streaming request. If not set, the 'timeout' value is used. |
+| ttft_timeout | Optional[float] | Raise a `litellm.Timeout` if no first token arrives within this many seconds of the connection being accepted, to detect providers that hang before sending any content. When set, a non-streaming call is internally promoted to streaming and the caller still receives a standard response. Best set per deployment. Defaults to None (off). |
+| stream_idle_timeout | Optional[float] | Raise a `litellm.Timeout` if the gap between consecutive tokens exceeds this many seconds, to detect providers that stall mid-stream. Keep it well above the model's per-token p99 so it acts as a freeze detector rather than a slowness detector. Best set per deployment. Defaults to None (off). |
 | debug_level | Literal["DEBUG", "INFO"] | The debug level for the logging library in the router. Defaults to "INFO". |
 | client_ttl | int | Time-to-live for cached clients in seconds. Defaults to 3600. |
 | cache_kwargs | dict | Additional keyword arguments for the cache initialization. Use this for non-string Redis parameters that may fail when set via `REDIS_*` environment variables. |


### PR DESCRIPTION
Companion to BerriAI/litellm#30337, which adds two router timeout parameters. The router_settings documentation gate (`tests/documentation_tests/test_router_settings.py`) requires every `Router.__init__` parameter to appear in the router_settings reference table, so that PR cannot go green until these rows exist here.

ttft_timeout raises a `litellm.Timeout` when a provider accepts the connection but never sends a first token; stream_idle_timeout raises one when the gap between consecutive tokens grows too large. Both default to off and are intended to be set per deployment.

This only touches `docs/proxy/config_settings.md`; it adds two table rows after `stream_timeout`.