### PR TITLE
docs: align Docker tag and version references with the PEP 440 / SemVer scheme

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -362,7 +362,7 @@ docker run \
   -e AZURE_API_KEY=your-key \
   -e AZURE_API_BASE=https://your-resource.openai.azure.com/ \
   -p 4000:4000 \
-  docker.litellm.ai/berriai/litellm:main-latest \
+  docker.litellm.ai/berriai/litellm:latest \
   --config /app/config.yaml --detailed_debug
 ```
 

--- a/docs/learn/enterprise_quickstart.md
+++ b/docs/learn/enterprise_quickstart.md
@@ -37,7 +37,7 @@ All gateway and budget tests share one deployment and one org/team/key. Do this 
 Follow the [Docker Compose tab](/docs/proxy/docker_quick_start) in the Getting Started Tutorial. Condensed steps:
 
 ```bash
-docker pull ghcr.io/berriai/litellm-database:main-latest
+docker pull ghcr.io/berriai/litellm-database:latest
 curl -O https://raw.githubusercontent.com/BerriAI/litellm/main/docker-compose.yml
 ```
 
@@ -135,7 +135,7 @@ spec:
     spec:
       containers:
         - name: litellm
-          image: docker.litellm.ai/berriai/litellm-database:main-stable
+          image: docker.litellm.ai/berriai/litellm-database:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/docs/observability/datadog.md
+++ b/docs/observability/datadog.md
@@ -289,7 +289,7 @@ docker run \
     -e USE_DDTRACE=true \
     -e USE_DDPROFILER=true \
     -p 4000:4000 \
-    docker.litellm.ai/berriai/litellm:main-latest \
+    docker.litellm.ai/berriai/litellm:latest \
     --config /app/config.yaml --detailed_debug
 ```
 

--- a/docs/observability/newrelic.md
+++ b/docs/observability/newrelic.md
@@ -51,7 +51,7 @@ docker build -f Dockerfile -t litellm-newrelic:local .
 If you wish to specify the LiteLLM image version to use as a base, pass `--build-arg BASE_IMAGE=…` and/or `--build-arg BASE_TAG=…` to target a different base image or tag similar to the following command.
 
 ```shell
-BASE_TAG=v1.83.14-stable
+BASE_TAG=v1.89.4
 docker build \
   --build-arg BASE_IMAGE=docker.litellm.ai/berriai/litellm \
   --build-arg BASE_TAG=${BASE_TAG} \
@@ -68,7 +68,7 @@ The Dockerfile defines the layers added on top of an official LiteLLM container.
 
 ```dockerfile
 ARG BASE_IMAGE=docker.litellm.ai/berriai/litellm
-ARG BASE_TAG=main-stable
+ARG BASE_TAG=latest
 FROM ${BASE_IMAGE}:${BASE_TAG}
 
 USER root

--- a/docs/proxy/configs.md
+++ b/docs/proxy/configs.md
@@ -730,7 +730,7 @@ docker run --name litellm-proxy \
    -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
    -e LITELLM_CONFIG_BUCKET_TYPE="gcs" \
    -p 4000:4000 \
-   docker.litellm.ai/berriai/litellm-database:main-latest --detailed_debug
+   docker.litellm.ai/berriai/litellm-database:latest --detailed_debug
 ```
 
 </TabItem>
@@ -751,7 +751,7 @@ docker run --name litellm-proxy \
    -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
    -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
    -p 4000:4000 \
-   docker.litellm.ai/berriai/litellm-database:main-latest
+   docker.litellm.ai/berriai/litellm-database:latest
 ```
 </TabItem>
 </Tabs>

