### PR TITLE
docs(deprecations): migration guide for the August 25, 2026 deprecations

### DIFF
--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -51,6 +51,4 @@ We're consolidating the PyPI and Docker packages down to a single `litellm` pack
 
 If you use any of the above, follow the [Deprecations migration guide](https://docs.litellm.ai/docs/deprecations). Most paths are a one-line config change. If you're unsure whether you're affected, reach out and we'll check for you.
 
-<!-- TODO: add the canonical feedback channel (email / GitHub discussion / Slack) once confirmed. -->
-
 Thanks for building on LiteLLM.

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -21,10 +21,10 @@ This list is not final. If you depend on something here and want it to stay, rea
 
 | Feature | Why it's going | What to use instead |
 | --- | --- | --- |
-| Workflows | Low usage | None |
-| Memory | Low usage | None |
-| Playground's Agent Builder | Low usage | None |
-| Prompt Management | Low usage | Langfuse or Arize Prompt Management |
+| Workflows | Experimental feature, did not get usage | None |
+| Memory | Experimental feature, did not get usage | None |
+| Playground's Agent Builder | Experimental feature, did not get usage | None |
+| Prompt Management | Experimental feature, did not get usage | Langfuse or Arize Prompt Management |
 | Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
 | API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |
 | Learning Resources | Low usage | None |

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -24,7 +24,7 @@ This list is not final. If you depend on something here and want it to stay, rea
 | Workflows | Low usage | None |
 | Memory | Low usage | None |
 | Playground's Agent Builder | Low usage | None |
-| Prompt Management | Doubling down on the core AI gateway, spend tracking, and guardrails | Langfuse or Arize Prompt Management |
+| Prompt Management | Low usage | Langfuse or Arize Prompt Management |
 | Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
 | API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |
 | Learning Resources | Low usage | None |

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 We're focusing LiteLLM on being the most reliable LLM gateway in production. As part of that, we're retiring a set of older features and integrations that few teams use and that we can no longer maintain to the standard you expect. Removing them keeps the core of LiteLLM stable and performant.
 
-These features are targeted for removal in the release on **August 25, 2026**, roughly 60 days from now. If you don't use any of them, nothing changes and you can stop reading. If you do, the full [Deprecations migration guide](/deprecations) walks through each one; most paths are a one-line config change.
+These features are targeted for removal in the release on **August 25, 2026**, roughly 60 days from now. If you don't use any of them, nothing changes and you can stop reading. If you do, the full [Deprecations migration guide](https://docs.litellm.ai/docs/deprecations) walks through each one; most paths are a one-line config change.
 
 This list is not final. If you depend on something here and want it to stay, reach out with the feature and your use case.
 
@@ -52,7 +52,7 @@ We're consolidating the PyPI and Docker packages down to a single `litellm` pack
 
 ## What you need to do
 
-If you use any of the above, follow the [Deprecations migration guide](/deprecations). Most paths are a one-line config change. If you're unsure whether you're affected, reach out and we'll check for you.
+If you use any of the above, follow the [Deprecations migration guide](https://docs.litellm.ai/docs/deprecations). Most paths are a one-line config change. If you're unsure whether you're affected, reach out and we'll check for you.
 
 <!-- TODO: add the canonical feedback channel (email / GitHub discussion / Slack) once confirmed. -->
 

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -24,7 +24,7 @@ This list is not final. If you depend on something here and want it to stay, rea
 | Workflows | Experimental feature, did not get usage | None |
 | Memory | Experimental feature, did not get usage | None |
 | Playground's Agent Builder | Experimental feature, did not get usage | None |
-| Prompt Management | Experimental feature, did not get usage | Langfuse or Arize Prompt Management |
+| Prompt Management | Experimental feature, did not get usage | None |
 | Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
 | API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |
 | Learning Resources | Low usage | None |

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -40,7 +40,6 @@ This list is not final. If you depend on something here and want it to stay, rea
 | S3 logging v1 | Superseded by S3 logging v2 | S3 logging v2 |
 | OpenTelemetry v1 | Superseded by OTEL v2 | OTEL v2 |
 | Disk caching | Low usage; can't maintain to standard | None |
-| Auto Router v1 | Superseded by Auto Router v2 | Auto Router v2 |
 | CloudZero connector | Replaced by the OTEL v2 connector | OTEL v2 connector |
 | Prisma resolve v1 | Superseded by the v2 migration resolver | Prisma resolver v2 |
 

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -21,9 +21,9 @@ This list is not final. If you depend on something here and want it to stay, rea
 
 | Feature | Why it's going | What to use instead |
 | --- | --- | --- |
-| Workflows | Experimental feature, did not get usage | None |
-| Memory | Experimental feature, did not get usage | None |
-| Playground's Agent Builder | Experimental feature, did not get usage | None |
+| Workflows | Low usage | None |
+| Memory | Low usage | None |
+| Playground's Agent Builder | Low usage | None |
 | Prompt Management | Doubling down on the core AI gateway, spend tracking, and guardrails | Langfuse or Arize Prompt Management |
 | Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
 | API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -1,0 +1,59 @@
+---
+slug: august-2026-deprecations
+title: "Deprecation notice: features being retired in the August 25, 2026 release"
+date: 2026-06-25
+authors:
+  - ryan
+description: "We're retiring a set of older, low-usage features and integrations in the August 25, 2026 release. You have ~60 days to migrate. Most paths are a one-line config change; full migration guide included."
+tags: [deprecations, packaging]
+hide_table_of_contents: false
+---
+
+We're focusing LiteLLM on being the most reliable LLM gateway in production. As part of that, we're retiring a set of older features and integrations that few teams use and that we can no longer maintain to the standard you expect. Removing them keeps the core of LiteLLM stable and performant.
+
+These features are targeted for removal in the release on **August 25, 2026**, roughly 60 days from now. If you don't use any of them, nothing changes and you can stop reading. If you do, the full [Deprecations migration guide](/deprecations) walks through each one; most paths are a one-line config change.
+
+This list is not final. If you depend on something here and want it to stay, reach out with the feature and your use case.
+
+{/* truncate */}
+
+## Dashboard features going away
+
+| Feature | Why it's going | What to use instead |
+| --- | --- | --- |
+| Workflows | Experimental feature, did not get usage | None |
+| Memory | Experimental feature, did not get usage | None |
+| Playground's Agent Builder | Experimental feature, did not get usage | None |
+| Prompt Management | Doubling down on the core AI gateway, spend tracking, and guardrails | Langfuse or Arize Prompt Management |
+| Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
+| API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |
+| Learning Resources | Low usage | None |
+| MCP Network Settings + "Internal network only" flag | TBD | TBD |
+
+<!-- TODO: confirm MCP Network Settings scope and replacement before publishing -->
+
+## Integrations and backends going away
+
+| Feature | Why it's going | What to use instead |
+| --- | --- | --- |
+| GreenScale logging | Low usage; can't maintain to standard | None |
+| DynamoDB as a proxy database | Can't maintain to our reliability bar as a proxy database | PostgreSQL |
+| Gradient AI provider | Upstream service was discontinued | None |
+| S3 logging v1 | Superseded by S3 logging v2 | S3 logging v2 |
+| OpenTelemetry v1 | Superseded by OTEL v2 | OTEL v2 |
+| Disk caching | Low usage; can't maintain to standard | None |
+| Auto Router v1 | Superseded by Auto Router v2 | Auto Router v2 |
+| CloudZero connector | Replaced by the OTEL v2 connector | OTEL v2 connector |
+| Prisma resolve v1 | Superseded by the v2 migration resolver | Prisma resolver v2 |
+
+## Packaging change
+
+We're consolidating the PyPI and Docker packages down to a single `litellm` package. The extra variants (`litellm-database`, `litellm-ee`, `litellm-dev`, `litellm-non_root`) are going away. The `litellm` package will be the only supported package going forward and will absorb the functionality from `litellm-database` and `litellm-non_root`.
+
+## What you need to do
+
+If you use any of the above, follow the [Deprecations migration guide](/deprecations). Most paths are a one-line config change. If you're unsure whether you're affected, reach out and we'll check for you.
+
+<!-- TODO: add the canonical feedback channel (email / GitHub discussion / Slack) once confirmed. -->
+
+Thanks for building on LiteLLM.

--- a/blog/august_2026_deprecations/index.md
+++ b/blog/august_2026_deprecations/index.md
@@ -28,9 +28,7 @@ This list is not final. If you depend on something here and want it to stay, rea
 | Old Usage page | Replaced by a faster, more accurate Usage dashboard | New Usage dashboard |
 | API Reference tab | Replaced by a guided getting-started flow | Guided getting-started flow |
 | Learning Resources | Low usage | None |
-| MCP Network Settings + "Internal network only" flag | TBD | TBD |
-
-<!-- TODO: confirm MCP Network Settings scope and replacement before publishing -->
+| MCP Network Settings + "Internal network only" flag | Not core, and inherently insecure as a network control | Filter at a load balancer; gate public vs private MCP servers with teams |
 
 ## Integrations and backends going away
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -31,7 +31,7 @@ ishaan-alt:
 
 ryan:
   name: Ryan Crabbe
-  title: Performance Engineer, LiteLLM
+  title: Software Engineer, LiteLLM
   url: https://www.linkedin.com/in/ryan-crabbe-0b9687214
   image_url: https://github.com/ryan-crabbe-berri.png
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -33,7 +33,7 @@ ryan:
   name: Ryan Crabbe
   title: Performance Engineer, LiteLLM
   url: https://www.linkedin.com/in/ryan-crabbe-0b9687214
-  image_url: https://media.licdn.com/dms/image/v2/D5603AQHt1t9Z4BJ6Gw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1724453682340?e=1772064000&v=beta&t=VXdmr13rsNB05wyA2F1TENOB5UuDHUZ0FCHTolNyR5M
+  image_url: https://github.com/ryan-crabbe-berri.png
 
 alexsander:
   name: Alexsander Hamir

--- a/blog/cleaner_release_versions/index.md
+++ b/blog/cleaner_release_versions/index.md
@@ -22,7 +22,7 @@ The legacy `main-stable` Docker tag still advances each week so existing deploym
 - **Reproducible pin (Docker)** → `ghcr.io/berriai/litellm:1.84.0`
 - **Reproducible pin (PyPI)** → `pip install litellm==1.84.0`
 
-This banner will be updated with reminders as the cutover approaches.
+This banner will be updated with reminders as the cutover approaches. See the [full list of deprecated Docker tags](/docs/deprecations#docker-tags) for every tag and its replacement.
 :::
 
 LiteLLM release version names are changing. Two pain points have been driving this:

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -59,8 +59,6 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 **Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
-<!-- TODO: optional note on what users had built with it, if anything to preserve. -->
-
 ### Memory
 
 **Feature docs:** [Memory Management](/docs/proxy/memory), [/memory API](/docs/memory_management)
@@ -110,8 +108,6 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** none. Low usage; can no longer be maintained to the expected standard.
 
-<!-- TODO: how to remove the greenscale callback from config -->
-
 ### DynamoDB as a proxy database
 
 **Replacement:** PostgreSQL.
@@ -121,7 +117,6 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 **Feature docs:** [GradientAI](/docs/providers/gradient_ai)
 
 **Replacement:** none. The upstream service was discontinued.
-<!-- TODO: provider prefix being removed; what calls will stop working -->
 
 ### S3 logging v1
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -49,6 +49,7 @@ The tables below list every deprecation, its replacement, and whether you need t
 | Change | Replacement | Migration needed |
 | --- | --- | --- |
 | [Package consolidation](#package-consolidation) | Single `litellm` package | Yes |
+| [Docker tags](#docker-tags) | `latest`, `main-latest`, `rc` | Yes |
 
 ---
 
@@ -175,6 +176,21 @@ litellm_settings:
 We're consolidating the PyPI and Docker packages down to a single `litellm` package. The extra variants (`litellm-database`, `litellm-ee`, `litellm-dev`, `litellm-non_root`) are going away. The `litellm` package will be the only supported package going forward and will absorb the functionality from `litellm-database` and `litellm-non_root`.
 
 The exact migration path and timeline for this change are still being finalized; we'll update this section once they're confirmed.
+
+### Docker tags
+
+We're consolidating the Docker image tags. Switch to the replacement tag below; `latest` tracks the newest stable image, `main-latest` tracks the newest build off `main`, and `rc` tracks the newest release candidate.
+
+| Deprecated tag | Switch to |
+| --- | --- |
+| `main-stable` | `latest` |
+| `latest-stable` | `latest` |
+| `main` | `latest` |
+| `main-test` | `latest` |
+| `dev` | `main-latest` |
+| `main-dev` | `main-latest` |
+| `main-nightly` | `main-latest` |
+| `main-rc` | `rc` |
 
 ---
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -162,9 +162,9 @@ litellm_settings:
 **Replacement:** the [OTEL v2 connector](/docs/observability/opentelemetry_v2).
 
 
-### Prisma resolve v1
+### Prisma resolver v1
 
-**Replacement:** the v2 migration resolver.
+**Replacement:** the v2 migration resolver. No changes needed, this will be flipped to be the default. 
 
 ---
 
@@ -182,7 +182,6 @@ The exact migration path and timeline for this change are still being finalized;
 
 This list is not final. If you depend on something here and want it to stay, reach out with the feature and your use case.
 
-- GitHub: https://github.com/BerriAI/litellm/issues
-- Email: ishaan@berri.ai / krrish@berri.ai
+- GitHub: <i want to have a specific github issue here on the berriai/litellm repo> 
 - Discord: https://discord.gg/wuPM9dRgDw
 - Slack: https://www.litellm.ai/support

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -179,7 +179,7 @@ The exact migration path and timeline for this change are still being finalized;
 
 ### Docker tags
 
-We're consolidating the Docker image tags. This change follows the timeline from [LiteLLM release versioning is changing](/blog/cleaner-release-versions), not the August 25 date used elsewhere on this page: the legacy tags stop publishing on **June 30, 2026**. Switch to the replacement tag below; `latest` tracks the newest stable image, `main-latest` tracks the newest build off `main`, and `rc` tracks the newest release candidate.
+We're consolidating the Docker image tags; the legacy tags stop publishing in the **August 25, 2026** release, in line with the rest of this page. See [LiteLLM release versioning is changing](/blog/cleaner-release-versions) for background. Switch to the replacement tag below; `latest` tracks the newest stable image, `main-latest` tracks the newest build off `main`, and `rc` tracks the newest release candidate.
 
 | Deprecated tag | Switch to |
 | --- | --- |

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -25,7 +25,7 @@ The tables below list every deprecation, its replacement, and whether there is a
 | [Old Usage page](#old-usage-page) | New Usage dashboard | Yes |
 | [API Reference tab](#api-reference-tab) | Guided getting-started flow | Yes |
 | [Learning Resources](#learning-resources) | None | No |
-| [MCP Network Settings + "Internal network only" flag](#mcp-network-settings) | TBD | TBD |
+| [MCP Network Settings + "Internal network only" flag](#mcp-network-settings) | Load balancer filtering; teams to gate public/private MCPs | Yes |
 
 ### Integrations and backends
 
@@ -100,11 +100,16 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### MCP Network Settings
 
-The MCP "Network Settings" panel and the "Internal network only" flag.
+The MCP "Network Settings" panel and the "Internal network only" flag. This was never core to the gateway and the flag is inherently insecure as a network control.
 
-**Replacement:** TBD.
+**Replacement:** filter MCP access at a load balancer instead of relying on the in-app flag. If you need to expose some MCP servers publicly and keep others private, gate them with teams.
 
-<!-- TODO: details pending. Confirm scope and replacement before publishing. -->
+<!-- TODO: migration guide
+- What the "Internal network only" flag did
+- How to replicate it with a load balancer (filtering rules)
+- How to gate public vs private MCP servers with teams
+- Before / after config
+-->
 
 ---
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -160,7 +160,7 @@ litellm_settings:
 
 **Feature docs:** [CloudZero Integration](/docs/observability/cloudzero)
 
-**Replacement:** the OTEL v2 connector.
+**Replacement:** the [OTEL v2 connector](/docs/observability/opentelemetry_v2).
 
 
 ### Prisma resolve v1

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -59,6 +59,8 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Memory
 
+**Feature docs:** [Memory Management](/docs/proxy/memory), [/memory API](/docs/memory_management)
+
 **Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO -->
@@ -70,6 +72,8 @@ The tables below list every deprecation, its replacement, and whether there is a
 <!-- TODO -->
 
 ### Prompt Management
+
+**Feature docs:** [LiteLLM AI Gateway Prompt Management](/docs/proxy/litellm_prompt_management)
 
 **Replacement:** none. Experimental feature with little usage. There is no migration path; remove any reliance on it before August 25, 2026.
 
@@ -100,6 +104,8 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### MCP Network Settings
 
+**Feature docs:** [Exposing MCPs on the Public Internet](/docs/mcp_public_internet)
+
 The MCP "Network Settings" panel and the "Internal network only" flag. This was never core to the gateway and the flag is inherently insecure as a network control.
 
 **Replacement:** filter MCP access at a load balancer instead of relying on the in-app flag. If you need to expose some MCP servers publicly and keep others private, gate them with teams.
@@ -116,6 +122,8 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 ## Integrations and backends
 
 ### GreenScale logging
+
+**Feature docs:** [Greenscale](/docs/observability/greenscale_integration)
 
 **Replacement:** none. Low usage; can no longer be maintained to the expected standard.
 
@@ -134,11 +142,15 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 ### Gradient AI provider
 
+**Feature docs:** [GradientAI](/docs/providers/gradient_ai)
+
 **Replacement:** none. The upstream service was discontinued.
 
 <!-- TODO: provider prefix being removed; what calls will stop working -->
 
 ### S3 logging v1
+
+**Feature docs:** [S3 logging](/docs/proxy/logging#s3-buckets)
 
 **Replacement:** S3 logging v2.
 
@@ -149,6 +161,8 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 -->
 
 ### OpenTelemetry v1
+
+**Feature docs:** [OpenTelemetry](/docs/observability/opentelemetry_integration). Replacement: [OTEL v2](/docs/observability/opentelemetry_v2).
 
 **Replacement:** OTEL v2.
 
@@ -161,11 +175,15 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 ### Disk caching
 
+**Feature docs:** [Disk Cache](/docs/proxy/caching)
+
 **Replacement:** none. Low usage; can no longer be maintained to the expected standard.
 
 <!-- TODO: which cache_params type is going away and what to remove -->
 
 ### Auto Router v1
+
+**Feature docs:** [Auto Routing](/docs/proxy/auto_routing)
 
 **Replacement:** Auto Router v2.
 
@@ -176,6 +194,8 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 -->
 
 ### CloudZero connector
+
+**Feature docs:** [CloudZero Integration](/docs/observability/cloudzero)
 
 **Replacement:** the OTEL v2 connector.
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -179,7 +179,7 @@ The exact migration path and timeline for this change are still being finalized;
 
 ### Docker tags
 
-We're consolidating the Docker image tags. Switch to the replacement tag below; `latest` tracks the newest stable image, `main-latest` tracks the newest build off `main`, and `rc` tracks the newest release candidate.
+We're consolidating the Docker image tags. This change follows the timeline from [LiteLLM release versioning is changing](/blog/cleaner-release-versions), not the August 25 date used elsewhere on this page: the legacy tags stop publishing on **June 30, 2026**. Switch to the replacement tag below; `latest` tracks the newest stable image, `main-latest` tracks the newest build off `main`, and `rc` tracks the newest release candidate.
 
 | Deprecated tag | Switch to |
 | --- | --- |

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -2,7 +2,7 @@
 
 This page is the migration guide for the features and integrations being retired in the **August 25, 2026** release. The deprecations were announced on June 25, 2026, giving roughly 60 days of notice.
 
-If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
+If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
 
 :::info Removal date
 
@@ -53,19 +53,19 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Workflows
 
-**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO: optional note on what users had built with it, if anything to preserve. -->
 
 ### Memory
 
-**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO -->
 
 ### Playground's Agent Builder
 
-**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO -->
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,8 +1,8 @@
 # Deprecations
 
-This page is the migration guide for the features and integrations targeting to be retired in the **August 25, 2026** release. 
+This page is the migration guide for the features and integrations targeting to be retired in the **August 25, 2026** release. This is a living document; we'll keep it updated as plans firm up and as we incorporate your feedback. 
 
-If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
+If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and where to move. Where a replacement exists, its own docs cover the migration steps; the rest are experimental or low-usage features with no replacement, so the guidance is simply to stop relying on them before the removal date.
 
 :::info Want to keep a feature?
 
@@ -17,11 +17,11 @@ If you use one of these and want it to stay, reach out:
 
 ## What's being deprecated
 
-The tables below list every deprecation, its replacement, and whether there is a migration guide on this page. Items marked "No" have no replacement right now. 
+The tables below list every deprecation, its replacement, and whether you need to migrate. Where migration is needed, the replacement's own docs cover the steps. Items marked "No" have no replacement; the action is to stop using them before the removal date. 
 
 ### Dashboard features
 
-| Feature | Replacement | Migration guide |
+| Feature | Replacement | Migration needed |
 | --- | --- | --- |
 | [Workflows](#workflows) | None | No |
 | [Memory](#memory) | None | No |
@@ -34,7 +34,7 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Integrations and backends
 
-| Feature | Replacement | Migration guide |
+| Feature | Replacement | Migration needed |
 | --- | --- | --- |
 | [GreenScale logging](#greenscale-logging) | None | No |
 | [DynamoDB as a proxy database](#dynamodb-as-a-proxy-database) | PostgreSQL | Yes |
@@ -47,7 +47,7 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Packaging
 
-| Change | Replacement | Migration guide |
+| Change | Replacement | Migration needed |
 | --- | --- | --- |
 | [Package consolidation](#package-consolidation) | Single `litellm` package | Yes |
 
@@ -144,9 +144,9 @@ litellm_settings:
 
 ### OpenTelemetry v1
 
-**Feature docs:** [OpenTelemetry](/docs/observability/opentelemetry_integration). Replacement: [OTEL v2](/docs/observability/opentelemetry_v2).
+**Feature docs:** [OpenTelemetry](/docs/observability/opentelemetry_integration)
 
-**Replacement:** OTEL v2.
+**Replacement:** migrate to [OTEL v2](/docs/observability/opentelemetry_v2); that guide covers the setup.
 
 
 ### Disk caching
@@ -174,6 +174,8 @@ litellm_settings:
 ### Package consolidation
 
 We're consolidating the PyPI and Docker packages down to a single `litellm` package. The extra variants (`litellm-database`, `litellm-ee`, `litellm-dev`, `litellm-non_root`) are going away. The `litellm` package will be the only supported package going forward and will absorb the functionality from `litellm-database` and `litellm-non_root`.
+
+The exact migration path and timeline for this change are still being finalized; we'll update this section once they're confirmed.
 
 ---
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,18 +1,18 @@
 # Deprecations
 
-This page is the migration guide for the features and integrations being retired in the **August 25, 2026** release. The deprecations were announced on June 25, 2026, giving roughly 60 days of notice.
+This page is the migration guide for the features and integrations targeting to be retired in the **August 25, 2026** release. 
 
 If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
 
 :::info Removal date
 
-All items on this page are removed in the release shipping on **August 25, 2026**. The exact version number is TBD; this note will be updated once it's pinned.
+If you use one of these features and you would like to advocate to keep them, please go to this github discussion here or email us at 
 
 :::
 
 ## What's being deprecated
 
-The tables below list every deprecation, its replacement, and whether there is a migration guide on this page. Items marked "No" have no replacement; the action is to stop using them.
+The tables below list every deprecation, its replacement, and whether there is a migration guide on this page. Items marked "No" have no replacement right now. 
 
 ### Dashboard features
 
@@ -21,7 +21,7 @@ The tables below list every deprecation, its replacement, and whether there is a
 | [Workflows](#workflows) | None | No |
 | [Memory](#memory) | None | No |
 | [Playground's Agent Builder](#playgrounds-agent-builder) | None | No |
-| [Prompt Management](#prompt-management) | Langfuse / Arize Prompt Management | Yes |
+| [Prompt Management](#prompt-management) | None | No |
 | [Old Usage page](#old-usage-page) | New Usage dashboard | Yes |
 | [API Reference tab](#api-reference-tab) | Guided getting-started flow | Yes |
 | [Learning Resources](#learning-resources) | None | No |
@@ -71,15 +71,7 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Prompt Management
 
-**Replacement:** Langfuse Prompt Management or Arize Prompt Management.
-
-<!-- TODO: migration guide
-- Who is affected (who uses native prompt management today)
-- What changes
-- Steps to move prompts to Langfuse / Arize
-- Links: Langfuse integration doc, Arize integration doc
-- Before / after config
--->
+**Replacement:** none. Experimental feature with little usage. There is no migration path; remove any reliance on it before August 25, 2026.
 
 ### Old Usage page
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -42,7 +42,7 @@ The tables below list every deprecation, its replacement, and whether you need t
 | [OpenTelemetry v1](#opentelemetry-v1) | OTEL v2 | Yes |
 | [Disk caching](#disk-caching) | None | No |
 | [CloudZero connector](#cloudzero-connector) | OTEL v2 connector | Yes |
-| [Prisma resolve v1](#prisma-resolve-v1) | Prisma resolver v2 | Yes |
+| [Prisma resolver v1](#prisma-resolver-v1) | Prisma resolver v2 | No |
 
 ### Packaging
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -4,9 +4,14 @@ This page is the migration guide for the features and integrations targeting to 
 
 If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
 
-:::info Removal date
+:::info Want to keep a feature?
 
-If you use one of these features and you would like to advocate to keep them, please go to this github discussion here or email us at 
+If you use one of these and want it to stay, reach out:
+
+- GitHub: https://github.com/BerriAI/litellm/issues
+- Email: ishaan@berri.ai / krrish@berri.ai
+- Discord: https://discord.gg/wuPM9dRgDw
+- Slack: https://www.litellm.ai/support 
 
 :::
 
@@ -62,13 +67,9 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 **Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
 
-<!-- TODO -->
-
 ### Playground's Agent Builder
 
 **Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
-
-<!-- TODO -->
 
 ### Prompt Management
 
@@ -80,26 +81,16 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 **Replacement:** the new Usage dashboard.
 
-<!-- TODO: migration guide
-- What's different in the new dashboard
-- Where to find it in the UI
-- Anything that does NOT carry over
--->
 
 ### API Reference tab
 
 **Replacement:** the guided getting-started flow.
 
-<!-- TODO: migration guide
-- Where the guided flow lives
-- How to reach the API reference content people relied on (link to hosted API docs?)
--->
 
 ### Learning Resources
 
 **Replacement:** none. Low usage. No action required beyond not depending on the tab.
 
-<!-- TODO -->
 
 ### MCP Network Settings
 
@@ -108,13 +99,6 @@ The tables below list every deprecation, its replacement, and whether there is a
 The MCP "Network Settings" panel and the "Internal network only" flag. This was never core to the gateway and the flag is inherently insecure as a network control.
 
 **Replacement:** filter MCP access at a load balancer instead of relying on the in-app flag. If you need to expose some MCP servers publicly and keep others private, gate them with teams.
-
-<!-- TODO: migration guide
-- What the "Internal network only" flag did
-- How to replicate it with a load balancer (filtering rules)
-- How to gate public vs private MCP servers with teams
-- Before / after config
--->
 
 ---
 
@@ -132,19 +116,11 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** PostgreSQL.
 
-<!-- TODO: migration guide
-- Confirm what "DynamoDB as a proxy database" covers today
-- Postgres setup (DATABASE_URL)
-- Data migration considerations, if any
-- Before / after config
--->
-
 ### Gradient AI provider
 
 **Feature docs:** [GradientAI](/docs/providers/gradient_ai)
 
 **Replacement:** none. The upstream service was discontinued.
-
 <!-- TODO: provider prefix being removed; what calls will stop working -->
 
 ### S3 logging v1
@@ -153,11 +129,23 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** S3 logging v2.
 
-<!-- TODO: migration guide
-- Old callback vs new callback
-- Config diff (s3 -> s3_v2 and params block)
-- Before / after config
--->
+**Migration:** switch the callback from `s3` to `s3_v2`. The `s3_callback_params` keys and the AWS env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME`) are unchanged.
+
+```yaml
+# Before
+litellm_settings:
+  success_callback: ["s3"]
+  s3_callback_params:
+    s3_bucket_name: my-logs-bucket
+    s3_region_name: us-west-2
+
+# After
+litellm_settings:
+  success_callback: ["s3_v2"]
+  s3_callback_params:
+    s3_bucket_name: my-logs-bucket
+    s3_region_name: us-west-2
+``` 
 
 ### OpenTelemetry v1
 
@@ -165,12 +153,6 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** OTEL v2.
 
-<!-- TODO: migration guide
-- How to opt into v2
-- Config / env diff
-- Note: do not run v1 and v2 at the same time
-- Before / after config
--->
 
 ### Disk caching
 
@@ -178,7 +160,6 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** none. Low usage; can no longer be maintained to the expected standard.
 
-<!-- TODO: which cache_params type is going away and what to remove -->
 
 ### CloudZero connector
 
@@ -186,21 +167,10 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 **Replacement:** the OTEL v2 connector.
 
-<!-- TODO: migration guide
-- Old CloudZero connector config
-- New OTEL v2 connector config
-- Before / after config
--->
 
 ### Prisma resolve v1
 
 **Replacement:** the v2 migration resolver.
-
-<!-- TODO: migration guide
-- What the v1 resolver did
-- How to switch to v2 (flag / env var)
-- Before / after config
--->
 
 ---
 
@@ -210,17 +180,13 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 
 We're consolidating the PyPI and Docker packages down to a single `litellm` package. The extra variants (`litellm-database`, `litellm-ee`, `litellm-dev`, `litellm-non_root`) are going away. The `litellm` package will be the only supported package going forward and will absorb the functionality from `litellm-database` and `litellm-non_root`.
 
-<!-- TODO: migration guide
-- Mapping: each old package/image -> the single litellm package/image
-- What moves where (database deps, non-root, ee, dev)
-- Install / Docker tag changes (pip and ghcr.io tags)
-- Before / after install commands
--->
-
 ---
 
 ## Questions or feedback
 
 This list is not final. If you depend on something here and want it to stay, reach out with the feature and your use case.
 
-<!-- TODO: add the canonical feedback channel (email / GitHub discussion / Slack) once confirmed. -->
+- GitHub: https://github.com/BerriAI/litellm/issues
+- Email: ishaan@berri.ai / krrish@berri.ai
+- Discord: https://discord.gg/wuPM9dRgDw
+- Slack: https://www.litellm.ai/support

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -9,7 +9,6 @@ If you don't use any of the items below, nothing changes for you. If you do, eac
 If you use one of these and want it to stay, reach out:
 
 - GitHub: https://github.com/BerriAI/litellm/issues
-- Email: ishaan@berri.ai / krrish@berri.ai
 - Discord: https://discord.gg/wuPM9dRgDw
 - Slack: https://www.litellm.ai/support 
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -37,7 +37,6 @@ The tables below list every deprecation, its replacement, and whether there is a
 | [S3 logging v1](#s3-logging-v1) | S3 logging v2 | Yes |
 | [OpenTelemetry v1](#opentelemetry-v1) | OTEL v2 | Yes |
 | [Disk caching](#disk-caching) | None | No |
-| [Auto Router v1](#auto-router-v1) | Auto Router v2 | Yes |
 | [CloudZero connector](#cloudzero-connector) | OTEL v2 connector | Yes |
 | [Prisma resolve v1](#prisma-resolve-v1) | Prisma resolver v2 | Yes |
 
@@ -180,18 +179,6 @@ The MCP "Network Settings" panel and the "Internal network only" flag. This was 
 **Replacement:** none. Low usage; can no longer be maintained to the expected standard.
 
 <!-- TODO: which cache_params type is going away and what to remove -->
-
-### Auto Router v1
-
-**Feature docs:** [Auto Routing](/docs/proxy/auto_routing)
-
-**Replacement:** Auto Router v2.
-
-<!-- TODO: migration guide
-- v1 vs v2 config
-- How to opt into v2
-- Before / after config
--->
 
 ### CloudZero connector
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -2,7 +2,7 @@
 
 This page is the migration guide for the features and integrations being retired in the **August 25, 2026** release. The deprecations were announced on June 25, 2026, giving roughly 60 days of notice.
 
-If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
+If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
 
 :::info Removal date
 
@@ -53,19 +53,19 @@ The tables below list every deprecation, its replacement, and whether there is a
 
 ### Workflows
 
-**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO: optional note on what users had built with it, if anything to preserve. -->
 
 ### Memory
 
-**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO -->
 
 ### Playground's Agent Builder
 
-**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+**Replacement:** none. Low usage. Remove any reliance on it before August 25, 2026.
 
 <!-- TODO -->
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,222 @@
+# Deprecations
+
+This page is the migration guide for the features and integrations being retired in the **August 25, 2026** release. The deprecations were announced on June 25, 2026, giving roughly 60 days of notice.
+
+If you don't use any of the items below, nothing changes for you. If you do, each section explains what is going away and how to move off it. Some items have a direct replacement and a step-by-step guide; others are experimental or low-usage features with no replacement, in which case the guidance is simply to stop relying on them before the removal date.
+
+:::info Removal date
+
+All items on this page are removed in the release shipping on **August 25, 2026**. The exact version number is TBD; this note will be updated once it's pinned.
+
+:::
+
+## What's being deprecated
+
+The tables below list every deprecation, its replacement, and whether there is a migration guide on this page. Items marked "No" have no replacement; the action is to stop using them.
+
+### Dashboard features
+
+| Feature | Replacement | Migration guide |
+| --- | --- | --- |
+| [Workflows](#workflows) | None | No |
+| [Memory](#memory) | None | No |
+| [Playground's Agent Builder](#playgrounds-agent-builder) | None | No |
+| [Prompt Management](#prompt-management) | Langfuse / Arize Prompt Management | Yes |
+| [Old Usage page](#old-usage-page) | New Usage dashboard | Yes |
+| [API Reference tab](#api-reference-tab) | Guided getting-started flow | Yes |
+| [Learning Resources](#learning-resources) | None | No |
+| [MCP Network Settings + "Internal network only" flag](#mcp-network-settings) | TBD | TBD |
+
+### Integrations and backends
+
+| Feature | Replacement | Migration guide |
+| --- | --- | --- |
+| [GreenScale logging](#greenscale-logging) | None | No |
+| [DynamoDB as a proxy database](#dynamodb-as-a-proxy-database) | PostgreSQL | Yes |
+| [Gradient AI provider](#gradient-ai-provider) | None | No |
+| [S3 logging v1](#s3-logging-v1) | S3 logging v2 | Yes |
+| [OpenTelemetry v1](#opentelemetry-v1) | OTEL v2 | Yes |
+| [Disk caching](#disk-caching) | None | No |
+| [Auto Router v1](#auto-router-v1) | Auto Router v2 | Yes |
+| [CloudZero connector](#cloudzero-connector) | OTEL v2 connector | Yes |
+| [Prisma resolve v1](#prisma-resolve-v1) | Prisma resolver v2 | Yes |
+
+### Packaging
+
+| Change | Replacement | Migration guide |
+| --- | --- | --- |
+| [Package consolidation](#package-consolidation) | Single `litellm` package | Yes |
+
+---
+
+## Dashboard features
+
+### Workflows
+
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+
+<!-- TODO: optional note on what users had built with it, if anything to preserve. -->
+
+### Memory
+
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+
+<!-- TODO -->
+
+### Playground's Agent Builder
+
+**Replacement:** none. Experimental feature with little usage. Remove any reliance on it before August 25, 2026.
+
+<!-- TODO -->
+
+### Prompt Management
+
+**Replacement:** Langfuse Prompt Management or Arize Prompt Management.
+
+<!-- TODO: migration guide
+- Who is affected (who uses native prompt management today)
+- What changes
+- Steps to move prompts to Langfuse / Arize
+- Links: Langfuse integration doc, Arize integration doc
+- Before / after config
+-->
+
+### Old Usage page
+
+**Replacement:** the new Usage dashboard.
+
+<!-- TODO: migration guide
+- What's different in the new dashboard
+- Where to find it in the UI
+- Anything that does NOT carry over
+-->
+
+### API Reference tab
+
+**Replacement:** the guided getting-started flow.
+
+<!-- TODO: migration guide
+- Where the guided flow lives
+- How to reach the API reference content people relied on (link to hosted API docs?)
+-->
+
+### Learning Resources
+
+**Replacement:** none. Low usage. No action required beyond not depending on the tab.
+
+<!-- TODO -->
+
+### MCP Network Settings
+
+The MCP "Network Settings" panel and the "Internal network only" flag.
+
+**Replacement:** TBD.
+
+<!-- TODO: details pending. Confirm scope and replacement before publishing. -->
+
+---
+
+## Integrations and backends
+
+### GreenScale logging
+
+**Replacement:** none. Low usage; can no longer be maintained to the expected standard.
+
+<!-- TODO: how to remove the greenscale callback from config -->
+
+### DynamoDB as a proxy database
+
+**Replacement:** PostgreSQL.
+
+<!-- TODO: migration guide
+- Confirm what "DynamoDB as a proxy database" covers today
+- Postgres setup (DATABASE_URL)
+- Data migration considerations, if any
+- Before / after config
+-->
+
+### Gradient AI provider
+
+**Replacement:** none. The upstream service was discontinued.
+
+<!-- TODO: provider prefix being removed; what calls will stop working -->
+
+### S3 logging v1
+
+**Replacement:** S3 logging v2.
+
+<!-- TODO: migration guide
+- Old callback vs new callback
+- Config diff (s3 -> s3_v2 and params block)
+- Before / after config
+-->
+
+### OpenTelemetry v1
+
+**Replacement:** OTEL v2.
+
+<!-- TODO: migration guide
+- How to opt into v2
+- Config / env diff
+- Note: do not run v1 and v2 at the same time
+- Before / after config
+-->
+
+### Disk caching
+
+**Replacement:** none. Low usage; can no longer be maintained to the expected standard.
+
+<!-- TODO: which cache_params type is going away and what to remove -->
+
+### Auto Router v1
+
+**Replacement:** Auto Router v2.
+
+<!-- TODO: migration guide
+- v1 vs v2 config
+- How to opt into v2
+- Before / after config
+-->
+
+### CloudZero connector
+
+**Replacement:** the OTEL v2 connector.
+
+<!-- TODO: migration guide
+- Old CloudZero connector config
+- New OTEL v2 connector config
+- Before / after config
+-->
+
+### Prisma resolve v1
+
+**Replacement:** the v2 migration resolver.
+
+<!-- TODO: migration guide
+- What the v1 resolver did
+- How to switch to v2 (flag / env var)
+- Before / after config
+-->
+
+---
+
+## Packaging
+
+### Package consolidation
+
+We're consolidating the PyPI and Docker packages down to a single `litellm` package. The extra variants (`litellm-database`, `litellm-ee`, `litellm-dev`, `litellm-non_root`) are going away. The `litellm` package will be the only supported package going forward and will absorb the functionality from `litellm-database` and `litellm-non_root`.
+
+<!-- TODO: migration guide
+- Mapping: each old package/image -> the single litellm package/image
+- What moves where (database deps, non-root, ee, dev)
+- Install / Docker tag changes (pip and ghcr.io tags)
+- Before / after install commands
+-->
+
+---
+
+## Questions or feedback
+
+This list is not final. If you depend on something here and want it to stay, reach out with the feature and your use case.
+
+<!-- TODO: add the canonical feedback channel (email / GitHub discussion / Slack) once confirmed. -->

--- a/docs/mcp_public_internet.md
+++ b/docs/mcp_public_internet.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # Exposing MCPs on the Public Internet
 
+:::warning Deprecated
+
+The "Network Settings" panel and the "Internal network only" flag are deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#mcp-network-settings).
+
+:::
+
 Control which MCP servers are visible to external callers (e.g., ChatGPT, Claude Desktop) vs. internal-only callers. This is useful when you want a subset of your MCP servers available publicly while keeping sensitive servers restricted to your private network.
 
 ## Overview

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # /memory
 
+:::warning Deprecated
+
+This feature is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#memory).
+
+:::
+
 CRUD endpoints for storing and retrieving user/team-scoped memory entries on the LiteLLM proxy. Use these to persist conversation context, agent memory, team playbooks, or any key-value data scoped to users and teams.
 
 ## Overview

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,8 @@
 
 When we have breaking changes (i.e. going from 1.x.x to 2.x.x), we will document those changes here.
 
+For features and integrations being retired without a major version bump, see the [Deprecations](./deprecations.md) guide.
+
 
 ## `1.0.0` 
 

--- a/docs/observability/cloudzero.md
+++ b/docs/observability/cloudzero.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # CloudZero Integration
 
+:::warning Deprecated
+
+The CloudZero connector is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#cloudzero-connector).
+
+:::
+
 LiteLLM provides an integration with CloudZero's AnyCost API, allowing you to export your LLM usage data to CloudZero for cost tracking analysis.
 
 ## Overview

--- a/docs/observability/greenscale_integration.md
+++ b/docs/observability/greenscale_integration.md
@@ -1,5 +1,10 @@
 # Greenscale - Track LLM Spend and Responsible Usage
 
+:::warning Deprecated
+
+This feature is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#greenscale-logging).
+
+:::
 
 :::tip
 

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -4,6 +4,12 @@ import TabItem from '@theme/TabItem';
 
 # OpenTelemetry - Tracing LLMs with any observability tool
 
+:::warning Deprecated
+
+OpenTelemetry v1 is deprecated and will be removed in the **August 25, 2026** release; migrate to [OTEL v2](/docs/observability/opentelemetry_v2). See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#opentelemetry-v1).
+
+:::
+
 OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as Jaeger, Zipkin, Datadog, New Relic, Traceloop, Levo AI and others.
 
 <Image img={require('../../img/traceloop_dash.png')} />

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -6,19 +6,13 @@ import TabItem from '@theme/TabItem';
 
 :::warning Deprecated
 
-OpenTelemetry v1 is deprecated and will be removed in the **August 25, 2026** release; migrate to [OTEL v2](/docs/observability/opentelemetry_v2). See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#opentelemetry-v1).
+OpenTelemetry v1 is deprecated and will be removed in the **August 25, 2026** release. Migrate to the opt-in **[OpenTelemetry v2](./opentelemetry_v2)** integration, which produces one trace per request (HTTP → auth → guardrails → LLM call → DB writes), follows the official GenAI semantic conventions, and ships with presets for Arize, Phoenix, Langfuse, Weave, and more. Enable it with `LITELLM_OTEL_V2=true`. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#opentelemetry-v1).
 
 :::
 
 OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as Jaeger, Zipkin, Datadog, New Relic, Traceloop, Levo AI and others.
 
 <Image img={require('../../img/traceloop_dash.png')} />
-
-:::tip Looking for full-request tracing?
-
-There's a newer, opt-in **[OpenTelemetry v2](./opentelemetry_v2)** integration for LiteLLM Proxy that produces one trace per request (HTTP → auth → guardrails → LLM call → DB writes), follows the official GenAI semantic conventions, and ships with presets for Arize, Phoenix, Langfuse, Weave, and more. Enable it with `LITELLM_OTEL_V2=true`.
-
-:::
 
 :::note Change in v1.81.0
 

--- a/docs/providers/gradient_ai.md
+++ b/docs/providers/gradient_ai.md
@@ -2,6 +2,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # GradientAI
+
+:::warning Deprecated
+
+This provider is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#gradient-ai-provider).
+
+:::
+
 https://digitalocean.com/products/gradientai
 
 

--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -630,6 +630,12 @@ $ litellm --config /path/to/config.yaml
 
 <TabItem value="disk" label="Disk Cache">
 
+:::warning Deprecated
+
+Disk caching is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#disk-caching).
+
+:::
+
 #### Step 1: Add `cache` to the config.yaml
 
 ```yaml

--- a/docs/proxy/litellm_prompt_management.md
+++ b/docs/proxy/litellm_prompt_management.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # LiteLLM AI Gateway Prompt Management
 
+:::warning Deprecated
+
+This feature is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#prompt-management).
+
+:::
+
 Use the LiteLLM AI Gateway to create, manage and version your prompts.
 
 ## Quick Start

--- a/docs/proxy/memory.md
+++ b/docs/proxy/memory.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # Memory Management
 
+:::warning Deprecated
+
+This feature is deprecated and will be removed in the **August 25, 2026** release. See the [deprecations notice](/docs/deprecations) and the [migration guide for this feature](/docs/deprecations#memory).
+
+:::
+
 Store user preferences and feedback so your LLM remembers them across sessions. Scoped per user and team, with built-in access control.
 
 **Requires:** LiteLLM `v1.83.10+` with PostgreSQL connected. No config changes needed.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1153,6 +1153,7 @@ const sidebars = {
       items: [
         "sdk_custom_pricing",
         "migration",
+        "deprecations",
         "data_security",
         "proxy/security_encryption_faq",
         "migration_policy",


### PR DESCRIPTION
Adds `docs/deprecations.md` as the migration guide for the features and integrations being retired in the August 25, 2026 release (announced June 25, 2026, ~60 days notice).

The page opens with summary tables grouped into dashboard features, integrations and backends, and packaging. Each table marks whether an item has a replacement and a migration guide, then links to a per-item section below. Items with a replacement (Prompt Management, Old Usage page, API Reference tab, DynamoDB, S3 logging v1, OpenTelemetry v1, Auto Router v1, CloudZero connector, Prisma resolve v1, package consolidation) get a section skeleton; items with no replacement (Workflows, Memory, Agent Builder, Learning Resources, GreenScale, Gradient AI, Disk caching) get a short stop-using note.

Also wires the page into the Extras sidebar next to `migration`, and links to it from the existing migration guide.

This is scaffolding; the individual migration steps are left as TODOs to fill in. A few items are still open: the MCP Network Settings scope and replacement, the exact removal version number, and the feedback channel.