### PR TITLE
docs(search): add TinyFish search provider docs

### DIFF
--- a/docs/integrations/websearch_interception.md
+++ b/docs/integrations/websearch_interception.md
@@ -184,6 +184,7 @@ Configure which search provider to use. LiteLLM supports multiple search provide
 | **Linkup** | `linkup` | `LINKUP_API_KEY` |
 | **Serper** | `serper` | `SERPER_API_KEY` |
 | **SearchAPI.io** | `searchapi` | `SEARCHAPI_API_KEY` |
+| **TinyFish** | `tinyfish` | `TINYFISH_API_KEY` |
 
 See [Search Providers Documentation](../search/index.md) for detailed setup instructions.
 

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -2,7 +2,7 @@
 
 | Feature | Supported | 
 |---------|-----------|
-| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent` |
+| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent`, `tinyfish` |
 | Cost Tracking | ✅ |
 | Logging | ✅ |
 | Load Balancing | ❌ |
@@ -210,7 +210,7 @@ See the [official Perplexity Search documentation](https://docs.perplexity.ai/ap
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | string or array | Yes | Search query. Can be a single string or array of strings |
-| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"brave"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, `"searxng"`, `"linkup"`, `"duckduckgo"`, `"searchapi"`, `"serper"`, or `"you_com"` or `"apiserpent"` |
+| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"brave"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, `"searxng"`, `"linkup"`, `"duckduckgo"`, `"searchapi"`, `"serper"`, `"you_com"`, `"apiserpent"`, or `"tinyfish"` |
 | `search_tool_name` | string | Yes (Proxy) | Name of the search tool configured in `config.yaml` |
 | `max_results` | integer | No | Maximum number of results to return (1-20). Default: 10 |
 | `search_domain_filter` | array | No | List of domains to filter results (max 20 domains) |
@@ -281,6 +281,7 @@ The response follows Perplexity's search format with the following structure:
 | SearchAPI.io | `SEARCHAPI_API_KEY` | `searchapi` |
 | You.com | `YOUCOM_API_KEY` *(optional — omit for keyless free tier)* | `you_com` |
 | APISerpent | `APISERPENT_API_KEY` | `apiserpent` |
+| TinyFish | `TINYFISH_API_KEY` | `tinyfish` |
 
 See the individual provider documentation for detailed setup instructions and provider-specific parameters.
 

--- a/docs/search/tinyfish.md
+++ b/docs/search/tinyfish.md
@@ -1,0 +1,81 @@
+# TinyFish Search
+
+**Get API Key:** [https://tinyfish.ai](https://tinyfish.ai)
+
+**API Docs:** [https://docs.tinyfish.ai/search-api](https://docs.tinyfish.ai/search-api)
+
+## LiteLLM Python SDK
+
+```python showLineNumbers title="TinyFish Search"
+import os
+from litellm import search
+
+os.environ["TINYFISH_API_KEY"] = "your-api-key"
+
+response = search(
+    query="latest AI developments",
+    search_provider="tinyfish",
+    max_results=5
+)
+```
+
+## LiteLLM AI Gateway
+
+### 1. Setup config.yaml
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-5
+    litellm_params:
+      model: gpt-5
+      api_key: os.environ/OPENAI_API_KEY
+
+search_tools:
+  - search_tool_name: tinyfish-search
+    litellm_params:
+      search_provider: tinyfish
+      api_key: os.environ/TINYFISH_API_KEY
+```
+
+### 2. Start the proxy
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+### 3. Test the search endpoint
+
+```bash showLineNumbers title="Test Request"
+curl http://0.0.0.0:4000/v1/search/tinyfish-search \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "latest AI developments",
+    "max_results": 5
+  }'
+```
+
+## Provider-specific Parameters
+
+```python showLineNumbers title="TinyFish Search with Provider-specific Parameters"
+import os
+from litellm import search
+
+os.environ["TINYFISH_API_KEY"] = "your-api-key"
+
+response = search(
+    query="latest tech news",
+    search_provider="tinyfish",
+    max_results=10,               # Capped at 20
+    country="us",                 # Mapped to TinyFish's location parameter
+    search_domain_filter=["techcrunch.com", "theverge.com"],
+    # TinyFish-specific parameters
+    language="en",                # Language code
+    page=2,                       # Page number
+    include_thumbnail=True        # Include result thumbnails
+)
+```
+
+Set `TINYFISH_API_BASE` to override the default API endpoint (`https://api.search.tinyfish.ai`).

--- a/docs/search/tinyfish.md
+++ b/docs/search/tinyfish.md
@@ -68,7 +68,7 @@ os.environ["TINYFISH_API_KEY"] = "your-api-key"
 response = search(
     query="latest tech news",
     search_provider="tinyfish",
-    max_results=10,               # Capped at 20
+    max_results=5,                # Capped at 10, enforced client-side
     country="us",                 # Mapped to TinyFish's location parameter
     search_domain_filter=["techcrunch.com", "theverge.com"],
     # TinyFish-specific parameters

--- a/docs/search/tinyfish.md
+++ b/docs/search/tinyfish.md
@@ -74,7 +74,7 @@ response = search(
     # TinyFish-specific parameters
     language="en",                # Language code
     page=2,                       # Page number
-    include_thumbnail=True        # Include result thumbnails
+    recency_minutes=1440          # Only results from the last N minutes
 )
 ```
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -921,6 +921,7 @@ const sidebars = {
             "search/serper",
             "search/you_com",
             "search/apiserpent",
+            "search/tinyfish",
           ]
         },
         "skills",


### PR DESCRIPTION
TinyFish was added as a search provider in BerriAI/litellm#30634 (with follow-up BerriAI/litellm#31997), but the docs don't mention it anywhere. This adds TinyFish everywhere the other search providers are documented.

## Changes

Adds TinyFish to the search providers table on docs/integrations/websearch_interception.md with its `search_provider` value (`tinyfish`) and environment variable (`TINYFISH_API_KEY`), matching the format of the existing rows.

Adds a docs/search/tinyfish.md provider page following the same structure as the other provider pages (SDK usage, gateway config, provider-specific parameters), registers it in sidebars.js, and lists `tinyfish` in the supported providers table, the `search_provider` parameter docs, and the environment variable table on docs/search/index.md.

## Type

📖 Documentation