### PR TITLE
docs(release_notes): promote v1.92.0 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.91.0 — MCP OAuth v2, Rust OCR Gateway & Realtime Performance](/release_notes/v1.91.0/v1-91-0)
+### [v1.92.0 — Claude Sonnet 5, Production MCP OAuth & New Providers](/release_notes/v1.92.0/v1-92-0)
 
-_July 4, 2026_
+_July 11, 2026_
 
-A new MCP Gateway OAuth 2.0 v2 resolver with cross-replica single-flight refresh, a Rust workspace shipping an async-first Mistral OCR bridge and an experimental Axum realtime gateway, realtime session-establishment latency cuts via connection-pool pre-warming and client-disconnect cancellation, least-privilege MCP defaults for team keys, and around 48 new models spanning a large Cloudflare Workers AI batch, Gemini 3 image models, Mistral Medium 3.5 and OCR 3/4, GLM/zai, and SambaNova.
+First-class Claude Sonnet 5 support across Anthropic, Amazon Bedrock (including regional inference profiles), Vertex AI, and Azure AI with a 1M-token context window, reasoning, computer use, and PDF input; a production-ready MCP OAuth 2.0 On-Behalf-Of arm on the v2 resolver with RFC 9728 to RFC 8414 endpoint discovery, persisted Dynamic Client Registration, per-server outbound concurrency limits, and an `mcp_tool_search` virtual tool for large tool catalogs; two new providers in Tencent (DeepSeek V4 flash and pro) and Google Distributed Cloud Gemini for on-prem and sovereign deployments; access-control hardening across the key, user, and team endpoints plus AES-256-GCM at-rest credential encryption; and faster spend and budget hot paths with Redis-cluster reconnect and read-replica boot resilience.
 
 ---
 
@@ -22,6 +22,7 @@ A new MCP Gateway OAuth 2.0 v2 resolver with cross-replica single-flight refresh
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.92.0](/release_notes/v1.92.0/v1-92-0)   | Jul 11, 2026 | Claude Sonnet 5, production MCP OAuth (On-Behalf-Of) v2, Tencent & GDC providers |
 | [v1.91.0](/release_notes/v1.91.0/v1-91-0)   | Jul 4, 2026  | MCP OAuth 2.0 v2 resolver, Rust OCR gateway, realtime performance |
 | [v1.90.0](/release_notes/v1.90.0/v1-90-0)   | Jun 26, 2026 | Six new providers, OpenTelemetry v2 metrics parity, streaming-reliability sweep |
 | [v1.89.0](/release_notes/v1.89.0/v1-89-0)   | Jun 10, 2026 | Claude Fable 5, A2A agent providers, MCP per-server controls |

