### PR TITLE
Surface Claude Code cost-savings blog as first-class docs link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -228,6 +228,7 @@ const sidebars = {
           type: "category",
           label: "Claude Code",
           items: [
+            { type: "link", label: "Cut Claude Code Costs", href: "/blog/save-claude-code-costs-with-litellm" },
             "claude_code_compatibility",
             "tutorials/claude_responses_api",
             "tutorials/claude_code_max_subscription",


### PR DESCRIPTION
The blog post "5 ways to cut Claude Code costs with LiteLLM" (`/blog/save-claude-code-costs-with-litellm`) was previously reachable only from the blog. This adds it as a first-class link at the top of the "Claude Code" sidebar category so users discover it directly from the docs. The motivation is that the post answers a lot of early cost questions, and far more users browse the docs than the blog, so surfacing it there puts the guidance in front of the people who need it.

The change is a single `type: "link"` entry in `sidebars.js`; no doc content moved.

Originating Slack thread: https://berriaillm.slack.com/archives/C09MLSU2DS8/p1783356716264619?thread_ts=1783222898.604389&cid=C09MLSU2DS8


---
_Generated by [Claude Code](https://claude.ai/code/session_01PCygvSZAbz8dYZQqx4451M)_