### PR TITLE
chore(compat-matrix): refresh for v1.90.0 + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-30T06:12:11Z",
+  "generated_at": "2026-06-30T17:33:26Z",
   "litellm_version": "v1.90.0",
   "claude_code_version": "2.1.126",
   "providers": [
@@ -16,8 +16,7 @@
       "name": "Basic messaging (non-streaming)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -39,8 +38,7 @@
       "name": "Basic messaging (streaming)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -62,8 +60,7 @@
       "name": "Tool use",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -85,52 +82,7 @@
       "name": "Prompt caching (5m TTL)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
-        },
-        "bedrock_invoke": {
           "status": "pass"
-        },
-        "bedrock_converse": {
-          "status": "pass"
-        },
-        "vertex_ai": {
-          "status": "pass"
-        },
-        "azure": {
-          "status": "pass"
-        }
-      }
-    },
-    {
-      "id": "vision",
-      "name": "Vision",
-      "providers": {
-        "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
-        },
-        "bedrock_invoke": {
-          "status": "pass"
-        },
-        "bedrock_converse": {
-          "status": "pass"
-        },
-        "vertex_ai": {
-          "status": "pass"
-        },
-        "azure": {
-          "status": "pass"
-        }
-      }
-    },
-    {
-      "id": "thinking",
-      "name": "Thinking",
-      "providers": {
-        "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -148,12 +100,55 @@
       }
     },
     {
+      "id": "vision",
+      "name": "Vision",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "pass"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+        },
+        "vertex_ai": {
+          "status": "pass"
+        },
+        "azure": {
+          "status": "pass"
+        }
+      }
+    },
+    {
+      "id": "thinking",
+      "name": "Thinking",
+      "providers": {
+        "anthropic": {
+          "status": "pass"
+        },
+        "bedrock_invoke": {
+          "status": "pass"
+        },
+        "bedrock_converse": {
+          "status": "fail",
+          "error": "[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events"
+        },
+        "vertex_ai": {
+          "status": "pass"
+        },
+        "azure": {
+          "status": "pass"
+        }
+      }
+    },
+    {
       "id": "tool_use_streaming",
       "name": "Tool use (streaming / fine-grained)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -175,8 +170,7 @@
       "name": "Extended thinking + tool use",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -198,8 +192,7 @@
       "name": "PDF document input",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -221,8 +214,7 @@
       "name": "Prompt caching (1h TTL)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -244,8 +236,7 @@
       "name": "Web search (server tool)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -267,8 +258,7 @@
       "name": "Structured outputs",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"
@@ -311,8 +301,7 @@
       "name": "Tool search (MCP discovery)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\\\"},\\\"request_id\\\":\\\"req_011CcYwpTUPcQ553QyjGCBAX\\\"}. Received Model Group=claude-haiku-4-5\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "fail",
@@ -334,8 +323,7 @@
       "name": "Long context (1M)",
       "providers": {
         "anthropic": {
-          "status": "fail",
-          "error": "[claude-sonnet-4-6] claude CLI failed: exit=1; api_status=400; text=Credit balance is too low"
+          "status": "pass"
         },
         "bedrock_invoke": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 2 green->red regression(s):
  - Prompt caching (5m TTL) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
  - Vision [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.90.0` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-06-30T17:33:26Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Long context (1M)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.