### PR TITLE
docs(mcp-oauth): document oauth2_flow as required for oauth2 MCP servers

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -395,13 +395,14 @@ See the **[MCP OAuth guide](./mcp_oauth.md)** for setup instructions, sequence d
 
 LiteLLM v 1.77.6 added support for OAuth 2.0 Client Credentials for MCP servers.
 
-You can configure this either in `config.yaml` or directly from the LiteLLM UI (MCP Servers → Authentication → OAuth).
+You can configure this either in `config.yaml` or directly from the LiteLLM UI (MCP Servers → Authentication → OAuth). Every `auth_type: oauth2` server must declare its flow via `oauth2_flow`: `authorization_code` for interactive browser sign-in (shown below) or `client_credentials` for machine-to-machine tokens.
 
 ```yaml
 mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
     client_secret: os.environ/GITHUB_OAUTH_CLIENT_SECRET
 ```

--- a/docs/mcp_control.md
+++ b/docs/mcp_control.md
@@ -94,6 +94,7 @@ mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     authorization_url: https://github.com/login/oauth/authorize
     token_url: https://github.com/login/oauth/access_token
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
@@ -118,6 +119,7 @@ mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     authorization_url: https://github.com/login/oauth/authorize
     token_url: https://github.com/login/oauth/access_token
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
@@ -272,6 +274,7 @@ mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     authorization_url: https://github.com/login/oauth/authorize
     token_url: https://github.com/login/oauth/access_token
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID

--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -1,12 +1,12 @@
 # MCP OAuth
 
-LiteLLM supports two OAuth 2.0 flows for MCP servers:
+LiteLLM supports two OAuth 2.0 flows for MCP servers. Every `auth_type: oauth2` server in `config.yaml` must declare which one it uses via `oauth2_flow`:
 
-| Flow | Use Case | How It Works |
-|------|----------|--------------|
-| **Interactive (PKCE)** | User-facing apps (Claude Code, Cursor) | Browser-based consent, per-user tokens |
-| **Machine-to-Machine (M2M)** | Backend services, CI/CD, automated agents | `client_credentials` grant, proxy-managed tokens |
-| **On-Behalf-Of (OBO)** | User-context tool calls to protected MCP servers | LiteLLM exchanges the caller token for a scoped MCP token. See [MCP OBO Auth](./mcp_obo_auth.md). |
+| Flow | `oauth2_flow` | Use Case | How It Works |
+|------|---------------|----------|--------------|
+| **Interactive (PKCE)** | `authorization_code` | User-facing apps (Claude Code, Cursor) | Browser-based consent, per-user tokens |
+| **Machine-to-Machine (M2M)** | `client_credentials` | Backend services, CI/CD, automated agents | `client_credentials` grant, proxy-managed tokens |
+| **On-Behalf-Of (OBO)** | n/a (uses `auth_type: oauth2_token_exchange`) | User-context tool calls to protected MCP servers | LiteLLM exchanges the caller token for a scoped MCP token. See [MCP OBO Auth](./mcp_obo_auth.md). |
 
 ## Interactive OAuth (PKCE)
 
@@ -19,6 +19,7 @@ mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
     client_secret: os.environ/GITHUB_OAUTH_CLIENT_SECRET
 ```
@@ -225,6 +226,7 @@ mcp_servers:
   my_mcp_server:
     url: "https://my-mcp-server.com/mcp"
     auth_type: oauth2
+    oauth2_flow: client_credentials
     client_id: os.environ/MCP_CLIENT_ID
     client_secret: os.environ/MCP_CLIENT_SECRET
     token_url: "https://auth.example.com/oauth/token"
@@ -273,6 +275,7 @@ mcp_servers:
   test_oauth2:
     url: "http://localhost:8765/mcp"
     auth_type: oauth2
+    oauth2_flow: client_credentials
     client_id: "test-client"
     client_secret: "test-secret"
     token_url: "http://localhost:8765/oauth/token"
@@ -302,7 +305,7 @@ curl http://localhost:4000/mcp-rest/tools/call \
 | Field | Required | Description |
 |-------|----------|-------------|
 | `auth_type` | Yes | Must be `oauth2`. For RFC 8693 On-Behalf-Of, use `oauth2_token_exchange` instead — see [MCP OBO Auth](./mcp_obo_auth.md). |
-| `oauth2_flow` | No | Explicit flow selector. One of `"client_credentials"` (M2M) or `"authorization_code"` (interactive PKCE). If omitted, LiteLLM infers from the other fields: `authorization_url` present → interactive; only `token_url` + `client_id` + `client_secret` → client credentials. Set explicitly when in doubt — for example, when a legacy DB row has both `authorization_url` and `token_url` but you want M2M. |
+| `oauth2_flow` | Yes | Flow selector. One of `"client_credentials"` (M2M) or `"authorization_code"` (interactive PKCE, including `delegate_auth_to_upstream`). Required for every `auth_type: oauth2` server in `config.yaml`; the proxy refuses to start if it is missing or invalid. Servers created through the UI get it from the OAuth flow type selector. Only legacy database rows created before this field existed fall back to inference from field shape at request time; config entries are never inferred. |
 | `client_id` | Yes for M2M, optional for interactive | OAuth2 client ID. Required for `client_credentials`. For interactive flows, can be obtained via Dynamic Client Registration (RFC 7591) at `POST /{server_name}/register` if the upstream supports it. Supports `os.environ/VAR_NAME`. |
 | `client_secret` | Yes for M2M, optional for interactive | OAuth2 client secret. Same applicability as `client_id`. Supports `os.environ/VAR_NAME`. |
 | `token_url` | Yes for M2M, optional for interactive | Token endpoint URL. LiteLLM POSTs to this for `client_credentials` and for the authorization-code exchange. |
@@ -419,10 +422,11 @@ mcp_servers:
   notion_mcp:
     url: "https://mcp.notion.com/mcp"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     delegate_auth_to_upstream: true
 ```
 
