### PR TITLE
docs(proxy): document enterprise billable request metering

### DIFF
--- a/docs/proxy/billing_metrics.md
+++ b/docs/proxy/billing_metrics.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ✨ Billable Request Metering
+# Billable Request Metering
 
 LiteLLM Enterprise [pricing is usage-based](../enterprise#how-is-pricing-structured). Billable request metering is how a licensed, connected deployment reports that usage: the proxy counts successful requests to LLM, MCP, and A2A endpoints and pushes a single OpenTelemetry counter to LiteLLM's collector over OTLP/HTTP, authenticated with a mutual TLS client certificate issued for your deployment.
 

--- a/docs/proxy/billing_metrics.md
+++ b/docs/proxy/billing_metrics.md
@@ -1,0 +1,138 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# ✨ Billable Request Metering
+
+LiteLLM Enterprise [pricing is usage-based](../enterprise#how-is-pricing-structured). Billable request metering is how a licensed, connected deployment reports that usage: the proxy counts successful requests to LLM, MCP, and A2A endpoints and pushes a single OpenTelemetry counter to LiteLLM's collector over OTLP/HTTP, authenticated with a mutual TLS client certificate issued for your deployment.
+
+:::info
+
+Requires a `LITELLM_LICENSE` and metering credentials from your LiteLLM onboarding. If you have neither, [contact us](https://enterprise.litellm.ai/demo).
+
+:::
+
+Metering is off unless every required setting below is present, and a misconfiguration can never break the proxy: on any error the exporter is disabled and requests continue to be served normally.
+
+## What is sent
+
+One counter, `litellm.enterprise.billable_requests`, incremented once per 2xx response on a billable endpoint. Each increment carries the endpoint category (`llm`, `mcp`, or `a2a`), the route (e.g. `/chat/completions`), the status code, and the model id when the response includes one. The exporter also stamps the LiteLLM version and the license org id as resource attributes.
+
+Nothing else leaves the deployment. No prompts, no responses, no virtual keys, and never the license key itself; the deployment is identified by the TLS client certificate, not by anything in the payload. The metering exporter runs on its own OpenTelemetry meter provider, fully separate from any [OTEL logging](../observability/opentelemetry_integration) you configure, so your own metrics pipeline is untouched and metering data never reaches your OTEL backend.
+
+## What counts as billable
+
+A billable request is an inbound request that returns a 2xx status on the inference surface (POST requests to chat completions, completions, embeddings, responses, rerank, moderations, images, audio, `/v1/messages`, videos, OCR, search, RAG, Gemini `generateContent`, and provider passthrough routes), on the MCP transport (`/mcp` and its per-server aliases, plus `/mcp-rest/tools/call`), or on the A2A `message/send` route. GET reads, management and discovery endpoints, health probes, and failed requests do not bill.
+
+The exported count is designed to line up with the **successful requests** number on the Admin UI usage page. Where the two can diverge (websocket realtime traffic, some management writes), the metered count is always the lower one.
+
+## Configure with environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LITELLM_BILLING_METRICS_ENDPOINT` | Yes | Collector URL to push to. Use `https://telemetry.litellm.ai` unless told otherwise |
+| `LITELLM_BILLING_METRICS_CLIENT_CERT` | Yes | mTLS client certificate issued for your deployment. File path or inline PEM |
+| `LITELLM_BILLING_METRICS_CLIENT_KEY` | Yes | Private key for the client certificate. File path or inline PEM |
+| `LITELLM_BILLING_METRICS_CA_CERT` | No | CA bundle for verifying the collector's server certificate. Only for private or test collectors; `telemetry.litellm.ai` presents a publicly trusted certificate, so leave this unset |
+| `LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS` | No | Push cadence in milliseconds. Default `60000` |
+
+```bash
+export LITELLM_LICENSE="eyJ..."
+export LITELLM_BILLING_METRICS_ENDPOINT="https://telemetry.litellm.ai"
+export LITELLM_BILLING_METRICS_CLIENT_CERT="/etc/litellm/billing-mtls/tls.crt"
+export LITELLM_BILLING_METRICS_CLIENT_KEY="/etc/litellm/billing-mtls/tls.key"
+
+litellm --config config.yaml
+```
+
+Each certificate variable accepts either a filesystem path or the PEM content itself (recognized by the `-----BEGIN` prefix). Inline PEM exists for secret stores that inject values as environment content and cannot mount files, such as ECS tasks reading AWS Secrets Manager or Cloud Run reading Secret Manager; the proxy writes it to a private temp file at startup and points the exporter there. Mixing the two also works, e.g. a mounted CA with injected client credentials.
+
+All of these can also be supplied through the config's `environment_variables` block instead of the shell:
+
+```yaml
+environment_variables:
+  LITELLM_BILLING_METRICS_ENDPOINT: "https://telemetry.litellm.ai"
+  LITELLM_BILLING_METRICS_CLIENT_CERT: "-----BEGIN CERTIFICATE-----\n..."
+  LITELLM_BILLING_METRICS_CLIENT_KEY: "-----BEGIN PRIVATE KEY-----\n..."
+```
+
+## Verify it is running
+
+A successfully configured proxy logs one line when the first request arrives:
+
+```
+Enterprise billing metrics enabled: exporting to https://telemetry.litellm.ai every 60000 ms
+```
+
+This is the only positive signal. If metering is disabled because the deployment is unlicensed, the proxy logs it at debug level only; every other disable path (missing or unreadable configuration, exporter init failure) logs a warning naming the variable at fault. Quiet logs alone do not mean metering is on, so check for the `enabled` line on each component that serves billable traffic.
+
+## Deploy
+
+<Tabs>
+<TabItem value="helm" label="Helm">
+
+Both the [single-deployment chart](https://github.com/BerriAI/litellm/tree/main/helm/litellm-helm) and the [microservices chart](./microservices_helm) take a top-level `billingMetrics` block, off by default. Create a TLS Secret from your issued certificate and enable the block:
+
+```bash
+kubectl create secret tls litellm-billing-metrics-mtls --cert=client.crt --key=client.key
+```
+
+```yaml
+billingMetrics:
+  enabled: true
+```
+
+`litellm-billing-metrics-mtls` is the conventional Secret name the chart looks for; set `billingMetrics.secretName` if yours is named differently. The Secret is mounted read-only and the certificate never passes through the environment. On the microservices chart both the `gateway` and the `backend` meter (the backend serves the per-server MCP transport); the migrations Job gets no metering config. Enabling the block without a Secret name, or with an empty endpoint, fails the Helm render rather than deploying a proxy that silently never exports.
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `billingMetrics.enabled` | `false` | Enable metering |
+| `billingMetrics.endpoint` | `https://telemetry.litellm.ai` | Collector to push to |
+| `billingMetrics.secretName` | `litellm-billing-metrics-mtls` | Existing TLS Secret with `tls.crt` and `tls.key` |
+| `billingMetrics.caSecretName` | `""` | Existing Secret with `ca.crt`; private/test collectors only |
+| `billingMetrics.exportIntervalMs` | `""` | Push cadence; the proxy defaults to `60000` |
+
+</TabItem>
+<TabItem value="terraform" label="Terraform (AWS / GCP)">
+
+The reference stacks at [`terraform/litellm/aws`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws) (ECS Fargate) and [`terraform/litellm/gcp`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp) (Cloud Run) gate metering entirely on `billing_metrics_endpoint`; when it is empty (the default) no billing configuration is added to the containers. The certificate and key are passed as PEM variables, stored in Secrets Manager or Secret Manager, and injected as environment values, so no volume is needed:
+
+```hcl
+billing_metrics_endpoint = "https://telemetry.litellm.ai"
+```
+
+```bash
+export TF_VAR_billing_metrics_client_cert_pem="$(cat client.crt)"
+export TF_VAR_billing_metrics_client_key_pem="$(cat client.key)"
+```
+
+A plan-time precondition requires the certificate and key together whenever the endpoint is set, so a half-configured metering block fails `terraform plan` instead of deploying a proxy that logs "missing config" and never exports. `billing_metrics_ca_cert_pem` stays empty for the production collector.
+
+</TabItem>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+  -e LITELLM_LICENSE="eyJ..." \
+  -e LITELLM_BILLING_METRICS_ENDPOINT="https://telemetry.litellm.ai" \
+  -e LITELLM_BILLING_METRICS_CLIENT_CERT="$(cat client.crt)" \
+  -e LITELLM_BILLING_METRICS_CLIENT_KEY="$(cat client.key)" \
+  -v $(pwd)/config.yaml:/app/config.yaml \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-stable \
+  --config /app/config.yaml
+```
+
+Passing the PEM content directly as environment values works because the certificate variables accept inline PEM; mounting the files and passing paths works equally well.
+
+</TabItem>
+</Tabs>
+
+## FAQ
+
+**Does this affect proxy performance?** The per-request cost is negligible (about 1.6 microseconds of classification and counting). The background export costs roughly one percent of throughput at the default 60 second interval and grows if you shorten `LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS`.
+
+**What happens on restart?** The proxy flushes the counter on shutdown, so buffered counts are not lost on a normal restart or rollout.
+
+**What if the collector is unreachable?** Requests are unaffected. Export failures are logged and the proxy keeps serving; the counter is cumulative, so transient export failures do not lose already-recorded counts within the exporter's retention.
+
+**Air-gapped deployments?** Metering needs outbound HTTPS to the collector. If your deployment cannot reach it, talk to us about alternatives during onboarding.

--- a/docs/proxy/billing_metrics.md
+++ b/docs/proxy/billing_metrics.md
@@ -133,6 +133,6 @@ Passing the PEM content directly as environment values works because the certifi
 
 **What happens on restart?** The proxy flushes the counter on shutdown, so buffered counts are not lost on a normal restart or rollout.
 
-**What if the collector is unreachable?** Requests are unaffected. Export failures are logged and the proxy keeps serving; the counter is cumulative, so transient export failures do not lose already-recorded counts within the exporter's retention.
+**What if the collector is unreachable?** Requests are unaffected. Export failures are logged and the proxy keeps serving; the counter is cumulative, so a later successful export carries the total including everything recorded while the collector was unreachable.
 
 **Air-gapped deployments?** Metering needs outbound HTTPS to the collector. If your deployment cannot reach it, talk to us about alternatives during onboarding.

--- a/docs/proxy/billing_metrics.md
+++ b/docs/proxy/billing_metrics.md
@@ -3,50 +3,38 @@ import TabItem from '@theme/TabItem';
 
 # Billable Request Metering
 
-LiteLLM Enterprise [pricing is usage-based](../enterprise#how-is-pricing-structured). Billable request metering is how a licensed, connected deployment reports that usage: the proxy counts successful requests to LLM, MCP, and A2A endpoints and pushes a single OpenTelemetry counter to LiteLLM's collector over OTLP/HTTP, authenticated with a mutual TLS client certificate issued for your deployment.
+LiteLLM Enterprise [pricing is usage-based](../enterprise#how-is-pricing-structured). Billable request metering reports that usage. The proxy counts successful requests to LLM, MCP, and A2A endpoints and pushes one OpenTelemetry counter to LiteLLM's collector, authenticated with the mTLS client certificate issued for your deployment.
+
+Only the request count is sent. Prompts, responses, virtual keys, and your license key never leave the deployment. Metering runs separately from any [OTEL logging](../observability/opentelemetry_integration) you configure and never touches your own metrics pipeline.
 
 :::info
 
-Requires a `LITELLM_LICENSE` and metering credentials from your LiteLLM onboarding. If you have neither, [contact us](https://enterprise.litellm.ai/demo).
+You need a `LITELLM_LICENSE` and metering credentials (`client.crt` and `client.key`) from your LiteLLM onboarding. Missing either? [Contact us](https://enterprise.litellm.ai/demo).
 
 :::
 
-Metering is off unless every required setting below is present, and a misconfiguration can never break the proxy: on any error the exporter is disabled and requests continue to be served normally.
+## Quick Start
 
-## What is sent
-
-One counter, `litellm.enterprise.billable_requests`, incremented once per 2xx response on a billable endpoint. Each increment carries the endpoint category (`llm`, `mcp`, or `a2a`), the route (e.g. `/chat/completions`), the status code, and the model id when the response includes one. The exporter also stamps the LiteLLM version and the license org id as resource attributes.
-
-Nothing else leaves the deployment. No prompts, no responses, no virtual keys, and never the license key itself; the deployment is identified by the TLS client certificate, not by anything in the payload. The metering exporter runs on its own OpenTelemetry meter provider, fully separate from any [OTEL logging](../observability/opentelemetry_integration) you configure, so your own metrics pipeline is untouched and metering data never reaches your OTEL backend.
-
-## What counts as billable
-
-A billable request is an inbound request that returns a 2xx status on the inference surface (POST requests to chat completions, completions, embeddings, responses, rerank, moderations, images, audio, `/v1/messages`, videos, OCR, search, RAG, Gemini `generateContent`, and provider passthrough routes), on the MCP transport (`/mcp` and its per-server aliases, plus `/mcp-rest/tools/call`), or on the A2A `message/send` route. GET reads, management and discovery endpoints, health probes, and failed requests do not bill.
-
-The exported count is designed to line up with the **successful requests** number on the Admin UI usage page. Where the two can diverge (websocket realtime traffic, some management writes), the metered count is always the lower one.
-
-## Configure with environment variables
+### 1. Set environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `LITELLM_BILLING_METRICS_ENDPOINT` | Yes | Collector URL to push to. Use `https://telemetry.litellm.ai` unless told otherwise |
-| `LITELLM_BILLING_METRICS_CLIENT_CERT` | Yes | mTLS client certificate issued for your deployment. File path or inline PEM |
-| `LITELLM_BILLING_METRICS_CLIENT_KEY` | Yes | Private key for the client certificate. File path or inline PEM |
-| `LITELLM_BILLING_METRICS_CA_CERT` | No | CA bundle for verifying the collector's server certificate. Only for private or test collectors; `telemetry.litellm.ai` presents a publicly trusted certificate, so leave this unset |
-| `LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS` | No | Push cadence in milliseconds. Default `60000` |
+| `LITELLM_BILLING_METRICS_ENDPOINT` | Yes | Collector URL. Use `https://telemetry.litellm.ai` |
+| `LITELLM_BILLING_METRICS_CLIENT_CERT` | Yes | mTLS client certificate. File path or inline PEM |
+| `LITELLM_BILLING_METRICS_CLIENT_KEY` | Yes | Private key for the certificate. File path or inline PEM |
+| `LITELLM_BILLING_METRICS_CA_CERT` | No | CA bundle for the collector. Leave unset for `telemetry.litellm.ai` |
+| `LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS` | No | Push interval in milliseconds. Default `60000` |
 
 ```bash
 export LITELLM_LICENSE="eyJ..."
 export LITELLM_BILLING_METRICS_ENDPOINT="https://telemetry.litellm.ai"
-export LITELLM_BILLING_METRICS_CLIENT_CERT="/etc/litellm/billing-mtls/tls.crt"
-export LITELLM_BILLING_METRICS_CLIENT_KEY="/etc/litellm/billing-mtls/tls.key"
-
-litellm --config config.yaml
+export LITELLM_BILLING_METRICS_CLIENT_CERT="/etc/litellm/billing-mtls/client.crt"
+export LITELLM_BILLING_METRICS_CLIENT_KEY="/etc/litellm/billing-mtls/client.key"
 ```
 
-Each certificate variable accepts either a filesystem path or the PEM content itself (recognized by the `-----BEGIN` prefix). Inline PEM exists for secret stores that inject values as environment content and cannot mount files, such as ECS tasks reading AWS Secrets Manager or Cloud Run reading Secret Manager; the proxy writes it to a private temp file at startup and points the exporter there. Mixing the two also works, e.g. a mounted CA with injected client credentials.
+The certificate variables accept a file path or the PEM content itself. Use inline PEM when your secret store injects values as environment variables and cannot mount files, for example ECS with AWS Secrets Manager or Cloud Run with Secret Manager.
 
-All of these can also be supplied through the config's `environment_variables` block instead of the shell:
+You can also set these in the config file:
 
 ```yaml
 environment_variables:
@@ -55,46 +43,56 @@ environment_variables:
   LITELLM_BILLING_METRICS_CLIENT_KEY: "-----BEGIN PRIVATE KEY-----\n..."
 ```
 
-## Verify it is running
+### 2. Start the proxy
 
-A successfully configured proxy logs one line when the first request arrives:
+```bash
+litellm --config config.yaml
+```
+
+### 3. Verify
+
+Send a request through the proxy, then check the logs for:
 
 ```
 Enterprise billing metrics enabled: exporting to https://telemetry.litellm.ai every 60000 ms
 ```
 
-This is the only positive signal. If metering is disabled because the deployment is unlicensed, the proxy logs it at debug level only; every other disable path (missing or unreadable configuration, exporter init failure) logs a warning naming the variable at fault. Quiet logs alone do not mean metering is on, so check for the `enabled` line on each component that serves billable traffic.
+If this line is missing, look for a warning naming the misconfigured variable. Metering problems never affect request serving. On any error the exporter is disabled and the proxy runs normally.
 
 ## Deploy
 
 <Tabs>
 <TabItem value="helm" label="Helm">
 
-Both the [single-deployment chart](https://github.com/BerriAI/litellm/tree/main/helm/litellm-helm) and the [microservices chart](./microservices_helm) take a top-level `billingMetrics` block, off by default. Create a TLS Secret from your issued certificate and enable the block:
+Both the [standard chart](https://github.com/BerriAI/litellm/tree/main/helm/litellm-helm) and the [microservices chart](./microservices_helm) have a `billingMetrics` block, off by default.
+
+1. Create a TLS Secret from your issued certificate:
 
 ```bash
 kubectl create secret tls litellm-billing-metrics-mtls --cert=client.crt --key=client.key
 ```
+
+2. Enable metering in your values:
 
 ```yaml
 billingMetrics:
   enabled: true
 ```
 
-`litellm-billing-metrics-mtls` is the conventional Secret name the chart looks for; set `billingMetrics.secretName` if yours is named differently. The Secret is mounted read-only and the certificate never passes through the environment. On the microservices chart both the `gateway` and the `backend` meter (the backend serves the per-server MCP transport); the migrations Job gets no metering config. Enabling the block without a Secret name, or with an empty endpoint, fails the Helm render rather than deploying a proxy that silently never exports.
+The chart looks for the Secret name `litellm-billing-metrics-mtls` by default.
 
 | Value | Default | Description |
 |-------|---------|-------------|
 | `billingMetrics.enabled` | `false` | Enable metering |
-| `billingMetrics.endpoint` | `https://telemetry.litellm.ai` | Collector to push to |
+| `billingMetrics.endpoint` | `https://telemetry.litellm.ai` | Collector URL |
 | `billingMetrics.secretName` | `litellm-billing-metrics-mtls` | Existing TLS Secret with `tls.crt` and `tls.key` |
-| `billingMetrics.caSecretName` | `""` | Existing Secret with `ca.crt`; private/test collectors only |
-| `billingMetrics.exportIntervalMs` | `""` | Push cadence; the proxy defaults to `60000` |
+| `billingMetrics.caSecretName` | `""` | Existing Secret with `ca.crt`. Leave empty for the default collector |
+| `billingMetrics.exportIntervalMs` | `""` | Push interval. The proxy defaults to `60000` |
 
 </TabItem>
 <TabItem value="terraform" label="Terraform (AWS / GCP)">
 
-The reference stacks at [`terraform/litellm/aws`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws) (ECS Fargate) and [`terraform/litellm/gcp`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp) (Cloud Run) gate metering entirely on `billing_metrics_endpoint`; when it is empty (the default) no billing configuration is added to the containers. The certificate and key are passed as PEM variables, stored in Secrets Manager or Secret Manager, and injected as environment values, so no volume is needed:
+The reference stacks at [`terraform/litellm/aws`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/aws) (ECS Fargate) and [`terraform/litellm/gcp`](https://github.com/BerriAI/litellm/tree/main/terraform/litellm/gcp) (Cloud Run) enable metering when `billing_metrics_endpoint` is set:
 
 ```hcl
 billing_metrics_endpoint = "https://telemetry.litellm.ai"
@@ -105,7 +103,7 @@ export TF_VAR_billing_metrics_client_cert_pem="$(cat client.crt)"
 export TF_VAR_billing_metrics_client_key_pem="$(cat client.key)"
 ```
 
-A plan-time precondition requires the certificate and key together whenever the endpoint is set, so a half-configured metering block fails `terraform plan` instead of deploying a proxy that logs "missing config" and never exports. `billing_metrics_ca_cert_pem` stays empty for the production collector.
+The stack stores the certificate and key in Secrets Manager (AWS) or Secret Manager (GCP) and injects them as environment variables. No volume is needed.
 
 </TabItem>
 <TabItem value="docker" label="Docker">
@@ -122,17 +120,21 @@ docker run \
   --config /app/config.yaml
 ```
 
-Passing the PEM content directly as environment values works because the certificate variables accept inline PEM; mounting the files and passing paths works equally well.
-
 </TabItem>
 </Tabs>
 
+## What counts as billable
+
+A request counts when it returns a 2xx status on an LLM inference endpoint (chat completions, embeddings, responses, images, audio, and the other inference routes), the MCP transport, or the A2A `message/send` route. GET reads, management endpoints, health probes, and failed requests do not count.
+
+The count lines up with the **successful requests** number on the Admin UI usage page.
+
 ## FAQ
 
-**Does this affect proxy performance?** The per-request cost is negligible (about 1.6 microseconds of classification and counting). The background export costs roughly one percent of throughput at the default 60 second interval and grows if you shorten `LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS`.
+**Does this affect proxy performance?** No meaningful impact at the default settings. The per-request cost is about 1.6 microseconds.
 
-**What happens on restart?** The proxy flushes the counter on shutdown, so buffered counts are not lost on a normal restart or rollout.
+**What if the collector is unreachable?** Requests are unaffected. The counter is cumulative, so counts recorded during an outage are included in the next successful export.
 
-**What if the collector is unreachable?** Requests are unaffected. Export failures are logged and the proxy keeps serving; the counter is cumulative, so a later successful export carries the total including everything recorded while the collector was unreachable.
+**What happens on restart?** The proxy flushes the counter on shutdown, so no counts are lost.
 
-**Air-gapped deployments?** Metering needs outbound HTTPS to the collector. If your deployment cannot reach it, talk to us about alternatives during onboarding.
+**Air-gapped deployments?** Metering needs outbound HTTPS to the collector. If your deployment cannot reach it, talk to us during onboarding.

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -898,6 +898,11 @@ router_settings:
 | LITELLM_ANTHROPIC_BETA_HEADERS_URL | Custom URL for fetching Anthropic beta headers configuration. Default is the GitHub main branch URL
 | LITELLM_ANTHROPIC_DISABLE_URL_SUFFIX | Disable automatic URL suffix appending for Anthropic API base URLs. When set to `true`, prevents LiteLLM from automatically adding `/v1/messages` or `/v1/complete` to custom Anthropic API endpoints
 | LITELLM_ASSETS_PATH | Path to directory for UI assets and logos. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/assets` in Docker.
+| LITELLM_BILLING_METRICS_ENDPOINT | Collector URL for [enterprise billable-request metering](billing_metrics). Requires an enterprise license; unset disables metering
+| LITELLM_BILLING_METRICS_CLIENT_CERT | mTLS client certificate for billable-request metering. Accepts a file path or inline PEM content
+| LITELLM_BILLING_METRICS_CLIENT_KEY | Private key matching `LITELLM_BILLING_METRICS_CLIENT_CERT`. Accepts a file path or inline PEM content
+| LITELLM_BILLING_METRICS_CA_CERT | CA bundle for verifying the metering collector. Only for private or test collectors; unset uses the system trust store
+| LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS | Push cadence for billable-request metering in milliseconds. Default is 60000
 | LITELLM_BLOG_POSTS_URL | Custom URL for fetching LiteLLM blog posts JSON. Default is the GitHub main branch URL
 | LITELLM_CLI_JWT_EXPIRATION_HOURS | Expiration time in hours for CLI-generated JWT tokens. Default is 24 hours
 | LITELLM_CLI_SSO_CLAIM_MAP | Alias for `CLI_SSO_CLAIM_MAP` — allowlisted OIDC claims for CLI SSO attribution metadata

--- a/sidebars.js
+++ b/sidebars.js
@@ -478,6 +478,7 @@ const sidebars = {
             "proxy/model_management",
             "proxy/prod",
             "proxy/multi_region",
+            "proxy/billing_metrics",
             "proxy/worker_startup_hooks",
             "proxy/release_cycle",
           ],


### PR DESCRIPTION
## Summary

User-facing docs for the push-based billable-request metering shipped in BerriAI/litellm#31592. Adds docs/proxy/billing_metrics.md covering what the exported counter contains and deliberately excludes, which routes count as billable and how the count relates to the Admin UI successful-requests number, the five LITELLM_BILLING_METRICS_* environment variables with inline-PEM-or-path semantics, the positive enabled log line operators should verify on each metered component, and deployment recipes for the two Helm charts (billingMetrics block), the AWS/GCP Terraform reference stacks, and plain Docker. The page is registered under Setup & Deployment in sidebars.js, next to Multi-Region Deployment. The five environment variables are also added to the environment variables reference table in docs/proxy/config_settings.md, which the litellm repo's documentation CI checks against

Validated with npx docusaurus build; the new page builds and its links resolve (the pre-existing broken-link warnings on main are untouched)