### PR TITLE
docs(budget-fallbacks): document key-level budget_fallbacks

### DIFF
--- a/docs/proxy/budget_fallbacks.md
+++ b/docs/proxy/budget_fallbacks.md
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem';
 
 # Budget Fallbacks
 
+:::info
+
+Available on `v1.92.x` and later.
+
+:::
+
 Reroute requests to a fallback model when a key's [`model_max_budget`](./users#-virtual-key-model-specific) is exceeded, instead of returning a `budget_exceeded` error.
 
 By default `model_max_budget` blocks requests once a key's spend on a model crosses its cap. `budget_fallbacks` lets you configure a per-model fallback chain on the key itself, so the request is silently rerouted to the first fallback that still has budget remaining. Spend is attributed to the fallback model, not the exhausted one.

--- a/docs/proxy/budget_fallbacks.md
+++ b/docs/proxy/budget_fallbacks.md
@@ -1,0 +1,104 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Budget Fallbacks
+
+Reroute requests to a fallback model when a key's [`model_max_budget`](./users#-virtual-key-model-specific) is exceeded, instead of returning a `budget_exceeded` error.
+
+By default `model_max_budget` blocks requests once a key's spend on a model crosses its cap. `budget_fallbacks` lets you configure a per-model fallback chain on the key itself, so the request is silently rerouted to the first fallback that still has budget remaining. Spend is attributed to the fallback model, not the exhausted one.
+
+This is a virtual key setting; it does not require any changes to `config.yaml` or router-level fallbacks.
+
+## When it triggers
+
+The fallback is applied when all of the following hold:
+
+The key has `model_max_budget` configured for the requested model, and the accumulated spend on that model has crossed its `budget_limit`. The key also has an entry in `budget_fallbacks` for the requested model. The first fallback in the chain that is itself within budget (either because it has no `model_max_budget` entry, or its cap has not been reached) is chosen; if every fallback is over budget, the original `BudgetExceededError` is raised.
+
+Router-level fallbacks (`fallbacks: [{model: [...]}]` in `config.yaml`) are unaffected and continue to run on downstream provider errors. `budget_fallbacks` only applies to the per-key `model_max_budget` check inside the auth layer.
+
+## Quick Start
+
+### 1. Generate a key with a per-model budget and a fallback chain
+
+```bash
+curl 'http://0.0.0.0:4000/key/generate' \
+  --header 'Authorization: Bearer sk-1234' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model_max_budget": {
+      "anthropic-haiku-4-5": {"budget_limit": 0.01, "time_period": "1d"}
+    },
+    "budget_fallbacks": {
+      "anthropic-haiku-4-5": ["gpt-5.5"]
+    }
+  }'
+```
+
+`budget_fallbacks` is a `Dict[str, List[str]]` keyed by the primary model name. The value is the ordered fallback chain for that model.
+
+### 2. Send a request
+
+Point the client at the primary model as usual:
+
+```bash
+curl 'http://0.0.0.0:4000/v1/chat/completions' \
+  --header 'Authorization: Bearer <sk-generated-key>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model": "anthropic-haiku-4-5",
+    "messages": [{"role": "user", "content": "hello"}]
+  }'
+```
+
+While the key is under its `anthropic-haiku-4-5` cap the request runs on `anthropic-haiku-4-5`. Once the cap is crossed subsequent requests are transparently served by `gpt-5.5` without any `budget_exceeded` error surfacing to the caller.
+
+### 3. Confirm the reroute
+
+`/spend/logs?api_key=<sk-generated-key>` will attribute the post-fallback usage to `gpt-5.5` (both the deployment and the `model_group`), so cost tracking, tagging, and per-model budgets remain accurate.
+
+## Chained fallbacks
+
+Each list entry is tried in order; the first fallback still within its own `model_max_budget` wins. This means you can define a tiered chain that steps down through progressively cheaper or higher-limit models:
+
+```bash
+curl 'http://0.0.0.0:4000/key/generate' \
+  --header 'Authorization: Bearer sk-1234' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model_max_budget": {
+      "gpt-5":         {"budget_limit": 5.0,  "time_period": "1d"},
+      "gpt-5-mini":    {"budget_limit": 2.0,  "time_period": "1d"},
+      "gpt-5-nano":    {"budget_limit": 1.0,  "time_period": "1d"}
+    },
+    "budget_fallbacks": {
+      "gpt-5": ["gpt-5-mini", "gpt-5-nano"]
+    }
+  }'
+```
+
+A request for `gpt-5` stays on `gpt-5` until it exhausts $5/day, then rolls to `gpt-5-mini` until that key hits $2/day, then rolls to `gpt-5-nano`. If `gpt-5-nano` is also over its $1/day cap the request finally returns `budget_exceeded`.
+
+Fallbacks that are not present in `model_max_budget` are treated as unlimited from the budget check's point of view and will always be selected if reached.
+
+## Updating an existing key
+
+Use `/key/update` to change the fallback chain without regenerating the key:
+
+```bash
+curl 'http://0.0.0.0:4000/key/update' \
+  --header 'Authorization: Bearer sk-1234' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "key": "sk-generated-key",
+    "budget_fallbacks": {"anthropic-haiku-4-5": ["gpt-5.5", "gpt-5-nano"]}
+  }'
+```
+
+## Notes
+
+`budget_fallbacks` is persisted on `LiteLLM_VerificationToken` and evaluated inside the auth layer, so the reroute happens before the request reaches the router. Every route that goes through key auth is covered, including `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`.
+
+Because the model is rewritten on the parsed request body, provider-specific route handlers (for example `/v1/messages`, which re-parses the body) still see the rerouted model name.
+
+Related: [Virtual Key model_max_budget](./users#-virtual-key-model-specific), [Fallback Management endpoints](./fallback_management), [Reliability and fallbacks](./reliability).

--- a/docs/proxy/budget_fallbacks.md
+++ b/docs/proxy/budget_fallbacks.md
@@ -95,10 +95,6 @@ curl 'http://0.0.0.0:4000/key/update' \
   }'
 ```
 
-## Notes
+## Related
 
-`budget_fallbacks` is persisted on `LiteLLM_VerificationToken` and evaluated inside the auth layer, so the reroute happens before the request reaches the router. Every route that goes through key auth is covered, including `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`.
-
-Because the model is rewritten on the parsed request body, provider-specific route handlers (for example `/v1/messages`, which re-parses the body) still see the rerouted model name.
-
-Related: [Virtual Key model_max_budget](./users#-virtual-key-model-specific), [Fallback Management endpoints](./fallback_management), [Reliability and fallbacks](./reliability).
+[Virtual Key model_max_budget](./users#-virtual-key-model-specific), [Fallback Management endpoints](./fallback_management), [Reliability and fallbacks](./reliability).

--- a/docs/proxy/fallback_management.md
+++ b/docs/proxy/fallback_management.md
@@ -265,3 +265,7 @@ Specifically triggered when content policy violations occur.
 - Fallbacks are attempted in the order specified in `fallback_models`
 - The maximum number of fallbacks attempted is controlled by the router's `max_fallbacks` setting
 - Changes take effect immediately and are persisted to the database
+
+## Related
+
+- [Budget Fallbacks](./budget_fallbacks): reroute a request to another model when a per-key `model_max_budget` is exceeded, instead of returning `budget_exceeded`.

--- a/docs/proxy/fallback_management.md
+++ b/docs/proxy/fallback_management.md
@@ -266,6 +266,6 @@ Specifically triggered when content policy violations occur.
 - The maximum number of fallbacks attempted is controlled by the router's `max_fallbacks` setting
 - Changes take effect immediately and are persisted to the database
 
-## Related
+## Budget Fallbacks
 
 - [Budget Fallbacks](./budget_fallbacks): reroute a request to another model when a per-key `model_max_budget` is exceeded, instead of returning `budget_exceeded`.

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -482,6 +482,8 @@ Expected response on failure
 </TabItem>
 </Tabs>
 
+To reroute requests to another model once a per-model budget is exceeded instead of returning `budget_exceeded`, see [Budget Fallbacks](./budget_fallbacks).
+
 
 ### Agents
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -532,6 +532,7 @@ const sidebars = {
             "proxy/rate_limit_tiers",
             "proxy/temporary_budget_increase",
             "proxy/budget_reset_and_tz",
+            "proxy/budget_fallbacks",
           ],
         },
         "proxy/caching",


### PR DESCRIPTION
## Summary

Documents the new `budget_fallbacks` field on virtual keys shipped in [BerriAI/litellm#31783](https://github.com/BerriAI/litellm/pull/31783).

`budget_fallbacks` reroutes a request to the first fallback model still within its own `model_max_budget` instead of returning `budget_exceeded`. The doc covers the reroute semantics, the `Dict[str, List[str]]` payload shape, chaining across tiers, and spend attribution to the fallback model.

Cross-linked from the `model_max_budget` section in `docs/proxy/users.md` and from `docs/proxy/fallback_management.md`. Added to the "Budgets + Rate Limits" sidebar section.

## Test plan

- [ ] `npm run build` succeeds and the new page renders at `/docs/proxy/budget_fallbacks`
- [ ] Sidebar shows the new entry under Budgets + Rate Limits
- [ ] Cross-links from `users.md` and `fallback_management.md` resolve