### PR TITLE
docs(proxy): document litellm-proxy db generate command

### DIFF
--- a/docs/proxy/cli.md
+++ b/docs/proxy/cli.md
@@ -323,6 +323,16 @@ This page documents all command-line interface (CLI) arguments available for the
      litellm --use_prisma_db_push
      ```
 
+### litellm-proxy db generate
+   - Generates the Prisma client using the schema bundled with `litellm-proxy-extras`.
+   - Resolves the schema path for you, so you do not need to know the internal `site-packages` location or pass `--schema` by hand. This is the generate-step companion to `db push` and `migrate deploy`, which already use the same bundled schema.
+   - Works after a plain `pip install 'litellm[proxy]'` even when the venv is not activated, such as when the proxy is invoked by absolute path in Docker or installer scripts.
+   - Requires `litellm-proxy-extras`, which ships with `litellm[proxy]`. If it is missing, the command prints an install hint and exits.
+   - **Usage:**
+     ```shell
+     litellm-proxy db generate
+     ```
+
 ## Debugging
 
 ### --debug


### PR DESCRIPTION
Documents the new `litellm-proxy db generate` command in the proxy CLI reference, alongside the existing `--use_prisma_db_push` entry.

This is the docs companion to BerriAI/litellm#30051, which adds the command so `prisma generate` works out of the box after `pip install 'litellm[proxy]'` without activating the venv. Draft until that PR lands.
