### PR TITLE
docs(integrations): document DAKERA_API_KEY and DAKERA_API_URL env vars

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -600,6 +600,8 @@ router_settings:
 | DATABRICKS_CLIENT_ID | Client ID for Databricks OAuth M2M authentication (Service Principal application ID)
 | DATABRICKS_CLIENT_SECRET | Client secret for Databricks OAuth M2M authentication
 | DATABRICKS_USER_AGENT | Custom user agent string for Databricks API requests. Used for partner telemetry attribution
+| DAKERA_API_KEY | API key for Dakera persistent memory integration. Used by `DakeraMemoryLogger` to authenticate with the self-hosted Dakera server. Defaults to empty string (no auth).
+| DAKERA_API_URL | Base URL for the self-hosted Dakera memory server. Used by `DakeraMemoryLogger`. Defaults to `http://localhost:3300`.
 | DAYS_IN_A_MONTH | Days in a month for calculation purposes. Default is 28
 | DAYS_IN_A_WEEK | Days in a week for calculation purposes. Default is 7
 | DAYS_IN_A_YEAR | Days in a year for calculation purposes. Default is 365

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -601,7 +601,7 @@ router_settings:
 | DATABRICKS_CLIENT_SECRET | Client secret for Databricks OAuth M2M authentication
 | DATABRICKS_USER_AGENT | Custom user agent string for Databricks API requests. Used for partner telemetry attribution
 | DAKERA_API_KEY | API key for Dakera persistent memory integration. Used by `DakeraMemoryLogger` to authenticate with the self-hosted Dakera server. Defaults to empty string (no auth).
-| DAKERA_API_URL | Base URL for the self-hosted Dakera memory server. Used by `DakeraMemoryLogger`. Defaults to `http://localhost:3300`.
+| DAKERA_API_URL | Base URL for the self-hosted Dakera memory server. Used by `DakeraMemoryLogger`. Defaults to `http://localhost:3000`.
 | DAYS_IN_A_MONTH | Days in a month for calculation purposes. Default is 28
 | DAYS_IN_A_WEEK | Days in a week for calculation purposes. Default is 7
 | DAYS_IN_A_YEAR | Days in a year for calculation purposes. Default is 365


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/BerriAI/litellm/pull/31812 which adds the `DakeraMemoryLogger` integration.

The `tests/documentation_tests/test_env_keys.py` CI check verifies that every `os.getenv()` call in litellm source code has a corresponding entry in this docs file. This PR adds the two entries required:

- `DAKERA_API_KEY` — API key for the self-hosted Dakera memory server
- `DAKERA_API_URL` — Base URL for the Dakera server (default: `http://localhost:3300`)

## Changes

Added two rows to the `### environment variables - Reference` table in `docs/proxy/config_settings.md`, alphabetically between `DATABRICKS_USER_AGENT` and `DAYS_IN_A_MONTH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)