### PR TITLE
docs(blog): two-week stability update (MCP gateway + 134 fixes)

### DIFF
--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -1,96 +1,95 @@
 ---
 slug: two-week-stability-update
-title: "Stability Update: Locking Down the MCP Gateway (and 134 fixes in two weeks)"
+title: "Two-Week Stability Update: MCP Credential Resolver and Pass-Through Memory"
 date: 2026-07-11T12:00:00
 authors:
   - ishaan
-description: "A two-week product quality and stability recap: 134 bug fixes led by MCP Gateway credential hardening, new-model billing correctness, and streaming pass-through downloads — plus our next goal, 95% end-to-end test coverage."
+description: "A two-week product quality update. We addressed two major issues (MCP credential resolution and pass-through memory) and shipped 134 bug fixes in total. Plus our next goal: 95% end-to-end test coverage."
 tags: [stability, mcp, performance, product]
 hide_table_of_contents: false
 ---
 
-A quick product quality and stability update for the last two weeks (June 27 – July 11, 2026).
+Over the last two weeks we addressed two major product quality issues:
 
-We shipped **134 bug fixes**. The headline is the **MCP Gateway** — half of everything we fixed (50 of 134) went into one idea: **credentials should live in exactly one locked place, and only ever reach the one server they belong to.**
+1. The MCP Gateway did not have a single class for credential resolution.
+2. Pass-through APIs had high memory consumption.
 
-Below: the MCP story first, then the AI-Eng and performance work, the full number breakdown, and the next goal.
+Across the same window we shipped 134 bug fixes in total. This post covers the two big changes first, then the rest of the AI Eng and reliability work, the full breakdown, and what we are doing next.
 
 {/* truncate */}
 
-## MCP Gateway stability — 50 of 134 fixes
+## MCP Gateway: a single credential resolver
 
-**In plain terms:** LiteLLM sits between your AI app (Claude Desktop, Cursor, an agent) and the real tools it wants to use (GitHub, a database, an internal API). Those tools need a credential. The whole question is: **how does the gateway decide which credential to attach — and what happens when it isn't sure?**
+The MCP Gateway connects a user's AI app (Claude Desktop, Cursor, an agent) to the upstream MCP servers it wants to use, and it has to attach the right credential for each upstream.
 
