### PR TITLE
docs(zai): sync supported models and pricing with the model cost map

### DIFF
--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -51,8 +51,12 @@ We support ALL Z.AI GLM models, just set `zai/` as a prefix when sending complet
 
 | Model Name | Function Call | Notes |
 |------------|---------------|-------|
-| glm-4.7 | `completion(model="zai/glm-4.7", messages)` | **Latest flagship**, 200K context, **Reasoning** |
-| glm-4.6 | `completion(model="zai/glm-4.6", messages)` | 200K context |
+| glm-5.1 | `completion(model="zai/glm-5.1", messages)` | **Latest flagship**, 200K context, **Reasoning** |
+| glm-5 | `completion(model="zai/glm-5", messages)` | 200K context, **Reasoning** |
+| glm-5-code | `completion(model="zai/glm-5-code", messages)` | Coding-optimized, 200K context, **Reasoning** |
+| glm-4.7 | `completion(model="zai/glm-4.7", messages)` | 200K context, **Reasoning** |
+| glm-4.7-flash | `completion(model="zai/glm-4.7-flash", messages)` | **FREE tier**, 200K context, **Reasoning** |
+| glm-4.6 | `completion(model="zai/glm-4.6", messages)` | 200K context, **Reasoning** |
 | glm-4.5 | `completion(model="zai/glm-4.5", messages)` | 128K context |
 | glm-4.5v | `completion(model="zai/glm-4.5v", messages)` | Vision model |
 | glm-4.5-x | `completion(model="zai/glm-4.5-x", messages)` | Premium tier |
@@ -65,8 +69,12 @@ We support ALL Z.AI GLM models, just set `zai/` as a prefix when sending complet
 
 | Model | Input ($/1M tokens) | Output ($/1M tokens) | Cached Input ($/1M tokens) | Context Window |
 |-------|---------------------|----------------------|---------------------------|----------------|
+| glm-5.1 | $1.40 | $4.40 | $0.26 | 200K |
+| glm-5 | $1.00 | $3.20 | $0.20 | 200K |
+| glm-5-code | $1.20 | $5.00 | $0.30 | 200K |
 | glm-4.7 | $0.60 | $2.20 | $0.11 | 200K |
-| glm-4.6 | $0.60 | $2.20 | - | 200K |
+| glm-4.7-flash | **FREE** | **FREE** | - | 200K |
+| glm-4.6 | $0.60 | $2.20 | $0.11 | 200K |
 | glm-4.5 | $0.60 | $2.20 | - | 128K |
 | glm-4.5v | $0.60 | $1.80 | - | 128K |
 | glm-4.5-x | $2.20 | $8.90 | - | 128K |


### PR DESCRIPTION
The Z.AI provider page listed supported models and pricing only through glm-4.7, while the model cost map already ships the GLM-5 family (glm-5, glm-5.1, glm-5-code) and the glm-4.7-flash free tier. The Z.AI integration forwards any `zai/`-prefixed model to the Z.AI API without an allowlist, so these already work; this brings the Supported Models and Model Pricing tables in line with the registry so users can discover them. glm-5.1 is marked as the current flagship. Pricing and context windows come from the model cost map: glm-5.1 at $1.40/$4.40 per 1M in/out, glm-5 at $1.00/$3.20, glm-5-code at $1.20/$5.00, and glm-4.7-flash free, all at 200K context. This pass also corrects the glm-4.6 row, whose cached-input price ($0.11 per 1M) and reasoning support were missing from the tables.
