### PR TITLE
docs(prometheus): fix /metrics auth default since v1.85.0

### DIFF
--- a/docs/proxy/prometheus.md
+++ b/docs/proxy/prometheus.md
@@ -42,12 +42,10 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 }'
 ```
 
-View Metrics on `/metrics` (requires a LiteLLM API key since v1.85.0):
+View Metrics on `/metrics`:
 ```shell
 curl http://localhost:4000/metrics \
   -H "Authorization: Bearer sk-..."
-
-# <proxy_base_url>/metrics
 ```
 
 ### Multiple Workers
@@ -625,18 +623,9 @@ Here is a screenshot of the metrics you can monitor with the LiteLLM Grafana Das
 
 ## Authentication on `/metrics` endpoint
 
-:::info Default changed in v1.85.0
-As of [v1.85.0](https://github.com/BerriAI/litellm/releases/tag/v1.85.0), **`/metrics` requires LiteLLM API key authentication by default**. Earlier versions left it unauthenticated unless you set `require_auth_for_metrics_endpoint: true`.
-:::
+**By default, `/metrics` requires LiteLLM API key authentication** (since v1.85.0).
 
-Prometheus scrapers and manual `curl` checks must send a valid key in the `Authorization` header:
-
-```bash
-curl http://localhost:4000/metrics \
-  -H "Authorization: Bearer sk-..."
-```
-
-Example `prometheus.yml` scrape config:
+For Prometheus, add `authorization` to your scrape config:
 
 ```yaml
 scrape_configs:
@@ -648,18 +637,12 @@ scrape_configs:
       - targets: ['localhost:4000']
 ```
 
-### Opt out (unauthenticated `/metrics`)
-
-If your Prometheus setup cannot send auth headers, restore unauthenticated access by setting:
+To allow unauthenticated access:
 
 ```yaml
 litellm_settings:
   require_auth_for_metrics_endpoint: false
 ```
-
-:::warning
-Leaving `/metrics` unauthenticated exposes spend and usage metrics to anyone who can reach the endpoint. Only disable auth if the endpoint is network-restricted.
-:::
 
 ## FAQ 
 

--- a/docs/proxy/prometheus.md
+++ b/docs/proxy/prometheus.md
@@ -42,9 +42,10 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 }'
 ```
 
-View Metrics on `/metrics`, Visit `http://localhost:4000/metrics` 
+View Metrics on `/metrics` (requires a LiteLLM API key since v1.85.0):
 ```shell
-http://localhost:4000/metrics
+curl http://localhost:4000/metrics \
+  -H "Authorization: Bearer sk-..."
 
 # <proxy_base_url>/metrics
 ```
@@ -622,16 +623,43 @@ Here is a screenshot of the metrics you can monitor with the LiteLLM Grafana Das
 
 
 
-## Add authentication on /metrics endpoint
+## Authentication on `/metrics` endpoint
 
-**By default /metrics endpoint is unauthenticated.** 
+:::info Default changed in v1.85.0
+As of [v1.85.0](https://github.com/BerriAI/litellm/releases/tag/v1.85.0), **`/metrics` requires LiteLLM API key authentication by default**. Earlier versions left it unauthenticated unless you set `require_auth_for_metrics_endpoint: true`.
+:::
 
-You can opt into running litellm authentication on the /metrics endpoint by setting the following on the config 
+Prometheus scrapers and manual `curl` checks must send a valid key in the `Authorization` header:
+
+```bash
+curl http://localhost:4000/metrics \
+  -H "Authorization: Bearer sk-..."
+```
+
+Example `prometheus.yml` scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'litellm'
+    authorization:
+      type: Bearer
+      credentials: <LITELLM_API_KEY>
+    static_configs:
+      - targets: ['localhost:4000']
+```
+
+### Opt out (unauthenticated `/metrics`)
+
+If your Prometheus setup cannot send auth headers, restore unauthenticated access by setting:
 
 ```yaml
 litellm_settings:
-  require_auth_for_metrics_endpoint: true
+  require_auth_for_metrics_endpoint: false
 ```
+
+:::warning
+Leaving `/metrics` unauthenticated exposes spend and usage metrics to anyone who can reach the endpoint. Only disable auth if the endpoint is network-restricted.
+:::
 
 ## FAQ 
 


### PR DESCRIPTION
## Summary
- Correct the Prometheus docs: `/metrics` requires LiteLLM API key auth **by default** since v1.85.0 (commit BerriAI/litellm@35bbca60)
- Update Quick Start `curl` example to include `Authorization: Bearer`
- Add Prometheus `authorization.credentials` scrape config example
- Document opt-out via `require_auth_for_metrics_endpoint: false`

Fixes stale guidance that said the endpoint was unauthenticated by default and that `require_auth_for_metrics_endpoint: true` was opt-in — reported by a user whose Prometheus scrapes started failing with 401 after upgrade.

## Test plan
- [x] Verified against current LiteLLM code (`require_auth_for_metrics_endpoint: Optional[bool] = True` in `litellm/__init__.py`)
- [ ] Docs site preview renders the updated auth section and admonitions correctly


Made with [Cursor](https://cursor.com)