### PR TITLE
docs: fix stability blog title spacing

### DIFF
--- a/blog/stability/index.md
+++ b/blog/stability/index.md
@@ -1,6 +1,6 @@
 ---
 slug: stability
-title: "June Stability Update:We're Making Stability a First-Class Citizen at
+title: "June Stability Update: We're Making Stability a First-Class Citizen at
 LiteLLM"
 date: 2026-06-15T10:00:00
 authors:


### PR DESCRIPTION
## Summary
- Fix missing space after "Update:" in the June Stability blog title front matter.

## Tests
- PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run build

Note: the build completed successfully with existing Docusaurus warnings/broken-link warnings unrelated to this one-line title fix.