### PR TITLE
docs: document the coordination redis

### DIFF
--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -27,27 +27,25 @@ calling the LLM API again.
 
 When the proxy verifies a **virtual key** (customer API key), results are cached so the database is not queried on every request. By default that cache lives **only in each worker process**—so after a deploy, new pods or extra Uvicorn workers each warm their own cache and can trigger more DB reads until warmed.
 
-Set `litellm_settings.enable_redis_auth_cache: true` to mirror virtual-key auth data into **the same Redis instance** configured under `litellm_settings.cache` / `cache_params`. Workers and replicas then share cached auth entries across the cluster.
+Set `litellm_settings.enable_redis_auth_cache: true` to mirror virtual-key auth data into the proxy's Redis. Workers and replicas then share cached auth entries across the cluster.
 
 **Requirements**
 
-- `litellm_settings.cache` must be **`true`** (Redis for the proxy is initialized during cache setup). See [All settings](./config_settings).
-- `cache_params.type` must be **`redis`** (or Redis Cluster, per your cache config); the auth cache attaches to that Redis client. See [supported `cache_params`](#supported-cache_params-on-proxy-configyaml).
+- The proxy must have a Redis client. Configure one with [`general_settings.coordination_redis`](./coordination_redis), or let the auth cache attach to a plain-Redis response cache (`litellm_settings.cache: true` and `cache_params.type: redis`, or Redis Cluster). A semantic response cache does not provide one; see [how the coordination Redis is resolved](./coordination_redis#how-the-coordination-redis-is-resolved).
 - Optionally set **`general_settings.user_api_key_cache_ttl`** (seconds): TTL applies to both the in-memory and Redis tiers when Redis auth caching is enabled, so stale keys expire consistently.
 
 Example:
 
 ```yaml
-litellm_settings:
-  cache: true
-  enable_redis_auth_cache: true
-  cache_params:
-    type: redis
+general_settings:
+  coordination_redis:
     host: os.environ/REDIS_HOST
     port: 6379
-
-general_settings:
+    password: os.environ/REDIS_PASSWORD
   user_api_key_cache_ttl: 300 # optional; seconds
+
+litellm_settings:
+  enable_redis_auth_cache: true
 ```
 
 :::tip

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -104,9 +104,10 @@ litellm_settings:
     ttl: 600 # ttl for caching
     disable_copilot_system_to_assistant: False # DEPRECATED - GitHub Copilot API supports system prompts.
 
-  # Virtual key auth cache — shares API key / virtual-key auth across workers via Redis.
+  # Virtual key auth cache - shares API key / virtual-key auth across workers via Redis.
   # Reduces DB round trips when caches are cold on new workers or pods.
-  # Requires litellm_settings.cache: true AND cache_params.type: redis above.
+  # Requires a Redis client on the proxy: general_settings.coordination_redis,
+  # or a plain-redis response cache (cache: true AND cache_params.type: redis above).
   enable_redis_auth_cache: false
 
 callback_settings:
@@ -135,6 +136,20 @@ general_settings:
   maximum_spend_logs_retention_period: 30d # The maximum time to retain spend logs before deletion.
   maximum_spend_logs_retention_interval: 1d # interval in which the spend log cleanup task should run in.
   user_mcp_management_mode: restricted  # or "view_all"
+
+  # Coordination Redis - shared state across pods (rate limits, parallel request
+  # limits, spend buffer, pod lock, shared health checks). Independent of the
+  # response cache under litellm_settings.cache.
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+    # url: os.environ/REDIS_URL  # alternative to host/port/password
+    # ssl: true
+    # startup_nodes: [{host: ..., port: ...}]  # Redis Cluster
+    # sentinel_nodes: [[host, port]]           # Redis Sentinel
+    # service_name: mymaster
+    # sentinel_password: os.environ/REDIS_SENTINEL_PASSWORD
 
   # Database Settings
   database_url: string
@@ -212,7 +227,7 @@ router_settings:
 | context_window_fallbacks | array of objects | Fallbacks to use when a ContextWindowExceededError is encountered. [Further docs](./reliability#context-window-fallbacks) |
 | cache | boolean | If true, enables caching. [Further docs](./caching) |
 | cache_params | object | Parameters for the cache. [Further docs](./caching#supported-cache_params-on-proxy-configyaml) |
-| enable_redis_auth_cache | boolean | When `true`, stores virtual-key auth payloads in Redis (same client as response caching) so every worker/pod shares cached auth lookups—fewer repeated database reads on cache misses. **Requires `cache: true` and `cache_params.type: redis`** (Redis or Redis Cluster). Optional: set `general_settings.user_api_key_cache_ttl` so TTL applies consistently to memory and Redis. [Further docs](./caching#virtual-key-authentication-cache-redis) |
+| enable_redis_auth_cache | boolean | When `true`, stores virtual-key auth payloads in the proxy's Redis so every worker/pod shares cached auth lookups; fewer repeated database reads on cache misses. **Requires a Redis client on the proxy**, from [`general_settings.coordination_redis`](./coordination_redis) or from a plain-Redis response cache (`cache: true` and `cache_params.type: redis`, or Redis Cluster). Optional: set `general_settings.user_api_key_cache_ttl` so TTL applies consistently to memory and Redis. [Further docs](./caching#virtual-key-authentication-cache-redis) |
 | disable_end_user_cost_tracking | boolean | If true, turns off end user cost tracking on prometheus metrics + litellm spend logs table on proxy. |
 | enable_end_user_cost_tracking_prometheus_only | boolean | If true, includes the `end_user` label on Prometheus metrics. Disabled by default to keep Prometheus cardinality bounded. [Further docs](./prometheus#tracking-end_user-on-prometheus) |
 | cost_discount_config | object | Provider-specific percentage discounts applied to cost calculations. Configure under `litellm_settings`. [Further docs](./provider_discounts) |
@@ -326,6 +341,7 @@ router_settings:
 | always_include_stream_usage | boolean | If true, includes usage metrics in every streaming response chunk |
 | auto_redirect_ui_login_to_sso | boolean | If true, automatically redirects UI login page to SSO provider |
 | control_plane_url | string | URL of the control plane for cross-instance state sharing |
+| coordination_redis | object | Redis connection used for cross-pod state: key/user/team rate limits, parallel request limits, the Redis spend transaction buffer, the pod lock manager, and shared health checks. Takes precedence over borrowing a plain-Redis response cache, which in turn takes precedence over building a client from `REDIS_*` environment variables. Supports `host`/`port`/`password`, `url`, `ssl`, Cluster `startup_nodes`, and Sentinel `sentinel_nodes`/`service_name`/`sentinel_password`. [Further docs](./coordination_redis) |
 | custom_auth_run_common_checks | boolean | If true, runs LiteLLM's standard auth validation alongside custom auth (key/team/user/project model allowlists, budgets, rate limits). Default is `false` — see [Custom Auth — Enforce model access](./custom_auth#enforce-model-access-budgets-and-teamproject-checks) |
 | custom_ui_sso_sign_in_handler | string | Custom handler for SSO sign-in logic in the UI |
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |

--- a/docs/proxy/coordination_redis.md
+++ b/docs/proxy/coordination_redis.md
@@ -1,0 +1,159 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Coordination Redis
+
+The proxy uses a Redis instance to share state between pods and workers. This is the **coordination Redis**, and it is configured under `general_settings.coordination_redis`, independently of the LLM response cache
+
+Everything that has to agree across replicas rides on it:
+
+- Cross-pod **tpm/rpm rate limits** for keys, users, teams, and end users
+- **Parallel request limits** (`max_parallel_requests` and its team/key equivalents)
+- **Spend tracking** through the Redis transaction buffer (`general_settings.use_redis_transaction_buffer`)
+- The **pod lock manager**, which elects the single pod allowed to flush spend updates to the database
+- **Shared health checks** (`general_settings.use_shared_health_check`)
+
+Without it, each pod counts tokens, requests, and spend in its own process memory, so a key limited to 100 RPM effectively gets 100 RPM per pod
+
+:::info
+
+The coordination Redis is separate from the [response cache](./caching). The response cache is configured only under `litellm_settings.cache` / `cache_params`, and it can be a semantic cache, an S3 bucket, or nothing at all, while coordination still runs on Redis
+
+:::
+
+## Quick Start
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+```
+
+Every value supports `os.environ/` references. A connection URL works too, in place of host/port/password:
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    url: os.environ/REDIS_URL
+```
+
+:::tip
+
+Prefer `host`, `port`, and `password` over `url` in production. See [Redis 'port', 'host', 'password'. NOT 'redis_url'](./prod#4-use-redis-porthost-password-not-redis_url)
+
+:::
+
+## How the coordination Redis is resolved
+
+The proxy picks the first of these that yields a connection:
+
+1. The explicit `general_settings.coordination_redis` block
+2. The response cache, when `litellm_settings.cache_params.type` is `redis` (or Redis Cluster). Its client is borrowed for coordination
+3. The `REDIS_*` environment variables, which build a standalone client: `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`, or `REDIS_URL`, or `REDIS_CLUSTER_NODES`, or `REDIS_SENTINEL_NODES`, with TLS via `REDIS_SSL` and friends
+
+If none of the three produce a connection, coordination falls back to per-pod in-memory state, which is only correct for a single-replica deployment
+
+Steps 2 and 3 mean existing deployments keep working untouched. Step 3 also closes a gap: a proxy configured with a semantic response cache, or no response cache, previously had no coordination Redis even when `REDIS_HOST` was set in the environment
+
+## TLS, Cluster, and Sentinel
+
+<Tabs>
+
+<TabItem value="tls" label="TLS">
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+    ssl: true
+```
+
+</TabItem>
+
+<TabItem value="cluster" label="Redis Cluster">
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    startup_nodes:
+      - host: os.environ/REDIS_CLUSTER_NODE_1_HOST
+        port: os.environ/REDIS_CLUSTER_NODE_1_PORT
+      - host: os.environ/REDIS_CLUSTER_NODE_2_HOST
+        port: os.environ/REDIS_CLUSTER_NODE_2_PORT
+    password: os.environ/REDIS_PASSWORD
+```
+
+</TabItem>
+
+<TabItem value="sentinel" label="Redis Sentinel">
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    sentinel_nodes:
+      - ["os.environ/REDIS_SENTINEL_1_HOST", 26379]
+      - ["os.environ/REDIS_SENTINEL_2_HOST", 26379]
+    service_name: mymaster
+    sentinel_password: os.environ/REDIS_SENTINEL_PASSWORD
+```
+
+</TabItem>
+
+</Tabs>
+
+## Coexisting with a semantic response cache
+
+Because the two are configured separately, a semantic response cache and a plain coordination Redis run side by side. Point them at whichever instances you like; the semantic cache needs a vector-capable Redis, the coordination Redis does not
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis-semantic
+    similarity_threshold: 0.8
+    redis_semantic_cache_embedding_model: text-embedding-ada-002
+```
+
+## Coordination Redis vs router Redis
+
+`router_settings.redis_host` / `redis_port` / `redis_password` configures the **router's** Redis, which holds load-balancing state: deployment cooldowns, usage-based routing counters, and model-level rpm/tpm tracking
+
+Key, user, team, and end-user rate limits, parallel request limits, spend, the pod lock, and shared health checks all live on the coordination Redis instead. When the router has no Redis of its own, the proxy attaches the coordination Redis to it, so a single `coordination_redis` block is enough for most deployments. Configure `router_settings` explicitly when you want routing state on a different instance
+
+## Configure from the Admin UI
+
+Go to the **Caching** page in the Admin UI and open the **Coordination Redis** tab. Fill in the connection details, use **Test Connection** to confirm the proxy can reach the instance, and save. Settings persist to the database and take effect on the next proxy restart
+
+## Migrating from `cache: true` with `supported_call_types: []`
+
+Older guides recommend enabling a response cache and then disabling it for every call type:
+
+```yaml showLineNumbers title="config.yaml"
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis
+    supported_call_types: [] # Optional: Set cache for proxy, but not on the actual llm api call
+```
+
+That pattern exists only to get a Redis client onto the proxy; the response cache is switched off immediately afterwards. Replace it with a `coordination_redis` block, which says what it means and leaves `litellm_settings.cache` free for actual response caching:
+
+```yaml showLineNumbers title="config.yaml"
+general_settings:
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+```
+
+The old form keeps working. Nothing breaks if you leave it in place

--- a/docs/proxy/coordination_redis.md
+++ b/docs/proxy/coordination_redis.md
@@ -12,6 +12,7 @@ Everything that has to agree across replicas rides on it:
 - **Spend tracking** through the Redis transaction buffer (`general_settings.use_redis_transaction_buffer`)
 - The **pod lock manager**, which elects the single pod allowed to flush spend updates to the database
 - **Shared health checks** (`general_settings.use_shared_health_check`)
+- **Virtual key auth caching**, opt-in via `litellm_settings.enable_redis_auth_cache`, so workers and replicas share cached key lookups instead of each warming their own
 
 Without it, each pod counts tokens, requests, and spend in its own process memory, so a key limited to 100 RPM effectively gets 100 RPM per pod
 
@@ -51,11 +52,17 @@ The proxy picks the first of these that yields a connection:
 
 1. The explicit `general_settings.coordination_redis` block
 2. The response cache, when `litellm_settings.cache_params.type` is `redis` (or Redis Cluster). Its client is borrowed for coordination
-3. The `REDIS_*` environment variables, which build a standalone client: `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`, or `REDIS_URL`, or `REDIS_CLUSTER_NODES`, or `REDIS_SENTINEL_NODES`, with TLS via `REDIS_SSL` and friends
+3. The `REDIS_*` environment variables, which build a standalone client: `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`, or `REDIS_URL`. `REDIS_CLUSTER_NODES` builds a cluster client and `REDIS_SENTINEL_NODES` a sentinel-managed one, so the environment covers the same topologies as the config block. TLS comes from `REDIS_SSL` and friends
 
 If none of the three produce a connection, coordination falls back to per-pod in-memory state, which is only correct for a single-replica deployment
 
 Steps 2 and 3 mean existing deployments keep working untouched. Step 3 also closes a gap: a proxy configured with a semantic response cache, or no response cache, previously had no coordination Redis even when `REDIS_HOST` was set in the environment
+
+:::warning
+
+A `host` set in the `coordination_redis` block outranks a `REDIS_URL` exported in the environment. Earlier versions let the environment's url win and silently discard the explicit host and port, so a deployment carrying a global `REDIS_URL` alongside a `coordination_redis.host` will now connect to the host named in the block
+
+:::
 
 ## TLS, Cluster, and Sentinel
 
@@ -128,11 +135,13 @@ litellm_settings:
 
 `router_settings.redis_host` / `redis_port` / `redis_password` configures the **router's** Redis, which holds load-balancing state: deployment cooldowns, usage-based routing counters, and model-level rpm/tpm tracking
 
-Key, user, team, and end-user rate limits, parallel request limits, spend, the pod lock, and shared health checks all live on the coordination Redis instead. When the router has no Redis of its own, the proxy attaches the coordination Redis to it, so a single `coordination_redis` block is enough for most deployments. Configure `router_settings` explicitly when you want routing state on a different instance
+Key, user, team, and end-user rate limits, parallel request limits, spend, the pod lock, and shared health checks all live on the coordination Redis instead. When the router has no Redis of its own, the proxy attaches the coordination Redis to it, so a single `coordination_redis` block is enough for most deployments. The attach only happens in that case: an explicit `router_settings.redis_host` always wins for router state, so set it when you want routing state on a different instance
 
 ## Configure from the Admin UI
 
-Go to the **Caching** page in the Admin UI and open the **Coordination Redis** tab. Fill in the connection details, use **Test Connection** to confirm the proxy can reach the instance, and save. Settings persist to the database and take effect on the next proxy restart
+Go to the **Caching** page in the Admin UI and open the **Coordination Redis** tab. Fill in the connection details, use **Test Connection** to confirm the proxy can reach the instance, then **Save Changes**. Settings persist to the database and take effect on the next proxy restart, so a proxy with no config-file block and no `REDIS_*` environment variables can be pointed at a Redis entirely from the UI
+
+The same settings are available over the API through `GET` and `POST /coordination_redis/settings`, with `POST /coordination_redis/settings/test` for the connection check
 
 ## Migrating from `cache: true` with `supported_call_types: []`
 

--- a/docs/proxy/db_deadlocks.md
+++ b/docs/proxy/db_deadlocks.md
@@ -64,17 +64,15 @@ A single instance flushes the redis queue to the DB
 
 You can enable using the redis buffer by setting `use_redis_transaction_buffer: true` in the `general_settings` section of your `proxy_config.yaml` file. 
 
-Note: This setup requires litellm to be connected to a redis instance. 
+Note: This setup requires litellm to be connected to a redis instance. The buffer uses the proxy's [coordination Redis](./coordination_redis), which is configured independently of the response cache. 
 
 ```yaml showLineNumbers title="litellm proxy_config.yaml"
 general_settings:
   use_redis_transaction_buffer: true
-
-litellm_settings:
-  cache: True
-  cache_params:
-    type: redis
-    supported_call_types: [] # Optional: Set cache for proxy, but not on the actual llm api call
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
 ```
 
 ## Monitoring

--- a/docs/proxy/db_deadlocks.md
+++ b/docs/proxy/db_deadlocks.md
@@ -105,10 +105,11 @@ This means all available Redis connections are in use, and LiteLLM cannot obtain
 - Increase the `max_connections` parameter in your Redis config section in `proxy_config.yaml` to allow more simultaneous connections. For example:
 
 ```yaml
-litellm_settings:
-  cache: True
-  cache_params:
-    type: redis
+general_settings:
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
     max_connections: 100  # Increase as needed for your traffic
 ```
 

--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -353,11 +353,7 @@ Add this to your config:
 ```yaml
 general_settings:
   use_redis_transaction_buffer: true
-
-litellm_settings:
-  cache: true
-  cache_params:
-    type: redis
+  coordination_redis:
     host: your-redis-host
 ```
 

--- a/docs/proxy/io_token_rate_limits.md
+++ b/docs/proxy/io_token_rate_limits.md
@@ -131,7 +131,7 @@ Do **not** set both modes on the same deployment. If `itpm` or `otpm` is present
 
 ## Multi-Instance Deployment
 
-Share counters across proxy replicas with Redis:
+ITPM/OTPM are deployment-level limits, so their counters live with the rest of the router's load-balancing state; limits on keys, users, and teams use the [coordination Redis](./coordination_redis) instead. Share the counters across proxy replicas with the router's Redis:
 
 ```yaml showLineNumbers title="config.yaml"
 router_settings:

--- a/docs/proxy/load_balancing.md
+++ b/docs/proxy/load_balancing.md
@@ -133,6 +133,8 @@ router_settings:
   redis_password: your-password
 ```
 
+`router_settings` Redis holds the router's own load-balancing state, including model-level rate limits, cooldowns, and usage-based routing counters; key, user, and team rate limits use the [coordination Redis](./coordination_redis) instead, and the router falls back to it when it has no Redis of its own.
+
 
 :::info
 Detailed information about [routing strategies can be found here](../routing)
@@ -220,6 +222,8 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 ## Load Balancing using multiple litellm instances (Kubernetes, Auto Scaling)
 
 LiteLLM Proxy supports sharing rpm/tpm shared across multiple litellm instances, pass `redis_host`, `redis_password` and `redis_port` to enable this. (LiteLLM will use Redis to track rpm/tpm usage )
+
+This covers the router's deployment-level state. Rate limits on virtual keys, users, and teams are tracked on the [coordination Redis](./coordination_redis), configured under `general_settings.coordination_redis`.
 
 Example config
 

--- a/docs/proxy/multi_region.md
+++ b/docs/proxy/multi_region.md
@@ -49,11 +49,11 @@ Every proxy instance in every region must share the following. If any of these d
 | `LITELLM_LICENSE` | Same license key in every region | Each instance validates the license independently; one key activates all of them |
 | `DISABLE_SCHEMA_UPDATE` | `true` on all proxy instances | Schema migrations must run exactly once (as a job), not raced by every instance in every region |
 
-Per region, you additionally run a Redis instance and set it in that region's proxy config (`router_settings` and cache settings). Redis state is regional: rate limits and cached responses are scoped to the region that served the request.
+Per region, you additionally run a Redis instance and point that region's proxy at it with [`general_settings.coordination_redis`](./coordination_redis). Setting `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` per region, as the environment blocks below do, is enough on its own; the proxy builds the coordination Redis client from those variables when no explicit block is present. Redis state is regional: rate limits and cached responses are scoped to the region that served the request.
 
 :::info
 
-Rate limits (TPM/RPM on keys, teams, and users) are enforced through Redis. With one Redis per region, a limit of 100 RPM means 100 RPM per region, not globally. If you need strictly global rate limiting, all instances must share one Redis, which puts a cross-region round trip in the request path for remote regions. Most deployments accept per-region enforcement.
+Rate limits (TPM/RPM on keys, teams, and users) are enforced through the coordination Redis. With one Redis per region, a limit of 100 RPM means 100 RPM per region, not globally. If you need strictly global rate limiting, all instances must share one Redis, which puts a cross-region round trip in the request path for remote regions. Most deployments accept per-region enforcement.
 
 :::
 

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -184,21 +184,20 @@ This is still something we're investigating. Keep track of it [here](https://git
 Recommended to do this for prod:
 
 ```yaml
-router_settings:
-  routing_strategy: simple-shuffle # (default) - recommended for best performance
-  # redis_url: "os.environ/REDIS_URL"
-  redis_host: os.environ/REDIS_HOST
-  redis_port: os.environ/REDIS_PORT
-  redis_password: os.environ/REDIS_PASSWORD
-
-litellm_settings:
-  cache: True
-  cache_params:
-    type: redis
+general_settings:
+  coordination_redis:
+    # url: "os.environ/REDIS_URL"
     host: os.environ/REDIS_HOST
     port: os.environ/REDIS_PORT
     password: os.environ/REDIS_PASSWORD
+
+router_settings:
+  routing_strategy: simple-shuffle # (default) - recommended for best performance
 ```
+
+`general_settings.coordination_redis` is the Redis every pod shares for key/user/team rate limits, parallel request limits, the spend transaction buffer, the pod lock, and shared health checks; see [Coordination Redis](./coordination_redis). The router picks it up automatically for its own load-balancing state (cooldowns, usage-based routing), so `router_settings.redis_host` / `redis_port` / `redis_password` are only needed when you want routing state on a different instance.
+
+The LLM response cache stays separate, under `litellm_settings.cache` / `cache_params`, and enabling it is optional.
 
 > **WARNING**
 **Usage-based routing is not recommended for production due to performance impacts.** Use `simple-shuffle` (default) for optimal performance in high-traffic scenarios.

--- a/docs/proxy/shared_health_check.md
+++ b/docs/proxy/shared_health_check.md
@@ -54,15 +54,14 @@ general_settings:
   # Health check interval (seconds)
   health_check_interval: 300  # 5 minutes
 
-# Redis configuration (required for shared health check)
-litellm_settings:
-  cache: true
-  cache_params:
-    type: redis
+  # Redis configuration (required for shared health check)
+  coordination_redis:
     host: your-redis-host
     port: 6379
     password: your-redis-password
 ```
+
+Shared health checks run on the proxy's [coordination Redis](./coordination_redis), which is configured independently of the LLM response cache.
 
 ### Environment Variables
 
@@ -81,7 +80,7 @@ export DEFAULT_SHARED_HEALTH_CHECK_LOCK_TTL=60
 
 ## Requirements
 
-- **Redis**: Required for shared state coordination
+- **Redis**: Required for shared state coordination. See [Coordination Redis](./coordination_redis)
 - **Background Health Checks**: Must be enabled (`background_health_checks: true`)
 - **Multiple Pods**: Most beneficial with 2+ proxy instances
 
@@ -244,11 +243,8 @@ general_settings:
   # Health check details
   health_check_details: true
 
-litellm_settings:
   # Redis configuration
-  cache: true
-  cache_params:
-    type: redis
+  coordination_redis:
     host: redis-cluster.example.com
     port: 6379
     password: os.environ/REDIS_PASSWORD

--- a/docs/proxy/spend_logs_deletion.md
+++ b/docs/proxy/spend_logs_deletion.md
@@ -33,11 +33,14 @@ general_settings:
   # Optional: set exact time for cleanup (Cron syntax)
   maximum_spend_logs_cleanup_cron: "0 4 * * *" # Run at 04:00 AM daily
 
-litellm_settings:
-  cache: true
-  cache_params:
-    type: redis
+  # Redis is used to elect the single pod that runs the cleanup
+  coordination_redis:
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
 ```
+
+See [Coordination Redis](./coordination_redis) for cluster, Sentinel, and environment-variable options.
 
 ### Configuration Options
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -607,6 +607,7 @@ const sidebars = {
             "proxy/budget_fallbacks",
           ],
         },
+        "proxy/coordination_redis",
         "proxy/caching",
         "proxy/memory",
         {


### PR DESCRIPTION
Documents `general_settings.coordination_redis`, the explicit config block for the proxy's coordination Redis: the instance behind cross-pod tpm/rpm rate limits, parallel request limits, the Redis spend transaction buffer, the pod lock manager, shared health checks, and the opt-in virtual key auth cache. Until now that Redis was only populated by configuring a plain-Redis response cache, so selecting a semantic cache (or no cache at all) silently downgraded every one of those to per-pod in-memory state.

Depends on BerriAI/litellm#32635 and BerriAI/litellm#32661; merge this after both of those ship.

The new page at `docs/proxy/coordination_redis.md` covers what the coordination Redis does, the config block, the resolution precedence (explicit block, then a borrowed plain-Redis response cache, then a client built from `REDIS_*` environment variables), TLS/cluster/sentinel, coexistence with a semantic response cache, the Admin UI tab, and migration off the `cache: true` plus `supported_call_types: []` workaround that existed solely to obtain a Redis client. It is registered in the sidebar immediately before `proxy/caching`.

Two behavior notes called out explicitly on the page: the environment fallback is new, so a proxy running a semantic response cache with `REDIS_HOST` exported previously had no coordination Redis and now gets one; and an explicit `coordination_redis.host` outranks a `REDIS_URL` in the environment, where the url used to win and silently discard the host and port.

The rest of the diff rewrites the pages that told readers to enable a response cache purely as a means of getting a Redis client (`db_deadlocks`, `shared_health_check`, `spend_logs_deletion`, `deploy`, `prod`), and clarifies the split between the router's own Redis for load-balancing state and the coordination Redis for key, user, and team limits (`load_balancing`, `io_token_rate_limits`, `multi_region`). The `enable_redis_auth_cache` requirement in `caching.md` and `config_settings.md` is reworded so it stays true for existing deployments; the old config forms all keep working and the page says so.

`npm run build` passes with no broken links or anchors on any page touched here.
