### PR TITLE
docs(you_com): use canonical YDC_API_KEY (note YOUCOM_API_KEY fallback)

### DIFF
--- a/docs/search/you_com.md
+++ b/docs/search/you_com.md
@@ -9,7 +9,7 @@ You.com offers two tiers:
 | **Keyless free tier** (default) | `https://api.you.com/v1/agents/search` | none | IP-throttled, ~100 queries/day |
 | **Keyed tier** | `https://ydc-index.io/v1/search` | `X-API-Key` | higher rate limits |
 
-If `YOUCOM_API_KEY` is not set, the adapter automatically uses the keyless endpoint — no signup required to start.
+If `YDC_API_KEY` is not set, the adapter automatically uses the keyless endpoint — no signup required to start. (The legacy `YOUCOM_API_KEY` is also accepted as a fallback.)
 
 ## LiteLLM Python SDK
 
@@ -35,7 +35,7 @@ for result in response.results:
 import os
 from litellm import search
 
-os.environ["YOUCOM_API_KEY"] = "sk-..."
+os.environ["YDC_API_KEY"] = "sk-..."  # legacy YOUCOM_API_KEY also accepted
 
 response = search(
     query="latest AI developments",
@@ -60,7 +60,7 @@ search_tools:
     litellm_params:
       search_provider: you_com
       # api_key optional - omit to use the keyless free tier
-      api_key: os.environ/YOUCOM_API_KEY
+      api_key: os.environ/YDC_API_KEY
 ```
 
 ### 2. Start the proxy


### PR DESCRIPTION
## What

Update the You.com Search docs to use the canonical `YDC_API_KEY` environment variable, keeping the legacy `YOUCOM_API_KEY` noted as an accepted fallback.

## Why

`YDC_API_KEY` is You.com's canonical API key env var (used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations). This pairs with the code change in BerriAI/litellm#31256, which makes the `you_com` provider prefer `YDC_API_KEY` while still accepting `YOUCOM_API_KEY`.

## Changes
- Intro note, Python SDK example, and gateway config example now use `YDC_API_KEY`.
- Backward compatibility with `YOUCOM_API_KEY` is called out.

Part of youdotcom-oss/integration-tracking#30
