### PR TITLE
docs(release-notes): backfill changelogs for v1.84.9, v1.85.6, v1.87.4, v1.88.4, v1.89.3

### DIFF
--- a/release_notes/v1.84.9/index.md
+++ b/release_notes/v1.84.9/index.md
@@ -1,0 +1,54 @@
+---
+title: "v1.84.9 - Anthropic Cache-Control Cap"
+slug: "v1-84-9"
+date: 2026-06-16T18:19:59
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.9
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.9
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.9` is a patch release on top of [`v1.84.8`](/release_notes/v1.84.8/v1-84-8). It caps Anthropic `cache_control` injection at the 4-block API limit so prompt-caching requests no longer fail when more blocks are eligible.
+
+### What's Changed
+
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.8...v1.84.9

--- a/release_notes/v1.85.6/index.md
+++ b/release_notes/v1.85.6/index.md
@@ -1,0 +1,62 @@
+---
+title: "v1.85.6 - Database Resilience Backport"
+slug: "v1-85-6"
+date: 2026-06-13T17:14:49
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.6
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.6
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.6` is a patch release on top of [`v1.85.5`](/release_notes/v1.85.5/v1-85-5). It backports the database-resilience set (Prisma reconnection, prepared-statement and timeout controls, 5xx on DB infra errors during auth) along with passthrough logging and costing fixes, a routing correction, and a dependency bump.
+
+### What's Changed
+
+- fix(router): use forwarded model_id for native Azure container IDs - [PR #27921](https://github.com/BerriAI/litellm/pull/27921)
+- fix(proxy): expose Prisma idle/connect timeout and extra DB URL params - [PR #28395](https://github.com/BerriAI/litellm/pull/28395)
+- fix(proxy): recover from cached-plan errors by reconnecting the Prisma client - [PR #29983](https://github.com/BerriAI/litellm/pull/29983)
+- feat(proxy): add option to disable server-side prepared statements for DB lookups - [PR #29984](https://github.com/BerriAI/litellm/pull/29984)
+- fix(proxy): return 5xx on DB infra errors during auth - [PR #29986](https://github.com/BerriAI/litellm/pull/29986)
+- fix(passthrough): resolve costing model when body model is unknown - [PR #30160](https://github.com/BerriAI/litellm/pull/30160)
+- fix(passthrough): skip `[DONE]` sentinels and non-JSON SSE frames in Anthropic streaming logging - [PR #30404](https://github.com/BerriAI/litellm/pull/30404)
+- fix(proxy): return deprecated-key lookup result directly in get_data combined view - [PR #30327](https://github.com/BerriAI/litellm/pull/30327)
+- chore(deps): bump vitest, brace-expansion, pypdf and tornado - [PR #30220](https://github.com/BerriAI/litellm/pull/30220)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.5...v1.85.6

--- a/release_notes/v1.87.4/index.md
+++ b/release_notes/v1.87.4/index.md
@@ -1,0 +1,61 @@
+---
+title: "v1.87.4 - Guardrails & Logging Fixes"
+slug: "v1-87-4"
+date: 2026-06-20T14:44:03
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.87.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.87.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.87.4` is a patch release on top of [`v1.87.3`](/release_notes/v1.87.3/v1-87-3). It backports guardrail correctness fixes (a single pre-call hook for model-level guardrails, no DB re-init on every poll, 400 instead of 500 when AIM blocks a request), caps Anthropic cache-control injection, and resolves several logging issues across Datadog batching, passthrough duplication, and Claude Code traces.
+
+### What's Changed
+
+- fix(datadog): split oversized batches on 413 instead of re-queueing forever - [PR #29444](https://github.com/BerriAI/litellm/pull/29444)
+- fix: stop use_chat_completions_api flag from leaking into provider request body - [PR #29447](https://github.com/BerriAI/litellm/pull/29447)
+- fix: duplicate Claude Code traces - [PR #29311](https://github.com/BerriAI/litellm/pull/29311)
+- fix: passthrough endpoints duplicate logs - [PR #29598](https://github.com/BerriAI/litellm/pull/29598)
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+- fix(guardrails): run pre_call hook once for model-level guardrails - [PR #30543](https://github.com/BerriAI/litellm/pull/30543)
+- fix(guardrails): stop re-initializing DB guardrails on every poll - [PR #30542](https://github.com/BerriAI/litellm/pull/30542)
+- fix(guardrails): return 400 not 500 when AIM blocks a request - [PR #30573](https://github.com/BerriAI/litellm/pull/30573)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.87.3...v1.87.4

--- a/release_notes/v1.88.4/index.md
+++ b/release_notes/v1.88.4/index.md
@@ -1,0 +1,58 @@
+---
+title: "v1.88.4 - Proxy Exception & Guardrails Fixes"
+slug: "v1-88-4"
+date: 2026-06-20T14:44:42
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.88.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.88.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.88.4` is a patch release on top of [`v1.88.3`](/release_notes/v1.88.3/v1-88-3). It restores readable `ProxyException` messages, returns 400 instead of 500 when AIM guardrails block a request, caps Anthropic cache-control injection, and corrects Datadog batch splitting and a chat-completions flag leak.
+
+### What's Changed
+
+- fix(proxy): populate Exception.args so str(ProxyException) returns message - [PR #29015](https://github.com/BerriAI/litellm/pull/29015)
+- fix(datadog): split oversized batches on 413 instead of re-queueing forever - [PR #29444](https://github.com/BerriAI/litellm/pull/29444)
+- fix: stop use_chat_completions_api flag from leaking into provider request body - [PR #29447](https://github.com/BerriAI/litellm/pull/29447)
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+- fix(guardrails): return 400 not 500 when AIM blocks a request - [PR #30573](https://github.com/BerriAI/litellm/pull/30573)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.88.3...v1.88.4

--- a/release_notes/v1.89.3/index.md
+++ b/release_notes/v1.89.3/index.md
@@ -1,0 +1,57 @@
+---
+title: "v1.89.3 - Guardrails & Cache-Control Fixes"
+slug: "v1-89-3"
+date: 2026-06-20T14:45:08
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.89.3
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.89.3
+```
+
+</TabItem>
+</Tabs>
+
+`v1.89.3` is a patch release on top of [`v1.89.2`](/release_notes/v1.89.2/v1-89-2). It backports guardrail correctness fixes (a single pre-call hook for model-level guardrails, no DB re-init on every poll, 400 instead of 500 when AIM blocks a request) and caps Anthropic cache-control injection at the 4-block limit.
+
+### What's Changed
+
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+- fix(guardrails): run pre_call hook once for model-level guardrails - [PR #30543](https://github.com/BerriAI/litellm/pull/30543)
+- fix(guardrails): stop re-initializing DB guardrails on every poll - [PR #30542](https://github.com/BerriAI/litellm/pull/30542)
+- fix(guardrails): return 400 not 500 when AIM blocks a request - [PR #30573](https://github.com/BerriAI/litellm/pull/30573)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.89.2...v1.89.3


### PR DESCRIPTION
## What

Adds the missing `release_notes/` changelog entries for five patch releases that shipped to PyPI and GHCR but never got one:

- `v1.84.9` (on top of v1.84.8)
- `v1.85.6` (on top of v1.85.5)
- `v1.87.4` (on top of v1.87.3)
- `v1.88.4` (on top of v1.88.3)
- `v1.89.3` (on top of v1.89.2)

## Why

Routine housekeeping. The changelog index was complete for every other 1.84.x-1.89.x release, so these five were the only gaps; this brings the index back in line across all the active lines.

## How each was built

Each entry covers the verified `vPREV..vTHIS` commit range (ancestry-checked) and lists only the user-facing PRs, with the version-bump and uv.lock chores filtered out. The Docker image tag in every "Deploy this version" block was verified to return 200 from the GHCR manifest API before writing. One v1.85.6 entry (the passthrough `[DONE]` streaming-logging fix) has no standalone upstream PR; it was a backport-only commit, so it links the backport PR that delivered it (#30404).

## Validation

`npm run build` passes locally and generates all five pages; the only build warnings are pre-existing and tied to older release notes / unrelated docs, none reference these five versions.