### PR TITLE
docs(prometheus): document PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1095,6 +1095,7 @@ router_settings:
 | PREDIBASE_API_BASE | Base URL for Predibase API
 | PRESIDIO_ANALYZER_API_BASE | Base URL for Presidio Analyzer service
 | PRESIDIO_ANONYMIZER_API_BASE | Base URL for Presidio Anonymizer service
+| PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT | Maximum seconds to spend emitting per-request Prometheus budget metrics before skipping; on timeout the emission is dropped in isolation so a slow Redis/DB lookup cannot cancel the whole success-logging event. Default is 5.0
 | PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES | Refresh interval in minutes for Prometheus budget metrics. Default is 5
 | PROMETHEUS_FALLBACK_STATS_SEND_TIME_HOURS | Fallback time in hours for sending stats to Prometheus. Default is 9
 | PROMETHEUS_URL | URL for Prometheus service


### PR DESCRIPTION
Documents the PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT environment variable in the proxy config settings reference

This env var bounds how long per-request Prometheus budget metric emission may take before it is skipped, so a slow Redis/DB lookup cannot cancel the whole success-logging event. Default is 5.0 seconds

Pairs with the code change in BerriAI/litellm that adds the timeout. The litellm documentation CI (test_env_keys) requires every os.getenv key to be present in this reference table, so this entry unblocks that check