### PR TITLE
docs(mcp): add Claude Code MCP demo and fix server URL ordering

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1213,7 +1213,7 @@ curl --location '<your-litellm-proxy-base-url>/v1/chat/completions' \
   "tools": [
     {
       "type": "mcp",
-      "server_url": "litellm_proxy/mcp/github",
+      "server_url": "litellm_proxy/github/mcp",
       "server_label": "github_mcp",
       "require_approval": "never"
     }

--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -382,11 +382,11 @@ The `Authorization` header carries the LiteLLM API key instead of an OAuth2 toke
 
 ```bash
 # WRONG — blocks OAuth2 discovery
-claude mcp add --transport http my_server http://proxy/mcp/server \
+claude mcp add --transport http my_server http://proxy/server/mcp \
     --header "Authorization: Bearer sk-..."
 
 # CORRECT — LiteLLM key in dedicated header, Authorization free for OAuth2
-claude mcp add --transport http my_server http://proxy/mcp/server \
+claude mcp add --transport http my_server http://proxy/server/mcp \
     --header "x-litellm-api-key: Bearer sk-..."
 ```
 

--- a/docs/tutorials/claude_mcp.md
+++ b/docs/tutorials/claude_mcp.md
@@ -7,6 +7,10 @@ This tutorial shows how to connect MCP servers to Claude Code via LiteLLM Proxy.
 
 Note: LiteLLM supports OAuth for MCP servers as well. [Learn more](https://docs.litellm.ai/docs/mcp#mcp-oauth)
 
+## Demo
+
+<iframe width="840" height="500" src="https://www.loom.com/embed/e3721fc44e284c559dc4dca67ba7603a" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
 ## Connecting MCP Servers
 
 You can connect MCP servers to Claude Code via LiteLLM Proxy.
@@ -46,7 +50,7 @@ mcp_servers:
 </Tabs>
 
 :::important
-The server name under `mcp_servers:` (e.g. `atlassian_mcp`, `github_mcp`) **must match** the name used in the Claude Code URL path (`/mcp/<server_name>`). A mismatch will cause a 404 error during OAuth.
+The server name under `mcp_servers:` (e.g. `atlassian_mcp`, `github_mcp`) **must match** the name used in the Claude Code URL path (`/<server_name>/mcp`). A mismatch will cause a 404 error during OAuth.
 :::
 
 2. Start LiteLLM Proxy
@@ -70,7 +74,7 @@ ngrok http 4000
 <TabItem value="github" label="GitHub MCP">
 
 ```bash
-claude mcp add --transport http litellm-github https://your-ngrok-url.ngrok-free.dev/mcp/github_mcp \
+claude mcp add --transport http litellm-github https://your-ngrok-url.ngrok-free.dev/github_mcp/mcp \
   --header "x-litellm-api-key: Bearer sk-1234"
 ```
 
@@ -78,7 +82,7 @@ claude mcp add --transport http litellm-github https://your-ngrok-url.ngrok-free
 <TabItem value="atlassian" label="Atlassian MCP">
 
 ```bash
-claude mcp add --transport http litellm-atlassian https://your-ngrok-url.ngrok-free.dev/mcp/atlassian_mcp \
+claude mcp add --transport http litellm-atlassian https://your-ngrok-url.ngrok-free.dev/atlassian_mcp/mcp \
   --header "x-litellm-api-key: Bearer sk-1234"
 ```
 
@@ -91,7 +95,7 @@ claude mcp add --transport http litellm-atlassian https://your-ngrok-url.ngrok-f
 |-----------|-------------|
 | `--transport http` | Use HTTP transport for the MCP connection |
 | `litellm-atlassian` | The name for this MCP server **on Claude Code** — can be anything you choose |
-| `https://your-ngrok-url.ngrok-free.dev/mcp/atlassian_mcp` | The LiteLLM proxy URL. Format: `<PROXY_URL>/mcp/<server_name_on_litellm>`. The `atlassian_mcp` part **must match** the key under `mcp_servers:` in your LiteLLM proxy config |
+| `https://your-ngrok-url.ngrok-free.dev/atlassian_mcp/mcp` | The LiteLLM proxy URL. Format: `<PROXY_URL>/<server_name_on_litellm>/mcp`. The `atlassian_mcp` part **must match** the key under `mcp_servers:` in your LiteLLM proxy config |
 | `--header "x-litellm-api-key: Bearer sk-1234"` | Your LiteLLM virtual key for authentication to the proxy |
 
 You can also add the MCP server directly to your `~/.claude.json` file instead of using `claude mcp add`. [See Claude Code docs](https://docs.anthropic.com/en/docs/claude-code/mcp).


### PR DESCRIPTION
Embeds the Loom walkthrough in the Claude Code MCP tutorial and corrects the server-specific URL path so it reads `<proxy_base_url>/<server_name>/mcp`, matching the routing used across the rest of the MCP docs.

Changes:
- `docs/tutorials/claude_mcp.md`: add a Demo section with the Loom embed; fix the `claude mcp add` URLs and the parameter-table format to `/<server_name>/mcp`.
- `docs/mcp_oauth.md`: fix the two troubleshooting `claude mcp add` examples to `http://proxy/server/mcp`.
- `docs/mcp.md`: fix the chat-completions `server_url` to `litellm_proxy/github/mcp` for consistency.

Left unchanged because they are correct as-is: the aggregate gateway endpoint `http://localhost:4000/mcp/` (no server name), the `/v1/mcp/...` and `/ui/mcp/oauth/...` paths, and Zapier's external `actions.zapier.com/mcp/...` URL. The `mcp_toolsets.md` toolset routes were left alone since toolsets may route differently from individual servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)