### PR TITLE
docs: add output_config.effort known issue + supported versions banner

### DIFF
--- a/docs/claude_code_compatibility.md
+++ b/docs/claude_code_compatibility.md
@@ -31,6 +31,13 @@ entry stays here until the named fix has landed in a `v*-stable` release;
 the next daily run after that tag is cut will flip the cells green and
 the entry will be removed.
 
+### All Claude Code requests fail with a 400 error — Sonnet 4.6 / Opus 4.6, all providers
+
+- **Affected versions**: v1.83.9 – v1.87.x
+- **Symptom**: A recent Claude Code update changed its default thinking behavior in a way that exposed a compatibility issue in LiteLLM. All requests to Sonnet 4.6 and Opus 4.6 models fail immediately with `400 output_config.effort: Input should be 'low', 'medium', 'high' or 'max'` across all providers.
+- **Workaround**: If upgrading is not immediately possible, add `drop_params: true` to the affected model entry in your proxy config. Extended thinking will be disabled but requests will succeed.
+- **Status**: Fixed in v1.88.0.
+
 ### Opus 4.7 extended thinking on Bedrock Invoke + Vertex AI
 
 - **Affected cells**: `extended_thinking × bedrock_invoke`, `extended_thinking × vertex_ai`. Anthropic-native and Azure Foundry are unaffected on the same tier.

--- a/docs/proxy/release_cycle.md
+++ b/docs/proxy/release_cycle.md
@@ -1,5 +1,9 @@
 # Release Cycle
 
+:::warning
+Only the latest patch of the 4 most recent minor versions is supported (e.g. v1.90.x, v1.89.x, v1.88.x, v1.87.x). Older versions are deprecated and do not receive fixes or support. See [GitHub Releases](https://github.com/BerriAI/litellm/releases) for the current supported set.
+:::
+
 Litellm Proxy has the following release cycle:
 
 - `1.x.x-dev.N` (nightly): Releases which pass ci/cd (no manual review). Published on PyPI as `1.x.x.devN`.


### PR DESCRIPTION
## Summary

- **`claude_code_compatibility.md`**: adds a known issue entry for the `output_config.effort` 400 error that affected all Claude Code requests on Sonnet 4.6 / Opus 4.6 across all providers in v1.83.9–v1.87.x (fixed in v1.88.0), with workaround
- **`release_cycle.md`**: adds a warning banner clarifying that only the latest patch of the 4 most recent minor versions is supported; older versions are deprecated

<img width="914" height="212" alt="image" src="https://github.com/user-attachments/assets/ca8d0f86-5c93-4b28-8f28-f96684013b36" />
<img width="889" height="367" alt="image" src="https://github.com/user-attachments/assets/a1bcb441-4b24-4e2f-9980-610125b94b13" />
