### PR TITLE
docs: add TrustedRouter OpenAI-compatible setup

### DIFF
--- a/docs/providers/trustedrouter.md
+++ b/docs/providers/trustedrouter.md
@@ -1,0 +1,89 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# TrustedRouter
+
+TrustedRouter exposes an OpenAI-compatible API. In LiteLLM, call it with the `openai/` provider prefix and set `api_base` to `https://api.trustedrouter.com/v1`.
+
+| Property | Details |
+|-------|-------|
+| Provider Route on LiteLLM | `openai/` with `api_base` |
+| API Endpoint for Provider | `https://api.trustedrouter.com/v1` |
+| Provider Docs | [TrustedRouter Docs ↗](https://trustedrouter.com/docs) |
+| Supported OpenAI Endpoints | `/chat/completions`, `/responses` |
+
+## API Keys
+
+Create an API key in the [TrustedRouter console](https://trustedrouter.com/console/api-keys).
+
+```python
+import os
+os.environ["TRUSTEDROUTER_API_KEY"] = "your-api-key"
+```
+
+## Sample Usage
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import os
+from litellm import completion
+
+response = completion(
+    model="openai/trustedrouter/auto",
+    api_base="https://api.trustedrouter.com/v1",
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    messages=[{"role": "user", "content": "Write a short haiku about routing."}],
+)
+
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+1. Add a model to `config.yaml`.
+
+```yaml
+model_list:
+  - model_name: trustedrouter-auto
+    litellm_params:
+      model: openai/trustedrouter/auto
+      api_base: https://api.trustedrouter.com/v1
+      api_key: os.environ/TRUSTEDROUTER_API_KEY
+```
+
+2. Start the proxy.
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+3. Send a request to the proxy.
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk-litellm-proxy-key' \
+  -d '{
+    "model": "trustedrouter-auto",
+    "messages": [
+      {"role": "user", "content": "Write a short haiku about routing."}
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Model IDs
+
+Use TrustedRouter model IDs after the `openai/` prefix. Common router aliases include:
+
+- `openai/trustedrouter/auto`
+- `openai/trustedrouter/zdr`
+- `openai/trustedrouter/e2e`
+- `openai/trustedrouter/synth`
+
+For the current model catalog and routing options, see [TrustedRouter models](https://trustedrouter.com/models).

--- a/sidebars.js
+++ b/sidebars.js
@@ -1079,6 +1079,7 @@ const sidebars = {
         "providers/tensormesh",
         "providers/togetherai",
         "providers/topaz",
+        "providers/trustedrouter",
         "providers/triton-inference-server",
         "providers/v0",
         "providers/vercel_ai_gateway",


### PR DESCRIPTION
## Summary
- Add a TrustedRouter provider docs page using LiteLLM's existing `openai/` OpenAI-compatible route.
- Show SDK and proxy configuration with `api_base="https://api.trustedrouter.com/v1"`.
- Add the page to the provider sidebar.

## Context
This follows the maintainer redirect from the closed LiteLLM core PR to the docs repo: https://github.com/BerriAI/litellm/pull/30321

## Validation
- `npm ci`
- `npm run build`

The build completed successfully. It emitted existing repository-wide Docusaurus warnings/broken-link reports that are not introduced by this page.
