### PR TITLE
Revert "docs(config_settings): document LITELLM_MCP_MAX_TOOL_NAME_LENGTH"

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -663,7 +663,6 @@ router_settings:
 | LITELLM_MCP_TOOL_LISTING_TIMEOUT | Timeout in seconds for listing tools from an MCP server. Default is 30
 | LITELLM_MCP_METADATA_TIMEOUT | HTTP client timeout in seconds for OAuth metadata fetching. Default is 10
 | LITELLM_MCP_HEALTH_CHECK_TIMEOUT | Health check timeout in seconds for MCP servers. Default is 10
-| LITELLM_MCP_MAX_TOOL_NAME_LENGTH | Maximum length for MCP tool names (after the server prefix is applied); longer names are excluded from tool listings since providers such as AWS Bedrock, OpenAI, and Gemini reject tool names over 64 characters. Set to 0 or a negative value to disable. Default is 64
 | LITELLM_MCP_STDIO_EXTRA_COMMANDS | Comma-separated extra command basenames allowed for MCP stdio transport beyond the built-in allowlist. Example: `my-mcp-bin`. Empty by default
 | MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL | Default TTL in seconds for MCP OAuth2 token cache. Default is 3600
 | MCP_OAUTH2_TOKEN_CACHE_MAX_SIZE | Maximum number of entries in MCP OAuth2 token cache. Default is 200


### PR DESCRIPTION
Reverts BerriAI/litellm-docs#501