### PR TITLE
docs: add GonkaRouter provider page

### DIFF
--- a/docs/providers/gonkarouter.md
+++ b/docs/providers/gonkarouter.md
@@ -1,0 +1,84 @@
+# GonkaRouter
+
+LiteLLM supports chat completions through [GonkaRouter ↗](https://gonkarouter.io), an OpenAI-compatible AI model router that provides unified access to open-source models running on the decentralized [Gonka ↗](https://gonka.ai) network. The always-current model catalog is published at [`GET /v1/models` ↗](https://api.gonkarouter.io/v1/models); reference any model as `gonkarouter/<model-id>`.
+
+## Usage with LiteLLM Python SDK
+
+```python
+import os
+from litellm import completion
+
+os.environ["GONKAROUTER_API_KEY"] = "your-gonkarouter-api-key"
+
+messages = [{"role": "user", "content": "Write a short poem"}]
+response = completion(model="gonkarouter/MiniMaxAI/MiniMax-M2.7", messages=messages)
+print(response)
+```
+
+### Streaming
+
+```python
+import os
+from litellm import completion
+
+os.environ["GONKAROUTER_API_KEY"] = "your-gonkarouter-api-key"
+
+response = completion(
+    model="gonkarouter/moonshotai/Kimi-K2.6",
+    messages=[{"role": "user", "content": "Write a short poem"}],
+    stream=True,
+)
+for chunk in response:
+    print(chunk)
+```
+
+## Usage with LiteLLM Proxy
+
+### 1. Set GonkaRouter models in config.yaml
+
+```yaml
+model_list:
+  - model_name: gonkarouter-model
+    litellm_params:
+      model: gonkarouter/MiniMaxAI/MiniMax-M2.7
+      api_key: "os.environ/GONKAROUTER_API_KEY" # ensure you have `GONKAROUTER_API_KEY` in your .env
+```
+
+### 2. Start proxy
+
+```bash
+litellm --config config.yaml
+```
+
+### 3. Query proxy
+
+Assuming the proxy is running on [http://localhost:4000](http://localhost:4000):
+
+```bash
+curl http://localhost:4000/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_LITELLM_MASTER_KEY" \
+  -d '{
+    "model": "gonkarouter-model",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "Write a short poem"
+      }
+    ]
+  }'
+```
+
+`-H "Authorization: Bearer YOUR_LITELLM_MASTER_KEY"` is only required if you have set a LiteLLM master key
+
+## Supported models
+
+GonkaRouter serves open-source models on the Gonka network, and the live list changes over time. The authoritative, always-current catalog is the public [`GET /v1/models` ↗](https://api.gonkarouter.io/v1/models) endpoint. Reference any entry as `gonkarouter/<model-id>`, for example `gonkarouter/MiniMaxAI/MiniMax-M2.7`.
+
+## Supported features
+
+GonkaRouter is OpenAI-compatible and supports chat completions, streaming, and tool calling.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1077,6 +1077,7 @@ const sidebars = {
         "providers/github",
         "providers/github_copilot",
         "providers/gmi",
+        "providers/gonkarouter",
         "providers/chatgpt",
         "providers/gradient_ai",
         "providers/groq",


### PR DESCRIPTION
## What does this PR do?

Adds the documentation page for the **GonkaRouter** provider. This is the companion docs PR for the provider registration in [BerriAI/litellm#32316](https://github.com/BerriAI/litellm/pull/32316) (the `url` field in `provider_endpoints_support.json` points here).

GonkaRouter is an OpenAI-compatible AI model router that provides unified access to open-source models (MiniMax, Kimi, and more) running on the decentralized [Gonka](https://gonka.ai) network. See https://gonkarouter.io.

### Changes
- **`docs/providers/gonkarouter.md`** — new provider page: Python SDK usage, streaming, LiteLLM Proxy config + query, supported models, and features. Mirrors the `gonkabroker` docs page.
- **`sidebars.js`** — adds `providers/gonkarouter` to the providers sidebar (next to `gmi`).

### Integration details
| | |
|---|---|
| API base URL | `https://api.gonkarouter.io/v1` |
| Authentication | `GONKAROUTER_API_KEY` (`Authorization: Bearer sk-…`) |
| Model naming | `gonkarouter/<model-id>` |
| Model catalog | `GET https://api.gonkarouter.io/v1/models` |

## Type
📖 Documentation