-That's the entire change. The flag is honored **only** when `auth_type: oauth2`; setting it on any other auth type is silently ignored.
+That's the entire change. Delegated servers are interactive, so they take `oauth2_flow: authorization_code`. The flag is honored **only** when `auth_type: oauth2`; setting it on any other auth type is silently ignored.
 
 :::warning Internal-only (`available_on_public_internet: false`) **and** upstream PKCE delegation
 
@@ -482,4 +486,5 @@ The bypass only fires when **every** target the request resolves to opts in. It 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `auth_type` | Yes | Must be `oauth2`. The flag is ignored otherwise. |
+| `oauth2_flow` | Yes | Set to `authorization_code`; delegation passes the client's interactive PKCE flow through to the upstream server. |
 | `delegate_auth_to_upstream` | Yes | Set to `true` to opt this server into PKCE passthrough. |

--- a/docs/tutorials/claude_mcp.md
+++ b/docs/tutorials/claude_mcp.md
@@ -29,6 +29,7 @@ mcp_servers:
     url: "https://api.githubcopilot.com/mcp"
     transport: "http"
     auth_type: oauth2
+    oauth2_flow: authorization_code
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
     client_secret: os.environ/GITHUB_OAUTH_CLIENT_SECRET
 ```
@@ -44,6 +45,7 @@ mcp_servers:
     url: "https://mcp.atlassian.com/v1/mcp"
     transport: "http"
     auth_type: oauth2
+    oauth2_flow: authorization_code
 ```
 
 </TabItem>


### PR DESCRIPTION
## What

Updates every `auth_type: oauth2` MCP server config example to include the now-required `oauth2_flow` field, and corrects the config reference to match current behavior.

Since BerriAI/litellm#32292, an `auth_type: oauth2` server in `config.yaml` must declare `oauth2_flow: client_credentials` (M2M) or `oauth2_flow: authorization_code` (interactive PKCE, including `delegate_auth_to_upstream`). The proxy raises a `ValueError` at startup when the field is missing or invalid, and no longer infers the flow from field shape for config entries. Only legacy DB rows created before the field existed still fall back to shape inference at request time.

Without this change, every oauth2 config example in the docs fails proxy startup on current builds.

Resolves LIT-4251

## Changes

`docs/mcp_oauth.md`: adds an `oauth2_flow` column to the flow comparison table so the interactive flow visibly maps to `authorization_code`; adds the field to the interactive setup, M2M setup, mock-server test config, and delegate-auth examples; rewrites the `oauth2_flow` config reference row from optional-with-inference to required; adds the field to the delegate section's config reference.

`docs/mcp_control.md`, `docs/tutorials/claude_mcp.md`, `docs/mcp.md`: adds `oauth2_flow` to the remaining oauth2 examples (`authorization_code` for all; they are interactive GitHub/Atlassian setups) and a sentence in mcp.md stating the flow must be declared.

## Screenshots

Each pair below renders the affected doc section from a local Docusaurus build, `main` on the left and this branch on the right.

### docs/mcp_oauth.md

The flow comparison table gains an `oauth2_flow` column so each flow visibly maps to its config value.

![flow comparison table](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMWQ1ZDdkMDQtZTkzNy00ZDkyLWEwYzYtMmFhY2MyNGE3ZTVhIiwiaWF0IjoxNzgzNDc5NzY5LCJleHAiOjE3ODQwODQ1NjksImZpbGVuYW1lIjoiZmxvd190YWJsZS5wbmcifQ.mWO5Ymr7vHRfHayUwSYbDiEfnKzCzdpAbAdYhwkWGUE)

