### PR TITLE
docs(blog): 5 ways to cut Claude Code costs with LiteLLM

### DIFF
--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -1,0 +1,120 @@
+---
+slug: save-claude-code-costs-with-litellm
+title: "4 ways to cut Claude Code costs with LiteLLM"
+date: 2026-07-04T10:00:00
+authors:
+  - krrish
+description: "Practical levers a platform admin can pull on the LiteLLM proxy to reduce Claude Code spend without asking developers to change a thing."
+tags: [claude-code, cost, budgets, headroom, mcp, prompt-caching]
+hide_table_of_contents: false
+---
+
+Claude Code is one of the heaviest consumers of input tokens in a modern engineering org. Long tool loops, large file reads, and MCP catalogs with hundreds of tools push every request toward the top of the context window, and the bill scales with it.
+
+If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), there are four levers the platform admin can pull to bring that cost down. None of them require a client-side change.
+
+{/* truncate */}
+
+## 1. Budget-based fallbacks
+
+Budget fallbacks let you cap a developer's daily spend on the expensive Claude model and silently degrade to a cheaper one once the cap is hit, instead of returning an error to their terminal. The config lives on the virtual key: attach `model_max_budget` per model and a `budget_fallbacks` chain that names the cheaper models to reroute to.
+
+```bash
+curl -X POST http://localhost:4000/key/generate \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_max_budget": {
+      "claude-opus-4-8":   {"budget_limit": 20.0, "time_period": "1d"},
+      "claude-sonnet-5":   {"budget_limit": 10.0, "time_period": "1d"},
+      "claude-haiku-4-5":  {"budget_limit": 5.0,  "time_period": "1d"}
+    },
+    "budget_fallbacks": {
+      "claude-opus-4-8":  ["claude-sonnet-5", "claude-haiku-4-5"],
+      "claude-sonnet-5":  ["claude-haiku-4-5"]
+    }
+  }'
+```
+
+Once the developer burns $20 of Opus in a day, subsequent Opus requests silently reroute to Sonnet; if Sonnet is also tapped out, Haiku picks up. Fallback models without a `model_max_budget` entry are treated as unlimited. Full reference in [Budget Fallbacks](../../docs/proxy/budget_fallbacks).
+
+## 2. Automatic Prompt Caching 
+
+Claude's prompt cache reads a cache hit for roughly 10% of the price of a fresh input token, but only if the request marks the right message with `cache_control`. LiteLLM injects that marker for you: point `cache_control_injection_points` at the system message (or the second-to-last user turn), and every Claude Code call through the proxy carries the checkpoint without any client-side edit.
+
+```yaml title="config.yaml"
+model_list:
+  - model_name: claude-sonnet-4-5
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+      cache_control_injection_points:
+        - location: message
+          role: system
+
+router_settings:
+  optional_pre_call_checks: ["prompt_caching"]
+```
+
+for automatically injecting this in all requests, do this 
+
+```yaml title="config.yaml"
+model_list:
+  - model_name: claude-sonnet-4.5-20250929
+    litellm_params:
+      model: vertex_ai/claude-sonnet-4-5@20250929
+      # ...
+
+router_settings:
+  default_litellm_params:
+    cache_control_injection_points:
+      - location: message
+        role: system
+  optional_pre_call_checks: ["prompt_caching"]
+```
+
+Turning on 'prompt_caching' as a pre call check, means if you run multiple deployments of the same Claude model, LiteLLM will intelligently route to the model deployment which was initially used for the request. 
+
+Details in [Auto-Inject Prompt Caching Checkpoints](../../docs/tutorials/prompt_caching) and [Claude Code - Prompt Cache Routing](../../docs/tutorials/claude_code_prompt_cache_routing).
+
+## 3. Prompt Compression (Headroom)
+
+Prompt cache trims the static prefix; Headroom trims the dynamic middle. Tool outputs, file reads, database dumps, and RAG payloads get rewritten into a compressed form before they reach the model, and if the model actually needs the original bytes, a `retrieve_headroom` tool call fetches them on demand. Reported savings run 60-95% on the compressible portion of Claude Code traffic.
+
+Headroom runs as a sidecar container next to LiteLLM. Register it as a `pre_call` guardrail and either flip `default_on: true` or attach it to per-developer virtual keys.
+
+```yaml title="config.yaml"
+guardrails:
+  - guardrail_name: headroom-compression
+    litellm_params:
+      guardrail: headroom
+      mode: pre_call
+      api_base: https://your-headroom-service
+      default_on: true
+```
+
+The developer still exports `ANTHROPIC_BASE_URL` and runs `claude`; the only thing they notice is a smaller number on the spend log. Deployment Dockerfile and per-key rollout pattern are in the [Headroom guardrail setup guide](../../docs/proxy/headroom).
+
+## 4. Defer MCP tools
+
+A Claude Code session that connects to five or six MCP servers can easily surface a few hundred tools, and every one of those tool schemas ships on every `tools/list` call. That is pure input-token overhead on a workload where the model uses two or three tools per turn.
+
+Turn on `mcp_tool_search_enabled` on the virtual key, and LiteLLM replaces the full catalog with two virtual tools, `mcp_tool_search` and `mcp_tool_call`. The model searches by keyword, gets the ranked matches back, and calls the one it wants. The token cost of tool listing collapses from hundreds of schemas to two.
+
+```bash
+curl -X POST http://localhost:4000/key/generate \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "object_permission": {
+      "mcp_tool_search_enabled": true,
+      "mcp_servers": ["github", "slack", "linear", "jira"]
+    }
+  }'
+```
+
+Ranking is token-overlap over `name + description`, so there is no embedding dependency to run. The access surface does not widen; search only returns tools the key was already allowed to call. Full walkthrough in [MCP Tool Search](../../docs/mcp_tool_search).
+
+## Stacking the levers
+
+The four features compose. Budget-based fallbacks bound the total spend regardless of what else you do. Prompt cache checkpoints and Headroom compression each shave a different slice of the request payload before it hits the model. Tool search cuts the tool schema overhead at the front of every turn. Turn them on together and the same Claude Code workload runs on a fraction of the input tokens it did before, without touching a single developer machine.

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -36,7 +36,9 @@ curl -X POST http://localhost:4000/key/generate \
   }'
 ```
 
-Once the developer burns $20 of Opus in a day, subsequent Opus requests silently reroute to Sonnet; if Sonnet is also tapped out, Haiku picks up. Fallback models without a `model_max_budget` entry are treated as unlimited. Full reference in [Budget Fallbacks](../../docs/proxy/budget_fallbacks).
+Once the developer burns $20 of Opus in a day, subsequent Opus requests silently reroute to Sonnet; if Sonnet is also tapped out, Haiku picks up. Fallback models without a `model_max_budget` entry are treated as unlimited.
+
+**→ Learn more:** [Budget Fallbacks](../../docs/proxy/budget_fallbacks)
 
 ## 2. Automatic Prompt Caching 
 
@@ -75,7 +77,7 @@ router_settings:
 
 Turning on 'prompt_caching' as a pre call check, means if you run multiple deployments of the same Claude model, LiteLLM will intelligently route to the model deployment which was initially used for the request. 
 
-Details in [Auto-Inject Prompt Caching Checkpoints](../../docs/tutorials/prompt_caching) and [Claude Code - Prompt Cache Routing](../../docs/tutorials/claude_code_prompt_cache_routing).
+**→ Learn more:** [Auto-Inject Prompt Caching Checkpoints](../../docs/tutorials/prompt_caching) · [Claude Code - Prompt Cache Routing](../../docs/tutorials/claude_code_prompt_cache_routing)
 
 ## 3. Prompt Compression (Headroom)
 
@@ -93,7 +95,9 @@ guardrails:
       default_on: true
 ```
 
