### PR TITLE
docs(logging_spec): add reasoning_cost, cache_read_cost, cache_creation_cost to CostBreakdown

### DIFF
--- a/docs/proxy/logging_spec.md
+++ b/docs/proxy/logging_spec.md
@@ -49,6 +49,9 @@ The `cost_breakdown` field provides detailed cost breakdown for completion reque
 - **`output_cost`**: Cost of output/completion tokens (including reasoning tokens if applicable)
 - **`tool_usage_cost`**: Cost of built-in tools usage (e.g., web search, code interpreter)
 - **`total_cost`**: Total cost of input + output + tool usage
+- **`reasoning_cost`**: Cost of reasoning tokens, reported as a subset of `output_cost` (populated when the model returns reasoning tokens, e.g. `gemini-2.5-flash`, `o3`)
+- **`cache_read_cost`**: Cost of cache-read tokens, reported as a subset of `input_cost` (populated when cached tokens are present in the response)
+- **`cache_creation_cost`**: Cost of cache-creation tokens, reported as a subset of `input_cost` (populated when prompt caching is used, e.g. Anthropic models)
 
 **Note**: This field is populated for all call types. For non-completion calls, `input_cost` and `output_cost` may be 0.
 
@@ -58,10 +61,13 @@ The total cost relationship is: `response_cost = cost_breakdown.total_cost`
 
 ```python
 class CostBreakdown(TypedDict, total=False):
-    input_cost: float        # Cost of input/prompt tokens in USD
-    output_cost: float       # Cost of output/completion tokens in USD (includes reasoning)
-    tool_usage_cost: float   # Cost of built-in tools usage in USD
-    total_cost: float        # Total cost in USD
+    input_cost: float           # Cost of input/prompt tokens in USD
+    output_cost: float          # Cost of output/completion tokens in USD (includes reasoning)
+    tool_usage_cost: float      # Cost of built-in tools usage in USD
+    total_cost: float           # Total cost in USD
+    reasoning_cost: float       # Cost of reasoning tokens in USD; subset of output_cost
+    cache_read_cost: float      # Cost of cache-read tokens in USD; subset of input_cost
+    cache_creation_cost: float  # Cost of cache-creation tokens in USD; subset of input_cost
 ```
 
 ## StandardLoggingUserAPIKeyMetadata


### PR DESCRIPTION
## Summary

Documents the three new `CostBreakdown` fields added in BerriAI/litellm#31623: `reasoning_cost`, `cache_read_cost`, and `cache_creation_cost`. Each field is noted as a subset of `output_cost` or `input_cost` so it is clear there is no double-counting.

## Test plan

- [ ] Verify the rendered page at `/docs/proxy/logging_spec#cost-breakdown` shows the three new fields in both the bullet list and the type definition block