### PR TITLE
docs(sandbox): document SDK-only path and add curl/OpenAI SDK tabs for the proxy

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Sandbox / Code Execution
 
 Run model-generated code inside an isolated sandbox and get its output back. The API is provider-agnostic; e2b is the first supported backend, talked to directly over HTTPS with no extra SDK dependency.
@@ -169,6 +172,9 @@ litellm --config /path/to/config.yaml
 
 #### 4. Call `/v1/responses`
 
+<Tabs>
+<TabItem value="curl" label="curl">
+
 ```bash
 curl -s "http://localhost:4000/v1/responses" \
   -H "Authorization: Bearer sk-1234" \
@@ -179,6 +185,41 @@ curl -s "http://localhost:4000/v1/responses" \
     "input": "Product of first 6 primes. Just the number."
   }'
 ```
+
+</TabItem>
+<TabItem value="openai" label="OpenAI SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="sk-1234", base_url="http://localhost:4000/v1")
+
+response = client.responses.create(
+    model="gpt-5",
+    tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+    input="Product of first 6 primes. Just the number.",
+)
+print(response.output_text)
+```
+
+</TabItem>
+<TabItem value="litellm" label="LiteLLM SDK">
+
+```python
+import litellm
+
+response = await litellm.aresponses(
+    model="openai/gpt-5",
+    tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+    input="Product of first 6 primes. Just the number.",
+    api_base="http://localhost:4000",
+    api_key="sk-1234",
+)
+print(response.output_text)
+```
+
+</TabItem>
+</Tabs>
 
 Response contains a `code_interpreter_call` item with a `cntr_*` `container_id` wrapping the e2b sandbox id.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -127,11 +127,50 @@ result = await litellm.acode_interpreter_tool(
 
 Behind the scenes the call goes directly to e2b's REST API: `POST api.e2b.app/sandboxes` to create, a streamed NDJSON `POST` to the per-sandbox host on port 49999 to execute, and `DELETE api.e2b.app/sandboxes/{id}` to tear down.
 
-## LiteLLM Proxy: Responses API code interpreter interceptor
+## Responses API code interpreter interceptor
 
 Route OpenAI's `code_interpreter` tool to your sandbox instead of OpenAI's container. The client request stays plain Responses API.
 
-### Setup
+### SDK
+
+Register the sandbox tool, install the interceptor as a callback, call `litellm.aresponses` with the `code_interpreter` tool unchanged.
+
+```python showLineNumbers title="sandbox_interceptor.py"
+import os, litellm
+from litellm.sandbox.sandbox_tools import register_sandbox_tools
+from litellm.integrations.code_interpreter_interception.handler import (
+    CodeInterpreterInterceptionLogger,
+)
+
+os.environ["E2B_API_KEY"] = "e2b_..."
+os.environ["OPENAI_API_KEY"] = "sk-..."
+
+register_sandbox_tools([
+    {
+        "sandbox_tool_name": "my-e2b",
+        "litellm_params": {
+            "sandbox_provider": "e2b",
+            "api_key": "os.environ/E2B_API_KEY",
+        },
+    }
+])
+
+litellm.callbacks = [
+    CodeInterpreterInterceptionLogger(
+        enabled_providers=["openai"],
+        sandbox_tool_name="my-e2b",
+    )
+]
+
+response = await litellm.aresponses(
+    model="openai/gpt-5",
+    tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+    input="Product of first 6 primes. Just the number.",
+)
+print(response.output_text)
+```
+
+### Proxy setup
 
 #### 1. Set keys
 
@@ -198,22 +237,6 @@ response = client.responses.create(
     model="gpt-5",
     tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
     input="Product of first 6 primes. Just the number.",
-)
-print(response.output_text)
-```
-
-</TabItem>
-<TabItem value="litellm" label="LiteLLM SDK">
-
-```python
-import litellm
-
-response = await litellm.aresponses(
-    model="openai/gpt-5",
-    tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
-    input="Product of first 6 primes. Just the number.",
-    api_base="http://localhost:4000",
-    api_key="sk-1234",
 )
 print(response.output_text)
 ```


### PR DESCRIPTION
## Summary

Follow-up to [litellm-docs#385](https://github.com/BerriAI/litellm-docs/pull/385). The merged page only covered the proxy path for the code interpreter interceptor, so an SDK reader had to guess how to wire the callback. Two additions:

**SDK section** under `## Responses API code interpreter interceptor`: a single Python block showing `register_sandbox_tools(...)` + `litellm.callbacks = [CodeInterpreterInterceptionLogger(enabled_providers=["openai"], sandbox_tool_name="my-e2b")]` + `litellm.aresponses(model="openai/gpt-5", tools=[{"type": "code_interpreter", ...}], input=...)`. No proxy needed; the interceptor swaps the native `code_interpreter` tool for `litellm_code_execution`, runs the emitted code through the phase 1 sandbox primitive, and continues the agentic loop.

**Tabs in proxy step 4**: the "Call /v1/responses" step now shows curl and OpenAI SDK side by side, so an OpenAI SDK reader pointed at `localhost:4000/v1` gets a copy-paste-able call. LiteLLM-SDK-pointed-at-proxy was dropped from this tab set since the standalone SDK section above covers the LiteLLM SDK case without the proxy hop.

## Test plan

- [x] `npm start` and verify the new SDK section renders at `http://localhost:3002/docs/sandbox#sdk`
- [x] curl and OpenAI SDK tabs render at `#4-call-v1responses`
- [x] Imports, callbacks, and `register_sandbox_tools` signature match BerriAI/litellm#30905