The config reference row for `oauth2_flow` moves from optional with shape inference to required, and states that the proxy refuses to start when it is missing.

![oauth2_flow config reference](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvODM3YWMwOGQtNDg5ZC00ZmVhLTkyMjQtODI5NzQ4Zjk1ZWYwIiwiaWF0IjoxNzgzNDc5NzY5LCJleHAiOjE3ODQwODQ1NjksImZpbGVuYW1lIjoiY29uZmlnX3JlZmVyZW5jZS5wbmcifQ.pRnFKkn9yBvgdfdSOUmzJsXGaJBkGWABQ0thvAYkKKA)

The interactive PKCE and machine-to-machine setup examples now declare the flow explicitly.

![interactive PKCE example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNTliMmZjOTktMDE5Ny00NmI4LTkwMzQtNTA3ZjJmNTc4NzU4IiwiaWF0IjoxNzgzNDc5NzY5LCJleHAiOjE3ODQwODQ1NjksImZpbGVuYW1lIjoiaW50ZXJhY3RpdmVfZXhhbXBsZS5wbmcifQ.aFZ_AgaqL-NBMmcS7uwCKr3j9khsn1eZqn3nv8B9Ha4)

![M2M example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZGE1MmRhMTItZjk5Yy00MzQ3LTkyMjctNzk4ZDJjYWFlYmIyIiwiaWF0IjoxNzgzNDc5NzY5LCJleHAiOjE3ODQwODQ1NjksImZpbGVuYW1lIjoibTJtX2V4YW1wbGUucG5nIn0.Bb4KLux0l5Ayk_ylnJyff7xoOtJLe6LCPAuAWrJ6pic)

The delegate-auth example and its config reference add `oauth2_flow: authorization_code`, since delegated servers are interactive.

![delegate example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNzEwNGQwYjYtMjNiOS00MjFjLWJlYTQtZmI4OGU4ZThlY2Y2IiwiaWF0IjoxNzgzNDc5NzcwLCJleHAiOjE3ODQwODQ1NzAsImZpbGVuYW1lIjoiZGVsZWdhdGVfZXhhbXBsZS5wbmcifQ.gwrSyoChlpt9YT7aYiSFJ5C8rXZosPNnCIvjezdQJag)

![delegate config reference](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWViNGVkM2QtYzY5ZS00ODUwLTk4MDMtY2YzOThlMzJmOWM5IiwiaWF0IjoxNzgzNDc5NzcwLCJleHAiOjE3ODQwODQ1NzAsImZpbGVuYW1lIjoiZGVsZWdhdGVfcmVmZXJlbmNlLnBuZyJ9.zLheC0Hai-ZKJnRtrxEX4VUjhMXdxOcl7B406ksnrlQ)

### docs/mcp.md, docs/mcp_control.md, docs/tutorials/claude_mcp.md

The remaining oauth2 examples across these pages pick up the field, and the mcp.md overview adds a sentence explaining that the flow must be declared.

![mcp.md overview example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvY2ZjN2RmNjEtMTE1Ny00YjIzLWFkMzYtNzI0ZmQ0ZWViODdkIiwiaWF0IjoxNzgzNDc5NzcwLCJleHAiOjE3ODQwODQ1NzAsImZpbGVuYW1lIjoibWNwX292ZXJ2aWV3LnBuZyJ9.P3_6TKmW0EBQXcvC5m4U-sOA0GyY3fBCgGzhQc2guz4)

![mcp_control.md example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvY2EwYTU4ZjQtYmI4ZS00YjY2LWIyN2MtOWJmMmI4MDEyNDQ4IiwiaWF0IjoxNzgzNDc5NzcwLCJleHAiOjE3ODQwODQ1NzAsImZpbGVuYW1lIjoibWNwX2NvbnRyb2wucG5nIn0.8MkrF99v8w-xUMvVC9Sr4ImpN1R6levVbzITnIT3hOQ)

![claude_mcp.md example](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvODgwZWQxNDYtZTc3Yy00MGViLWFhZDUtZjBjOTVlMGFiODhjIiwiaWF0IjoxNzgzNDc5NzcwLCJleHAiOjE3ODQwODQ1NzAsImZpbGVuYW1lIjoiY2xhdWRlX21jcC5wbmcifQ.o435WxuXSMrQ-_eaPuD-NgWI1bTQh6j6MgRviaefYrc)

## Note on timing

This documents the behavior on `litellm_internal_staging` (required-in-config landed 2026-07-07). If the docs site should track the latest stable release, hold merging until that change ships; the examples themselves are forward-compatible either way since the field is accepted on older versions that still infer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102