-The developer still exports `ANTHROPIC_BASE_URL` and runs `claude`; the only thing they notice is a smaller number on the spend log. Deployment Dockerfile and per-key rollout pattern are in the [Headroom guardrail setup guide](../../docs/proxy/headroom).
+The developer still exports `ANTHROPIC_BASE_URL` and runs `claude`; the only thing they notice is a smaller number on the spend log.
+
+**→ Learn more:** [Headroom guardrail setup guide](../../docs/proxy/headroom)
 
 ## 4. Defer MCP tools
 
@@ -113,11 +117,13 @@ curl -X POST http://localhost:4000/key/generate \
   }'
 ```
 
-Ranking is token-overlap over `name + description`, so there is no embedding dependency to run. The access surface does not widen; search only returns tools the key was already allowed to call. Full walkthrough in [MCP Tool Search](../../docs/mcp_tool_search).
+Ranking is token-overlap over `name + description`, so there is no embedding dependency to run. The access surface does not widen; search only returns tools the key was already allowed to call.
+
+**→ Learn more:** [MCP Tool Search](../../docs/mcp_tool_search)
 
 ## 5. Auto routing
 
-Send every request to the smallest model that can handle it, so cheap requests never touch the expensive model. LiteLLM ships three flavors: [Semantic](../../docs/proxy/auto_routing) (embedding match), [Complexity](../../docs/proxy/auto_routing#complexity-router) (rule-based, zero external call), and [Adaptive](../../docs/adaptive_router) (learns from live traffic, beta).
+Send every request to the smallest model that can handle it, so cheap requests never touch the expensive model. LiteLLM ships three flavors: Semantic (embedding match), Complexity (rule-based, zero external call), and Adaptive (learns from live traffic, beta).
 
 Complexity router is the fastest to set up. Point Claude Code at `smart-router` and it classifies each request into a tier:
 
@@ -152,6 +158,8 @@ model_list:
           REASONING: o1-preview
       complexity_router_default_model: gpt-4o
 ```
