### PR TITLE
docs(vertex): document reasoning_effort -> thinking_level mapping for Gemini 3.x (#267)

### DIFF
--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -854,6 +854,21 @@ Added an additional non-OpenAI standard "disable" value for non-reasoning Gemini
 | "medium"         | "budget_tokens": 2048 |
 | "high"           | "budget_tokens": 4096 |
 
+**Mapping for Gemini 3.x models (thinking level)**
+
+For Gemini 3+ models, LiteLLM maps `reasoning_effort` to Gemini's `thinking_level` instead of a token budget. The resulting level depends on the specific model. [Code](https://github.com/BerriAI/litellm/blob/999637883ce34d3944c614f38f32cfbe0bc9062d/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py#L868-L913)
+
+| reasoning_effort | Gemini 3.x `*-flash`         | `gemini-3.1-pro-preview`     | Other Gemini 3+ (e.g. `gemini-3-pro`) |
+| ---------------- | ---------------------------- | ---------------------------- | ------------------------------------- |
+| "minimal"        | "thinkingLevel": "minimal"   | "thinkingLevel": "low"       | "thinkingLevel": "low"                |
+| "low"            | "thinkingLevel": "low"       | "thinkingLevel": "low"       | "thinkingLevel": "low"                |
+| "medium"         | "thinkingLevel": "medium"    | "thinkingLevel": "medium"    | "thinkingLevel": "high"               |
+| "high"           | "thinkingLevel": "high"      | "thinkingLevel": "high"      | "thinkingLevel": "high"               |
+| "disable"        | "thinkingLevel": "minimal"   | "thinkingLevel": "low"       | "thinkingLevel": "low"                |
+| "none"           | "thinkingLevel": "minimal"   | "thinkingLevel": "low"       | "thinkingLevel": "low"                |
+
+All levels above are sent with `includeThoughts: true`, except `"disable"` and `"none"`, which set `includeThoughts: false`. Gemini 3 cannot fully disable thinking, so the lowest available level is used with thoughts hidden.
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 


### PR DESCRIPTION
## What

Documents the `reasoning_effort` → `thinking_level` mapping used for **Gemini 3.x** models on Vertex AI, closing #267.

The existing "Thinking / `reasoning_content`" section only covers the older `reasoning_effort` → `thinkingBudget` (token-budget) mapping. Since then, LiteLLM added a separate `reasoning_effort` → `thinkingLevel` path for Gemini 3+ models (`_map_reasoning_effort_to_thinking_level`), so the docs were out of sync with the implementation.

## Details

The new table mirrors the current logic in [`vertex_and_google_ai_studio_gemini.py`](https://github.com/BerriAI/litellm/blob/999637883ce34d3944c614f38f32cfbe0bc9062d/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py#L868-L913):

- Gemini 3.x `*-flash` models support the `minimal` thinking level; other Gemini 3+ models floor to `low`.
- `gemini-3.1-pro-preview` maps `medium` → `medium`, whereas other non-flash Gemini 3+ models (e.g. `gemini-3-pro`) map `medium` → `high`.
- All levels are sent with `includeThoughts: true`, except `disable`/`none`, which set `includeThoughts: false` (Gemini 3 cannot fully disable thinking, so the lowest level is used with thoughts hidden).

Docs-only change; no code touched. The older thinkingBudget table is left unchanged.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
