### PR TITLE
docs(release-notes): add v1.84.10, v1.85.7, v1.86.7, v1.87.5, v1.88.5, v1.89.4 patch notes

### DIFF
--- a/release_notes/v1.84.10/index.md
+++ b/release_notes/v1.84.10/index.md
@@ -1,0 +1,58 @@
+---
+title: "v1.84.10 - Interrupted-Stream Cost Recovery"
+slug: "v1-84-10"
+date: 2026-06-24T04:00:54
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.84.10
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.84.10
+```
+
+</TabItem>
+</Tabs>
+
+`v1.84.10` is a patch release on top of [`v1.84.9`](/release_notes/v1.84.9/v1-84-9). It backports cost-tracking recovery for interrupted Anthropic streams — recovering output tokens, recording partial spend on the failure row, and costing interrupted and agentic streams — alongside OpenSSL and OSV-flagged dependency bumps for CVE coverage.
+
+### What's Changed
+
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix(deps): bump osv-flagged dependencies to clear known CVEs - [PR #31122](https://github.com/BerriAI/litellm/pull/31122)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.84.9...v1.84.10

--- a/release_notes/v1.85.7/index.md
+++ b/release_notes/v1.85.7/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.85.7 - Stream Cost Recovery & Cache-Control Cap"
+slug: "v1-85-7"
+date: 2026-06-24T04:58:06
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.85.7
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.85.7
+```
+
+</TabItem>
+</Tabs>
+
+`v1.85.7` is a patch release on top of [`v1.85.6`](/release_notes/v1.85.6/v1-85-6). It backports cost-tracking recovery for interrupted Anthropic streams, caps Anthropic `cache_control` injection at the 4-block API limit, and pulls in OpenSSL and OSV-flagged dependency bumps for CVE coverage. It also hardens usage parsing by coercing a dict `server_tool_use` into a typed `ServerToolUse` object.
+
+### What's Changed
+
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix(deps): bump osv-flagged dependencies to clear known CVEs - [PR #31122](https://github.com/BerriAI/litellm/pull/31122)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.85.6...v1.85.7

--- a/release_notes/v1.86.7/index.md
+++ b/release_notes/v1.86.7/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.86.7 - Stream Cost Recovery & MCP Key Scoping"
+slug: "v1-86-7"
+date: 2026-06-24T18:28:34
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.86.7
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.86.7
+```
+
+</TabItem>
+</Tabs>
+
+`v1.86.7` is a patch release on top of [`v1.86.6`](/release_notes/v1.86.6/v1-86-6). It backports cost-tracking recovery for interrupted Anthropic streams, adds a `no-mcp-servers` sentinel that scopes a key to zero MCP servers, caps Anthropic `cache_control` injection at the 4-block API limit, and bumps OpenSSL plus `cryptography`, `python-multipart`, `pydantic-settings`, and `pypdf` for CVE coverage.
+
+### What's Changed
+
+- fix(integrations): cap Anthropic cache_control injection at 4 blocks - [PR #30480](https://github.com/BerriAI/litellm/pull/30480)
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel - [PR #31029](https://github.com/BerriAI/litellm/pull/31029)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.86.6...v1.86.7

--- a/release_notes/v1.87.5/index.md
+++ b/release_notes/v1.87.5/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.87.5 - Web Search Costing & MCP Key Scoping"
+slug: "v1-87-5"
+date: 2026-06-24T18:28:54
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.87.5
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.87.5
+```
+
+</TabItem>
+</Tabs>
+
+`v1.87.5` is a patch release on top of [`v1.87.4`](/release_notes/v1.87.4/v1-87-4). It backports cost-tracking recovery for interrupted Anthropic streams, fixes a `completion_cost` `AttributeError` on streaming Anthropic web-search responses, adds a `no-mcp-servers` sentinel that scopes a key to zero MCP servers, and bumps the wolfi-base image to patch the OpenSSL CVE.
+
+### What's Changed
+
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel - [PR #31029](https://github.com/BerriAI/litellm/pull/31029)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix: completion_cost AttributeError on streaming Anthropic web_search responses - [PR #27346](https://github.com/BerriAI/litellm/pull/27346)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.87.4...v1.87.5

--- a/release_notes/v1.88.5/index.md
+++ b/release_notes/v1.88.5/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.88.5 - Vertex Batch Uploads & Stream Cost Recovery"
+slug: "v1-88-5"
+date: 2026-06-25T00:00:17
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.88.5
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.88.5
+```
+
+</TabItem>
+</Tabs>
+
+`v1.88.5` is a patch release on top of [`v1.88.4`](/release_notes/v1.88.4/v1-88-4). It streams OpenAI→Vertex batch JSONL uploads instead of buffering them in memory, backports cost-tracking recovery for interrupted Anthropic streams, adds a `no-mcp-servers` sentinel that scopes a key to zero MCP servers, and bumps OpenSSL plus runtime dependencies (`cryptography`, `aiohttp`) for CVE coverage. The bundled `litellm-enterprise` package is bumped to `0.1.42.post1`.
+
+### What's Changed
+
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel - [PR #31029](https://github.com/BerriAI/litellm/pull/31029)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix(vertex/files): stream OpenAI->Vertex batch JSONL uploads - [PR #31036](https://github.com/BerriAI/litellm/pull/31036)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.88.4...v1.88.5

--- a/release_notes/v1.89.2/index.md
+++ b/release_notes/v1.89.2/index.md
@@ -18,9 +18,13 @@ authors:
 hide_table_of_contents: false
 ---
 
-:::warning Potential performance regression — under investigation
+:::warning Potential performance regression under investigation
 
-We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+We're investigating a potential throughput regression in recent releases. It appears limited to certain deployment configurations rather than affecting all deployments, so we expect it to impact only a small subset of users; correctness and error rates are not affected.
+
+**Update (June 26, 2026):** We've identified potential causes and will need more time to test before we can confirm a fix. We'll update this note with the affected versions and the fix as soon as we have them.
+
+For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
 
 :::
 

--- a/release_notes/v1.89.3/index.md
+++ b/release_notes/v1.89.3/index.md
@@ -18,9 +18,13 @@ authors:
 hide_table_of_contents: false
 ---
 
-:::warning Potential performance regression — under investigation
+:::warning Potential performance regression under investigation
 
-We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+We're investigating a potential throughput regression in recent releases. It appears limited to certain deployment configurations rather than affecting all deployments, so we expect it to impact only a small subset of users; correctness and error rates are not affected.
+
+**Update (June 26, 2026):** We've identified potential causes and will need more time to test before we can confirm a fix. We'll update this note with the affected versions and the fix as soon as we have them.
+
+For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
 
 :::
 

--- a/release_notes/v1.89.4/index.md
+++ b/release_notes/v1.89.4/index.md
@@ -18,9 +18,13 @@ authors:
 hide_table_of_contents: false
 ---
 
-:::warning Potential performance regression — under investigation
+:::warning Potential performance regression under investigation
 
-We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+We're investigating a potential throughput regression in recent releases. It appears limited to certain deployment configurations rather than affecting all deployments, so we expect it to impact only a small subset of users; correctness and error rates are not affected.
+
+**Update (June 26, 2026):** We've identified potential causes and will need more time to test before we can confirm a fix. We'll update this note with the affected versions and the fix as soon as we have them.
+
+For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
 
 :::
 

--- a/release_notes/v1.89.4/index.md
+++ b/release_notes/v1.89.4/index.md
@@ -1,0 +1,66 @@
+---
+title: "v1.89.4 - Vertex Batch Uploads & CVE Patches"
+slug: "v1-89-4"
+date: 2026-06-25T02:38:49
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+:::warning Potential performance regression — under investigation
+
+We're investigating a potential throughput regression affecting recent releases. Correctness and error rates are not affected. We're still confirming which versions are impacted and a fix — we'll update this note as soon as we have them. For throughput-sensitive workloads, we recommend validating performance in a staging environment before rolling out an upgrade.
+
+:::
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.89.4
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.89.4
+```
+
+</TabItem>
+</Tabs>
+
+`v1.89.4` is a patch release on top of [`v1.89.3`](/release_notes/v1.89.3/v1-89-3). It streams OpenAI→Vertex batch JSONL uploads instead of buffering them in memory, backports cost-tracking recovery for interrupted Anthropic streams, adds a `no-mcp-servers` sentinel that scopes a key to zero MCP servers, and clears the remaining OSV-flagged CVEs with OpenSSL and dependency bumps. The bundled `litellm-enterprise` package is bumped to `0.1.42.post2`.
+
+### What's Changed
+
+- fix(passthrough): recover output tokens for interrupted anthropic streams - [PR #30787](https://github.com/BerriAI/litellm/pull/30787)
+- fix(proxy): record partial spend on the failure row for interrupted streams - [PR #30788](https://github.com/BerriAI/litellm/pull/30788)
+- feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel - [PR #31029](https://github.com/BerriAI/litellm/pull/31029)
+- fix(passthrough,streaming): recover cost on interrupted and agentic Anthropic streams - [PR #31035](https://github.com/BerriAI/litellm/pull/31035)
+- fix(vertex/files): stream OpenAI->Vertex batch JSONL uploads - [PR #31036](https://github.com/BerriAI/litellm/pull/31036)
+- fix(deps): bump osv-flagged dependencies to clear known CVEs - [PR #31122](https://github.com/BerriAI/litellm/pull/31122)
+- fix(docker): bump wolfi-base digest to patch openssl CVE-2026-34182 - [PR #31133](https://github.com/BerriAI/litellm/pull/31133)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.89.3...v1.89.4


### PR DESCRIPTION
Adds release notes for the six stable-line patch releases cut on June 24-25. They cover the interrupted Anthropic stream cost-recovery backports (#30787, #30788, #31035), the no-mcp-servers key sentinel (#31029), OpenAI to Vertex batch JSONL streaming (#31036), the completion_cost web-search fix on the 1.87.x line (#27346), the Anthropic cache_control four-block cap on the 1.84-1.86 lines (#30480), and the OpenSSL plus OSV-flagged dependency bumps for CVE coverage (#31122, #31133)

Each note's What's Changed list was cross-checked against the commits between its predecessor tag and the patch tag, with the per-line local commits (the server_tool_use coercion, the cryptography/pypdf/aiohttp CVE bumps, the litellm-enterprise post1/post2 bumps) captured in prose

This PR also refreshes the potential performance regression warning carried on v1.89.2, v1.89.3, and v1.89.4. The note now scopes the impact to certain deployment configurations and a small subset of users, and adds an investigation update that we have identified potential causes and need more time to test before confirming a fix
