### PR TITLE
docs: add Nika to projects

### DIFF
--- a/docs/projects/Nika.md
+++ b/docs/projects/Nika.md
@@ -1,0 +1,10 @@
+
+# Nika
+
+[Nika](https://github.com/supernovae-st/nika) is an open-source (AGPL, Rust) workflow engine for AI: repeatable work lives in plain `.nika.yaml` DAG files, statically checked before execution (schema, permits, cost floor) with tamper-evident traces after.
+
+Nika's provider layer speaks the OpenAI chat dialect, so a LiteLLM proxy slots in as the gateway: point Nika's `openai` provider at the proxy's base URL and every `infer` task in a workflow routes through LiteLLM — one gateway for keys, budgets and provider fallbacks, while Nika keeps the workflow-side guarantees (static checks before the run, hash-chained trace after).
+
+- [Github](https://github.com/supernovae-st/nika)
+- [Docs](https://docs.nika.sh)
+- [Provider catalog (the `openai` + `base_url` mechanism)](https://docs.nika.sh/reference/providers-catalog)

--- a/sidebars.js
+++ b/sidebars.js
@@ -1272,6 +1272,7 @@ const sidebars = {
             "projects/Agent Lightning",
             "projects/Harbor",
             "projects/GraphRAG",
+            "projects/Nika",
             "projects/Docq.AI",
             "projects/PDL",
             "projects/OpenInterpreter",


### PR DESCRIPTION
Adds docs/projects/Nika.md + the sidebar registration (both files, per the 461 precedent). Honest framing: Nika is not built ON LiteLLM — its provider layer speaks the OpenAI chat dialect, so a LiteLLM proxy slots in as the gateway via the documented openai + base_url mechanism (one gateway for keys/budgets/fallbacks, while Nika keeps workflow-side static checks and hash-chained traces). Nika is an open-source (AGPL, Rust) workflow engine for AI. Disclosure: I am the Nika author (first-party submission).