### PR TITLE
docs: document MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -993,6 +993,7 @@ router_settings:
 | MAX_IMAGE_URL_DOWNLOAD_SIZE_MB | Maximum size in MB for downloading images from URLs. Prevents memory issues from downloading very large images. Images exceeding this limit will be rejected before download. Set to 0 to completely disable image URL handling (all image_url requests will be blocked). Default is 50MB (matching [OpenAI's limit](https://platform.openai.com/docs/guides/images-vision?api-mode=chat#image-input-requirements))
 | MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES | Maximum length for the long side of high-resolution images. Default is 2000
 | MAX_REDIS_BUFFER_DEQUEUE_COUNT | Maximum count for Redis buffer dequeue operations. Default is 100
+| MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB | Maximum request body size in MB that LiteLLM will attempt to repair when it fails to parse as JSON. The repair fallback runs two full-body regex passes to fix invalid surrogate escapes, which blocks the event loop on large malformed payloads. Bodies above this size skip the repair and return a 400 immediately; bodies at or below it are still repaired. Set to 0 to disable the cap and always attempt repair. Default is 1 (MB)
 | MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES | Maximum length for the short side of high-resolution images. Default is 768
 | MAX_SIZE_IN_MEMORY_QUEUE | Maximum size for in-memory queue. Default is 10000
 | MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB | Maximum size in KB for each item in memory cache. Default is 512 or 1024


### PR DESCRIPTION
## What

Documents the new `MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB` environment variable introduced in BerriAI/litellm#31497, adding it to the proxy environment variables reference in `docs/proxy/config_settings.md`.

## Why

When the proxy fails to parse a request body as JSON, it falls back to a surrogate-repair path that runs two full-body regex passes to fix invalid surrogate escapes. On multi-MB malformed payloads that work blocks the event loop for hundreds of ms, which on single-worker pods stalls co-tenant requests. The new env var caps the body size LiteLLM will attempt to repair; above the cap it returns a 400 immediately, and bodies at or below it are repaired exactly as before. Default is 1MB, env-overridable, and set to 0 to disable the cap.

Source PR: BerriAI/litellm#31497 (LIT-3541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)