### PR TITLE
docs: add routing documentation for new strategies

### DIFF
--- a/docs/routing/china-domestic-free-sources.md
+++ b/docs/routing/china-domestic-free-sources.md
@@ -1,0 +1,68 @@
+# China Domestic Free Sources
+
+Pre-configured free LLM sources for Chinese developers. These sources are accessible from mainland China without VPN.
+
+## Overview
+
+Chinese developers face unique challenges:
+- Need VPN to access international LLM APIs
+- Prefer local models for latency and privacy
+
+This configuration provides pre-configured free sources that work in China.
+
+## Sources
+
+### SiliconFlow (硅基流动)
+
+- **Website**: https://cloud.siliconflow.cn
+- **Free Models**: DeepSeek-R1, Qwen2.5-72B
+- **Registration**: Free credits on signup
+
+### Zhipu (智谱)
+
+- **Website**: https://open.bigmodel.cn
+- **Free Models**: GLM-4-Flash (永久免费)
+- **Registration**: 20M tokens free
+
+## Configuration
+
+```yaml
+model_list:
+  # SiliconFlow
+  - model_name: sf-deepseek-r1
+    litellm_params:
+      model: siliconflow/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  - model_name: sf-qwen2.5-72b
+    litellm_params:
+      model: siliconflow/Qwen/Qwen2.5-72B-Instruct
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  # Zhipu
+  - model_name: glm-4-flash
+    litellm_params:
+      model: zhipu/glm-4-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+
+  - model_name: glm-4.7-flash
+    litellm_params:
+      model: zhipu/glm-4.7-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+```
+
+## Environment Variables
+
+```bash
+export SILICONFLOW_API_KEY="your-key"
+export ZHIPU_API_KEY="your-key"
+```
+
+## Related
+
+- [Task-Aware Routing](./task-aware-routing.md)
+- [Local-First Routing](./local-first-routing.md)

--- a/docs/routing/local-first-routing.md
+++ b/docs/routing/local-first-routing.md
@@ -1,0 +1,56 @@
+# Local-First Routing
+
+Route requests to local models first, then fall back to cloud models. This minimizes latency and cost while maintaining privacy.
+
+## Overview
+
+Local-first routing prioritizes local models (e.g., Ollama) for:
+- **Lower latency**: Local models respond faster
+- **Zero cost**: No API charges
+- **Better privacy**: Data stays on your machine
+
+## Configuration
+
+```yaml
+router_settings:
+  routing_strategy: local-first-routing
+  routing_strategy_args:
+    local_provider: ollama
+    local_fallback_order:
+      - local
+      - domestic_free
+      - openrouter_free
+      - openrouter_paid
+```
+
+## Usage
+
+```python
+import litellm
+
+# This will prefer local models if available
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+## How It Works
+
+1. Request comes in for a model
+2. Router checks if a local alternative exists
+3. If local model available, use it
+4. If not, fall back to cloud model
+
+## Local Model Detection
+
+Models are considered "local" if they contain:
+- `ollama/`
+- `localhost:`
+- `127.0.0.1:`
+- `local/`
+
+## Related
+
+- [Task-Aware Routing](./task-aware-routing.md)
+- [China Domestic Free Sources](./china-domestic-free-sources.md)

--- a/docs/routing/task-aware-routing.md
+++ b/docs/routing/task-aware-routing.md
@@ -1,0 +1,85 @@
+# Task-Aware Routing
+
+Route requests based on task type (coding, chinese, general, english, fast). This allows you to define task-specific model preferences.
+
+## Overview
+
+Task-aware routing lets you specify different models for different tasks. For example:
+- **coding**: Prefer fast coding models (devstral, qwen3-coder)
+- **chinese**: Prefer Chinese-optimized models (qwen3, glm-4)
+- **general**: Prefer general-purpose models (gemma4, nemotron)
+
+## Configuration
+
+```yaml
+router_settings:
+  routing_strategy: task-aware-routing
+  routing_strategy_args:
+    task_mapping:
+      coding: [devstral, qwen3-coder, claude-sonnet]
+      chinese: [qwen3, sf-qwen2.5-72b, claude-sonnet]
+      general: [gemma4, nemotron-ultra-free, claude-sonnet]
+      english: [ornith-35b, nemotron-ultra-free, claude-opus]
+      fast: [deepseek-r1-14b, sf-deepseek-r1, glm-4-flash]
+    default_task: general
+```
+
+## Usage
+
+When making a request, include the `task` parameter in `metadata`:
+
+```python
+import litellm
+
+# Pass task via metadata (recommended)
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Write a Python function"}],
+    metadata={"task": "coding"}
+)
+```
+
+### Alternative: Pass via kwargs
+
+```python
+# Pass task directly as kwargs
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Write a Python function"}],
+    task="coding"
+)
+```
+
+### HTTP API
+
+```bash
+curl -X POST http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "messages": [{"role": "user", "content": "Write code"}],
+    "metadata": {"task": "coding"}
+  }'
+```
+
+## Task Types
+
+| Task | Description | Recommended Models |
+|------|-------------|-------------------|
+| `coding` | Code generation, debugging | devstral, qwen3-coder |
+| `chinese` | Chinese language tasks | qwen3, glm-4 |
+| `general` | General purpose | gemma4, nemotron |
+| `english` | English language tasks | ornith, claude |
+| `fast` | Quick responses | deepseek-r1-14b |
+
+## How It Works
+
+1. Request comes in with `task` parameter
+2. Router looks up `task_mapping[task]` to get model list
+3. First available model from the list is selected
+4. If no model found, falls back to `default_task`
+
+## Related
+
+- [Local-First Routing](./local-first-routing.md)
+- [China Domestic Free Sources](./china-domestic-free-sources.md)


### PR DESCRIPTION
## Description

Add documentation for three new routing strategies:

1. **Task-Aware Routing** - Route requests based on task type (coding/chinese/general/english/fast)
2. **Local-First Routing** - Prefer local models, fallback to cloud
3. **China Domestic Free Sources** - SiliconFlow and Zhipu configuration

## Files Added

- `docs/routing/task-aware-routing.md`
- `docs/routing/local-first-routing.md`
- `docs/routing/china-domestic-free-sources.md`

## Related Code PR

💻 **Code PR**: [BerriAI/litellm#31955](https://github.com/BerriAI/litellm/pull/31955)

This documentation corresponds to the code changes that implement these routing strategies.