### PR TITLE
docs(headroom): note availability from v1.91.0.rc1

### DIFF
--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # Prompt Compression (Headroom)
 
+:::info
+
+The Headroom integration is available from LiteLLM `v1.91.0.rc1` and later.
+
+:::
+
 Headroom is the context optimization layer for LLM applications. It compresses tool outputs, database results, file reads, and RAG payloads before they reach the model, so you get the same answers at a fraction of the tokens.
 
 This is available on both `/v1/chat/completions` and `/v1/messages` (Anthropic format).


### PR DESCRIPTION
Stacks on top of #420. Adds an info admonition at the top of the Headroom doc clarifying that the integration is available from LiteLLM `v1.91.0.rc1` onward, so readers on older builds do not configure a guardrail that does not exist in their installed version.

Base set to `claude/silly-solomon-f60a38`; once #420 merges, this can rebase onto `main`.

## Test plan

- [ ] Renders the new admonition above the intro paragraph on `/docs/proxy/headroom`