-The core change is a **single typed credential resolver**. Before, outbound MCP auth was inferred from *whichever fields happened to be present* on a server row, resolved through a precedence cascade — and when nothing matched cleanly it **fell back silently** (forwarding the caller's own token, or attaching none). That silent-fallback path is exactly where the leak and bypass bugs lived. Now there is one `resolve_credentials` that dispatches on **one declared mode**, each with its own fully-typed config, and **fails closed** if a mode isn't handled.
+Before, the MCP Gateway would infer the authentication method a user was trying to use based on the credentials they set. We have now built a credential resolver class that lets a user explicitly specify which auth method they are using. We believe this will significantly drive down a class of bugs users were reporting on MCPs.
 
-### Before — infer the credential from whatever fields are set
+### Before: infer the auth method from whatever credentials are set
 
 ```mermaid
 flowchart TD
   Req["Outbound MCP call"] --> Chk{"Which fields are set?<br/>auth_value? client_id?<br/>token? header?"}
   Chk -->|precedence cascade| Pick["Pick one by priority order"]
   Chk -.->|nothing matched| Fall["Silent fallback:<br/>forward caller's token<br/>or attach none"]
-  Pick --> Bugs["→ wrong header forwarded<br/>→ token fan-out to wrong upstream<br/>→ stale / cross-user token"]
+  Pick --> Bugs["wrong header forwarded<br/>token sent to wrong upstream<br/>stale or cross-user token"]
   Fall --> Bugs
   classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
   class Fall,Bugs bad;
 ```
 
-**Why this was bad:** there was no single place that decided which credential to attach, and no error when the decision was ambiguous. Field-presence inference meant two different code paths could read the same server row and disagree; the precedence cascade meant adding a field could silently change which credential won; and the silent fallback meant an unhandled case still sent *something* upstream instead of refusing. Ambiguity resolved to "attach a credential anyway" rather than "stop."
+Why this was bad: there was no single place that decided which credential to attach, and no error when the decision was ambiguous. Inferring from set fields meant two code paths could read the same server and disagree. The precedence order meant adding a field could silently change which credential won. And the silent fallback meant an unhandled case still sent something upstream instead of refusing. Ambiguity resolved to "attach a credential anyway" instead of "stop."
 
-**The types of bugs we saw from this:**
+The types of bugs we saw from this:
 
-- Tokens leaking to the wrong upstream server (Authorization fan-out).
+- Tokens sent to the wrong upstream server.
 - Duplicate or stale `Authorization` headers slipping through.
-- MCP requests skipping the normal team / route / key checks.
+- MCP requests skipping the normal team, route, and key checks.
 - Cached OAuth tokens going stale or crossing between users.
 - Upstream URLs and secrets showing up in logs.
 
-### After — one typed resolver, dispatch on a declared mode, fail closed
+### After: the user declares the auth method, and it fails closed
 
 ```mermaid
 flowchart TD
-  Req["Outbound MCP call"] --> R{"resolve_credentials<br/>match on ONE declared mode"}
+  Req["Outbound MCP call"] --> R{"resolve_credentials<br/>match on the declared mode"}
   R --> m1["none"]
-  R --> m2["api_key<br/>(static header · BYOK)"]
-  R --> m3["passthrough<br/>(client forwards upstream token)"]
-  R --> m4["authorization_code<br/>(per-user 3LO, gateway-stored)"]
-  R --> m5["client_credentials<br/>(gateway M2M)"]
-  R --> m6["token_exchange<br/>(RFC 8693 on-behalf-of)"]
-  R --> m7["aws_sigv4<br/>(Bedrock AgentCore)"]
-  R ==>|unknown / unhandled mode| X["FAIL CLOSED<br/>assert_never → type error at build,<br/>raises at runtime — never a silent None"]
-  m1 & m2 & m3 & m4 & m5 & m6 & m7 --> Auth["typed httpx.Auth → one upstream"]
+  R --> m2["api_key (static header, BYOK)"]
+  R --> m3["passthrough (client forwards token)"]
+  R --> m4["authorization_code (per-user OAuth)"]
+  R --> m5["client_credentials (gateway M2M)"]
+  R --> m6["token_exchange (on-behalf-of)"]
+  R --> m7["aws_sigv4 (Bedrock AgentCore)"]
+  R ==>|unknown mode| X["Fail closed<br/>type error at build,<br/>raises at runtime, never a silent None"]
+  m1 & m2 & m3 & m4 & m5 & m6 & m7 --> Auth["typed auth, one upstream"]
   classDef good fill:#e8f7ee,stroke:#16a34a,color:#14532d;
   classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
   class R,Auth good;
   class X bad;
 ```
 
-Each arm receives its own fully-typed config — **no field-presence guessing, no precedence cascade**. The `match` is exhaustive with an `assert_never` tail, so adding a mode without handling it fails the type checker, and a bypassed gate raises loudly instead of returning no auth.
+Each mode has its own fully typed config, so there is no guessing from which fields are set and no precedence order. The match is exhaustive, so adding a mode without handling it fails the type checker, and an unhandled case raises instead of quietly attaching no auth.
 
-## AI Eng — LLM providers (27 fixes)
+## AI Eng: LLM providers (27 fixes)
 
-**Central theme: new models are correct on day one — especially the money math.** The bulk of this work made sure new **Claude 4.8 / Opus 4.8** and **Bedrock Invoke** requests bill correctly and do not silently drop capabilities.
+The theme here was making new models correct on day one, especially the billing math. Most of this work made sure new Claude 4.8 / Opus 4.8 and Bedrock Invoke requests bill correctly and do not silently drop capabilities.
 
-- **Billing accuracy:** tier-only deployments were billing **$0** — now billed correctly; regional inference profiles resolve to regional pricing; tiered-pricing costs are coerced safely.
-- **Capability correctness:** mid-conversation system messages honored for Claude 4.8+ on Bedrock; adaptive thinking/effort translated for pre-4.6 models; `@version` suffixes stripped in model lookup.
-- **Translation fidelity:** `cache_control` TTL preserved on Bedrock cache points; reasoning tokens preserved through chat → responses; in-stream error events now raise real API errors instead of vanishing.
+- Billing accuracy: tier-only deployments were billing $0 and are now billed correctly, regional inference profiles resolve to regional pricing, and tiered-pricing costs are coerced safely.
+- Capability correctness: mid-conversation system messages are honored for Claude 4.8+ on Bedrock, adaptive thinking/effort is translated for pre-4.6 models, and `@version` suffixes are stripped in model lookup.
+- Translation fidelity: `cache_control` TTL is preserved on Bedrock cache points, reasoning tokens are preserved through chat to responses, and in-stream error events now raise real API errors instead of vanishing.
 
-## Performance — streaming pass-through downloads
+## Performance: pass-through memory
 
-**The performance story in one line:** on pass-through routes, stop holding a large file download in memory when you can stream it through.
-
-Large **non-JSON** pass-through downloads — batch-result files, binary / octet-stream downloads — now stream chunk-by-chunk instead of being buffered whole in memory. This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
+Pass-through APIs had high memory consumption. Large non-JSON pass-through downloads (batch-result files, binary and octet-stream downloads) were buffered whole in memory before being sent on. We changed this to stream the response chunk by chunk, so memory stays flat regardless of file size. This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
 
 ```mermaid
 flowchart TB
-  subgraph B["Before — buffer the whole file"]
+  subgraph B["Before: buffer the whole file"]
     direction LR
     U1[Upstream] -->|entire body| L1["LiteLLM<br/>holds full file in RAM<br/>(memory grows with size)"]
   end
-  subgraph A["After — stream it through"]
+  subgraph A["After: stream it through"]
     direction LR
-    U2[Upstream] -->|chunk| L2["LiteLLM<br/>forwards chunk-by-chunk<br/>(flat memory)"] -->|chunk| C2[Client]
+    U2[Upstream] -->|chunk| L2["LiteLLM<br/>forwards chunk by chunk<br/>(flat memory)"] -->|chunk| C2[Client]
   end
   classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
   classDef good fill:#e8f7ee,stroke:#16a34a,color:#14532d;
@@ -98,12 +97,12 @@ flowchart TB
   class L2 good;
 ```
 
-Before, a large batch-result file meant the proxy held the entire body in RAM before sending it on; now memory stays flat regardless of size. **JSON responses still buffer by design** — so spend logging and guardrails can inspect the body.
+JSON responses still buffer by design, so spend logging and guardrails can inspect the body.
 
-Two more fixes in the same spirit — don't pay for work nobody needs:
+Two more fixes in the same spirit, don't pay for work nobody needs:
 
-- **Prometheus** skips budget-metric DB lookups entirely when the gauges are no-ops (nothing is scraping them).
-- The **complexity router** builds its semantic route index once under concurrent cold-start, instead of rebuilding it per request.
+- Prometheus skips budget-metric DB lookups entirely when the gauges are no-ops (nothing is scraping them).
+- The complexity router builds its semantic route index once under concurrent cold-start, instead of rebuilding it per request.
 
 ## By the numbers
 
@@ -111,18 +110,16 @@ Every fix, bucketed by the area it landed in.
 
 | Area | Fixes |
 |---|---|
-| MCP Gateway | **50** |
+| MCP Gateway | 50 |
 | LLM Providers (AI Eng) | 27 |
 | Proxy Core / Reliability | 23 |
 | UI / Dashboard | 20 |
 | Logging / Observability | 9 |
 | Guardrails | 5 |
-| **Total** | **134** |
+| Total | 134 |
 
-A note on the count: these **134** are every merged `fix:` PR in the two-week window. One reported ticket usually becomes several fix PRs — the MCP hardening alone was ~50 commits behind a handful of tickets — so the PR count runs higher than the reported-ticket count.
+A note on the count: these 134 are every merged `fix:` PR in the two-week window. One reported ticket usually becomes several fix PRs (the MCP work alone was around 50 commits behind a handful of tickets), so the PR count runs higher than the reported-ticket count.
 
 ## Next goal: 95% end-to-end test coverage
 
-Most of the 134 fixes above were caught late — in staging or by a report. The next lever is catching them **before they merge**. We are pushing **end-to-end test coverage to 95%** across the product, and we believe this will **significantly improve release quality** — fewer regressions reaching a release, and less time spent hot-fixing after one ships.
-
-Same lens next sprint: root causes, not symptoms.
+Most of the 134 fixes above were caught late, in staging or by a report. The next lever is catching them before they merge. We are pushing end-to-end test coverage to 95% across the product, and we believe this will significantly improve release quality: fewer regressions reaching a release, and less time spent hot-fixing after one ships.

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -36,7 +36,15 @@ flowchart TD
   class Fall,Bugs bad;
 ```
 
-Field-presence inference + a precedence cascade + a silent fallback = no single place that decides, and no error when the decision is ambiguous.
+**Why this was bad:** there was no single place that decided which credential to attach, and no error when the decision was ambiguous. Field-presence inference meant two different code paths could read the same server row and disagree; the precedence cascade meant adding a field could silently change which credential won; and the silent fallback meant an unhandled case still sent *something* upstream instead of refusing. Ambiguity resolved to "attach a credential anyway" rather than "stop."
+
+**The types of bugs we saw from this:**
+
+- Tokens leaking to the wrong upstream server (Authorization fan-out).
+- Duplicate or stale `Authorization` headers slipping through.
+- MCP requests skipping the normal team / route / key checks.
+- Cached OAuth tokens going stale or crossing between users.
+- Upstream URLs and secrets showing up in logs.
 
 ### After — one typed resolver, dispatch on a declared mode, fail closed
 
@@ -60,44 +68,6 @@ flowchart TD
 
 Each arm receives its own fully-typed config — **no field-presence guessing, no precedence cascade**. The `match` is exhaustive with an `assert_never` tail, so adding a mode without handling it fails the type checker, and a bypassed gate raises loudly instead of returning no auth.
 
-### The DCR-bridge sealed envelope
-
-The hardest case is an MCP client that does OAuth **Dynamic Client Registration** (Claude, Cursor): it can hold only *one* bearer, but that bearer must carry both the caller's LiteLLM identity **and** the upstream OAuth grant — ideally with no server-side storage. The `oauth_delegate` mode solves this with a **litellm-signed sealed envelope**:
-
-```mermaid
-flowchart LR
-  U["User completes<br/>upstream OAuth"] --> M["Token endpoint MINTS<br/>llm_env_… (HS256 JWT)<br/>· identity: server_id + key_hash<br/>· grant: upstream token, encrypted<br/>· keys via scrypt(master_key)"]
-  M --> H["Client holds ONE bearer<br/>(zero server-side storage)"]
-  H --> E["MCP edge OPENS envelope<br/>(total over hostile input)"]
-  E --> P["Admit under recovered identity<br/>key · team · route gate"]
-  P --> D["Decrypt inner grant →<br/>forward upstream token"]
-  D --> Up["Upstream MCP server"]
-  classDef gw fill:#eaf1ff,stroke:#2563eb,color:#1e3a8a;
-  class M,E,P gw;
-```
-
-The upstream token is **never in plaintext** anywhere in the envelope, and the signing/encryption keys are derived from the proxy `master_key` with **memory-hard scrypt** (n=2¹⁵, ~50ms/~32MB per derivation), so guessing a candidate master key is memory-hard rather than a bare hash compare.
-
-### What kinds of bugs this removes
-
-- Tokens leaking to the wrong upstream server (Authorization fan-out).
-- Duplicate or stale `Authorization` headers slipping through.
-- MCP requests skipping the normal team / route / key checks.
-- Cached OAuth tokens going stale or crossing between users.
-- Upstream URLs and secrets showing up in logs.
-
-### Credential modes the resolver supports
-
-| Mode | What it is |
-|---|---|
-| `none` | No upstream credential (no-op auth, never an error) |
-| `api_key` | Static header, any scheme — BYOK is a per-user-seeded source |
-| `passthrough` | Client forwards its own upstream-audience token |
-| `authorization_code` | Per-user 3-legged OAuth; gateway-stored token, per-user isolated |
-| `client_credentials` | Gateway service account (machine-to-machine) |
-| `token_exchange` | RFC 8693 on-behalf-of (swap the caller's inbound token) |
-| `aws_sigv4` | AWS SigV4 per-request signing (e.g. Bedrock AgentCore) |
-
 ## AI Eng — LLM providers (27 fixes)
 
 **Central theme: new models are correct on day one — especially the money math.** The bulk of this work made sure new **Claude 4.8 / Opus 4.8** and **Bedrock Invoke** requests bill correctly and do not silently drop capabilities.
@@ -113,7 +83,7 @@ The upstream token is **never in plaintext** anywhere in the envelope, and the s
 Large **non-JSON** pass-through downloads — batch-result files, binary / octet-stream downloads — now stream chunk-by-chunk instead of being buffered whole in memory. This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
 
 ```mermaid
-flowchart LR
+flowchart TB
   subgraph B["Before — buffer the whole file"]
     direction LR
     U1[Upstream] -->|entire body| L1["LiteLLM<br/>holds full file in RAM<br/>(memory grows with size)"]

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -19,42 +19,66 @@ Below: the MCP story first, then the AI-Eng and performance work, the full numbe
 
 ## MCP Gateway stability — 50 of 134 fixes
 
-**In plain terms:** LiteLLM sits between your AI app (Claude Desktop, Cursor, an agent) and the real tools it wants to use (GitHub, a database, an internal API). Those tools need a credential. The whole question is: **who holds the credential, and can it leak to the wrong place?**
+**In plain terms:** LiteLLM sits between your AI app (Claude Desktop, Cursor, an agent) and the real tools it wants to use (GitHub, a database, an internal API). Those tools need a credential. The whole question is: **how does the gateway decide which credential to attach — and what happens when it isn't sure?**
 
-Two weeks ago the answer was "the credential travels with every request and could be handed to the wrong server." Now it is **"the credential lives in one locked vault inside the gateway, encrypted, and is only ever sent to the one server it belongs to."**
+The core change is a **single typed credential resolver**. Before, outbound MCP auth was inferred from *whichever fields happened to be present* on a server row, resolved through a precedence cascade — and when nothing matched cleanly it **fell back silently** (forwarding the caller's own token, or attaching none). That silent-fallback path is exactly where the leak and bypass bugs lived. Now there is one `resolve_credentials` that dispatches on **one declared mode**, each with its own fully-typed config, and **fails closed** if a mode isn't handled.
 
-### Before — the credential rode along with the request
+### Before — infer the credential from whatever fields are set
 
 ```mermaid
-flowchart LR
-  C["MCP Client<br/>(Claude, Cursor)<br/>holds the raw upstream token"]
-  C -->|token sent with request| G["LiteLLM Gateway<br/>(old path)<br/>forwards the header onward"]
-  G -->|intended| A["Correct MCP server<br/>(GitHub)"]
-  G -.->|token leaks here too ✕| B["Wrong MCP server<br/>(Internal API)"]
+flowchart TD
+  Req["Outbound MCP call"] --> Chk{"Which fields are set?<br/>auth_value? client_id?<br/>token? header?"}
+  Chk -->|precedence cascade| Pick["Pick one by priority order"]
+  Chk -.->|nothing matched| Fall["Silent fallback:<br/>forward caller's token<br/>or attach none"]
+  Pick --> Bugs["→ wrong header forwarded<br/>→ token fan-out to wrong upstream<br/>→ stale / cross-user token"]
+  Fall --> Bugs
   classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
-  classDef ok fill:#f8fafc,stroke:#cbd5e1,color:#0f172a;
-  class B,G bad;
-  class A,C ok;
+  class Fall,Bugs bad;
 ```
 
-The credential lived **in transit** — on the client and inside each request. A token meant for one server could reach another (Authorization fan-out), and bridge keys were not derived with a memory-hard hash.
+Field-presence inference + a precedence cascade + a silent fallback = no single place that decides, and no error when the decision is ambiguous.
 
-### After — the credential lives only in the gateway vault
+### After — one typed resolver, dispatch on a declared mode, fail closed
+
+```mermaid
+flowchart TD
+  Req["Outbound MCP call"] --> R{"resolve_credentials<br/>match on ONE declared mode"}
+  R --> m1["none"]
+  R --> m2["api_key<br/>(static header · BYOK)"]
+  R --> m3["passthrough<br/>(client forwards upstream token)"]
+  R --> m4["authorization_code<br/>(per-user 3LO, gateway-stored)"]
+  R --> m5["client_credentials<br/>(gateway M2M)"]
+  R --> m6["token_exchange<br/>(RFC 8693 on-behalf-of)"]
+  R --> m7["aws_sigv4<br/>(Bedrock AgentCore)"]
+  R ==>|unknown / unhandled mode| X["FAIL CLOSED<br/>assert_never → type error at build,<br/>raises at runtime — never a silent None"]
+  m1 & m2 & m3 & m4 & m5 & m6 & m7 --> Auth["typed httpx.Auth → one upstream"]
+  classDef good fill:#e8f7ee,stroke:#16a34a,color:#14532d;
+  classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
+  class R,Auth good;
+  class X bad;
+```
+
+Each arm receives its own fully-typed config — **no field-presence guessing, no precedence cascade**. The `match` is exhaustive with an `assert_never` tail, so adding a mode without handling it fails the type checker, and a bypassed gate raises loudly instead of returning no auth.
+
+### The DCR-bridge sealed envelope
+
+The hardest case is an MCP client that does OAuth **Dynamic Client Registration** (Claude, Cursor): it can hold only *one* bearer, but that bearer must carry both the caller's LiteLLM identity **and** the upstream OAuth grant — ideally with no server-side storage. The `oauth_delegate` mode solves this with a **litellm-signed sealed envelope**:
 
 ```mermaid
 flowchart LR
-  C["MCP Client<br/>authenticates once<br/>with a gateway key"]
-  C -->|gateway key only<br/>no upstream secret| G["LiteLLM MCP Gateway<br/>🔒 scrypt-encrypted vault<br/>policy gate · per-user token isolation"]
-  G -->|bound to one upstream| A["Correct MCP server<br/>(GitHub)"]
+  U["User completes<br/>upstream OAuth"] --> M["Token endpoint MINTS<br/>llm_env_… (HS256 JWT)<br/>· identity: server_id + key_hash<br/>· grant: upstream token, encrypted<br/>· keys via scrypt(master_key)"]
+  M --> H["Client holds ONE bearer<br/>(zero server-side storage)"]
+  H --> E["MCP edge OPENS envelope<br/>(total over hostile input)"]
+  E --> P["Admit under recovered identity<br/>key · team · route gate"]
+  P --> D["Decrypt inner grant →<br/>forward upstream token"]
+  D --> Up["Upstream MCP server"]
   classDef gw fill:#eaf1ff,stroke:#2563eb,color:#1e3a8a;
-  classDef ok fill:#f8fafc,stroke:#cbd5e1,color:#0f172a;
-  class G gw;
-  class A,C ok;
+  class M,E,P gw;
 ```
 
-The credential now lives **only inside the gateway vault**, encrypted with memory-hard scrypt and bound to exactly one upstream. The client never holds an upstream secret, and every call passes the same auth and permission gate as normal LLM traffic.
+The upstream token is **never in plaintext** anywhere in the envelope, and the signing/encryption keys are derived from the proxy `master_key` with **memory-hard scrypt** (n=2¹⁵, ~50ms/~32MB per derivation), so guessing a candidate master key is memory-hard rather than a bare hash compare.
 
-### What kinds of bugs this class of change removes
+### What kinds of bugs this removes
 
 - Tokens leaking to the wrong upstream server (Authorization fan-out).
 - Duplicate or stale `Authorization` headers slipping through.
@@ -62,20 +86,17 @@ The credential now lives **only inside the gateway vault**, encrypted with memor
 - Cached OAuth tokens going stale or crossing between users.
 - Upstream URLs and secrets showing up in logs.
 
-### Auth types the gateway supports
+### Credential modes the resolver supports
 
-Every one of these now stores its secret in the gateway vault (encrypted) rather than trusting the client to carry it.
-
-| Auth type | What it is | Secret held in vault |
-|---|---|---|
-| `none` | Public server, no auth | — |
-| `api_key` | API key sent in a header | ✅ |
-| `bearer_token` | Static bearer token | ✅ |
-| `basic` | HTTP Basic (user : password) | ✅ |
-| `authorization` | Raw `Authorization` header value | ✅ |
-| `oauth2` | OAuth 2.0 — `authorization_code` (interactive) and `client_credentials` (machine-to-machine) | ✅ + per-user token isolation |
-| `aws_sigv4` | AWS SigV4 request signing | ✅ |
-| `token` | Generic token credential | ✅ |
+| Mode | What it is |
+|---|---|
+| `none` | No upstream credential (no-op auth, never an error) |
+| `api_key` | Static header, any scheme — BYOK is a per-user-seeded source |
+| `passthrough` | Client forwards its own upstream-audience token |
+| `authorization_code` | Per-user 3-legged OAuth; gateway-stored token, per-user isolated |
+| `client_credentials` | Gateway service account (machine-to-machine) |
+| `token_exchange` | RFC 8693 on-behalf-of (swap the caller's inbound token) |
+| `aws_sigv4` | AWS SigV4 per-request signing (e.g. Bedrock AgentCore) |
 
 ## AI Eng — LLM providers (27 fixes)
 

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -71,15 +71,24 @@ Each mode has its own fully typed config, so there is no guessing from which fie
 
 ## AI Eng: LLM providers (27 fixes)
 
-The theme here was making new models correct on day one, especially the billing math. Most of this work made sure new Claude 4.8 / Opus 4.8 and Bedrock Invoke requests bill correctly and do not silently drop capabilities.
+The 27 AI Eng fixes, by area:
 
-- Billing accuracy: tier-only deployments were billing $0 and are now billed correctly, regional inference profiles resolve to regional pricing, and tiered-pricing costs are coerced safely.
-- Capability correctness: mid-conversation system messages are honored for Claude 4.8+ on Bedrock, adaptive thinking/effort is translated for pre-4.6 models, and `@version` suffixes are stripped in model lookup.
-- Translation fidelity: `cache_control` TTL is preserved on Bedrock cache points, reasoning tokens are preserved through chat to responses, and in-stream error events now raise real API errors instead of vanishing.
+| Area | Fixes |
+|---|---|
+| Routing & fallbacks | 8 |
+| Bedrock | 8 |
+| Anthropic | 4 |
+| Responses API | 3 |
+| Cost / pricing | 2 |
+| Vertex | 1 |
+| Rerank | 1 |
+| Total | 27 |
+
+The most common theme was billing correctness for new Claude and Bedrock models: tier-only deployments that were billing $0, regional pricing resolution, and preserving cache and reasoning-token accounting through translation.
 
 ## Performance: pass-through memory
 
-Pass-through APIs had high memory consumption. Large non-JSON pass-through downloads (batch-result files, binary and octet-stream downloads) were buffered whole in memory before being sent on. We changed this to stream the response chunk by chunk, so memory stays flat regardless of file size. This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
+Pass-through APIs had high memory consumption. Large non-JSON pass-through downloads (batch-result files, binary and octet-stream downloads) were buffered whole in memory before being sent on. We changed this to stream the response chunk by chunk, so memory stays flat regardless of file size ([#32386](https://github.com/BerriAI/litellm/pull/32386)). This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
 
 ```mermaid
 flowchart TB
@@ -123,3 +132,42 @@ A note on the count: these 134 are every merged `fix:` PR in the two-week window
 ## Next goal: 95% end-to-end test coverage
 
 Most of the 134 fixes above were caught late, in staging or by a report. The next lever is catching them before they merge. We are pushing end-to-end test coverage to 95% across the product, and we believe this will significantly improve release quality: fewer regressions reaching a release, and less time spent hot-fixing after one ships.
+
+## Appendix: the PRs
+
+### MCP Gateway
+
+Credential resolver:
+
+- [#32815](https://github.com/BerriAI/litellm/pull/32815) credential class merge (the single typed resolver)
+- [#32652](https://github.com/BerriAI/litellm/pull/32652) stale token invalidation
+- [#32715](https://github.com/BerriAI/litellm/pull/32715) semantic filter fail-closed
+
+Pass-through and delegate credential modes:
+
+- [#31989](https://github.com/BerriAI/litellm/pull/31989) passthrough / delegate modes
+- [#32414](https://github.com/BerriAI/litellm/pull/32414) passthrough UI enum
+- [#32556](https://github.com/BerriAI/litellm/pull/32556) passthrough call relay
+- [#32752](https://github.com/BerriAI/litellm/pull/32752) configured client for passthrough
+- [#32735](https://github.com/BerriAI/litellm/pull/32735) no DCR persist for passthrough
+- [#32507](https://github.com/BerriAI/litellm/pull/32507) token exchange secret pairing
+
+DCR bridge (LIT-4337):
+
+- [#32745](https://github.com/BerriAI/litellm/pull/32745) plumbing
+- [#32747](https://github.com/BerriAI/litellm/pull/32747) authorize relay
+- [#32753](https://github.com/BerriAI/litellm/pull/32753) facade
+- [#32804](https://github.com/BerriAI/litellm/pull/32804) UI
+- [#32527](https://github.com/BerriAI/litellm/pull/32527) DCR redirect_uri
+
+Sealed envelope and delegate admission (LIT-4338):
+
+- [#32748](https://github.com/BerriAI/litellm/pull/32748) envelope module
+- [#32794](https://github.com/BerriAI/litellm/pull/32794) envelope edge consumer
+- [#32824](https://github.com/BerriAI/litellm/pull/32824) delegate admission
+
+### Performance
+
+- [#32386](https://github.com/BerriAI/litellm/pull/32386) stream non-SSE pass-through responses instead of buffering in memory
+- [#32404](https://github.com/BerriAI/litellm/pull/32404) stop request params from clobbering merged target query params
+- [#32834](https://github.com/BerriAI/litellm/pull/32834) Prometheus skips budget-metric DB lookups when gauges are no-ops

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -1,6 +1,6 @@
 ---
 slug: two-week-stability-update
-title: "Two-Week Stability Update: MCP Credential Resolver and Pass-Through Memory"
+title: "July stability update: hardening MCP auth and cutting pass-through memory"
 date: 2026-07-11T12:00:00
 authors:
   - ishaan

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -131,6 +131,8 @@ A note on the count: these 134 are every merged `fix:` PR in the two-week window
 
 Most of the 134 fixes above were caught late, in staging or by a report. The next lever is catching them before they merge. We are pushing end-to-end test coverage to 95% across the product, and we believe this will significantly improve release quality: fewer regressions reaching a release, and less time spent hot-fixing after one ships.
 
+We are learning from [Meta's approach to fixing bugs fast](https://engineering.fb.com/2021/02/17/developer-tools/fix-fast/) and adopting a higher testing bar across the product.
+
 ## Appendix
 
 PRs from this window.

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -71,20 +71,17 @@ Each mode has its own fully typed config, so there is no guessing from which fie
 
 ## AI Eng: LLM providers (27 fixes)
 
-The 27 AI Eng fixes, by area:
+AI engineering spent the two weeks driving down reported bugs, mostly on new models. The 27 fixes, grouped by the type of bug they removed:
 
-| Area | Fixes |
+| Type of bug fixed | Count |
 |---|---|
-| Routing & fallbacks | 8 |
-| Bedrock | 8 |
-| Anthropic | 4 |
-| Responses API | 3 |
-| Cost / pricing | 2 |
-| Vertex | 1 |
-| Rerank | 1 |
+| New-model capabilities silently dropped (mid-conversation system messages, thinking/effort translation, cache TTL, version handling) | 10 |
+| Billing / cost wrong (tier-only deployments billing $0, regional pricing, new-model cost-map entries) | 6 |
+| Routing & fallback correctness (auth propagation and model selection under the complexity router) | 6 |
+| Response & streaming fidelity (reasoning tokens preserved through translation, in-stream errors surfaced instead of swallowed) | 5 |
 | Total | 27 |
 
-The most common theme was billing correctness for new Claude and Bedrock models: tier-only deployments that were billing $0, regional pricing resolution, and preserving cache and reasoning-token accounting through translation.
+Most of the volume landed on Bedrock and the routing layer.
 
 ## Performance: pass-through memory
 
@@ -100,6 +97,7 @@ flowchart TB
     direction LR
     U2[Upstream] -->|chunk| L2["LiteLLM<br/>forwards chunk by chunk<br/>(flat memory)"] -->|chunk| C2[Client]
   end
+  L1 ~~~ U2
   classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
   classDef good fill:#e8f7ee,stroke:#16a34a,color:#14532d;
   class L1 bad;
@@ -133,9 +131,11 @@ A note on the count: these 134 are every merged `fix:` PR in the two-week window
 
 Most of the 134 fixes above were caught late, in staging or by a report. The next lever is catching them before they merge. We are pushing end-to-end test coverage to 95% across the product, and we believe this will significantly improve release quality: fewer regressions reaching a release, and less time spent hot-fixing after one ships.
 
-## Appendix: the PRs
+## Appendix
 
-### MCP Gateway
+PRs from this window.
+
+**MCP Gateway**
 
 Credential resolver:
 
@@ -166,7 +166,7 @@ Sealed envelope and delegate admission (LIT-4338):
 - [#32794](https://github.com/BerriAI/litellm/pull/32794) envelope edge consumer
 - [#32824](https://github.com/BerriAI/litellm/pull/32824) delegate admission
 
-### Performance
+**Performance**
 
 - [#32386](https://github.com/BerriAI/litellm/pull/32386) stream non-SSE pass-through responses instead of buffering in memory
 - [#32404](https://github.com/BerriAI/litellm/pull/32404) stop request params from clobbering merged target query params

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -113,7 +113,7 @@ Two more fixes in the same spirit, don't pay for work nobody needs:
 
 ## By the numbers
 
-Every fix, bucketed by the area it landed in.
+All 134 fixes, by area:
 
 | Area | Fixes |
 |---|---|
@@ -125,13 +125,13 @@ Every fix, bucketed by the area it landed in.
 | Guardrails | 5 |
 | Total | 134 |
 
-A note on the count: these 134 are every merged `fix:` PR in the two-week window. One reported ticket usually becomes several fix PRs (the MCP work alone was around 50 commits behind a handful of tickets), so the PR count runs higher than the reported-ticket count.
+These 134 are every merged `fix:` PR in the two weeks. One reported ticket often turns into several fix PRs, so this count is higher than the number of tickets in Linear.
 
 ## Next goal: 95% end-to-end test coverage
 
-Most of the 134 fixes above were caught late, in staging or by a report. The next lever is catching them before they merge. We are pushing end-to-end test coverage to 95% across the product, and we believe this will significantly improve release quality: fewer regressions reaching a release, and less time spent hot-fixing after one ships.
+Most of these 134 bugs were caught late, in staging or from a user report. We want to catch them before they merge. We are pushing end-to-end test coverage to 95% across the product. We believe this will significantly improve release quality and mean fewer bugs reach a release.
 
-We are learning from [Meta's approach to fixing bugs fast](https://engineering.fb.com/2021/02/17/developer-tools/fix-fast/) and adopting a higher testing bar across the product.
+We are learning from [Meta's approach to fixing bugs fast](https://engineering.fb.com/2021/02/17/developer-tools/fix-fast/) and raising our testing bar.
 
 ## Appendix
 

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -129,7 +129,7 @@ These 134 are every merged `fix:` PR in the two weeks. One reported ticket often
 
 ## Next goal: 95% end-to-end test coverage
 
-Most of these 134 bugs were caught late, in staging or from a user report. We want to catch them before they merge. We are pushing end-to-end test coverage to 95% across the product. We believe this will significantly improve release quality and mean fewer bugs reach a release.
+Most of these 134 bugs were caught late, in staging or from a user report. We want to catch them before they merge. We believe by investing in improving our e2e testing coverage we can significantly reduce the number of reported regressions from users on an upgrade.
 
 We are learning from [Meta's approach to fixing bugs fast](https://engineering.fb.com/2021/02/17/developer-tools/fix-fast/) and raising our testing bar.
 

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -168,6 +168,44 @@ Sealed envelope and delegate admission (LIT-4338):
 - [#32794](https://github.com/BerriAI/litellm/pull/32794) envelope edge consumer
 - [#32824](https://github.com/BerriAI/litellm/pull/32824) delegate admission
 
+**AI Eng (LLM providers)**
+
+Bedrock:
+
+- [#32882](https://github.com/BerriAI/litellm/pull/32882) flag Claude 4.8+ entries with supports_mid_conversation_system
+- [#32831](https://github.com/BerriAI/litellm/pull/32831) gate in-place system role messages for Claude Invoke
+- [#32578](https://github.com/BerriAI/litellm/pull/32578) keep mid-conversation system messages for Claude Invoke
+- [#32658](https://github.com/BerriAI/litellm/pull/32658) retain clear_tool_uses context-management edits and emit the beta header
+- [#32551](https://github.com/BerriAI/litellm/pull/32551) honor cache_control ttl on message-level cachePoint blocks
+- [#32538](https://github.com/BerriAI/litellm/pull/32538) preserve cache_control ttl on message-level cache points
+- [#32840](https://github.com/BerriAI/litellm/pull/32840) add jp.anthropic.claude-opus-4-8 to the model cost map
+- [#32389](https://github.com/BerriAI/litellm/pull/32389) resolve regional inference profiles to regional pricing
+
+Anthropic:
+
+- [#32874](https://github.com/BerriAI/litellm/pull/32874) thread the real provider through capability probes (was pinned to anthropic)
+- [#32867](https://github.com/BerriAI/litellm/pull/32867) translate adaptive thinking/effort for pre-4.6 models
+- [#32833](https://github.com/BerriAI/litellm/pull/32833) strip @version suffix in model lookup
+
+Routing and fallbacks:
+
+- [#32859](https://github.com/BerriAI/litellm/pull/32859) complexity router keyword tiers (max aggregation, blank-keyword hardening)
+- [#32943](https://github.com/BerriAI/litellm/pull/32943) complexity router logging and auth propagation, index built once
+- [#32873](https://github.com/BerriAI/litellm/pull/32873) fallback rules routing split (bare-Claude coverage, cost-map precedence, legacy schema)
+
+Responses API:
+
+- [#32835](https://github.com/BerriAI/litellm/pull/32835) raise APIError on in-stream error events
+- [#32837](https://github.com/BerriAI/litellm/pull/32837) preserve reasoning_tokens through chat to responses
+- [#32034](https://github.com/BerriAI/litellm/pull/32034) idempotent response-id encoding (prevents MCP gateway double-encoding)
+
+Cost, Vertex, Rerank:
+
+- [#32387](https://github.com/BerriAI/litellm/pull/32387) add gpt-realtime-2.1 models with regional uplift
+- coerce string tiered-pricing costs and share the tier helper
+- [#32550](https://github.com/BerriAI/litellm/pull/32550) forward realtime health check params (Vertex)
+- [#32533](https://github.com/BerriAI/litellm/pull/32533) log rerank params at debug to stop leaking request content
+
 **Performance**
 
 - [#32386](https://github.com/BerriAI/litellm/pull/32386) stream non-SSE pass-through responses instead of buffering in memory

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -1,0 +1,137 @@
+---
+slug: two-week-stability-update
+title: "Stability Update: Locking Down the MCP Gateway (and 134 fixes in two weeks)"
+date: 2026-07-11T12:00:00
+authors:
+  - ishaan
+description: "A two-week product quality and stability recap: 134 bug fixes led by MCP Gateway credential hardening, new-model billing correctness, and streaming pass-through downloads — plus our next goal, 95% end-to-end test coverage."
+tags: [stability, mcp, performance, product]
+hide_table_of_contents: false
+---
+
+A quick product quality and stability update for the last two weeks (June 27 – July 11, 2026).
+
+We shipped **134 bug fixes**. The headline is the **MCP Gateway** — half of everything we fixed (50 of 134) went into one idea: **credentials should live in exactly one locked place, and only ever reach the one server they belong to.**
+
+Below: the MCP story first, then the AI-Eng and performance work, the full number breakdown, and the next goal.
+
+{/* truncate */}
+
+## MCP Gateway stability — 50 of 134 fixes
+
+**In plain terms:** LiteLLM sits between your AI app (Claude Desktop, Cursor, an agent) and the real tools it wants to use (GitHub, a database, an internal API). Those tools need a credential. The whole question is: **who holds the credential, and can it leak to the wrong place?**
+
+Two weeks ago the answer was "the credential travels with every request and could be handed to the wrong server." Now it is **"the credential lives in one locked vault inside the gateway, encrypted, and is only ever sent to the one server it belongs to."**
+
+### Before — the credential rode along with the request
+
+```mermaid
+flowchart LR
+  C["MCP Client<br/>(Claude, Cursor)<br/>holds the raw upstream token"]
+  C -->|token sent with request| G["LiteLLM Gateway<br/>(old path)<br/>forwards the header onward"]
+  G -->|intended| A["Correct MCP server<br/>(GitHub)"]
+  G -.->|token leaks here too ✕| B["Wrong MCP server<br/>(Internal API)"]
+  classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
+  classDef ok fill:#f8fafc,stroke:#cbd5e1,color:#0f172a;
+  class B,G bad;
+  class A,C ok;
+```
+
+The credential lived **in transit** — on the client and inside each request. A token meant for one server could reach another (Authorization fan-out), and bridge keys were not derived with a memory-hard hash.
+
+### After — the credential lives only in the gateway vault
+
+```mermaid
+flowchart LR
+  C["MCP Client<br/>authenticates once<br/>with a gateway key"]
+  C -->|gateway key only<br/>no upstream secret| G["LiteLLM MCP Gateway<br/>🔒 scrypt-encrypted vault<br/>policy gate · per-user token isolation"]
+  G -->|bound to one upstream| A["Correct MCP server<br/>(GitHub)"]
+  classDef gw fill:#eaf1ff,stroke:#2563eb,color:#1e3a8a;
+  classDef ok fill:#f8fafc,stroke:#cbd5e1,color:#0f172a;
+  class G gw;
+  class A,C ok;
+```
+
+The credential now lives **only inside the gateway vault**, encrypted with memory-hard scrypt and bound to exactly one upstream. The client never holds an upstream secret, and every call passes the same auth and permission gate as normal LLM traffic.
+
+### What kinds of bugs this class of change removes
+
+- Tokens leaking to the wrong upstream server (Authorization fan-out).
+- Duplicate or stale `Authorization` headers slipping through.
+- MCP requests skipping the normal team / route / key checks.
+- Cached OAuth tokens going stale or crossing between users.
+- Upstream URLs and secrets showing up in logs.
+
+### Auth types the gateway supports
+
+Every one of these now stores its secret in the gateway vault (encrypted) rather than trusting the client to carry it.
+
+| Auth type | What it is | Secret held in vault |
+|---|---|---|
+| `none` | Public server, no auth | — |
+| `api_key` | API key sent in a header | ✅ |
+| `bearer_token` | Static bearer token | ✅ |
+| `basic` | HTTP Basic (user : password) | ✅ |
+| `authorization` | Raw `Authorization` header value | ✅ |
+| `oauth2` | OAuth 2.0 — `authorization_code` (interactive) and `client_credentials` (machine-to-machine) | ✅ + per-user token isolation |
+| `aws_sigv4` | AWS SigV4 request signing | ✅ |
+| `token` | Generic token credential | ✅ |
+
+## AI Eng — LLM providers (27 fixes)
+
+**Central theme: new models are correct on day one — especially the money math.** The bulk of this work made sure new **Claude 4.8 / Opus 4.8** and **Bedrock Invoke** requests bill correctly and do not silently drop capabilities.
+
+- **Billing accuracy:** tier-only deployments were billing **$0** — now billed correctly; regional inference profiles resolve to regional pricing; tiered-pricing costs are coerced safely.
+- **Capability correctness:** mid-conversation system messages honored for Claude 4.8+ on Bedrock; adaptive thinking/effort translated for pre-4.6 models; `@version` suffixes stripped in model lookup.
+- **Translation fidelity:** `cache_control` TTL preserved on Bedrock cache points; reasoning tokens preserved through chat → responses; in-stream error events now raise real API errors instead of vanishing.
+
+## Performance — streaming pass-through downloads
+
+**The performance story in one line:** on pass-through routes, stop holding a large file download in memory when you can stream it through.
+
+Large **non-JSON** pass-through downloads — batch-result files, binary / octet-stream downloads — now stream chunk-by-chunk instead of being buffered whole in memory. This covers the provider pass-through routes (`/vertex_ai/*`, `/bedrock/*`, `/openai/*`, `/anthropic/*`, and others) and custom pass-through endpoints.
+
+```mermaid
+flowchart LR
+  subgraph B["Before — buffer the whole file"]
+    direction LR
+    U1[Upstream] -->|entire body| L1["LiteLLM<br/>holds full file in RAM<br/>(memory grows with size)"]
+  end
+  subgraph A["After — stream it through"]
+    direction LR
+    U2[Upstream] -->|chunk| L2["LiteLLM<br/>forwards chunk-by-chunk<br/>(flat memory)"] -->|chunk| C2[Client]
+  end
+  classDef bad fill:#fdecec,stroke:#dc2626,color:#7f1d1d;
+  classDef good fill:#e8f7ee,stroke:#16a34a,color:#14532d;
+  class L1 bad;
+  class L2 good;
+```
+
+Before, a large batch-result file meant the proxy held the entire body in RAM before sending it on; now memory stays flat regardless of size. **JSON responses still buffer by design** — so spend logging and guardrails can inspect the body.
+
+Two more fixes in the same spirit — don't pay for work nobody needs:
+
+- **Prometheus** skips budget-metric DB lookups entirely when the gauges are no-ops (nothing is scraping them).
+- The **complexity router** builds its semantic route index once under concurrent cold-start, instead of rebuilding it per request.
+
+## By the numbers
+
+Every fix, bucketed by the area it landed in.
+
+| Area | Fixes |
+|---|---|
+| MCP Gateway | **50** |
+| LLM Providers (AI Eng) | 27 |
+| Proxy Core / Reliability | 23 |
+| UI / Dashboard | 20 |
+| Logging / Observability | 9 |
+| Guardrails | 5 |
+| **Total** | **134** |
+
+A note on the count: these **134** are every merged `fix:` PR in the two-week window. One reported ticket usually becomes several fix PRs — the MCP hardening alone was ~50 commits behind a handful of tickets — so the PR count runs higher than the reported-ticket count.
+
+## Next goal: 95% end-to-end test coverage
+
+Most of the 134 fixes above were caught late — in staging or by a report. The next lever is catching them **before they merge**. We are pushing **end-to-end test coverage to 95%** across the product, and we believe this will **significantly improve release quality** — fewer regressions reaching a release, and less time spent hot-fixing after one ships.
+
+Same lens next sprint: root causes, not symptoms.

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -71,17 +71,17 @@ Each mode has its own fully typed config, so there is no guessing from which fie
 
 ## AI Eng: LLM providers (27 fixes)
 
-AI engineering spent the two weeks driving down reported bugs, mostly on new models. The 27 fixes, grouped by the type of bug they removed:
+AI Eng was focused on driving down reported bugs. Most of them were on new models (Claude 4.8, Opus 4.8, Bedrock Invoke). Here are the types of bugs we fixed:
 
-| Type of bug fixed | Count |
+| Type of bug | Count |
 |---|---|
-| New-model capabilities silently dropped (mid-conversation system messages, thinking/effort translation, cache TTL, version handling) | 10 |
-| Billing / cost wrong (tier-only deployments billing $0, regional pricing, new-model cost-map entries) | 6 |
-| Routing & fallback correctness (auth propagation and model selection under the complexity router) | 6 |
-| Response & streaming fidelity (reasoning tokens preserved through translation, in-stream errors surfaced instead of swallowed) | 5 |
+| New model capabilities getting dropped | 10 |
+| Wrong cost or billing | 6 |
+| Routing or fallback picking the wrong model | 6 |
+| Broken response or streaming output | 5 |
 | Total | 27 |
 
-Most of the volume landed on Bedrock and the routing layer.
+Most of these were on Bedrock and the routing layer.
 
 ## Performance: pass-through memory
 


### PR DESCRIPTION
Draft blog post for docs.litellm.ai/blog — a two-week product quality & stability recap (June 27 – July 11, 2026).

**Slug:** `/blog/two-week-stability-update` · **Author:** ishaan

### What it covers
- **MCP Gateway stability** (50 of 134 fixes) — credentials now live in one encrypted gateway vault, bound to a single upstream; before/after mermaid diagrams + supported auth-types table.
- **AI Eng** (27) — new-model correctness + billing accuracy (Claude 4.8 / Opus 4.8, Bedrock Invoke).
- **Performance** — large non-JSON pass-through downloads now stream instead of buffering in memory (provider + custom pass-through routes; JSON still buffers by design).
- **By the numbers** — 134 fixes: MCP 50 / LLM Providers 27 / Proxy Core 23 / UI 20 / Logging 9 / Guardrails 5, with the reported-ticket vs. fix-PR reconciliation.
- **Next goal** — 95% end-to-end test coverage.

Filed as a **draft for review**. Diagrams use mermaid (native Docusaurus render); can swap to a React component if we want the exact HTML look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)