### PR TITLE
docs: add no-perf-regression banner to v1.89.5

### DIFF
--- a/release_notes/v1.89.5/index.md
+++ b/release_notes/v1.89.5/index.md
@@ -18,6 +18,16 @@ authors:
 hide_table_of_contents: false
 ---
 
+:::info Update: no performance regression found
+
+An earlier version of this note flagged a potential throughput regression. We investigated and could not confirm or reproduce any regression in the released version. The one report we received came from a deployment running custom code on top of what we shipped, and our testing points to those changes, not LiteLLM, as the likely cause.
+
+Correctness and error rates were never affected. If you're on this version, there's nothing you need to do.
+
+We're still monitoring incoming reports and will update this note if anything changes.
+
+:::
+
 ## Deploy this version
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
## What

Adds the same resolved `:::info` "no performance regression found" banner from **v1.89.4** to the **v1.89.5** release note (identical text).

## Why

Keeps the messaging consistent across the 1.89 line so users landing on v1.89.5 see the same reassurance. Companion to #473.