+
+**→ Learn more:** [Complexity Router](../../docs/proxy/auto_routing#complexity-router) · [Semantic Auto Routing](../../docs/proxy/auto_routing) · [Adaptive Router](../../docs/adaptive_router)
 
 ## Stacking the levers
 

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -118,3 +118,9 @@ Ranking is token-overlap over `name + description`, so there is no embedding dep
 ## Stacking the levers
 
 The four features compose. Budget-based fallbacks bound the total spend regardless of what else you do. Prompt cache checkpoints and Headroom compression each shave a different slice of the request payload before it hits the model. Tool search cuts the tool schema overhead at the front of every turn. Turn them on together and the same Claude Code workload runs on a fraction of the input tokens it did before, without touching a single developer machine.
+
+## What's next: auto routing
+
+The natural next step past static fallbacks is picking the right model per request, not per budget window. LiteLLM ships three approaches to this today. [Semantic auto routing](../../docs/proxy/auto_routing) matches the input against utterances you define and dispatches to specialized models via embeddings. The [Complexity Router](../../docs/proxy/auto_routing#complexity-router) uses rule-based scoring for zero-latency classification with no external API call. The [Adaptive Router](../../docs/adaptive_router) is a beta that learns from live traffic which model performs best for each request type and balances quality against cost automatically.
+
+This is an area we are actively investing in. If you're interested in shaping where auto routing goes next, join the discussion at [litellm#32168](https://github.com/BerriAI/litellm/discussions/32168).

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -17,28 +17,23 @@ If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), the
 
 ## 1. Budget windows + budget fallbacks
 
-Two knobs, used together on the virtual key.
+Two knobs on the virtual key.
 
-**Budget windows** cap how much the key can spend on a given model over a rolling time period. Set `model_max_budget` with a `budget_limit` (dollars) and a `time_period` ("1d", "7d", "30d", etc). LiteLLM tracks spend per model per window and resets automatically when the window rolls.
-
-**Budget fallbacks** decide what happens once a window is exhausted. Instead of returning a 429 to the developer's terminal, attach a `budget_fallbacks` chain that names the cheaper models to reroute to. The request silently falls to the first fallback still under its own budget.
-
-Windows alone. `model_max_budget` caps daily spend per model on the key:
+**Budget windows** cap how much the key can spend inside a rolling time period. Set `max_budget` (dollars) and `budget_duration` ("24h", "7d", "30d", etc). LiteLLM resets the counter automatically at the end of every window. You can stack windows too, e.g. $10/day AND $100/month, so one bad afternoon can't burn the whole month:
 
 ```bash
-curl -X POST http://localhost:4000/key/generate \
-  -H "Authorization: Bearer $ADMIN_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model_max_budget": {
-      "claude-opus-4-8":   {"budget_limit": 20.0, "time_period": "1d"},
-      "claude-sonnet-5":   {"budget_limit": 10.0, "time_period": "1d"},
-      "claude-haiku-4-5":  {"budget_limit": 5.0,  "time_period": "1d"}
-    }
+curl 'http://0.0.0.0:4000/key/generate' \
+  --header 'Authorization: Bearer <your-master-key>' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "budget_limits": [
+      {"budget_duration": "24h", "max_budget": 10},
+      {"budget_duration": "30d", "max_budget": 100}
+    ]
   }'
 ```
 
-Windows + fallbacks. Add `budget_fallbacks` so the request degrades instead of erroring at the ceiling:
+**Budget fallbacks** decide what happens once a per-model budget is exhausted. Instead of erroring at the developer's terminal, attach `model_max_budget` per model and a `budget_fallbacks` chain naming the cheaper models to reroute to. The request silently falls to the first fallback still under its own budget:
 
 ```bash
 curl -X POST http://localhost:4000/key/generate \

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -169,4 +169,4 @@ The five features compose. Budget-based fallbacks bound the total spend regardle
 
 ## Help us make this better
 
-We're actively investing in cost optimization across the whole stack. If you've got ideas, on auto routing, better cache heuristics, smarter budget policies, anything, join the discussion at [litellm#32168](https://github.com/BerriAI/litellm/discussions/32168).
+We're actively investing in cost optimization across the whole stack. If you've got ideas, on auto routing, better cache heuristics, smarter budget policies, anything, join the discussion at [litellm#32172](https://github.com/BerriAI/litellm/discussions/32172).

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -17,9 +17,11 @@ If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), the
 
 ## 1. Budget windows + budget fallbacks
 
-Two knobs, used together. A budget window (`model_max_budget` with a `time_period`) caps how much a virtual key can spend on a given model in a rolling window, say $20 of Opus per day per developer. That alone stops runaway spend, but at the ceiling every subsequent request errors out at the developer's terminal, which is a bad experience.
+Two knobs, used together on the virtual key.
 
-Budget fallbacks paper over the ceiling. Attach a `budget_fallbacks` chain to the same key and, once a model is tapped out for the window, requests silently reroute to the next cheaper model still under budget.
+**Budget windows** cap how much the key can spend on a given model over a rolling time period. Set `model_max_budget` with a `budget_limit` (dollars) and a `time_period` ("1d", "7d", "30d", etc). LiteLLM tracks spend per model per window and resets automatically when the window rolls.
+
+**Budget fallbacks** decide what happens once a window is exhausted. Instead of returning a 429 to the developer's terminal, attach a `budget_fallbacks` chain that names the cheaper models to reroute to. The request silently falls to the first fallback still under its own budget.
 
 ```bash
 curl -X POST http://localhost:4000/key/generate \
@@ -40,7 +42,7 @@ curl -X POST http://localhost:4000/key/generate \
 
 Once the developer burns $20 of Opus in a day, subsequent Opus requests silently reroute to Sonnet; if Sonnet is also tapped out, Haiku picks up. Fallback models without a `model_max_budget` entry are treated as unlimited.
 
-**→ Learn more:** [Budget Fallbacks](../../docs/proxy/budget_fallbacks)
+**→ Learn more:** [Budget Windows](../../docs/proxy/users#set-multiple-budget-windows-on-a-key) · [Budget Fallbacks](../../docs/proxy/budget_fallbacks)
 
 ## 2. Automatic Prompt Caching 
 

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -15,9 +15,11 @@ If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), the
 
 {/* truncate */}
 
-## 1. Budget-based fallbacks
+## 1. Budget windows + budget fallbacks
 
-Budget fallbacks let you cap a developer's daily spend on the expensive Claude model and silently degrade to a cheaper one once the cap is hit, instead of returning an error to their terminal. The config lives on the virtual key: attach `model_max_budget` per model and a `budget_fallbacks` chain that names the cheaper models to reroute to.
+Two knobs, used together. A budget window (`model_max_budget` with a `time_period`) caps how much a virtual key can spend on a given model in a rolling window, say $20 of Opus per day per developer. That alone stops runaway spend, but at the ceiling every subsequent request errors out at the developer's terminal, which is a bad experience.
+
+Budget fallbacks paper over the ceiling. Attach a `budget_fallbacks` chain to the same key and, once a model is tapped out for the window, requests silently reroute to the next cheaper model still under budget.
 
 ```bash
 curl -X POST http://localhost:4000/key/generate \

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -23,6 +23,23 @@ Two knobs, used together on the virtual key.
 
 **Budget fallbacks** decide what happens once a window is exhausted. Instead of returning a 429 to the developer's terminal, attach a `budget_fallbacks` chain that names the cheaper models to reroute to. The request silently falls to the first fallback still under its own budget.
 
+Windows alone. `model_max_budget` caps daily spend per model on the key:
+
+```bash
+curl -X POST http://localhost:4000/key/generate \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_max_budget": {
+      "claude-opus-4-8":   {"budget_limit": 20.0, "time_period": "1d"},
+      "claude-sonnet-5":   {"budget_limit": 10.0, "time_period": "1d"},
+      "claude-haiku-4-5":  {"budget_limit": 5.0,  "time_period": "1d"}
+    }
+  }'
+```
+
+Windows + fallbacks. Add `budget_fallbacks` so the request degrades instead of erroring at the ceiling:
+
 ```bash
 curl -X POST http://localhost:4000/key/generate \
   -H "Authorization: Bearer $ADMIN_KEY" \

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -117,7 +117,41 @@ Ranking is token-overlap over `name + description`, so there is no embedding dep
 
 ## 5. Auto routing
 
