### PR TITLE
docs(blog): add Tin, Mateo, Yassin as authors on the July stability update

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -53,6 +53,11 @@ mateo:
   url: https://www.linkedin.com/in/mateo-wang
   image_url: /img/mateo.jpeg
 
+tin:
+  name: Tin Lo
+  title: MCP Eng, LiteLLM
+  image_url: https://media.licdn.com/dms/image/v2/D4E03AQH0K2Tx1GzBhQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1677601930841?e=1785369600&v=beta&t=-r46FiQh1uny60kMPAbGDtnINzyc3CZ72u6xt2UvMrc
+
 mubashir:
   name: Mubashir Osmani
   url: https://www.linkedin.com/in/mubashirosmani

--- a/blog/two_week_stability_update/index.md
+++ b/blog/two_week_stability_update/index.md
@@ -4,6 +4,9 @@ title: "July stability update: hardening MCP auth and cutting pass-through memor
 date: 2026-07-11T12:00:00
 authors:
   - ishaan
+  - tin
+  - mateo
+  - yassin
 description: "A two-week product quality update. We addressed two major issues (MCP credential resolution and pass-through memory) and shipped 134 bug fixes in total. Plus our next goal: 95% end-to-end test coverage."
 tags: [stability, mcp, performance, product]
 hide_table_of_contents: false


### PR DESCRIPTION
Follow-up to #542 (already merged). Adds the remaining authors to the July stability update post:

- New `tin` entry in `authors.yml` (Tin Lo, MCP Eng, with profile photo).
- Lists all four authors on the post: Ishaan, Tin, Mateo, Yassin.

No content changes to the post body; authors only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)