--- a/release_notes/v1.92.0/index.md
+++ b/release_notes/v1.92.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.92.0rc1 - Claude Sonnet 5, Production MCP OAuth & New Providers"
-slug: "v1-92-0-rc-1"
-date: 2026-07-04T23:30:00
+title: "v1.92.0 - Claude Sonnet 5, Production MCP OAuth & New Providers"
+slug: "v1-92-0"
+date: 2026-07-11T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,14 +30,14 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.92.0-rc.1
+docker.litellm.ai/berriai/litellm:1.92.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.92.0rc1
+pip install litellm==1.92.0
 ```
 
 </TabItem>
@@ -107,6 +107,7 @@ Claude Sonnet 5 ships with pricing entries for Anthropic (`claude-sonnet-5`), Am
     - Drop `toolSpec.strict` for Opus 4.7/4.8 to unblock tool calls - [PR #31923](https://github.com/BerriAI/litellm/pull/31923)
     - Drop `strict`/`additionalProperties` from `toolSpec` for Claude Sonnet 4 - [PR #31943](https://github.com/BerriAI/litellm/pull/31943)
     - Omit empty `additionalModelRequestFields` and `system` from the Converse payload - [PR #29565](https://github.com/BerriAI/litellm/pull/29565)
+    - Expand `os.environ/` references for AWS auth params, then all fields, in DB-sourced models - [PR #32256](https://github.com/BerriAI/litellm/pull/32256), [PR #32405](https://github.com/BerriAI/litellm/pull/32405)
 - **[Anthropic](../../docs/providers/anthropic)**
     - Bill streaming 1h prompt-cache writes at the 1h rate - [PR #32073](https://github.com/BerriAI/litellm/pull/32073)
     - Drop unsignable thinking blocks and allow a null signature in logging - [PR #31654](https://github.com/BerriAI/litellm/pull/31654)
@@ -204,6 +205,9 @@ Claude Sonnet 5 ships with pricing entries for Anthropic (`claude-sonnet-5`), Am
     - Add `litellm_overhead_with_guardrails_latency_metric` - [PR #31593](https://github.com/BerriAI/litellm/pull/31593)
     - Expose `project_alias` in custom metadata labels and expose MCP tool metadata - [PR #31784](https://github.com/BerriAI/litellm/pull/31784), [PR #31899](https://github.com/BerriAI/litellm/pull/31899)
     - Bound per-request budget metric emission with a timeout - [PR #31632](https://github.com/BerriAI/litellm/pull/31632)
+- **[OpenTelemetry](../../docs/observability/opentelemetry_integration)**
+    - Stamp `gen_ai.response.time_to_first_chunk` on streaming LLM spans - [PR #32236](https://github.com/BerriAI/litellm/pull/32236)
+    - Restore `error.*` span attributes on v2 error spans - [PR #32524](https://github.com/BerriAI/litellm/pull/32524)
 - **[S3](../../docs/proxy/logging)**
     - Send `Content-MD5` on PUT and support optional server-side encryption in the s3 v2 logger - [PR #31928](https://github.com/BerriAI/litellm/pull/31928)
 - **[Microsoft Sentinel](../../docs/proxy/logging)**
@@ -281,6 +285,7 @@ Claude Sonnet 5 ships with pricing entries for Anthropic (`claude-sonnet-5`), Am
     - Highlight MCP cards red when the logged-in user is missing per-user env vars - [PR #29856](https://github.com/BerriAI/litellm/pull/29856)
     - BYOM visibility, preview UX, and admin-settings gating - [PR #31809](https://github.com/BerriAI/litellm/pull/31809)
     - Re-add the chat UI and allow a simple UI for MCP OBO auth - [PR #31893](https://github.com/BerriAI/litellm/pull/31893)
+    - Keep an in-flight OAuth resume from resetting when the create-server modal mounts closed - [PR #32416](https://github.com/BerriAI/litellm/pull/32416)
 
 ## Performance / Loadbalancing / Reliability improvements
 
@@ -299,6 +304,8 @@ Claude Sonnet 5 ships with pricing entries for Anthropic (`claude-sonnet-5`), Am
     - Tag-routing denylist support via a `!` prefix - [PR #31728](https://github.com/BerriAI/litellm/pull/31728)
     - Declarative fallback generalizations for unknown models - [PR #29718](https://github.com/BerriAI/litellm/pull/29718)
     - Skip the health check for semantic auto_router deployments - [PR #31668](https://github.com/BerriAI/litellm/pull/31668)
+- **Build**
+    - Bump the wolfi-base digest for glibc 2.43-r10 - [PR #32277](https://github.com/BerriAI/litellm/pull/32277)
 
 ## Documentation Updates
 
@@ -306,15 +313,15 @@ Claude Sonnet 5 ships with pricing entries for Anthropic (`claude-sonnet-5`), Am
 
 ### PR roll-up by ownership area
 
-PRs by ownership area (total: 218)
+PRs by ownership area (total: 226)
 
 - LLM API Endpoints: 30
 - UI: 28
-- MCP: 27
-- Models & Providers: 25
+- MCP: 28
+- Models & Providers: 27
+- Other (CI / chore / tests / version bumps): 24
 - Auth & Management: 23
-- Other (CI / chore / tests / version bumps): 21
-- Logging: 20
+- Logging: 22
 - Spend / Budgets / Rate Limits: 18
 - Guardrails: 12
 - Performance: 11
@@ -334,4 +341,4 @@ PRs by ownership area (total: 218)
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.91.0-rc.1...v1.92.0-rc.1
+[`v1.91.0...v1.92.0`](https://github.com/BerriAI/litellm/compare/v1.91.0...v1.92.0)


### PR DESCRIPTION
Promotes the v1.92.0 release candidate notes to stable. Renames the `v1.92.0rc1` folder to `v1.92.0`, drops the `rc` from the title, slug, Docker tag, and pip install, sets the date to July 11, and switches the Full Changelog to the stable-to-stable `v1.91.0...v1.92.0` compare.

Following the v1.91.0 promotion pattern, this folds in the six user-facing PRs that landed between rc1 and rc2: the Bedrock `os.environ/` reference expansion for DB-sourced models (#32256, #32405), two OpenTelemetry span changes (#32236, #32524), the MCP OAuth resume fix (#32416), and the wolfi-base digest bump (#32277). The remaining rc1-to-rc2 commits are release mechanics (backport, UI rebuild, build artifacts) and are not noted. The ownership roll-up total moves from 218 to 226 to cover those eight PRs, and the changelog landing page now leads with v1.92.0.

Two things to know for review. There is no `v1.92.0` git tag yet; the latest 1.92.0 tag upstream is `v1.92.0-rc.2`, so the compare link will 404 until the stable tag is pushed and the date is set to today rather than derived from a tag. The roll-up total of 226 is 218 plus the eight PRs in the rc1-to-rc2 range; the original 218 came from the release-notes tooling and is not reproducible from a plain git count, so it is an estimate rather than a canonical recount.