### PR TITLE
docs(sidebar): add Cost Optimization category to proxy sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -633,6 +633,19 @@ const sidebars = {
             "proxy/billing",
           ],
         },
+        {
+          type: "category",
+          label: "Cost Optimization",
+          items: [
+            "proxy/auto_routing",
+            "adaptive_router",
+            {
+              type: "link",
+              label: "Prompt Compression",
+              href: "/docs/completion/prompt_compression#server-side-callback-loop-v1messages",
+            },
+          ],
+        },
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds a Cost Optimization category under LiteLLM AI Gateway (Proxy) on the proxy index page. Groups three existing pages so users have one entry point for spend-reduction features. Links to auto routing (proxy/auto_routing), adaptive routing (adaptive_router), and prompt compression (jumps to the server-side callback section on /docs/completion/prompt_compression).

## Test plan

- [ ] Run `npm start` and confirm the Cost Optimization category renders in the left sidebar at /docs/simple_proxy
- [ ] Click each item and confirm the target pages load
- [ ] Confirm Prompt Compression link scrolls to the server-side-callback-loop-v1messages anchor