### PR TITLE
docs(proxy): mark ITPM/OTPM rate limits as [Beta]

### DIFF
--- a/docs/proxy/io_token_rate_limits.md
+++ b/docs/proxy/io_token_rate_limits.md
@@ -1,4 +1,4 @@
-# Separate ITPM / OTPM Rate Limits
+# [Beta] Separate ITPM / OTPM Rate Limits
 
 Enforce **input tokens per minute (ITPM)** and **output tokens per minute (OTPM)** separately on router deployments.
 


### PR DESCRIPTION
## Summary
- Mark the Separate ITPM / OTPM Rate Limits docs page as `[Beta]` in the page title (sidebar label)

## Test plan
- [ ] Verify sidebar shows `[Beta] Separate ITPM / OTPM Rate Limits` under Budgets + Rate Limits
- [ ] Confirm page renders correctly at `/docs/proxy/io_token_rate_limits`


Made with [Cursor](https://cursor.com)