### PR TITLE
docs(data_security): remove Security Certifications section

### DIFF
--- a/docs/data_security.md
+++ b/docs/data_security.md
@@ -12,15 +12,6 @@ At LiteLLM, **safeguarding your data privacy and security** is our top priority.
 
 For security inquiries, please contact us at support@berri.ai
 
-## **Security Certifications**
-
-| **Certification** | **Status**                                                                                      |
-|-------------------|-------------------------------------------------------------------------------------------------|
-| SOC 2 Type I      | Certified. Report available upon request on Enterprise plan.                                                           |
-| SOC 2 Type II     | Certified. Report available upon request on Enterprise plan.                   |
-| ISO 27001          | Certified. Report available upon request on Enterprise                              |
-
-
 ## Collection of Personal Data
 
 ### For Self-hosted LiteLLM Users:


### PR DESCRIPTION
Removes the Security Certifications section (SOC 2 Type I/II and ISO 27001 table) from the Data Privacy and Security doc.

No internal links pointed to the `#security-certifications` anchor, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)