### PR TITLE
docs(proxy): document fail_closed_budget_enforcement

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -145,6 +145,7 @@ general_settings:
   database_extra_connection_params: {}  # Extra key/value pairs appended to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. sslmode, pgbouncer, statement_cache_size). Overrides LiteLLM defaults.
   database_disable_prepared_statements: boolean  # if true, appends pgbouncer=true to the Prisma connection URL, disabling server-side prepared statements. For PgBouncer transaction pooling and avoiding "cached plan must not change result type" errors during rolling migrations.
   allow_requests_on_db_unavailable: boolean  # if true, will allow requests that can not connect to the DB to verify Virtual Key to still work 
+  fail_closed_budget_enforcement: boolean  # if true, validates spend against the DB for every budgeted request and rejects with 503 when spend cannot be verified against Redis or the DB
 
   custom_auth: string
   max_parallel_requests: 0 # the max parallel requests allowed per deployment
@@ -261,6 +262,7 @@ router_settings:
 | database_extra_connection_params | object | Escape hatch — extra key/value pairs appended verbatim to the Prisma `DATABASE_URL` / `DIRECT_URL` query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets. |
 | database_disable_prepared_statements | boolean | Appends `pgbouncer=true` to the Prisma connection URL, disabling reuse of server-side prepared statements. Use behind PgBouncer transaction pooling, or to avoid `cached plan must not change result type` errors during rolling schema migrations. An explicit `pgbouncer` key in `database_extra_connection_params` takes precedence. [Disable Server-Side Prepared Statements](configs#disable-server-side-prepared-statements) |
 | allow_requests_on_db_unavailable | boolean | If true, allows requests to succeed even if DB is unreachable. **Only use this if running LiteLLM in your VPC** This will allow requests to work even when LiteLLM cannot connect to the DB to verify a Virtual Key [Doc on graceful db unavailability](prod#5-if-running-litellm-on-vpc-gracefully-handle-db-unavailability) |
+| fail_closed_budget_enforcement | boolean | Default `false`. When `true`, budget checks validate spend against the authoritative database for every budgeted request (key, team, user, organization, end-user, tag, and per-window budgets) instead of trusting only the cross-pod Redis counter, and a request is rejected with a `503` when current spend can be verified against neither Redis nor the database. Use this when a configured budget must be a hard ceiling even while Redis is degraded or restarting; leave it off to keep healthy under-budget traffic off the database. [Doc on budget enforcement](./users#hard-budget-enforcement-fail-closed) |
 | custom_auth | string | Write your own custom authentication logic [Doc Custom Auth](./custom_auth) |
 | max_parallel_requests | integer | The max parallel requests allowed per deployment |
 | global_max_parallel_requests | integer | The max parallel requests allowed on the proxy overall |

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -696,6 +696,21 @@ general_settings:
   proxy_budget_rescheduler_max_time: 1
 ```
 
+## Hard budget enforcement (fail closed)
+
+Budget checks read current spend from a cross-pod counter in Redis, which keeps enforcement fast and consistent across workers and replicas. The counter is the source of truth on the hot path, and the database is reconciled in the background. If Redis restarts and reloads an older snapshot, the counter can come back lower than the spend already recorded in the database; on the hot path that stale value is trusted, which can let a key keep spending past its `max_budget` until the counter is corrected.
+
+For deployments where a configured budget must be a hard ceiling even while Redis is degraded, set `fail_closed_budget_enforcement`:
+
+```yaml
+general_settings:
+  fail_closed_budget_enforcement: true
+```
+
+With it enabled, every budgeted request validates spend against the authoritative database before being admitted (covering key, team, user, organization, end-user, tag, and per-window budgets), so a stale or missing Redis counter cannot under-report spend. The database read is coalesced and cached in-process for a few seconds, so the extra load is bounded to roughly one read per budgeted entity per cache window per worker rather than one read per request. If current spend can be verified against neither Redis nor the database, the request is rejected with a `503` instead of being admitted on an unverifiable budget.
+
+Leave the setting off (the default) to keep healthy under-budget traffic entirely off the database; in the default mode the counter is still cross-checked against the database whenever it reads below the caller's last-known recorded spend, which catches the common stale-counter case without a per-request database read.
+
 ## Set Rate Limits 
 
 You can set: 


### PR DESCRIPTION
## Summary

Documents the new `general_settings.fail_closed_budget_enforcement` flag added in the proxy PR (BerriAI/litellm#30684), which makes budget enforcement validate spend against the authoritative database for every budgeted request and reject with a 503 when spend cannot be verified against Redis or the database.

## Changes

`docs/proxy/config_settings.md`: adds `fail_closed_budget_enforcement` to the `general_settings` YAML example and the reference table.

`docs/proxy/users.md`: adds a "Hard budget enforcement (fail closed)" section under Budgets explaining when to use the flag, what it covers (key, team, user, organization, end-user, tag, and per-window budgets), the bounded database cost, the 503-on-unverifiable behavior, and the default behavior when the flag is off.

## Related

Proxy change: https://github.com/BerriAI/litellm/pull/30684

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or config parsing impact in this PR.
> 
> **Overview**
> Documents **`general_settings.fail_closed_budget_enforcement`** for the proxy behavior introduced in BerriAI/litellm#30684.
> 
> **`docs/proxy/config_settings.md`** adds the flag to the `general_settings` YAML example and the reference table (default `false`, per-request DB validation when `true`, **503** when spend cannot be verified via Redis or DB, link to the users guide).
> 
> **`docs/proxy/users.md`** adds **Hard budget enforcement (fail closed)** under budgets: Redis hot-path vs DB authority after Redis restarts, scope (key/team/user/org/end-user/tag/per-window budgets), coalesced in-process DB reads, and how default mode differs (no per-request DB read; cross-check when Redis is below last-known spend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25b7942f82ec091f0173007c157f293483f5125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->