-Static fallbacks pick the cheaper model only after a budget is blown. Auto routing goes one step further and picks the right model per request, so cheap requests never touch the expensive model in the first place. LiteLLM ships three approaches today. [Semantic auto routing](../../docs/proxy/auto_routing) matches the input against utterances you define and dispatches to specialized models via embeddings. The [Complexity Router](../../docs/proxy/auto_routing#complexity-router) uses rule-based scoring for zero-latency classification with no external API call. The [Adaptive Router](../../docs/adaptive_router) is a beta that learns from live traffic which model performs best for each request type and balances quality against cost automatically.
+Send every request to the smallest model that can handle it, so cheap requests never touch the expensive model. LiteLLM ships three flavors: [Semantic](../../docs/proxy/auto_routing) (embedding match), [Complexity](../../docs/proxy/auto_routing#complexity-router) (rule-based, zero external call), and [Adaptive](../../docs/adaptive_router) (learns from live traffic, beta).
+
+Complexity router is the fastest to set up. Point Claude Code at `smart-router` and it classifies each request into a tier:
+
+```yaml title="config.yaml"
+model_list:
+  # Target models
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: gpt-4o-mini
+
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+
+  - model_name: claude-sonnet
+    litellm_params:
+      model: claude-sonnet-4-20250514
+
+  - model_name: o1-preview
+    litellm_params:
+      model: o1-preview
+
+  # Complexity router
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE: gpt-4o-mini
+          MEDIUM: gpt-4o
+          COMPLEX: claude-sonnet
+          REASONING: o1-preview
+      complexity_router_default_model: gpt-4o
+```
 
 ## Stacking the levers
 

--- a/blog/save_claude_code_costs/index.md
+++ b/blog/save_claude_code_costs/index.md
@@ -1,6 +1,6 @@
 ---
 slug: save-claude-code-costs-with-litellm
-title: "4 ways to cut Claude Code costs with LiteLLM"
+title: "5 ways to cut Claude Code costs with LiteLLM"
 date: 2026-07-04T10:00:00
 authors:
   - krrish
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 Claude Code is one of the heaviest consumers of input tokens in a modern engineering org. Long tool loops, large file reads, and MCP catalogs with hundreds of tools push every request toward the top of the context window, and the bill scales with it.
 
-If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), there are four levers the platform admin can pull to bring that cost down. None of them require a client-side change.
+If Claude Code already points at a LiteLLM proxy (via `ANTHROPIC_BASE_URL`), there are five levers the platform admin can pull to bring that cost down. None of them require a client-side change.
 
 {/* truncate */}
 
@@ -115,12 +115,14 @@ curl -X POST http://localhost:4000/key/generate \
 
 Ranking is token-overlap over `name + description`, so there is no embedding dependency to run. The access surface does not widen; search only returns tools the key was already allowed to call. Full walkthrough in [MCP Tool Search](../../docs/mcp_tool_search).
 
+## 5. Auto routing
+
+Static fallbacks pick the cheaper model only after a budget is blown. Auto routing goes one step further and picks the right model per request, so cheap requests never touch the expensive model in the first place. LiteLLM ships three approaches today. [Semantic auto routing](../../docs/proxy/auto_routing) matches the input against utterances you define and dispatches to specialized models via embeddings. The [Complexity Router](../../docs/proxy/auto_routing#complexity-router) uses rule-based scoring for zero-latency classification with no external API call. The [Adaptive Router](../../docs/adaptive_router) is a beta that learns from live traffic which model performs best for each request type and balances quality against cost automatically.
+
 ## Stacking the levers
 
-The four features compose. Budget-based fallbacks bound the total spend regardless of what else you do. Prompt cache checkpoints and Headroom compression each shave a different slice of the request payload before it hits the model. Tool search cuts the tool schema overhead at the front of every turn. Turn them on together and the same Claude Code workload runs on a fraction of the input tokens it did before, without touching a single developer machine.
+The five features compose. Budget-based fallbacks bound the total spend regardless of what else you do. Prompt cache checkpoints and Headroom compression each shave a different slice of the request payload before it hits the model. MCP tool search cuts the tool schema overhead at the front of every turn. Auto routing sends every request to the smallest model that can handle it. Turn them on together and the same Claude Code workload runs on a fraction of the input tokens it did before, without touching a single developer machine.
 
-## What's next: auto routing
+## Help us make this better
 
-The natural next step past static fallbacks is picking the right model per request, not per budget window. LiteLLM ships three approaches to this today. [Semantic auto routing](../../docs/proxy/auto_routing) matches the input against utterances you define and dispatches to specialized models via embeddings. The [Complexity Router](../../docs/proxy/auto_routing#complexity-router) uses rule-based scoring for zero-latency classification with no external API call. The [Adaptive Router](../../docs/adaptive_router) is a beta that learns from live traffic which model performs best for each request type and balances quality against cost automatically.
-
-This is an area we are actively investing in. If you're interested in shaping where auto routing goes next, join the discussion at [litellm#32168](https://github.com/BerriAI/litellm/discussions/32168).
+We're actively investing in cost optimization across the whole stack. If you've got ideas, on auto routing, better cache heuristics, smarter budget policies, anything, join the discussion at [litellm#32168](https://github.com/BerriAI/litellm/discussions/32168).


### PR DESCRIPTION
## Summary
New blog post walking platform admins through five levers on the LiteLLM proxy that reduce Claude Code input token spend without a client-side change:

1. Budget windows + budget fallbacks (key-level `max_budget`/`budget_duration` and per-model `budget_fallbacks`)
2. Automatic prompt cache checkpoint injection (`cache_control_injection_points` + `PromptCachingDeploymentCheck`)
3. Headroom prompt compression as a `pre_call` guardrail
4. MCP tool search (`mcp_tool_search_enabled` on the key)
5. Auto routing (Semantic, Complexity, Adaptive), with a copy-pasteable Complexity Router yaml

Each section ends with a bold **→ Learn more** line linking the underlying docs: `docs/proxy/users#set-multiple-budget-windows-on-a-key`, `docs/proxy/budget_fallbacks`, `docs/tutorials/prompt_caching`, `docs/tutorials/claude_code_prompt_cache_routing`, `docs/proxy/headroom`, `docs/mcp_tool_search`, `docs/proxy/auto_routing`, `docs/adaptive_router`.

Closes with a broad CTA pointing readers at the [Cost Optimization Improvements discussion](https://github.com/BerriAI/litellm/discussions/32172).

## Test plan
- [x] `npm run start` locally renders the post at `/blog/save-claude-code-costs-with-litellm`
- [ ] All internal doc links resolve on the deployed site
- [x] Author key `krrish` exists in `blog/authors.yml`