### PR TITLE
docs(prompt-compression): mark feature as beta

### DIFF
--- a/docs/completion/prompt_compression.md
+++ b/docs/completion/prompt_compression.md
@@ -1,5 +1,11 @@
 # Prompt Compression (`compress()`)
 
+:::info Beta
+
+This feature is in beta. APIs and behavior may change before general availability.
+
+:::
+
 Use `litellm.compress()` to shrink long conversation history before calling `completion()`.
 
 The function keeps high-relevance and recent context, replaces low-relevance content with lightweight stubs, and returns a retrieval tool so the model can request full content only when needed.


### PR DESCRIPTION
## Summary

Adds a beta admonition to the top of the prompt compression page so readers know the API surface may change before general availability.

## Test plan

- [ ] Run `npm start` and confirm the beta banner renders at /docs/completion/prompt_compression