### PR TITLE
docs(bedrock_mantle): use bedrock_mantle/ prefix in Claude Mythos examples

### DIFF
--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -17,7 +17,7 @@ Use this provider to call Bedrock Mantle models with accurate **AWS Bedrock pric
 
 [Claude Mythos](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-mythos-preview.html) (`anthropic.claude-mythos-preview`) is available on Bedrock Mantle with **1M token input context**, 128K output, and support for reasoning, vision, and tool use.
 
-Use the `bedrock/mantle/` route prefix with standard AWS credentials.
+Use the `bedrock_mantle/` route prefix with standard AWS credentials.
 
 ### /messages
 
@@ -35,7 +35,7 @@ os.environ['AWS_REGION_NAME'] = "us-east-1"
 
 async def main():
     response = await litellm.anthropic_messages(
-        model="bedrock/mantle/anthropic.claude-mythos-preview",
+        model="bedrock_mantle/anthropic.claude-mythos-preview",
         max_tokens=1024,
         messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
     )
@@ -53,7 +53,7 @@ asyncio.run(main())
 model_list:
   - model_name: claude-mythos
     litellm_params:
-      model: bedrock/mantle/anthropic.claude-mythos-preview
+      model: bedrock_mantle/anthropic.claude-mythos-preview
       aws_region_name: us-east-1
 ```
 
@@ -95,7 +95,7 @@ os.environ['AWS_SECRET_ACCESS_KEY'] = "your-aws-secret-key"
 os.environ['AWS_REGION_NAME'] = "us-east-1"
 
 response = completion(
-    model="bedrock/mantle/anthropic.claude-mythos-preview",
+    model="bedrock_mantle/anthropic.claude-mythos-preview",
     messages=[{"role": "user", "content": "Explain quantum entanglement simply."}],
 )
 print(response)
@@ -110,7 +110,7 @@ print(response)
 model_list:
   - model_name: claude-mythos
     litellm_params:
-      model: bedrock/mantle/anthropic.claude-mythos-preview
+      model: bedrock_mantle/anthropic.claude-mythos-preview
       aws_region_name: us-east-1
 ```
 


### PR DESCRIPTION
## Relevant issues

LIT-3747

## Type

📖 Documentation

## Changes

The Claude Mythos section used the `bedrock/mantle/` route prefix, which LiteLLM parses as provider `bedrock` with model `mantle/...` and fails with "LLM Provider NOT provided". The correct single-token prefix is `bedrock_mantle/`, matching the rest of the page. This aligns the /messages and /chat/completions examples with the working form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration impact.
> 
> **Overview**
> Fixes **incorrect model route strings** in the Claude Mythos section of `docs/providers/bedrock_mantle.md`.
> 
> All examples that used `bedrock/mantle/...` are updated to **`bedrock_mantle/...`**, including the intro line and SDK / `config.yaml` samples for `/messages` and `/chat/completions`. This matches the tip at the top of the page and avoids LiteLLM treating `bedrock` as the provider with a broken `mantle/...` model id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5bd691112621944df1522b310d80fdcb0598d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->