### PR TITLE
Revert "docs: document MINIMUM_CUSTOM_KEY_LENGTH env var"

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1017,7 +1017,6 @@ router_settings:
 | MAX_POLICY_ESTIMATE_IMPACT_ROWS | Maximum number of rows returned when estimating the impact of a policy. Default is 1000
 | MAX_PAYLOAD_SIZE_FOR_DEBUG_LOG | Maximum payload size in bytes for full DEBUG serialization. Payloads exceeding this will be truncated in logs. Default is 102400 (100 KB)
 | MIN_NON_ZERO_TEMPERATURE | Minimum non-zero temperature value. Default is 0.0001
-| MINIMUM_CUSTOM_KEY_LENGTH | Minimum length for user supplied key values on /key/generate and /key/regenerate. Default is 20
 | MINIMUM_PROMPT_CACHE_TOKEN_COUNT | Minimum token count for caching a prompt. Default is 1024
 | MISTRAL_API_BASE | Base URL for Mistral API. Default is https://api.mistral.ai
 | MISTRAL_API_KEY | API key for Mistral API


### PR DESCRIPTION
Reverts #575, which was merged without review authorization. The MINIMUM_CUSTOM_KEY_LENGTH row can be re-added with proper review when BerriAI/litellm#33462 lands