### PR TITLE
docs(reasoning): document max_tokens budgeting for reasoning models

### DIFF
--- a/docs/reasoning_content.md
+++ b/docs/reasoning_content.md
@@ -111,6 +111,45 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 }
 ```
 
+## Budgeting `max_tokens` for reasoning models
+
+Reasoning tokens count toward the same completion budget as visible output: `max_completion_tokens` (and `max_tokens`) is an upper bound for visible output tokens and reasoning tokens combined. Several providers also reason by default, with no `thinking` or `reasoning_effort` in the request; DeepSeek, Moonshot AI, and Z.AI models behave this way, and current Gemini models default to thinking as well.
+
+The combination can produce a surprising failure mode. With a modest `max_tokens`, the model may spend the entire budget on hidden reasoning before emitting any visible text. The call then returns `finish_reason: "length"` with `content` empty or nearly empty, and the request is billed for the full completion, since reasoning tokens are billed as output tokens. From the response alone this looks like ordinary truncation.
+
+```python showLineNumbers
+response = litellm.completion(
+    model="moonshot/kimi-k2.5",  # reasons by default; no thinking param needed
+    messages=[{"role": "user", "content": "Shorten this sentence: ..."}],
+    max_tokens=200,
+)
+print(response.choices[0].finish_reason)                          # "length"
+print(repr(response.choices[0].message.content))                  # ''
+print(response.usage.completion_tokens_details.reasoning_tokens)  # 199
+```
+
+### Detecting reasoning-consumed budgets
+
+For non-streaming calls, check `usage.completion_tokens_details.reasoning_tokens`. If `finish_reason` is `"length"` and reasoning tokens account for all or nearly all of `completion_tokens`, the budget went to reasoning rather than to a long visible answer:
+
+```python showLineNumbers
+choice = response.choices[0]
+details = response.usage.completion_tokens_details
+reasoning_tokens = (details.reasoning_tokens or 0) if details else 0
+
+if choice.finish_reason == "length" and not choice.message.content:
+    print(
+        f"Empty response: {reasoning_tokens} of {response.usage.completion_tokens} "
+        "completion tokens were consumed by reasoning. Raise max_tokens."
+    )
+```
+
+For streaming calls, set `stream_options={"include_usage": True}` and read the same fields from the usage object on the final chunk. See [Streaming Usage](/docs/completion/usage#streaming-usage).
+
+### Sizing the budget
+
+Set `max_tokens` to cover the reasoning plus the answer, not the answer alone. Reasoning commonly runs to several hundred tokens even for short prompts; the request above that returned nothing at `max_tokens=200` finished cleanly at a higher cap with 623 reasoning tokens and 17 visible output tokens. Where the provider supports it, `reasoning_effort` reduces or disables reasoning; see the per-provider mapping notes, for example [Gemini](/docs/providers/gemini#usage---thinking--reasoning_content), where thinking cannot be fully disabled on Gemini 3 models. Proxy health checks hit the same interaction and support separate token limits for reasoning models; see [health check reasoning defaults](/docs/proxy/health#reasoning-vs-non-reasoning-defaults).
+
 ## Tool Calling with `thinking`
 
 Here's how to use `thinking` blocks by Anthropic with tool calling.


### PR DESCRIPTION
docs(reasoning): document max_tokens budgeting for reasoning models

## Problem

Several providers now return reasoning by default with no `thinking` or `reasoning_effort` in the request (DeepSeek, Moonshot AI, Z.AI; current Gemini models also default to thinking). Reasoning tokens count toward the completion budget, so a modest `max_tokens` can be consumed entirely by hidden reasoning: the call returns `finish_reason: "length"` with `content` empty or nearly empty, and the request is billed for the full completion. From the response alone this reads as ordinary truncation, which makes it a confusing first-contact failure with reasoning models.

I hit this building a model-comparison app on litellm. `moonshot/kimi-k2.5` at `max_tokens=200` returned `finish_reason: "length"`, `content: ''`, and `completion_tokens_details.reasoning_tokens: 199` of 200, billed; the identical request at a higher cap finished cleanly with 623 reasoning plus 17 visible tokens. The same pattern reproduced on Z.AI glm models and on `gemini/gemini-3.5-flash` (112 of 116 completion tokens consumed by reasoning at a 120 token cap). litellm itself handles all of this correctly; `reasoning_content` and `reasoning_tokens` are surfaced cleanly, which is exactly what makes the failure detectable.

The behavior is technically implied by the `max_completion_tokens` definition on the input params page ("including visible output tokens and reasoning tokens"), and the health check page acknowledges it for probes ("providers count reasoning tokens toward the completion budget"), but the trap itself and a detection recipe are not documented anywhere user-facing.

## What this adds

One section on the existing reasoning content page, "Budgeting `max_tokens` for reasoning models": the mechanism, the failure signature, detection via `usage.completion_tokens_details.reasoning_tokens` for non-streaming calls and `stream_options={"include_usage": True}` with the final-chunk usage for streams, and sizing guidance, with links to the existing Streaming Usage page, the Gemini `reasoning_effort` mapping (including its note that thinking cannot be fully disabled on Gemini 3), and the health check reasoning defaults.

## Why scoped here

The reasoning content page is where users land when a reasoning model misbehaves, so the budget interaction belongs there rather than on a new page. No sidebar change. No provider page is touched; the open zai (#530) and vertex (#509) docs PRs do not overlap this change.

Verified with `npm run build` (passes; the three cross-page links resolve in the built HTML).

**Disclosure:** built with my two-agent Claude workflow: Claude Code implemented against my written spec, verified with `npm run build` (Docusaurus link check) and automated review; the finding, the live reproductions, the scope decisions, and the verification standards are mine.