### PR TITLE
docs: document TOKEN_COUNTER_MAX_CONCURRENCY and TOKEN_COUNTER_MAX_REQUEST_CHARS

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1187,6 +1187,8 @@ router_settings:
 | TOGETHER_AI_110_B | Size parameter for Together AI 110B model. Default is 110
 | TOGETHER_AI_EMBEDDING_150_M | Size parameter for Together AI 150M embedding model. Default is 150
 | TOGETHER_AI_EMBEDDING_350_M | Size parameter for Together AI 350M embedding model. Default is 350
+| TOKEN_COUNTER_MAX_CONCURRENCY | Maximum concurrent local tokenization jobs per proxy worker for the token counting endpoints; requests over the cap receive a 429. Default is 32
+| TOKEN_COUNTER_MAX_REQUEST_CHARS | Maximum combined characters across all string fields accepted per token counting request; larger requests receive a 400. Default is 10000000
 | TOOL_CHOICE_OBJECT_TOKEN_COUNT | Token count for tool choice objects. Default is 4
 | TOOL_POLICY_CACHE_TTL_SECONDS | TTL in seconds for caching tool policy guardrail results. Default is 60
 | UI_LOGO_PATH | Path to the logo image used in the UI


### PR DESCRIPTION
I added these two environment variables to the proxy token-counting endpoints in BerriAI/litellm#33175 (they bound tokenization concurrency and request size). litellm's documentation check (tests/documentation_tests/test_env_keys.py) requires every env var referenced in code to have a row in the environment variables reference, so this adds both rows in alphabetical order:

- TOKEN_COUNTER_MAX_CONCURRENCY — max concurrent local tokenization jobs per proxy worker; excess requests get a 429. Default 32.
- TOKEN_COUNTER_MAX_REQUEST_CHARS — max combined characters across all string fields per token-count request; larger requests get a 400. Default 10000000.

I verified locally that test_env_keys.py passes with these rows in place.