### PR TITLE
docs: warn that model_cost entries may not be callable; surface get_valid_models

### DIFF
--- a/docs/completion/token_usage.md
+++ b/docs/completion/token_usage.md
@@ -145,6 +145,8 @@ model = "gpt-3.5-turbo"
 print(get_max_tokens(model)) # Output: 4097
 ```
 
+Note: `get_max_tokens` raises an `Exception` if the model is not in the model cost map, so wrap it in try/except when the model string is user-supplied.
+
 ### 8. `model_cost`
 
 * Output: Returns a dict object containing the max_tokens, input_cost_per_token, output_cost_per_token for all models on [community-maintained list](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)
@@ -154,6 +156,19 @@ from litellm import model_cost
 
 print(model_cost) # {'gpt-3.5-turbo': {'max_tokens': 4000, 'input_cost_per_token': 1.5e-06, 'output_cost_per_token': 2e-06}, ...}
 ```
+
+:::warning Pricing catalog, not an availability signal
+
+A model appearing in `model_cost` does not mean your API key can call it. The map exists for cost tracking: it holds pricing data for every model LiteLLM can calculate costs for, including entries that are retired by the provider, not yet generally available, or gated to specific accounts; live keys can get 404s back for mapped models. To find out what your keys can actually call, for example to seed a model picker in your app, query the provider endpoints with [`get_valid_models(check_provider_endpoint=True)`](https://docs.litellm.ai/docs/set_keys#get_valid_modelscheck_provider_endpoint-true):
+
+```python
+from litellm import get_valid_models
+
+# only models your configured keys can call right now
+models = get_valid_models(check_provider_endpoint=True)
+```
+
+:::
 
 ### 9. `register_model`
 

--- a/docs/set_keys.md
+++ b/docs/set_keys.md
@@ -184,6 +184,8 @@ os.environ = old_environ
 
 This helper will check the provider's endpoint for valid models.
 
+Without `check_provider_endpoint=True`, the returned list comes from LiteLLM's static model map, which holds pricing data for every model LiteLLM knows about; it can include models that are retired, not yet generally available, or gated to specific accounts, so it is not an availability signal. With `check_provider_endpoint=True`, each provider's live model endpoint is queried instead, and the result is the set of models your keys can call right now. Use it when availability matters, for example to seed a model picker or validate a user-supplied model name.
+
 Currently implemented for:
 - OpenAI (if OPENAI_API_KEY is set)
 - Fireworks AI (if FIREWORKS_AI_API_KEY is set)
@@ -208,6 +210,16 @@ from litellm import get_valid_models
 
 valid_models = get_valid_models(check_provider_endpoint=True, custom_llm_provider="openai")
 print(valid_models)
+```
+
+**Seed a model picker**:
+```python
+from litellm import get_valid_models
+
+# only models the configured keys can call right now,
+# unlike litellm.model_cost, which also holds pricing for retired / gated models
+available = get_valid_models(check_provider_endpoint=True)
+picker_options = sorted(available)
 ```
 
 ### `validate_environment(model: str)`


### PR DESCRIPTION
`litellm.model_cost` is the natural reference for which model strings exist, but it exists for cost tracking: it holds pricing data for every model LiteLLM can calculate costs for, including entries that are retired, not yet generally available, or account-gated at the provider, and a mapped model can still 404 for a given key. I hit this while seeding a model picker from `model_cost`; several mapped strings were rejected by the live providers. Related to BerriAI/litellm#32785, which came out of the same build session.

This adds a warning admonition on the `model_cost` section of the token usage page directing readers to `get_valid_models(check_provider_endpoint=True)` for live availability, expands that helper's section in set_keys to explain when to prefer the endpoint check over the static list, adds a model picker example, and adds a one line note that `get_max_tokens` raises for models absent from the map.

Verified with `npm run build` (passes; the new cross page anchor resolves in the built HTML; the only warnings are pre-existing ones in old release notes).

**Disclosure:** built with AI assistance (my two-agent Claude workflow — Claude Code implemented against my written spec). The issue analysis, scope decisions, and line-by-line review are mine.