### PR TITLE
docs(release-notes): flag potential performance regression on v1.89.2 / v1.89.3

### DIFF
--- a/release_notes/v1.89.2/index.md
+++ b/release_notes/v1.89.2/index.md
@@ -18,6 +18,12 @@ authors:
 hide_table_of_contents: false
 ---
 
+:::warning Potential performance regression — under investigation
+
+We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+
+:::
+
 ## Deploy this version
 
 import Tabs from '@theme/Tabs';

--- a/release_notes/v1.89.3/index.md
+++ b/release_notes/v1.89.3/index.md
@@ -18,6 +18,12 @@ authors:
 hide_table_of_contents: false
 ---
 
+:::warning Potential performance regression — under investigation
+
+We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+
+:::
+
 ## Deploy this version
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
Adds an under-investigation warning banner to the top of the v1.89.2 and v1.89.3 release notes.

The banner notes a potential throughput regression in recent releases, clarifies that correctness and error rates are unaffected, and advises validating performance in staging before upgrading throughput-sensitive workloads. Affected versions and a fix are still being confirmed; the note will be updated as we learn more.

No customer details or internal references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)