### PR TITLE
docs(config): document LITELLM_DISABLE_ACCESS_LOG_PATHS env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -915,6 +915,7 @@ router_settings:
 | LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRY_TIMEOUT | Timeout for retries of parallel requests in LiteLLM
 | LITELLM_DISABLE_LAZY_LOADING | When set to "1", "true", "yes", or "on", disables lazy loading of attributes (currently only affects encoding/tiktoken). This ensures encoding is initialized before VCR starts recording HTTP requests, fixing VCR cassette creation issues. See [issue #18659](https://github.com/BerriAI/litellm/issues/18659)
 | LITELLM_DISABLE_REDACT_SECRETS | When set to "true", disables automatic redaction of secrets (API keys, tokens, credentials) from proxy log output. Secret redaction is enabled by default.
+| LITELLM_DISABLE_ACCESS_LOG_PATHS | Comma-separated list of exact request paths whose uvicorn access-log lines should be dropped (e.g. health checks, root probes, metrics scrapes that flood logs). Path is matched against the portion before any query string. Empty/unset disables filtering.
 | LITELLM_MIGRATION_DIR | Custom migrations directory for prisma migrations, used for baselining db in read-only file systems.
 | LITELLM_HOSTED_UI | URL of the hosted UI for LiteLLM
 | LITELLM_UI_API_DOC_BASE_URL | Optional override for the API Reference base URL (used in sample code/docs) when the admin UI runs on a different host than the proxy. Defaults to `PROXY_BASE_URL` when unset.


### PR DESCRIPTION
Adds the missing reference-table row for `LITELLM_DISABLE_ACCESS_LOG_PATHS` in `docs/proxy/config_settings.md`.

This env var was added to litellm in BerriAI/litellm#30818 (read in `litellm/_logging.py` via `os.getenv`). The litellm `documentation_test_env_keys` check (run by the `documentation` and `code-quality` jobs) checks out this docs repo at `main`, scans litellm source for `os.getenv` keys, and asserts every key is listed in the `### environment variables - Reference` table here. Because this var was never documented, that check fails on every litellm PR built on the current base, not just one.

The description matches the behavior in `litellm/_logging.py`: a comma-separated list of exact request paths whose uvicorn access-log lines are dropped, matched against the path before any query string, empty/unset disables filtering.

Verification: copying this patched `config_settings.md` into the CI layout and running `python ./tests/documentation_tests/test_env_keys.py` from litellm exits 0 with "All keys are documented".

https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9