### PR TITLE
docs: clarify LLM Guard enterprise requirement

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -501,6 +501,12 @@ The `hide_secrets` guardrail check did not run on this request because api key=s
 ## Content Moderation
 ### Content Moderation with LLM Guard
 
+:::info
+
+`llmguard_moderations` requires a LiteLLM Enterprise license and the `litellm-enterprise` package. The OSS guardrail framework still supports custom guardrails and Presidio PII masking.
+
+:::
+
 Set the LLM Guard API Base in your environment
 
 ```env


### PR DESCRIPTION
## Summary

- Adds a local note to the LLM Guard documentation that `llmguard_moderations` requires a LiteLLM Enterprise license and the `litellm-enterprise` package.
- Clarifies that the OSS guardrail framework still supports custom guardrails and Presidio PII masking.

Addresses BerriAI/litellm#27072.

## Duplicate check

- Checked open PRs in `BerriAI/litellm` for `27072 OR llmguard_moderations enterprise`: no matching open PR found.
- Checked open PRs/issues in `BerriAI/litellm-docs` for `llmguard_moderations enterprise`: no matching open PR or issue found.

## Validation

- `git diff --check`
- `npm run build`

`npm run build` completed successfully. It reported existing site-wide Docusaurus warnings and broken links outside this changed section.

## Disclosure

This documentation update was prepared with AI assistance and manually reviewed before submission.
