### PR TITLE
docs(blog): incident report for Bedrock Invoke prompt cache invalidation

### DIFF
--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -19,11 +19,11 @@ hide_table_of_contents: false
 
 ## Summary
 
-Between July 4 and July 10, proxies running `v1.91.0` or `v1.91.1` silently broke Anthropic prompt caching for Claude Code sessions routed through Amazon Bedrock's Invoke API. For the customer who reported it, warm-session cache hit rates dropped from roughly 90% to 25-45% and team daily spend rose 2-3x for the same usage. Every request still returned a 200 with a correct completion; the only symptoms were a higher cache miss rate and a higher bill.
+Between July 4 and July 10, proxies running `v1.91.0` or `v1.91.1` silently broke Anthropic prompt caching for Claude Code sessions routed through Amazon Bedrock's Invoke API. For the customer who reported it, warm-session cache hit rates dropped from roughly 90% to 25-45% and team daily spend rose 2-3x for the same usage. Requests kept returning 200s with correct completions; the only symptoms were the cache miss rate and the bill.
 
-The regression was introduced by [PR #31364](https://github.com/BerriAI/litellm/pull/31364), which moved every `role: "system"` entry in `messages` into the top-level `system` field on the Invoke path. The fix shipped July 10 in `v1.91.2` across three PRs ([#32578](https://github.com/BerriAI/litellm/pull/32578), [#32831](https://github.com/BerriAI/litellm/pull/32831), [#32882](https://github.com/BerriAI/litellm/pull/32882)), with regression tests that fail on pre-fix code.
+The cause: [PR #31364](https://github.com/BerriAI/litellm/pull/31364) moved every `role: "system"` entry in `messages` into the top-level `system` field on the Invoke path, which invalidates every cache breakpoint past the first moved entry. The fix shipped July 10 in `v1.91.2` ([#32578](https://github.com/BerriAI/litellm/pull/32578), [#32831](https://github.com/BerriAI/litellm/pull/32831), [#32882](https://github.com/BerriAI/litellm/pull/32882)), with regression tests that fail on pre-fix code.
 
-We own this outcome entirely. The trigger was an undocumented change in how a new generation of Claude models and Claude Code use system messages, but customers run an LLM gateway precisely so they do not have to track provider quirks themselves. Translating requests faithfully, including their caching semantics, is our core job, and here we fell short. This post explains exactly what happened, why our testing and review failed to catch it, and what we have changed so this class of regression does not ship again.
+We own this outcome entirely. The trigger was an undocumented change in how new Claude models and Claude Code use system messages, but customers run a gateway precisely so they do not have to track provider quirks. Translating requests faithfully, including their caching semantics, is our core job.
 
 {/* truncate */}
 
@@ -31,31 +31,32 @@ We own this outcome entirely. The trigger was an undocumented change in how a ne
 
 ## Background
 
-Anthropic prompt caching is prefix based. Clients place `cache_control` breakpoints in the request, and a request reads from cache only up to the point where its payload matches a previously written prefix; cached tokens are billed at a small fraction of the normal input price. Agentic tools like Claude Code depend on this heavily because every turn resends the entire growing conversation. A warm Claude Code session routinely reads hundreds of thousands of tokens from cache per turn, so anything that rewrites content early in the payload turns almost the whole request back into full-price input tokens.
+Three facts set up the incident:
 
-On May 28, 2026, Anthropic released Claude Opus 4.8, the first model to accept `role: "system"` entries mid-conversation inside `messages` ([docs](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)). Claude Code began emitting these messages the same day. The feature did not appear in the Claude Code changelog, so gateways first encountered it as an unexplained new request shape in live traffic.
-
-Bedrock exposes Claude through two APIs that treat system content differently. Converse requires all system content in a top-level field and rejects system entries inside `messages` at any position; LiteLLM has hoisted them accordingly since December 2024 ([PR #7037](https://github.com/BerriAI/litellm/pull/7037)). Invoke accepts the native Anthropic Messages format, where models older than Opus 4.8 reject mid-conversation system entries with a 400 and newer models accept them.
+1. **Anthropic prompt caching is prefix based.** A request reads from cache only up to the point where its payload matches a previously written prefix; cached tokens cost a small fraction of normal input. Claude Code resends the entire growing conversation every turn, so a warm session reads hundreds of thousands of tokens from cache per turn, and anything that rewrites content early in the payload turns the rest back into full-price input.
+2. **Mid-conversation system messages are new.** On May 28, 2026, Claude Opus 4.8 shipped as the first model accepting `role: "system"` entries inside `messages` ([docs](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)). Claude Code (`v2.1.154`) began emitting them the same day, with no mention in its changelog.
+3. **Bedrock has two Anthropic APIs with different rules.** Converse requires all system content in a top-level field; LiteLLM has hoisted it there since December 2024 ([#7037](https://github.com/BerriAI/litellm/pull/7037)). Invoke takes the native Anthropic Messages format, where models older than Opus 4.8 reject mid-conversation system entries with a 400 and newer models accept them.
 
 ---
 
 ## What went wrong
 
-After May 28, a specific combination started failing: Claude Code sessions pointed at a Bedrock Invoke model older than Opus 4.8, using a proxy model alias that Claude Code could not map to a specific Claude version. Claude Code assumed the model supported mid-conversation system messages, emitted one, and the model rejected the request with a 400 mid-session.
-
-An enterprise customer hit exactly this, worked around it with a local patch set, and asked us to upstream it. One of those patches fixed the 400s by hoisting every system entry from `messages` into the top-level `system` field on the Invoke path, mirroring the longstanding Converse behavior. We shipped it as [PR #31364](https://github.com/BerriAI/litellm/pull/31364) in `v1.91.0` on July 4.
-
-Hoisting fixed the 400s but broke caching. Pulling a mid-conversation system entry out of `messages` rewrites the request prefix in two places at once: the top-level `system` block changes and the message list changes. From the model's perspective the previously cached prefix no longer matches, so every cache breakpoint past that point is invalidated. In a warm Claude Code session, that means nearly everything except the tool schemas misses cache on every turn, and the session pays full input price for context it had been reading at cache-hit rates.
+1. After May 28, Claude Code sessions on Bedrock Invoke began failing with 400s mid-session when two things were true: the model was older than Opus 4.8, and the proxy model alias did not tell Claude Code which Claude version it was talking to, so it assumed support and emitted mid-conversation system messages.
+2. An enterprise customer worked around the 400s with a local patch that hoisted every system entry from `messages` into top-level `system`, mirroring the Converse behavior, and asked us to upstream it. We shipped it as [#31364](https://github.com/BerriAI/litellm/pull/31364) in `v1.91.0` on July 4.
+3. The hoist fixed the 400s but rewrote the request prefix in two places at once: the top-level `system` block changes and the message list changes. Previously cached prefixes no longer match, so every cache breakpoint past the first moved entry is invalidated.
+4. Net effect in a warm Claude Code session: nearly everything except the tool schemas misses cache on every turn, at full input price.
 
 ---
 
 ## Detection and response
 
-On July 8, the affected customer reported the regression with request-level forensics that localized it for us: identical warm mid-session turns that had read 100% of a 306,892-token cached prefix the week before were now reading 17-22%, with everything past the first breakpoint re-written, all well inside the cache's 5-minute TTL, which ruled out expiry. They had also ruled out their own side by testing older Claude Code versions.
+On July 8 the affected customer reported the regression with request-level forensics that localized it for us: warm turns that had read 100% of a 306,892-token cached prefix the week before now read 17-22%, with everything past the first breakpoint re-written, all inside the cache's 5-minute TTL (ruling out expiry). Testing older Claude Code versions ruled out a client-side change. We reproduced it live the same day: a real Claude Code session against real Bedrock Invoke showed cache reads collapsing to 33,436 tokens exactly on the turns where Claude Code appended a mid-conversation system message.
 
-The same day, we reproduced it live: a real Claude Code session against real Bedrock Invoke showed cache reads collapsing to 33,436 tokens exactly on the turns where Claude Code appended a mid-conversation system message. [PR #32578](https://github.com/BerriAI/litellm/pull/32578) restored the correct behavior by hoisting only the leading run of system entries and forwarding mid-conversation ones untouched. Further investigation showed that forwarding them unconditionally would reintroduce the 400s on models below Opus 4.8, so [PR #32831](https://github.com/BerriAI/litellm/pull/32831) gated forwarding to models that support the feature, and [PR #32882](https://github.com/BerriAI/litellm/pull/32882) extended the supported-model list to Sonnet 5 and Fable 5, which had shipped after the initial gate was written.
+Three PRs fixed it, all released July 10 in `v1.91.2` with regression tests that fail on pre-fix code:
 
-All three fixes were backported with regression tests that fail on pre-fix code and released July 10 in `v1.91.2`. The customer upgraded July 12 and confirmed on July 13 that cache hit rates and spend were back to baseline.
+1. [#32578](https://github.com/BerriAI/litellm/pull/32578) hoists only the leading run of system entries and forwards mid-conversation ones untouched
+2. [#32831](https://github.com/BerriAI/litellm/pull/32831) gates forwarding to models that support the feature, since unconditional forwarding reintroduces the 400s below Opus 4.8
+3. [#32882](https://github.com/BerriAI/litellm/pull/32882) adds Sonnet 5 and Fable 5, which shipped after the gate was written
 
 | Date (2026) | Event |
 |---|---|
@@ -71,30 +72,25 @@ All three fixes were backported with regression tests that fail on pre-fix code 
 
 ## Why our process did not catch this
 
-Four gaps let this reach production undetected.
-
-First, the proof of fix was synthetic. We validated the original patch with single-turn requests showing a 400 become a 200. Those requests did not resemble what Claude Code actually sends: no multi-turn session, no cache breakpoints, no growing prefix. The one traffic shape that mattered was never exercised end to end.
-
-Second, the tests shipped with the change asserted the hoist as the new expected behavior, so they encoded the bug rather than catching it. When a PR redefines expected behavior, its own tests bless that behavior by construction; only an independent end-to-end check against real client traffic can catch the regression. Automated PR review tooling did not flag the caching implication either.
-
-Third, cost regressions are silent. Every response was a 200 with a correct completion, and the only signal was in cache read token counts. Nothing in our CI or monitoring measured cache hit rate, so there was no alarm to trip.
-
-Fourth, we leaned on documentation that was incomplete. Mid-conversation system messages never appeared in the Claude Code changelog, and as of July 13 the platform docs still describe the feature as Opus 4.8 only and unavailable on Bedrock, both of which live traffic contradicts. Provider behavior has to be established empirically, not from docs alone.
+1. **The proof of fix was synthetic.** We validated the original patch with single-turn requests showing a 400 become a 200: no multi-turn session, no cache breakpoints, no growing prefix. The one traffic shape that mattered was never exercised.
+2. **The PR's tests encoded the bug.** They asserted the hoist as the new expected behavior; when a PR redefines expected behavior, its own tests bless it by construction. Automated PR review tooling did not flag the caching implication either.
+3. **Cost regressions are silent.** Every response was a 200 with a correct completion. The only signal was cache-read token counts, which nothing in our CI or monitoring measured.
+4. **The documentation was incomplete.** The feature never appeared in the Claude Code changelog, and as of July 13 the platform docs still describe it as Opus 4.8 only and unavailable on Bedrock; live traffic contradicts both. Provider behavior has to be established empirically.
 
 ---
 
 ## What we are changing
 
-Our end-to-end suite now includes a scripted multi-turn Claude Code session that grows to roughly 250k tokens of context against real Bedrock and asserts that cache reads grow monotonically and never collapse; this work started in [PR #32963](https://github.com/BerriAI/litellm/pull/32963). A weekly load test checks for anomalies in spend, cache reads and writes, and turn latency, so silent cost regressions surface within days instead of waiting for a customer's bill.
-
-We are also closing the discovery gap that let an undocumented client change reach us through a 400 in production. Automated daily diffs of Anthropic's SDKs and documentation alert us to new features that need translation support, and live proxy traffic is monitored for new request shapes, such as unknown `anthropic-beta` headers, so client-side changes surface within a day of appearing.
-
-Finally, we changed the bar for merging translation fixes: a fix is not considered validated until it has been reproduced against the real client's traffic shape end to end. Synthetic requests demonstrating a status code change are not proof.
+- Our e2e suite gains a scripted multi-turn Claude Code session growing to roughly 250k tokens of context against real Bedrock, asserting cache reads grow monotonically and never collapse (started in [#32963](https://github.com/BerriAI/litellm/pull/32963))
+- A weekly load test flags anomalies in spend, cache reads and writes, and turn latency, so silent cost regressions surface in days rather than on a customer's bill
+- Daily automated diffs of Anthropic's SDKs and docs alert us to new features that need translation support before customer traffic finds them
+- Live proxy traffic is monitored for new request shapes, such as unknown `anthropic-beta` headers, so undocumented client changes surface within a day
+- Translation fixes now have a higher merge bar: validated means reproduced against the real client's traffic shape end to end; synthetic requests are not proof
 
 ---
 
 ## Known limitation: Bedrock Converse
 
-The fix applies to the Invoke path. Converse rejects system entries inside `messages` at any position, so on `bedrock_converse` we must still hoist, and Claude Code sessions routed through Converse will still lose cached prefix on every mid-conversation system message. If you run Claude Code against Bedrock, route it through the Invoke path (`bedrock/invoke/<model>`). We are raising the API constraint with AWS, and we are testing whether the Vertex AI and Azure paths need equivalent handling.
+Converse rejects system entries inside `messages` at any position, so on `bedrock_converse` we must still hoist, and Claude Code sessions routed through Converse still lose cached prefix on every mid-conversation system message. If you run Claude Code against Bedrock, route it through the Invoke path (`bedrock/invoke/<model>`). We are raising the API constraint with AWS, and we are testing whether the Vertex AI and Azure paths need equivalent handling.
 
-To every team whose bill went up because of this: we are sorry. The entire value of a gateway is that this class of provider change gets absorbed by us instead of reaching you, and the tests and monitoring above are how we intend to keep it that way.
+To every team whose bill went up because of this: we are sorry. The value of a gateway is that this class of provider change gets absorbed by us instead of reaching you, and the tests and monitoring above are how we intend to keep it that way.

--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -12,20 +12,20 @@ hide_table_of_contents: false
 
 **Date:** July 4 to July 10, 2026  
 **Affected versions:** `v1.91.0` and `v1.91.1`  
-**Severity:** High (silent cost regression; no correctness impact)  
+**Severity:** Medium (silent cost regression; no correctness impact)  
 **Status:** Resolved in `v1.91.2`
 
-> **Note:** If you run Claude Code against Amazon Bedrock through LiteLLM, upgrade to `v1.91.2` or higher.
+> **Note:** If you run Claude Code against Amazon Bedrock through LiteLLM on either `v1.91.0` or `v1.91.1`, upgrade to `v1.91.2` or higher.
 
 ## Summary
 
-Between July 4 and July 10, proxies running `v1.91.0` or `v1.91.1` silently broke Anthropic prompt caching for Claude Code sessions routed through Amazon Bedrock's Invoke API. For the customer who reported it, warm-session cache hit rates dropped from roughly 90% to 25-45% and team daily spend rose 2-3x for the same usage. Requests kept returning 200s with correct completions; the only symptoms were the cache miss rate and the bill.
+Between July 4 and July 10, proxies running `v1.91.0` or `v1.91.1` silently broke Anthropic prompt caching for Claude Code sessions routed through Amazon Bedrock's Invoke API. For the customers who reported it, warm-session cache hit rates dropped from roughly 90% to 25-45% and team daily spend rose 2-3x for the same usage. Requests kept returning 200s with correct completions; the only symptoms were the cache miss rate and the bill.
 
-The cause: [PR #31364](https://github.com/BerriAI/litellm/pull/31364) moved every `role: "system"` entry in `messages` into the top-level `system` field on the Invoke path, which invalidates every cache breakpoint past the first moved entry. The fix shipped July 10 in `v1.91.2` ([#32578](https://github.com/BerriAI/litellm/pull/32578), [#32831](https://github.com/BerriAI/litellm/pull/32831), [#32882](https://github.com/BerriAI/litellm/pull/32882)), with regression tests that fail on pre-fix code.
+The cause: [PR #31364](https://github.com/BerriAI/litellm/pull/31364) moved every `role: "system"` entry in `messages` into the top-level `system` field on the Invoke path, which invalidates every cache breakpoint past the tool definitions and system prompt. The fix shipped July 10 in `v1.91.2` ([#32578](https://github.com/BerriAI/litellm/pull/32578), [#32831](https://github.com/BerriAI/litellm/pull/32831), [#32882](https://github.com/BerriAI/litellm/pull/32882)), with regression tests that fail on pre-fix code.
 
-We own this outcome entirely. The trigger was an undocumented change in how new Claude models and Claude Code use system messages, but customers run a gateway precisely so they do not have to track provider quirks. Translating requests faithfully, including their caching semantics, is our core job.
+We own this outcome entirely. The trigger was a poorly documented change in how new Claude models and Claude Code use system messages, but customers run a gateway precisely so they do not have to track provider quirks. Translating requests faithfully, including their caching semantics, is our core job and here we fell short. This post explains exactly what happened, why our testing and review failed to catch it, and what we have changed so this class of regression does not ship again.
 
-{/* truncate */}
+{/_ truncate _/}
 
 ---
 
@@ -33,64 +33,78 @@ We own this outcome entirely. The trigger was an undocumented change in how new 
 
 Three facts set up the incident:
 
-1. **Anthropic prompt caching is prefix based.** A request reads from cache only up to the point where its payload matches a previously written prefix; cached tokens cost a small fraction of normal input. Claude Code resends the entire growing conversation every turn, so a warm session reads hundreds of thousands of tokens from cache per turn, and anything that rewrites content early in the payload turns the rest back into full-price input.
-2. **Mid-conversation system messages are new.** On May 28, 2026, Claude Opus 4.8 shipped as the first model accepting `role: "system"` entries inside `messages` ([docs](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)). Claude Code (`v2.1.154`) began emitting them the same day, with no mention in its changelog.
-3. **Bedrock has two Anthropic APIs with different rules.** Converse requires all system content in a top-level field; LiteLLM has hoisted it there since December 2024 ([#7037](https://github.com/BerriAI/litellm/pull/7037)). Invoke takes the native Anthropic Messages format, where models older than Opus 4.8 reject mid-conversation system entries with a 400 and newer models accept them.
+1. **Claude prompt caching is prefix based:**
+   1. the pricing of tokens in increasing cost is:
+      1. cache read (0.1x)
+      2. normal write (1x)
+      3. cache write (1.25x for 5m ttl, 2x for 1h ttl)
+   2. when Claude Code makes a new request, the Bedrock provider checks if any previous request was a truncated prefix of the current request. If so, it reads from the cache only up to that point.
+2. **Mid-conversation system messages are new:**
+   1. On May 28, 2026, Claude Opus 4.8 shipped as the first model accepting `role: "system"` entries inside `messages` ([docs](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)). This was documented on the Claude API docs [on the same day](https://web.archive.org/web/20260528184320/https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)
+   2. Claude Code (`v2.1.154`) began emitting them on May 28, 2026, with no mention in its changelog.
+   3. Bedrock documented the same support by [June 9, 2026](https://web.archive.org/web/20260609182343/https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-mid-conversation-system.html) at the latest (the first archive.org capture; the page may have appeared as early as May 28)
+3. **Bedrock has two Anthropic APIs with different rules:**
+   1. Converse requires all system content in a top-level field; LiteLLM has hoisted it there since December 2024 ([#7037](https://github.com/BerriAI/litellm/pull/7037)).
+   2. Invoke takes the native Anthropic Messages format, where models older than Opus 4.8 reject mid-conversation system entries with a 400 and newer models accept them.
 
 ---
 
 ## What went wrong
 
-1. After May 28, Claude Code sessions on Bedrock Invoke began failing with 400s mid-session when two things were true: the model was older than Opus 4.8, and the proxy model alias did not tell Claude Code which Claude version it was talking to, so it assumed support and emitted mid-conversation system messages.
+1. After May 28, Claude Code sessions on Bedrock Invoke began failing with 400s mid-session when two things were true:
+   1. the model was older than Opus 4.8
+   2. the model is served under an alias
+      1. Claude Code detects capabilities by looking for version substrings like `opus-4-7` or `sonnet-4-6` in the model name.
+      2. For example, an alias like `bedrock-claude` contains none, so Claude Code assumes the newest feature set and always emits mid-conversation system messages.
 2. An enterprise customer worked around the 400s with a local patch that hoisted every system entry from `messages` into top-level `system`, mirroring the Converse behavior, and asked us to upstream it. We shipped it as [#31364](https://github.com/BerriAI/litellm/pull/31364) in `v1.91.0` on July 4.
-3. The hoist fixed the 400s but rewrote the request prefix in two places at once: the top-level `system` block changes and the message list changes. Previously cached prefixes no longer match, so every cache breakpoint past the first moved entry is invalidated.
-4. Net effect in a warm Claude Code session: nearly everything except the tool schemas misses cache on every turn, at full input price.
+3. The hoist fixed the 400s but by always hoisting the system entries in `messages`, that would invalidate the entire `messages` cache whenever a new mid-conversation system message was written by Claude Code, which we measured to happen every ~3 turns on average.
+4. This greatly decreased the cache hit rate and increased the cache write rate, increasing spend.
 
 ---
 
 ## Detection and response
 
-On July 8 the affected customer reported the regression with request-level forensics that localized it for us: warm turns that had read 100% of a 306,892-token cached prefix the week before now read 17-22%, with everything past the first breakpoint re-written, all inside the cache's 5-minute TTL (ruling out expiry). Testing older Claude Code versions ruled out a client-side change. We reproduced it live the same day: a real Claude Code session against real Bedrock Invoke showed cache reads collapsing to 33,436 tokens exactly on the turns where Claude Code appended a mid-conversation system message.
+On July 8, an affected customer gave a detailed bug report of this regression. We reproduced it ourselves the same day end-to-end.
 
-Three PRs fixed it, all released July 10 in `v1.91.2` with regression tests that fail on pre-fix code:
+Three PRs fixed it, all released July 10 in `v1.91.2` after extensive end-to-end testing, with regression tests that fail on pre-fix code:
 
-1. [#32578](https://github.com/BerriAI/litellm/pull/32578) hoists only the leading run of system entries and forwards mid-conversation ones untouched
-2. [#32831](https://github.com/BerriAI/litellm/pull/32831) gates forwarding to models that support the feature, since unconditional forwarding reintroduces the 400s below Opus 4.8
-3. [#32882](https://github.com/BerriAI/litellm/pull/32882) adds Sonnet 5 and Fable 5, which shipped after the gate was written
+1. [#32578](https://github.com/BerriAI/litellm/pull/32578) disables mid-conversation system message hoisting on Invoke.
+2. [#32831](https://github.com/BerriAI/litellm/pull/32831) re-enables hoisting on models below Opus 4.8.
+3. [#32882](https://github.com/BerriAI/litellm/pull/32882) disables hoisting on Sonnet 5 and Fable 5, too.
 
-| Date (2026) | Event |
-|---|---|
-| May 28 | Opus 4.8 ships; Claude Code starts emitting mid-conversation system messages |
-| Jun 27 | Customer workaround upstreamed as [#31364](https://github.com/BerriAI/litellm/pull/31364) |
-| Jul 4 | `v1.91.0` ships with the regression |
-| Jul 6 | Customer observes 2-3x spend and collapsed cache hit rates |
-| Jul 8 | Regression reported; root cause reproduced live; fix opened |
-| Jul 10 | `v1.91.2` ships with all three fixes and regression tests |
-| Jul 13 | Customer confirms full recovery |
+| Date (2026) | Event                                                                                     |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| May 28      | Opus 4.8 ships; Claude Code starts emitting mid-conversation system messages              |
+| Jun 27      | Customer workaround upstreamed as [#31364](https://github.com/BerriAI/litellm/pull/31364) |
+| Jul 4       | `v1.91.0` ships with the regression                                                       |
+| Jul 6       | Customer observes 2-3x spend and collapsed cache hit rates                                |
+| Jul 8       | Regression reported; root cause identified; fix opened                                    |
+| Jul 10      | `v1.91.2` ships with all three fixes and regression tests                                 |
+| Jul 13      | Customer confirms full recovery                                                           |
 
 ---
 
 ## Why our process did not catch this
 
-1. **The proof of fix was synthetic.** We validated the original patch with single-turn requests showing a 400 become a 200: no multi-turn session, no cache breakpoints, no growing prefix. The one traffic shape that mattered was never exercised.
-2. **The PR's tests encoded the bug.** They asserted the hoist as the new expected behavior; when a PR redefines expected behavior, its own tests bless it by construction. Automated PR review tooling did not flag the caching implication either.
-3. **Cost regressions are silent.** Every response was a 200 with a correct completion. The only signal was cache-read token counts, which nothing in our CI or monitoring measured.
-4. **The documentation was incomplete.** The feature never appeared in the Claude Code changelog, and as of July 13 the platform docs still describe it as Opus 4.8 only and unavailable on Bedrock; live traffic contradicts both. Provider behavior has to be established empirically.
+1. **Testing the original patch was not end-to-end.** We validated the original patch with single-turn `curl` requests showing a 400 become a 200 that we assumed was the shape that Claude Code would use. That was not the case. We did not trace the root cause (we did not yet know mid-conversation system messages existed) or its caching implications, and treated it as a harmless edge case fix.
+2. **Cost regressions are silent.** Every response was a 200 with a correct completion. The only signal was cache-read token counts, which nothing in our CI or monitoring measured.
+3. **The documentation was incomplete.** The feature never appeared in the Claude Code changelog, and as of July 13 the Claude API docs still describe it as Opus 4.8 only (without mentioning Sonnet or Fable 5) and unavailable on Bedrock, which contradicts our empirical measurements.
 
 ---
 
 ## What we are changing
 
-- Our e2e suite gains a scripted multi-turn Claude Code session growing to roughly 250k tokens of context against real Bedrock, asserting cache reads grow monotonically and never collapse (started in [#32963](https://github.com/BerriAI/litellm/pull/32963))
-- A weekly load test flags anomalies in spend, cache reads and writes, and turn latency, so silent cost regressions surface in days rather than on a customer's bill
+- Our e2e suite will gain a scripted multi-turn Claude Code session growing to roughly 250k tokens of context against real Bedrock, asserting cache reads grow monotonically and never collapse (started in [#32963](https://github.com/BerriAI/litellm/pull/32963))
+- We will set up a weekly automated load test that will flag anomalies in spend, cache reads and writes, turn latency, error rates, etc., so cost and performance regressions are detected and fixed before a release.
 - Daily automated diffs of Anthropic's SDKs and docs alert us to new features that need translation support before customer traffic finds them
-- Live proxy traffic is monitored for new request shapes, such as unknown `anthropic-beta` headers, so undocumented client changes surface within a day
-- Translation fixes now have a higher merge bar: validated means reproduced against the real client's traffic shape end to end; synthetic requests are not proof
+- We [dogfood](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) LiteLLM internally and will set up monitoring for new request shapes, such as unknown `anthropic-beta` headers, and the same anomoly detction, which will alert us ahead of a release.
+- Bug fixes now have a higher merge bar: validated means reproduced against the real client's traffic on their exact end-user application end-to-end and a complete understanding of the root cause; synthetic requests are not enough.
 
 ---
 
-## Known limitation: Bedrock Converse
+## Known limitations
 
-Converse rejects system entries inside `messages` at any position, so on `bedrock_converse` we must still hoist, and Claude Code sessions routed through Converse still lose cached prefix on every mid-conversation system message. If you run Claude Code against Bedrock, route it through the Invoke path (`bedrock/invoke/<model>`). We are raising the API constraint with AWS, and we are testing whether the Vertex AI and Azure paths need equivalent handling.
+1. Converse rejects system entries inside `messages` at any position, so on `bedrock_converse` we must still hoist, and Claude Code sessions routed through Converse still lose cached prefix on every mid-conversation system message. If you run Claude Code against Bedrock, route it through the Invoke path (`bedrock/invoke/<model>`). We are raising the API constraint with AWS
+2. We are testing whether the Vertex AI and Azure paths need equivalent hoisting and will update this post when we have more info.
 
-To every team whose bill went up because of this: we are sorry. The value of a gateway is that this class of provider change gets absorbed by us instead of reaching you, and the tests and monitoring above are how we intend to keep it that way.
+To every team whose bill went up because of this: we are sorry. The value of a gateway is that this class of provider change gets absorbed by us instead of reaching you, and the tests, monitoring, and process improvements above are how we intend to keep it that way.

--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -1,0 +1,100 @@
+---
+slug: bedrock-invoke-prompt-caching-incident
+title: "Incident Report: Prompt Cache Invalidation for Claude Code on Bedrock Invoke"
+date: 2026-07-13T10:00:00
+authors:
+  - mateo
+  - krrish
+  - ishaan-alt
+tags: [incident-report, bedrock, caching, claude-code]
+hide_table_of_contents: false
+---
+
+**Date:** July 4 to July 10, 2026
+**Affected versions:** `v1.91.0` and `v1.91.1`
+**Severity:** High (silent cost regression; no correctness impact)
+**Status:** Resolved in `v1.91.2`
+
+> **Note:** If you run Claude Code against Amazon Bedrock through LiteLLM, upgrade to `v1.91.2` or higher.
+
+## Summary
+
+Between July 4 and July 10, proxies running `v1.91.0` or `v1.91.1` silently broke Anthropic prompt caching for Claude Code sessions routed through Amazon Bedrock's Invoke API. For the customer who reported it, warm-session cache hit rates dropped from roughly 90% to 25-45% and team daily spend rose 2-3x for the same usage. Every request still returned a 200 with a correct completion; the only symptoms were a higher cache miss rate and a higher bill.
+
+The regression was introduced by [PR #31364](https://github.com/BerriAI/litellm/pull/31364), which moved every `role: "system"` entry in `messages` into the top-level `system` field on the Invoke path. The fix shipped July 10 in `v1.91.2` across three PRs ([#32578](https://github.com/BerriAI/litellm/pull/32578), [#32831](https://github.com/BerriAI/litellm/pull/32831), [#32882](https://github.com/BerriAI/litellm/pull/32882)), with regression tests that fail on pre-fix code.
+
+We own this outcome entirely. The trigger was an undocumented change in how a new generation of Claude models and Claude Code use system messages, but customers run an LLM gateway precisely so they do not have to track provider quirks themselves. Translating requests faithfully, including their caching semantics, is our core job, and here we fell short. This post explains exactly what happened, why our testing and review failed to catch it, and what we have changed so this class of regression does not ship again.
+
+{/* truncate */}
+
+---
+
+## Background
+
+Anthropic prompt caching is prefix based. Clients place `cache_control` breakpoints in the request, and a request reads from cache only up to the point where its payload matches a previously written prefix; cached tokens are billed at a small fraction of the normal input price. Agentic tools like Claude Code depend on this heavily because every turn resends the entire growing conversation. A warm Claude Code session routinely reads hundreds of thousands of tokens from cache per turn, so anything that rewrites content early in the payload turns almost the whole request back into full-price input tokens.
+
+On May 28, 2026, Anthropic released Claude Opus 4.8, the first model to accept `role: "system"` entries mid-conversation inside `messages` ([docs](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)). Claude Code began emitting these messages the same day. The feature did not appear in the Claude Code changelog, so gateways first encountered it as an unexplained new request shape in live traffic.
+
+Bedrock exposes Claude through two APIs that treat system content differently. Converse requires all system content in a top-level field and rejects system entries inside `messages` at any position; LiteLLM has hoisted them accordingly since December 2024 ([PR #7037](https://github.com/BerriAI/litellm/pull/7037)). Invoke accepts the native Anthropic Messages format, where models older than Opus 4.8 reject mid-conversation system entries with a 400 and newer models accept them.
+
+---
+
+## What went wrong
+
+After May 28, a specific combination started failing: Claude Code sessions pointed at a Bedrock Invoke model older than Opus 4.8, using a proxy model alias that Claude Code could not map to a specific Claude version. Claude Code assumed the model supported mid-conversation system messages, emitted one, and the model rejected the request with a 400 mid-session.
+
+An enterprise customer hit exactly this, worked around it with a local patch set, and asked us to upstream it. One of those patches fixed the 400s by hoisting every system entry from `messages` into the top-level `system` field on the Invoke path, mirroring the longstanding Converse behavior. We shipped it as [PR #31364](https://github.com/BerriAI/litellm/pull/31364) in `v1.91.0` on July 4.
+
+Hoisting fixed the 400s but broke caching. Pulling a mid-conversation system entry out of `messages` rewrites the request prefix in two places at once: the top-level `system` block changes and the message list changes. From the model's perspective the previously cached prefix no longer matches, so every cache breakpoint past that point is invalidated. In a warm Claude Code session, that means nearly everything except the tool schemas misses cache on every turn, and the session pays full input price for context it had been reading at cache-hit rates.
+
+---
+
+## Detection and response
+
+On July 8, the affected customer reported the regression with request-level forensics that localized it for us: identical warm mid-session turns that had read 100% of a 306,892-token cached prefix the week before were now reading 17-22%, with everything past the first breakpoint re-written, all well inside the cache's 5-minute TTL, which ruled out expiry. They had also ruled out their own side by testing older Claude Code versions.
+
+The same day, we reproduced it live: a real Claude Code session against real Bedrock Invoke showed cache reads collapsing to 33,436 tokens exactly on the turns where Claude Code appended a mid-conversation system message. [PR #32578](https://github.com/BerriAI/litellm/pull/32578) restored the correct behavior by hoisting only the leading run of system entries and forwarding mid-conversation ones untouched. Further investigation showed that forwarding them unconditionally would reintroduce the 400s on models below Opus 4.8, so [PR #32831](https://github.com/BerriAI/litellm/pull/32831) gated forwarding to models that support the feature, and [PR #32882](https://github.com/BerriAI/litellm/pull/32882) extended the supported-model list to Sonnet 5 and Fable 5, which had shipped after the initial gate was written.
+
+All three fixes were backported with regression tests that fail on pre-fix code and released July 10 in `v1.91.2`. The customer upgraded July 12 and confirmed on July 13 that cache hit rates and spend were back to baseline.
+
+| Date (2026) | Event |
+|---|---|
+| May 28 | Opus 4.8 ships; Claude Code starts emitting mid-conversation system messages |
+| Jun 27 | Customer workaround upstreamed as [#31364](https://github.com/BerriAI/litellm/pull/31364) |
+| Jul 4 | `v1.91.0` ships with the regression |
+| Jul 6 | Customer observes 2-3x spend and collapsed cache hit rates |
+| Jul 8 | Regression reported; root cause reproduced live; fix opened |
+| Jul 10 | `v1.91.2` ships with all three fixes and regression tests |
+| Jul 13 | Customer confirms full recovery |
+
+---
+
+## Why our process did not catch this
+
+Four gaps let this reach production undetected.
+
+First, the proof of fix was synthetic. We validated the original patch with single-turn requests showing a 400 become a 200. Those requests did not resemble what Claude Code actually sends: no multi-turn session, no cache breakpoints, no growing prefix. The one traffic shape that mattered was never exercised end to end.
+
+Second, the tests shipped with the change asserted the hoist as the new expected behavior, so they encoded the bug rather than catching it. When a PR redefines expected behavior, its own tests bless that behavior by construction; only an independent end-to-end check against real client traffic can catch the regression. Automated PR review tooling did not flag the caching implication either.
+
+Third, cost regressions are silent. Every response was a 200 with a correct completion, and the only signal was in cache read token counts. Nothing in our CI or monitoring measured cache hit rate, so there was no alarm to trip.
+
+Fourth, we leaned on documentation that was incomplete. Mid-conversation system messages never appeared in the Claude Code changelog, and as of July 13 the platform docs still describe the feature as Opus 4.8 only and unavailable on Bedrock, both of which live traffic contradicts. Provider behavior has to be established empirically, not from docs alone.
+
+---
+
+## What we are changing
+
+Our end-to-end suite now includes a scripted multi-turn Claude Code session that grows to roughly 250k tokens of context against real Bedrock and asserts that cache reads grow monotonically and never collapse; this work started in [PR #32963](https://github.com/BerriAI/litellm/pull/32963). A weekly load test checks for anomalies in spend, cache reads and writes, and turn latency, so silent cost regressions surface within days instead of waiting for a customer's bill.
+
+We are also closing the discovery gap that let an undocumented client change reach us through a 400 in production. Automated daily diffs of Anthropic's SDKs and documentation alert us to new features that need translation support, and live proxy traffic is monitored for new request shapes, such as unknown `anthropic-beta` headers, so client-side changes surface within a day of appearing.
+
+Finally, we changed the bar for merging translation fixes: a fix is not considered validated until it has been reproduced against the real client's traffic shape end to end. Synthetic requests demonstrating a status code change are not proof.
+
+---
+
+## Known limitation: Bedrock Converse
+
+The fix applies to the Invoke path. Converse rejects system entries inside `messages` at any position, so on `bedrock_converse` we must still hoist, and Claude Code sessions routed through Converse will still lose cached prefix on every mid-conversation system message. If you run Claude Code against Bedrock, route it through the Invoke path (`bedrock/invoke/<model>`). We are raising the API constraint with AWS, and we are testing whether the Vertex AI and Azure paths need equivalent handling.
+
+To every team whose bill went up because of this: we are sorry. The entire value of a gateway is that this class of provider change gets absorbed by us instead of reaching you, and the tests and monitoring above are how we intend to keep it that way.

--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -10,9 +10,9 @@ tags: [incident-report, bedrock, caching, claude-code]
 hide_table_of_contents: false
 ---
 
-**Date:** July 4 to July 10, 2026
-**Affected versions:** `v1.91.0` and `v1.91.1`
-**Severity:** High (silent cost regression; no correctness impact)
+**Date:** July 4 to July 10, 2026  
+**Affected versions:** `v1.91.0` and `v1.91.1`  
+**Severity:** High (silent cost regression; no correctness impact)  
 **Status:** Resolved in `v1.91.2`
 
 > **Note:** If you run Claude Code against Amazon Bedrock through LiteLLM, upgrade to `v1.91.2` or higher.

--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -25,7 +25,7 @@ The cause: [PR #31364](https://github.com/BerriAI/litellm/pull/31364) moved ever
 
 We own this outcome entirely. The trigger was a poorly documented change in how new Claude models and Claude Code use system messages, but customers run a gateway precisely so they do not have to track provider quirks. Translating requests faithfully, including their caching semantics, is our core job and here we fell short. This post explains exactly what happened, why our testing and review failed to catch it, and what we have changed so this class of regression does not ship again.
 
-{/_ truncate _/}
+{/* truncate */}
 
 ---
 

--- a/blog/bedrock_invoke_prompt_caching_incident/index.md
+++ b/blog/bedrock_invoke_prompt_caching_incident/index.md
@@ -86,9 +86,10 @@ Three PRs fixed it, all released July 10 in `v1.91.2` after extensive end-to-end
 
 ## Why our process did not catch this
 
-1. **Testing the original patch was not end-to-end.** We validated the original patch with single-turn `curl` requests showing a 400 become a 200 that we assumed was the shape that Claude Code would use. That was not the case. We did not trace the root cause (we did not yet know mid-conversation system messages existed) or its caching implications, and treated it as a harmless edge case fix.
-2. **Cost regressions are silent.** Every response was a 200 with a correct completion. The only signal was cache-read token counts, which nothing in our CI or monitoring measured.
-3. **The documentation was incomplete.** The feature never appeared in the Claude Code changelog, and as of July 13 the Claude API docs still describe it as Opus 4.8 only (without mentioning Sonnet or Fable 5) and unavailable on Bedrock, which contradicts our empirical measurements.
+1. **Testing the original patch was not end-to-end.** We validated it with single-turn `curl` requests showing a 400 become a 200 that we assumed was the shape that Claude Code would use. That was not the case. We did not trace the root cause (we did not yet know mid-conversation system messages existed) or its caching implications, and treated it as a harmless edge case fix.
+2. **Review lacked the context to object.** The human reviewer saw a small compatibility patch with passing tests and no explanation of why Claude Code started sending these kinds of mid-conversation system messages, and our AI review bots did not flag the caching implication either. Nobody in the loop had the info to connect the hoist to cache invalidation.
+3. **Cost regressions are silent.** Every response was a 200 with a correct completion. The only signal was cache-read token counts, which nothing in our CI or monitoring measured.
+4. **The documentation was incomplete.** The feature never appeared in the Claude Code changelog, and as of July 13 the Claude API docs still describe it as Opus 4.8 only (without mentioning Sonnet or Fable 5) and unavailable on Bedrock, which contradicts our empirical measurements.
 
 ---
 


### PR DESCRIPTION
External-facing incident report for the v1.91.0 prompt caching regression on the Bedrock Invoke path (introduced by #31364 in litellm, fixed by #32578/#32831/#32882 in v1.91.2). Written from the internal RCA with customer names and internal testing details removed, following the ownership-forward style of the Cloudflare and Vercel outage posts: summary with impact numbers, background on prompt caching and mid-conversation system messages, root cause, detection and response with timeline, why our process did not catch it, remediation, and the known Converse limitation with routing guidance.