--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -25,7 +25,7 @@ To start using Litellm, run the following commands in a shell:
 <TabItem value="docker" label="Docker">
 
 ```
-docker pull docker.litellm.ai/berriai/litellm:main-latest
+docker pull docker.litellm.ai/berriai/litellm:latest
 ```
 
 [**See all docker images**](https://github.com/orgs/BerriAI/packages)
@@ -89,7 +89,7 @@ cosign verify \
   ghcr.io/berriai/litellm:<release-tag>
 ```
 
-Replace `<release-tag>` with the version you are deploying (e.g. `v1.83.0-stable`).
+Replace `<release-tag>` with the version you are deploying (e.g. `v1.89.4`).
 
 Expected output:
 
@@ -127,7 +127,7 @@ docker run \
     -e AZURE_API_KEY=d6*********** \
     -e AZURE_API_BASE=https://openai-***********/ \
     -p 4000:4000 \
-    docker.litellm.ai/berriai/litellm:main-stable \
+    docker.litellm.ai/berriai/litellm:latest \
     --config /app/config.yaml --detailed_debug
 ```
 
@@ -157,12 +157,12 @@ See all supported CLI args [here](https://docs.litellm.ai/docs/proxy/cli):
 
 Here's how you can run the docker image and pass your config to `litellm`
 ```shell
-docker run docker.litellm.ai/berriai/litellm:main-stable --config your_config.yaml
+docker run docker.litellm.ai/berriai/litellm:latest --config your_config.yaml
 ```
 
 Here's how you can run the docker image and start litellm on port 8002 with `num_workers=8`
 ```shell
-docker run docker.litellm.ai/berriai/litellm:main-stable --port 8002 --num_workers 8
+docker run docker.litellm.ai/berriai/litellm:latest --port 8002 --num_workers 8
 ```
 
 
@@ -170,7 +170,7 @@ docker run docker.litellm.ai/berriai/litellm:main-stable --port 8002 --num_worke
 
 ```shell
 # Use the provided base image
-FROM docker.litellm.ai/berriai/litellm:main-stable
+FROM docker.litellm.ai/berriai/litellm:latest
 
 # Set the working directory to /app
 WORKDIR /app
@@ -302,7 +302,7 @@ spec:
     spec:
       containers:
       - name: litellm
-        image: docker.litellm.ai/berriai/litellm:main-stable # it is recommended to fix a version generally
+        image: docker.litellm.ai/berriai/litellm:latest # it is recommended to fix a version generally
         args:
           - "--config"
           - "/app/proxy_server_config.yaml"
@@ -322,7 +322,7 @@ spec:
 ```
 
 :::info
-To avoid issues with predictability, difficulties in rollback, and inconsistent environments, use versioning or SHA digests (for example, `litellm:main-v1.30.3` or `litellm@sha256:12345abcdef...`) instead of `litellm:main-stable`.
+To avoid issues with predictability, difficulties in rollback, and inconsistent environments, use versioning or SHA digests (for example, `litellm:v1.89.4` or `litellm@sha256:12345abcdef...`) instead of `litellm:latest`.
 :::
 
 
@@ -420,7 +420,7 @@ Requirements:
 We maintain a [separate Dockerfile](https://github.com/BerriAI/litellm/pkgs/container/litellm-database) for reducing build time when running LiteLLM proxy with a connected Postgres Database 
 
 ```shell
-docker pull docker.litellm.ai/berriai/litellm-database:main-stable
+docker pull docker.litellm.ai/berriai/litellm-database:latest
 ```
 
 ```shell
@@ -431,7 +431,7 @@ docker run \
     -e AZURE_API_KEY=d6*********** \
     -e AZURE_API_BASE=https://openai-***********/ \
     -p 4000:4000 \
-    docker.litellm.ai/berriai/litellm-database:main-stable \
+    docker.litellm.ai/berriai/litellm-database:latest \
     --config /app/config.yaml --detailed_debug
 ```
 
@@ -459,7 +459,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: docker.litellm.ai/berriai/litellm:main-stable
+          image: docker.litellm.ai/berriai/litellm:latest
           imagePullPolicy: Always
           env:
             - name: AZURE_API_KEY
@@ -655,7 +655,7 @@ router_settings:
 Start docker container with config
 
 ```shell
-docker run docker.litellm.ai/berriai/litellm:main-stable --config your_config.yaml
+docker run docker.litellm.ai/berriai/litellm:latest --config your_config.yaml
 ```
 
 ### Deploy with Database + Redis
@@ -690,7 +690,7 @@ Start `litellm-database`docker container with config
 docker run --name litellm-proxy \
 -e DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname> \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm-database:main-stable --config your_config.yaml
+docker.litellm.ai/berriai/litellm-database:latest --config your_config.yaml
 ```
 
 ###  (Non Root) - without Internet Connection
@@ -700,7 +700,7 @@ By default `prisma generate` downloads [prisma's engine binaries](https://www.pr
 Use this docker image to deploy litellm with pre-generated prisma binaries.
 
 ```bash
-docker pull docker.litellm.ai/berriai/litellm-non_root:main-stable
+docker pull docker.litellm.ai/berriai/litellm-non_root:latest
 ```
 
 [Published Docker Image link](https://github.com/BerriAI/litellm/pkgs/container/litellm-non_root)
@@ -719,7 +719,7 @@ Use this, If you need to set ssl certificates for your on prem litellm proxy
 Pass `ssl_keyfile_path` (Path to the SSL keyfile) and `ssl_certfile_path` (Path to the SSL certfile) when starting litellm proxy 
 
 ```shell
-docker run docker.litellm.ai/berriai/litellm:main-stable \
+docker run docker.litellm.ai/berriai/litellm:latest \
     --ssl_keyfile_path ssl_test/keyfile.key \
     --ssl_certfile_path ssl_test/certfile.crt
 ```
@@ -734,7 +734,7 @@ Step 1. Build your custom docker image with hypercorn
 
 ```shell
 # Use the provided base image
-FROM docker.litellm.ai/berriai/litellm:main-stable
+FROM docker.litellm.ai/berriai/litellm:latest
 
 # Set the working directory to /app
 WORKDIR /app
@@ -797,7 +797,7 @@ litellm --config config.yaml --port 4000 --run_granian --num_workers 4
 Or with Docker:
 
 ```shell
-docker run docker.litellm.ai/berriai/litellm:main-stable \
+docker run docker.litellm.ai/berriai/litellm:latest \
     --config /app/config.yaml \
     --port 4000 \
     --run_granian \
@@ -821,7 +821,7 @@ Usage Example:
 In this example, we set the keepalive timeout to 75 seconds.
 
 ```shell showLineNumbers title="docker run"
-docker run docker.litellm.ai/berriai/litellm:main-stable \
+docker run docker.litellm.ai/berriai/litellm:latest \
     --keepalive_timeout 75
 ```
 
@@ -830,7 +830,7 @@ In this example, we set the keepalive timeout to 75 seconds.
 
 ```shell showLineNumbers title="Environment Variable"
 export KEEPALIVE_TIMEOUT=75
-docker run docker.litellm.ai/berriai/litellm:main-stable
+docker run docker.litellm.ai/berriai/litellm:latest
 ```
 
 
@@ -841,7 +841,7 @@ Use this to mitigate memory growth by recycling workers after a fixed number of 
 Usage Examples:
 
 ```shell showLineNumbers title="docker run (CLI flag)"
-docker run docker.litellm.ai/berriai/litellm:main-stable \
+docker run docker.litellm.ai/berriai/litellm:latest \
     --max_requests_before_restart 10000
 ```
 
@@ -849,7 +849,7 @@ Or set via environment variable:
 
 ```shell showLineNumbers title="Environment Variable"
 export MAX_REQUESTS_BEFORE_RESTART=10000
-docker run docker.litellm.ai/berriai/litellm:main-stable
+docker run docker.litellm.ai/berriai/litellm:latest
 ```
 
 
@@ -878,7 +878,7 @@ docker run --name litellm-proxy \
    -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
    -e LITELLM_CONFIG_BUCKET_TYPE="gcs" \
    -p 4000:4000 \
-   docker.litellm.ai/berriai/litellm-database:main-stable --detailed_debug
+   docker.litellm.ai/berriai/litellm-database:latest --detailed_debug
 ```
 
 </TabItem>
@@ -899,7 +899,7 @@ docker run --name litellm-proxy \
    -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
    -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
    -p 4000:4000 \
-   docker.litellm.ai/berriai/litellm-database:main-stable
+   docker.litellm.ai/berriai/litellm-database:latest
 ```
 </TabItem>
 </Tabs>
@@ -1026,7 +1026,7 @@ Run the following command, replacing `<database_url>` with the value you copied 
 docker run --name litellm-proxy \
    -e DATABASE_URL=<database_url> \
    -p 4000:4000 \
-   docker.litellm.ai/berriai/litellm-database:main-stable
+   docker.litellm.ai/berriai/litellm-database:latest
 ```
 
 #### 4. Access the Application:
@@ -1105,7 +1105,7 @@ services:
       context: .
       args:
         target: runtime
-    image: docker.litellm.ai/berriai/litellm:main-stable
+    image: docker.litellm.ai/berriai/litellm:latest
     ports:
       - "4000:4000" # Map the container port to the host, change the host port if necessary
     volumes:

--- a/docs/proxy/docker_image_security.md
+++ b/docs/proxy/docker_image_security.md
@@ -30,7 +30,7 @@ A commit hash is cryptographically immutable, making this the strongest verifica
 ```bash
 cosign verify \
   --key https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub \
-  ghcr.io/berriai/litellm:v1.83.0-stable
+  ghcr.io/berriai/litellm:v1.89.4
 ```
 
 Replace the image reference with any signed variant:
@@ -39,12 +39,12 @@ Replace the image reference with any signed variant:
 # litellm-database
 cosign verify \
   --key https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub \
-  ghcr.io/berriai/litellm-database:v1.83.0-stable
+  ghcr.io/berriai/litellm-database:v1.89.4
 
 # litellm-non_root
 cosign verify \
   --key https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub \
-  ghcr.io/berriai/litellm-non_root:v1.83.0-stable
+  ghcr.io/berriai/litellm-non_root:v1.89.4
 ```
 
 ### Verify with a release tag (convenience)
@@ -53,8 +53,8 @@ Tags are protected in this repository and resolve to the same key:
 
 ```bash
 cosign verify \
-  --key https://raw.githubusercontent.com/BerriAI/litellm/v1.83.0-stable/cosign.pub \
-  ghcr.io/berriai/litellm-database:v1.83.0-stable
+  --key https://raw.githubusercontent.com/BerriAI/litellm/v1.89.4/cosign.pub \
+  ghcr.io/berriai/litellm-database:v1.89.4
 ```
 
 ### Expected output
@@ -156,7 +156,7 @@ Get the digest after pulling:
 
 ```bash
 docker inspect --format='{{index .RepoDigests 0}}' \
-  ghcr.io/berriai/litellm-database:v1.83.0-stable
+  ghcr.io/berriai/litellm-database:v1.89.4
 ```
 
 Cosign verification works with digests too:

--- a/docs/proxy/docker_quick_start.md
+++ b/docs/proxy/docker_quick_start.md
@@ -85,7 +85,7 @@ Choose your install method. **Docker Compose** users complete their full setup i
 <TabItem value="docker" label="Docker">
 
 ```bash
-docker pull docker.litellm.ai/berriai/litellm:main-latest
+docker pull docker.litellm.ai/berriai/litellm:latest
 ```
 
 [**See all docker images**](https://github.com/orgs/BerriAI/packages)
@@ -109,7 +109,7 @@ Docker Compose bundles LiteLLM with a Postgres database. Follow the steps below 
 LiteLLM provides a dedicated `litellm-database` image for proxy deployments that connect to Postgres.
 
 ```bash
-docker pull ghcr.io/berriai/litellm-database:main-latest
+docker pull ghcr.io/berriai/litellm-database:latest
 ```
 
 See all available tags on the [GitHub Container Registry](https://github.com/BerriAI/litellm/pkgs/container/litellm-database).
@@ -328,7 +328,7 @@ docker run \
     -e AZURE_API_KEY=d6*********** \
     -e AZURE_API_BASE=https://openai-***********/ \
     -p 4000:4000 \
-    docker.litellm.ai/berriai/litellm:main-latest \
+    docker.litellm.ai/berriai/litellm:latest \
     --config /app/config.yaml --detailed_debug
 
 # RUNNING on http://0.0.0.0:4000
@@ -515,7 +515,7 @@ docker run \
     -e AZURE_API_KEY=d6*********** \
     -e AZURE_API_BASE=https://openai-***********/ \
     -p 4000:4000 \
-    ghcr.io/berriai/litellm-database:main-latest \
+    ghcr.io/berriai/litellm-database:latest \
     --config /app/config.yaml --detailed_debug
 ```
 

--- a/docs/proxy/guardrails/crowdstrike_aidr.md
+++ b/docs/proxy/guardrails/crowdstrike_aidr.md
@@ -94,7 +94,7 @@ docker run --rm \
   -e CS_AIDR_BASE_URL=$CS_AIDR_BASE_URL \
   -e OPENAI_API_KEY=$OPENAI_API_KEY \
   -v $(pwd)/config.yaml:/app/config.yaml \
-  ghcr.io/berriai/litellm:main-latest \
+  ghcr.io/berriai/litellm:latest \
   --config /app/config.yaml
 ```
 

--- a/docs/proxy/guardrails/pangea.md
+++ b/docs/proxy/guardrails/pangea.md
@@ -67,7 +67,7 @@ docker run --rm \
   -e PANGEA_AI_GUARD_TOKEN=$PANGEA_AI_GUARD_TOKEN \
   -e OPENAI_API_KEY=$OPENAI_API_KEY \
   -v $(pwd)/config.yaml:/app/config.yaml \
-  docker.litellm.ai/berriai/litellm:main-latest \
+  docker.litellm.ai/berriai/litellm:latest \
   --config /app/config.yaml
 ```
 

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -351,7 +351,7 @@ spec:
     spec:
       initContainers:
         - name: setup-ui
-          image: ghcr.io/berriai/litellm:main-stable
+          image: ghcr.io/berriai/litellm:latest
           command:
             - sh
             - -c
@@ -366,7 +366,7 @@ spec:
 
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:main-stable
+          image: ghcr.io/berriai/litellm:latest
           env:
             - name: LITELLM_NON_ROOT
               value: "true"

--- a/docs/secret_managers/custom_secret_manager.md
+++ b/docs/secret_managers/custom_secret_manager.md
@@ -76,7 +76,7 @@ docker run -d \
   --name litellm-proxy \
   -v $(pwd)/config.yaml:/app/config.yaml \
   -v $(pwd)/my_secret_manager.py:/app/my_secret_manager.py \
-  docker.litellm.ai/berriai/litellm:main-latest \
+  docker.litellm.ai/berriai/litellm:latest \
   --config /app/config.yaml \
   --port 4000 \
   --detailed_debug

--- a/docs/troubleshoot/rollback.md
+++ b/docs/troubleshoot/rollback.md
@@ -2,7 +2,7 @@
 
 This guide outlines the process for safely rolling back a LiteLLM Proxy deployment to a previous version.
 
-We recommend rolling back to the previous [stable release](https://github.com/BerriAI/litellm/releases). Stable releases come out every week and follow the `main-v<VERSION>-stable` tag convention (e.g., `main-v1.77.2-stable`).
+We recommend rolling back to the previous [stable release](https://github.com/BerriAI/litellm/releases). Stable releases come out every week and follow the `vX.Y.Z` tag convention (e.g., `v1.89.4`).
 
 ## 1. Determine Rollback Scope
 
@@ -38,7 +38,7 @@ Revert your deployment to the previous stable Docker image or Helm chart version
 Update your deployment manifest (e.g., K8s Deployment, Docker Compose) to use the previous version:
 ```yaml
 # Example: Reverting to the previous stable release
-image: docker.litellm.ai/berriai/litellm:main-v<VERSION>-stable
+image: docker.litellm.ai/berriai/litellm:v<VERSION>
 ```
 
 See [all available images](https://github.com/orgs/BerriAI/packages).

--- a/docs/tutorials/elasticsearch_logging.md
+++ b/docs/tutorials/elasticsearch_logging.md
@@ -221,7 +221,7 @@ services:
       - elasticsearch
       
   litellm:
-    image: docker.litellm.ai/berriai/litellm:main-latest
+    image: docker.litellm.ai/berriai/litellm:latest
     ports:
       - "4000:4000"
     environment:

--- a/docs/tutorials/openai_codex.md
+++ b/docs/tutorials/openai_codex.md
@@ -53,7 +53,7 @@ yarn global add @openai/codex
 docker run \
     -v $(pwd)/litellm_config.yaml:/app/config.yaml \
     -p 4000:4000 \
-    docker.litellm.ai/berriai/litellm:main-latest \
+    docker.litellm.ai/berriai/litellm:latest \
     --config /app/config.yaml
 ```
 


### PR DESCRIPTION
## What

LiteLLM has moved to PEP 440 / SemVer 2.0 versioning. Releases are now published as plain `vX.Y.Z` tags, and the rolling `main-stable` / `main-latest` tags are deprecated in favor of `:latest` (see the [cleaner release versions](/release_notes) announcement). This updates the evergreen docs that still teach the old naming so users copy-paste working, non-deprecated references

The changes are limited to general, cross-version guidance: deployment, install, rollback, observability, guardrail, and secret-manager pages. The rollback guide moves from the `main-v<VERSION>-stable` convention to `vX.Y.Z`, and the image-security guide's cosign examples move off `v1.83.0-stable` (a tag that returns 404, along with its `cosign.pub` raw URL) onto `v1.89.4`, which I verified resolves on GHCR and for the signing key

## What is intentionally left unchanged

References that pin a specific historical release stay as they are, because their suffixed tags are the ones that actually exist on the registry. That covers release notes, dated blog posts (model launches, the CVE advisory), and "available in `vX.Y.Z-stable` and above" feature floors. Rewriting those to a bare `vX.Y.Z` would point at tags that 404 for older lines

## Type

📖 Documentation
