### PR TITLE
docs(headroom): document default compression protections

### DIFF
--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -221,8 +221,6 @@ Headroom protects two message types by default, set on the Headroom container it
 - `user`/`system` messages, unless `ENV HEADROOM_COMPRESS_USER_MESSAGES=1` is set. Most Claude Code traffic is `user` role, so a default deployment compresses none of it.
 - Messages with an Anthropic `cache_control` marker, always. Compressing them would break prompt-cache byte matching. No override exists.
 
-`requests_compressed: 0` on `user`/`system`-heavy, cache-heavy traffic like Claude Code is expected, not a bug; the guardrail still ran and shows up normally in `x-litellm-applied-guardrails` and spend log `guardrail_information`.
-
 ## Configuration reference
 
 | Param        | Type   | Description                                                                                          |

--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -214,6 +214,14 @@ ENV HEADROOM_TELEMETRY=off
 CMD ["headroom", "proxy", "--host", "0.0.0.0", "--port", "8787"]
 ```
 
+### Headroom defaults that can make compression look like a no-op
+
+Headroom applies its own protection rules before compressing anything, independently of LiteLLM. These are configured on the Headroom container itself (as `ENV` vars in the Dockerfile above, or in the Headroom service's own config), not in LiteLLM's `config.yaml`. If a workload sees `requests_compressed: 0` even though the guardrail is wired up correctly and `x-litellm-applied-guardrails` shows `headroom-compression` ran, check these two defaults first:
+
+- **`HEADROOM_COMPRESS_USER_MESSAGES` defaults to `0`.** Headroom protects `user` and `system` role messages from compression unless this is set to `1`. Since most Claude Code traffic is `user` role messages, a default Headroom deployment compresses none of it. Set `ENV HEADROOM_COMPRESS_USER_MESSAGES=1` on the Headroom container to opt in.
+- **Messages carrying an Anthropic `cache_control` marker are always protected.** Anthropic prompt caching requires a byte-exact match on the cached prefix, so Headroom skips compressing any message with a `cache_control` block to avoid invalidating the cache. Claude Code relies heavily on prompt caching, so a large share of its messages fall into this category regardless of the setting above. There is no override for this behavior; it is a correctness requirement of prompt caching, not a tunable.
+
+Because both of these are enforced inside Headroom before LiteLLM sees the compressed payload, LiteLLM's own guardrail logs and spend log `guardrail_information` will correctly show the guardrail ran, even when it compressed nothing. A `requests_compressed: 0` result on a `user`/`system`-heavy, cache-heavy workload like Claude Code is expected default behavior, not a bug.
 
 ## Configuration reference
 

--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -214,14 +214,14 @@ ENV HEADROOM_TELEMETRY=off
 CMD ["headroom", "proxy", "--host", "0.0.0.0", "--port", "8787"]
 ```
 
-### Headroom defaults that can make compression look like a no-op
+### Why `requests_compressed` can be 0
 
-Headroom applies its own protection rules before compressing anything, independently of LiteLLM. These are configured on the Headroom container itself (as `ENV` vars in the Dockerfile above, or in the Headroom service's own config), not in LiteLLM's `config.yaml`. If a workload sees `requests_compressed: 0` even though the guardrail is wired up correctly and `x-litellm-applied-guardrails` shows `headroom-compression` ran, check these two defaults first:
+Headroom protects two message types by default, set on the Headroom container itself, not in LiteLLM's `config.yaml`:
 
-- **`HEADROOM_COMPRESS_USER_MESSAGES` defaults to `0`.** Headroom protects `user` and `system` role messages from compression unless this is set to `1`. Since most Claude Code traffic is `user` role messages, a default Headroom deployment compresses none of it. Set `ENV HEADROOM_COMPRESS_USER_MESSAGES=1` on the Headroom container to opt in.
-- **Messages carrying an Anthropic `cache_control` marker are always protected.** Anthropic prompt caching requires a byte-exact match on the cached prefix, so Headroom skips compressing any message with a `cache_control` block to avoid invalidating the cache. Claude Code relies heavily on prompt caching, so a large share of its messages fall into this category regardless of the setting above. There is no override for this behavior; it is a correctness requirement of prompt caching, not a tunable.
+- `user`/`system` messages, unless `ENV HEADROOM_COMPRESS_USER_MESSAGES=1` is set. Most Claude Code traffic is `user` role, so a default deployment compresses none of it.
+- Messages with an Anthropic `cache_control` marker, always. Compressing them would break prompt-cache byte matching. No override exists.
 
-Because both of these are enforced inside Headroom before LiteLLM sees the compressed payload, LiteLLM's own guardrail logs and spend log `guardrail_information` will correctly show the guardrail ran, even when it compressed nothing. A `requests_compressed: 0` result on a `user`/`system`-heavy, cache-heavy workload like Claude Code is expected default behavior, not a bug.
+`requests_compressed: 0` on `user`/`system`-heavy, cache-heavy traffic like Claude Code is expected, not a bug; the guardrail still ran and shows up normally in `x-litellm-applied-guardrails` and spend log `guardrail_information`.
 
 ## Configuration reference
 


### PR DESCRIPTION
## Relevant issues

Ref: https://github.com/BerriAI/litellm/issues/31969

## Changes

Adds a section to the Headroom deploy docs explaining two Headroom-side defaults that can make compression look like a no-op on Claude Code style traffic: `HEADROOM_COMPRESS_USER_MESSAGES` defaults to `0` and protects user/system messages, and messages carrying an Anthropic `cache_control` marker are always protected to preserve prompt cache byte matching. Both are enforced inside Headroom itself, not in LiteLLM's guardrail config, so they were previously undocumented on the LiteLLM side and showed up as a confusing `requests_compressed: 0` result.

## Type

📖 Documentation