### PR TITLE
docs: document LITELLM_ENABLE_HTTP2 environment variable

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -704,6 +704,7 @@ router_settings:
 | DISABLE_ADMIN_UI | Toggle to disable the admin UI
 | LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT | Flag to hide the "Default Credentials" info card on the admin UI login page (`/ui/login` and `/fallback/login`). Useful when UI credentials are managed via `UI_USERNAME` / `UI_PASSWORD` or SSO and the hardcoded hint about `admin` + `MASTER_KEY` becomes misleading or is flagged by security scanners. **Default is false**
 | LITELLM_ENABLE_HSTS | Flag to send the `Strict-Transport-Security` response header on proxy and UI responses. Only takes effect for deployments served over HTTPS. **Default is false**
+| LITELLM_ENABLE_HTTP2 | Flag to opt in to HTTP/2 for outbound LLM requests. When set to a truthy value (e.g. `True`), litellm uses the httpx transport with HTTP/2 enabled instead of aiohttp. Requires the `h2` package (`pip install h2`). Equivalent to setting `litellm.enable_http2 = True`. **Default is False**
 | DISABLE_AIOHTTP_TRANSPORT | Flag to disable aiohttp transport. When this is set to True, litellm will use httpx instead of aiohttp. **Default is False**
 | DISABLE_AIOHTTP_TRUST_ENV | Flag to disable aiohttp trust environment. When this is set to True, litellm will not trust the environment for aiohttp eg. `HTTP_PROXY` and `HTTPS_PROXY` environment variables will not be used when this is set to True. **Default is False**
 | DISABLE_SCHEMA_UPDATE | Toggle to disable schema updates


### PR DESCRIPTION
## What

Adds `LITELLM_ENABLE_HTTP2` to the **environment variables - Reference** table in `docs/proxy/config_settings.md`.

## Why

The opt-in HTTP/2 feature for outbound LLM requests (BerriAI/litellm#30370) introduces a new env var `LITELLM_ENABLE_HTTP2` (read via `os.getenv` in `litellm/llms/custom_httpx/http_handler.py`). The litellm `tests/documentation_tests/test_env_keys.py` check requires every env var used in code to be documented in this reference table, so the `code-quality` and `documentation` CI jobs fail until it is added.

## Verification

Ran `tests/documentation_tests/test_env_keys.py` locally with this docs change checked out into `docs/my-website` (mirroring CI's `BerriAI/litellm-docs` checkout step). Result:

```
All keys are documented in 'environment settings - Reference'.
```