### PR TITLE
docs(headroom): note LiteLLM v1.92.x version requirement

### DIFF
--- a/blog/headroom_integration/index.md
+++ b/blog/headroom_integration/index.md
@@ -32,6 +32,6 @@ Compression works on both `/v1/chat/completions` and `/v1/messages` (Anthropic f
 
 Turn it on per key, per request, or globally via `default_on: true`. Confirm it ran by checking the `x-litellm-applied-guardrails` response header or the Guardrails panel in the Logs UI.
 
-**Get started:** [Headroom guardrail setup guide](../../docs/proxy/headroom)
+**Get started:** [Headroom guardrail setup guide](../../docs/proxy/headroom) (requires LiteLLM v1.92.x or later; for testing ahead of the stable cut, grab the [v1.92.0-dev.1](https://github.com/BerriAI/litellm/releases/tag/v1.92.0-dev.1) dev release)
 
 **Discussion:** [GitHub discussion #31816](https://github.com/BerriAI/litellm/discussions/31816)

--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -15,7 +15,9 @@ Headroom runs as a sidecar service alongside LiteLLM. Client traffic continues t
 
 ## Requirements
 
-A reachable Headroom proxy. See [Deploy Headroom](#deploy-headroom) below for a one-file Dockerfile.
+LiteLLM v1.92.x or later, and a reachable Headroom proxy. See [Deploy Headroom](#deploy-headroom) below for a one-file Dockerfile.
+
+For testing ahead of the stable cut, use the [v1.92.0-dev.1](https://github.com/BerriAI/litellm/releases/tag/v1.92.0-dev.1) dev release.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Adds the minimum LiteLLM version (v1.92.x) to the Headroom guardrail requirements section in the docs and to the launch blog post's Get started line. Points readers at the [v1.92.0-dev.1](https://github.com/BerriAI/litellm/releases/tag/v1.92.0-dev.1) pre-release so they can try the integration before the stable cut lands.

## Test plan

- [ ] Preview the Headroom docs page and confirm the Requirements section shows the version note and dev release link.
- [ ] Preview the Headroom blog post and confirm the Get started line renders the version note and dev release link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)