### PR TITLE
docs: document AZURE_SENTINEL_AUDIT_STREAM_NAME env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -526,6 +526,7 @@ router_settings:
 | AZURE_SCOPE | For EntraID Auth, Scope for Azure services, defaults to "https://cognitiveservices.azure.com/.default"
 | AZURE_SENTINEL_DCR_IMMUTABLE_ID | Immutable ID of the Data Collection Rule for Azure Sentinel logging
 | AZURE_SENTINEL_STREAM_NAME | Stream name for Azure Sentinel logging
+| AZURE_SENTINEL_AUDIT_STREAM_NAME | Stream name for Azure Sentinel audit logs; falls back to AZURE_SENTINEL_STREAM_NAME when unset
 | AZURE_SENTINEL_CLIENT_SECRET | Client secret for Azure Sentinel authentication
 | AZURE_SENTINEL_ENDPOINT | Endpoint for Azure Sentinel logging
 | AZURE_SENTINEL_TENANT_ID | Tenant ID for Azure Sentinel authentication


### PR DESCRIPTION
Documents the AZURE_SENTINEL_AUDIT_STREAM_NAME environment variable in the environment settings reference, added in BerriAI/litellm#32010 (resolves LIT-4174). The variable lets Azure Sentinel audit logs target a separate DCR stream; it falls back to AZURE_SENTINEL_STREAM_NAME when unset.

This companion doc change is what the litellm `documentation` / code-quality check validates (test_env_keys.py), so BerriAI/litellm#32010 stays red on that check until this merges

Related: LIT-4175 (Azure Sentinel audit log schema + separate DCR stream docs)