### PR TITLE
docs(release_notes): align v1.92.0rc1 folder and title to rc naming convention

### DIFF
--- a/release_notes/v1.92.0rc1/index.md
+++ b/release_notes/v1.92.0rc1/index.md
@@ -1,5 +1,5 @@
 ---
-title: "v1.92.0-rc.1 - Claude Sonnet 5, Production MCP OAuth & New Providers"
+title: "v1.92.0rc1 - Claude Sonnet 5, Production MCP OAuth & New Providers"
 slug: "v1-92-0-rc-1"
 date: 2026-07-04T23:30:00
 authors:


### PR DESCRIPTION
Follow-up to #486. That PR added the notes under `release_notes/v1.92.0-rc.1` with a matching title, but the recent convention (v1.86.0rc1 through v1.91.0rc1) is the PEP 440 form `vX.Y.ZrcN`, which is also what the promotion-to-stable rename expects (`v1.91.0rc1` became `v1.91.0`). This renames the folder to `release_notes/v1.92.0rc1` and updates the title to `v1.92.0rc1`. The slug (`v1-92-0-rc-1`), Docker tag, and pip version are unchanged, so the published URL is unaffected.