### PR TITLE
docs(mcp): document MCP server variables and credential store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+When making public-facing docs, PR descriptions, comments, issues, commit messages, etc., always follow these guidelines to sound less AI-y:
+
+- prefer not to use emojis
+- don't use "—". Instead, reach for ";", ".", etc.
+- don't use the pattern "It's not X, it's Y", "You're not X, you're Y", etc.
+- don't use bulleted or numbered lists unless it would be nonsensical not to. Instead, prefer prose
+- be information dense, concise, and clear

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -173,9 +173,8 @@ Store credentials on the server and reference them in static headers or authenti
 <iframe width="840" height="500" src="https://www.loom.com/embed/12878e2be19140069170c3a270b50d1c" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 **When to use this:**
-- You want secrets like passwords and API tokens kept out of config files
-- Each user should connect with their own credentials
-- You want to reuse shared config (hostnames, protocols) across users
+- Each user needs to connect with their own static credentials
+- You want to reuse certain shared details (e.g., DB url) across users
 
 </TabItem>
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -166,6 +166,17 @@ These headers get sent with every request to the server. That's it.
 - You want full control over exactly what headers are sent
 - You're debugging and need to quickly add headers without changing auth configuration
 
+### Server Variables
+
+When an MCP server needs credentials that vary per user, or you simply want to keep sensitive values out of your static headers and authentication fields, define them as server variables. Each variable has a name, a value, and a scope, and you reference it anywhere in the server's static headers or authentication using `${VAR_NAME}`. For example, you can assemble a connection string as `${DB_PROTOCOL}://${CORP_USERNAME}:${CORP_PASSWORD}@${DB_HOSTNAME}`, and LiteLLM substitutes the resolved values before sending the request.
+
+Variables support two scopes. **Instance** variables hold a single value shared across every user of the server, which suits hostnames, protocols, and other non-secret configuration. **Per-user** variables are supplied individually by each user, so each caller connects with their own identity and LiteLLM resolves the correct value at request time. This lets one registered server serve many users without everyone sharing the same credentials, and it keeps secrets like database passwords and API tokens out of your config files.
+
+<Image 
+  img={require('../img/release_notes/mcp_credential_store.png')}
+  style={{width: '80%', display: 'block', margin: '0'}}
+/>
+
 </TabItem>
 
 <TabItem value="config" label="config.yaml">

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -172,10 +172,9 @@ When an MCP server needs credentials that vary per user, or you simply want to k
 
 Variables support two scopes. **Instance** variables hold a single value shared across every user of the server, which suits hostnames, protocols, and other non-secret configuration. **Per-user** variables are supplied individually by each user, so each caller connects with their own identity and LiteLLM resolves the correct value at request time. This lets one registered server serve many users without everyone sharing the same credentials, and it keeps secrets like database passwords and API tokens out of your config files.
 
-<Image 
-  img={require('../img/release_notes/mcp_credential_store.png')}
-  style={{width: '80%', display: 'block', margin: '0'}}
-/>
+This video walks through defining server variables and referencing them in headers and authentication.
+
+<iframe width="840" height="500" src="https://www.loom.com/embed/12878e2be19140069170c3a270b50d1c" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 </TabItem>
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -168,13 +168,14 @@ These headers get sent with every request to the server. That's it.
 
 ### Server Variables
 
-When an MCP server needs credentials that vary per user, or you simply want to keep sensitive values out of your static headers and authentication fields, define them as server variables. Each variable has a name, a value, and a scope, and you reference it anywhere in the server's static headers or authentication using `${VAR_NAME}`. For example, you can assemble a connection string as `${DB_PROTOCOL}://${CORP_USERNAME}:${CORP_PASSWORD}@${DB_HOSTNAME}`, and LiteLLM substitutes the resolved values before sending the request.
-
-Variables support two scopes. **Instance** variables hold a single value shared across every user of the server, which suits hostnames, protocols, and other non-secret configuration. **Per-user** variables are supplied individually by each user, so each caller connects with their own identity and LiteLLM resolves the correct value at request time. This lets one registered server serve many users without everyone sharing the same credentials, and it keeps secrets like database passwords and API tokens out of your config files.
-
-This video walks through defining server variables and referencing them in headers and authentication.
+Store credentials on the server and reference them in static headers or authentication with `${VAR_NAME}` (e.g. `${DB_PROTOCOL}://${CORP_USERNAME}:${CORP_PASSWORD}@${DB_HOSTNAME}`). Scope each variable as **Instance** (shared) or **Per-user** (each user supplies their own).
 
 <iframe width="840" height="500" src="https://www.loom.com/embed/12878e2be19140069170c3a270b50d1c" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
+**When to use this:**
+- You want secrets like passwords and API tokens kept out of config files
+- Each user should connect with their own credentials
+- You want to reuse shared config (hostnames, protocols) across users
 
 </TabItem>
 

--- a/release_notes/v1.89.0/index.md
+++ b/release_notes/v1.89.0/index.md
@@ -64,6 +64,8 @@ pip install litellm==1.89.0
 
 This release lets you securely store per-server credentials for MCP servers directly on the gateway. Define variables once on a server, scoped either as **Instance** (shared across all users) or **Per-user** (each user supplies their own value), and reference them in static headers or authentication using `${VAR_NAME}` syntax (for example, `${DB_PROTOCOL}://${CORP_USERNAME}:${CORP_PASSWORD}@${DB_HOSTNAME}`), letting each user connect their own identity.
 
+[Get Started](../../docs/mcp#server-variables)
+
 ## New Providers and Endpoints
 
 ### New Providers (3 new providers)


### PR DESCRIPTION
## Summary
Adds documentation for the MCP server variables / credential store feature shipped in v1.89.0 ([PR #28917](https://github.com/BerriAI/litellm/pull/28917)). The v1.89.0 release notes announced the feature but `docs/mcp.md` had no coverage of it.

Adds a "Server Variables" subsection to `docs/mcp.md` (under the UI tab, alongside Static Headers) explaining named variables, the `${VAR_NAME}` substitution syntax in static headers and authentication, and the difference between Instance (shared) and Per-user scopes.

## Test plan
- [ ] Build the docs site and confirm the new "Server Variables" section renders under the MCP UI tab with the image displaying correctly.