### PR TITLE
docs(generateContent): document native top-level request fields

### DIFF
--- a/docs/generateContent.md
+++ b/docs/generateContent.md
@@ -232,6 +232,65 @@ curl -L -X POST 'http://localhost:4000/v1beta/models/gemini-flash:streamGenerate
 </Tabs>
 
 
+## Native request fields
+
+The `generateContent` endpoint is a drop-in for Google's [Generative Language REST API](https://ai.google.dev/api/generate-content), so the top-level fields that Google's `GenerateContentRequest` carries as siblings of `generationConfig` are forwarded to Google verbatim. This covers `safetySettings`, `toolConfig`, `cachedContent`, and `labels`. Send them at the top level of the request body exactly as you would when calling Google directly; there is no need to wrap them in `extra_body`. If you do pass `extra_body`, an explicit value there wins on conflict.
+
+<Tabs>
+<TabItem value="curl-native" label="curl">
+
+```bash showLineNumbers title="Native top-level fields via LiteLLM Proxy"
+curl -L -X POST 'http://localhost:4000/v1beta/models/gemini-flash:generateContent' \
+-H 'content-type: application/json' \
+-H 'authorization: Bearer sk-1234' \
+-d '{
+  "contents": [
+    {
+      "parts": [{"text": "Say hi"}],
+      "role": "user"
+    }
+  ],
+  "generationConfig": {
+    "maxOutputTokens": 100
+  },
+  "safetySettings": [
+    {
+      "category": "HARM_CATEGORY_HATE_SPEECH",
+      "threshold": "BLOCK_NONE"
+    }
+  ],
+  "toolConfig": {
+    "functionCallingConfig": {"mode": "AUTO"}
+  }
+}'
+```
+
+</TabItem>
+
+<TabItem value="sdk-native" label="LiteLLM Python SDK">
+
+```python showLineNumbers title="Native top-level fields via LiteLLM Python SDK"
+from litellm.google_genai import generate_content
+import os
+
+# Set API key
+os.environ["GEMINI_API_KEY"] = "your-gemini-api-key"
+
+response = generate_content(
+    model="gemini/gemini-2.0-flash",
+    contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+    safetySettings=[
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+    ],
+    toolConfig={"functionCallingConfig": {"mode": "AUTO"}},
+)
+print(response)
+```
+
+</TabItem>
+</Tabs>
+
+
 ## Related 
 
 - [Use LiteLLM with gemini-cli](../docs/tutorials/litellm_gemini_cli)


### PR DESCRIPTION
Follows up BerriAI/litellm#31235, which made the proxy's native `generateContent` endpoint forward Google's top-level `GenerateContentRequest` fields (`safetySettings`, `toolConfig`, `cachedContent`, `labels`) verbatim instead of dropping them. Before that fix, callers had to wrap these fields in `extra_body` for them to reach Google.

This documents the behavior on the `/generateContent` page with a new "Native request fields" section. It explains that the endpoint is a drop-in for Google's Generative Language REST API, so these fields can be sent at the top level alongside `generationConfig` without wrapping them in `extra_body`, and that an explicit `extra_body` value still wins on conflict. The section shows both a curl example against the proxy and the equivalent LiteLLM Python SDK call.

Verified with `npm run build`; the only reported warnings are pre-existing broken anchors in unrelated `release_notes` pages.

This is the docs follow-up requested by a maintainer on BerriAI/litellm#31235 so users tracking BerriAI/litellm#12671 can discover the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
