### PR TITLE
chore(compat-matrix): refresh for v1.91.0 + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-01T06:17:17Z",
-  "litellm_version": "v1.90.0",
+  "generated_at": "2026-07-06T06:18:22Z",
+  "litellm_version": "v1.91.0",
   "claude_code_version": "2.1.126",
   "providers": [
     "anthropic",
@@ -22,7 +22,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -109,8 +110,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -132,7 +132,7 @@
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -219,7 +219,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
@@ -256,13 +257,15 @@
       "name": "Structured outputs",
       "providers": {
         "anthropic": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-opus-4-7] claude CLI failed: exit=1; text=Based on the schema, I need to provide answer as an integer."
         },
         "bedrock_invoke": {
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 4 green->red regression(s):
  - Basic messaging (non-streaming) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
  - Prompt caching (1h TTL) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
  - Structured outputs [anthropic]: pass -> fail ([claude-opus-4-7] claude CLI failed: exit=1; text=Based on the schema, I need to provide answer as an integer.)
  - Structured outputs [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.91.0` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-07-06T06:18:22Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=fail, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Long context (1M)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.