### PR TITLE
docs: add CompatCanary to community projects

### DIFF
--- a/docs/projects/CompatCanary.md
+++ b/docs/projects/CompatCanary.md
@@ -1,0 +1,17 @@
+# CompatCanary
+
+[CompatCanary](https://github.com/CognizenOrg/compatcanary) is an open-source conformance scanner for OpenAI-compatible endpoints. It sends deterministic probes through a LiteLLM proxy and records observed behavior for chat completions, streaming, tool calls, structured outputs, and the Responses API.
+
+Start with the Chat Completions surface exposed by a configured LiteLLM model:
+
+```bash
+export OPENAI_API_KEY="your-litellm-key"
+npx --yes compatcanary@latest scan \
+  --base-url http://localhost:4000/v1 \
+  --model your-model \
+  --profile chat
+```
+
+Use `--profile modern` to include Responses API probes, and `--format markdown` or `--format json` to save reviewable evidence for local debugging or CI.
+
+See the [project repository](https://github.com/CognizenOrg/compatcanary) and a [reproducible LiteLLM setup with reviewed reports](https://github.com/CognizenOrg/compatcanary/blob/main/evidence/setups/litellm-1.91.1-github-models.md).

--- a/sidebars.js
+++ b/sidebars.js
@@ -1271,6 +1271,7 @@ const sidebars = {
             "projects/Google ADK",
             "projects/Agent Lightning",
             "projects/Harbor",
+            "projects/CompatCanary",
             "projects/GraphRAG",
             "projects/Docq.AI",
             "projects/PDL",


### PR DESCRIPTION
Adds CompatCanary to the projects built on LiteLLM section with a minimal proxy scan example and links to reproducible LiteLLM evidence.

This follows the maintainer request in [discussion #32855](https://github.com/BerriAI/litellm/discussions/32855#discussioncomment-17608423).

Verification: `npm run build` completed successfully. The build still reports existing repository-wide broken-link and SSG warnings; none point to the new page.
