### PR TITLE
docs: document the weekly release schedule

### DIFF
--- a/docs/proxy/release_cycle.md
+++ b/docs/proxy/release_cycle.md
@@ -18,6 +18,18 @@ See [LiteLLM release versioning is changing](/blog/cleaner-release-versions) for
 
 Follow our release notes [here](https://github.com/BerriAI/litellm/releases).
 
+## Weekly schedule
+
+Each week runs the same loop against one version line. The first nightly (`dev`) build, typically Tuesday, opens the next minor version (for example `1.86.0`), and that base rides every build until it ships as stable. A second nightly follows midweek, typically Thursday. On Saturday the release candidate is cut (`1.86.0rc1`) and enters a roughly week-long window for early testers and QA. Late the following week, on Friday or Saturday, the prior week's `rc` is promoted to stable with the suffix dropped (`1.85.0rc1` becomes `1.85.0`), identical to that `rc` unless a fix was backported. Each Saturday therefore does double duty: the current week's `rc` is cut while the previous week's `rc` becomes stable.
+
+| Day | What ships |
+| --- | --- |
+| Tuesday | First nightly `dev` build; opens the next minor (`1.86.0.dev1`) |
+| Thursday | Second nightly `dev` build, cumulative (`1.86.0.dev2`) |
+| Saturday | New `rc` cut (`1.86.0rc1`); prior week's `rc` promoted to stable |
+
+If a Saturday `rc` fails QA it is not promoted; a fix lands, a follow-up `rc` may be cut, and the schedule picks up from there.
+
 
 ## FAQ
 

--- a/docs/proxy/release_cycle.md
+++ b/docs/proxy/release_cycle.md
@@ -27,6 +27,7 @@ Each week runs the same loop against one version line. The first nightly (`dev`)
 | Tuesday | First nightly `dev` build; opens the next minor (`1.86.0.dev1`) |
 | Thursday | Second nightly `dev` build, cumulative (`1.86.0.dev2`) |
 | Saturday | New `rc` cut (`1.86.0rc1`); prior week's `rc` promoted to stable |
+| Next Tuesday | Next line's first nightly opens (`1.87.0.dev1`); the loop repeats, and `1.86.0rc1` becomes stable that Fri/Sat |
 
 If a Saturday `rc` fails QA it is not promoted; a fix lands, a follow-up `rc` may be cut, and the schedule picks up from there.
 

--- a/docs/proxy/release_cycle.md
+++ b/docs/proxy/release_cycle.md
@@ -27,7 +27,7 @@ Each week runs the same loop against one version line. The first nightly (`dev`)
 | Tuesday | First nightly `dev` build; opens the next minor (`1.86.0.dev1`) |
 | Thursday | Second nightly `dev` build, cumulative (`1.86.0.dev2`) |
 | Saturday | New `rc` cut (`1.86.0rc1`); prior week's `rc` promoted to stable |
-| Next Tuesday | Next line's first nightly opens (`1.87.0.dev1`); the loop repeats, and `1.86.0rc1` becomes stable that Fri/Sat |
+| Next Tuesday | Next line's first nightly opens (`1.87.0.dev1`); the loop repeats |
 
 If a Saturday `rc` fails QA it is not promoted; a fix lands, a follow-up `rc` may be cut, and the schedule picks up from there.
 


### PR DESCRIPTION
Adds a Weekly schedule section to the release cycle page. The page already described the release types (dev/rc/stable) and versioning, but not the week-to-week rhythm.

The cadence: two nightly dev builds midweek (typically Tuesday and Thursday), with Tuesday's build opening the next minor version that rides every build for the week. A release candidate is cut every Saturday and goes through a roughly week-long window for early testers and QA. The following Friday or Saturday, the prior week's rc is promoted to stable with the suffix dropped, identical to that rc unless a fix was backported. This mirrors the internal Project-Releaser Operator Runbook.

Left the existing FAQ 'typically Sunday' wording untouched for now.