### PR TITLE
docs: remove misleading litellm-database pull from Docker Compose quickstart

### DIFF
--- a/docs/proxy/docker_quick_start.md
+++ b/docs/proxy/docker_quick_start.md
@@ -108,23 +108,13 @@ LiteLLM 1.84.0 and newer require Python 3.10 or higher (`requires-python >=3.10`
 
 Docker Compose bundles LiteLLM with a Postgres database. Follow the steps below — the proxy will be fully running by the end.
 
-### Step 1 — Pull the LiteLLM database image
+`docker compose up` pulls the images defined in `docker-compose.yml` (`docker.litellm.ai/berriai/litellm:main-stable` and `postgres:16`). You don't need a separate `litellm-database` pull for this path.
 
-LiteLLM provides a dedicated `litellm-database` image for proxy deployments that connect to Postgres.
-
-```bash
-docker pull ghcr.io/berriai/litellm-database:latest
-```
-
-See all available tags on the [GitHub Container Registry](https://github.com/BerriAI/litellm/pkgs/container/litellm-database).
-
----
-
-### Step 2 — Set up a database
+### Step 1 — Set up a database
 
 Complete all three config files **before** running `docker compose up`. The proxy server will not start correctly if any of these are missing.
 
-#### 2.1 — Get `docker-compose.yml` and create `.env`
+#### 1.1 — Get `docker-compose.yml` and create `.env`
 
 ```bash
 # Get the docker compose file
@@ -143,7 +133,7 @@ echo 'AZURE_API_BASE="https://openai-***********/"' >> .env
 echo 'AZURE_API_KEY="your-azure-api-key"' >> .env
 ```
 
-#### 2.2 — Create `config.yaml`
+#### 1.2 — Create `config.yaml`
 
 The default `docker-compose.yml` starts a Postgres container at `db:5432`. Your `config.yaml` must include `database_url` pointing to it:
 
@@ -165,7 +155,7 @@ general_settings:
 `database_url` enables virtual keys, spend tracking, and the UI. Replace it with your [Supabase](https://supabase.com/) or [Neon](https://neon.tech/) connection string if you prefer a managed database.
 :::
 
-#### 2.3 — Create `prometheus.yml`
+#### 1.3 — Create `prometheus.yml`
 
 This file **must exist as a file** before `docker compose up`. If it is missing, Docker auto-creates it as an empty directory and the Prometheus container fails to start.
 
@@ -197,7 +187,7 @@ All three files (`.env`, `config.yaml`, `prometheus.yml`) must be present before
 
 ---
 
-### Step 3 — Start the proxy server and test it
+### Step 2 — Start the proxy server and test it
 
 After `config.yaml`, `prometheus.yml`, and `.env` are complete, start the proxy:
 
@@ -773,12 +763,11 @@ Error: cannot create subdirectories in ".../prometheus.yml": not a directory
 Docker created `prometheus.yml` as an **empty directory** instead of a file. This happens when the file is missing at `docker compose up` time.
 
 Fix it:
-Then create the file (see [Step 2.3 — Create `prometheus.yml`](#23--create-prometheusyml)) and run `docker compose up` again.
 ```bash
 rm -rf prometheus.yml
 ```
 
-Then create the file (see [Step 2.4](#step-24--create-prometheusyml)) and run `docker compose up` again.
+Then create the file (see [Step 1.3 — Create `prometheus.yml`](#13--create-prometheusyml)) and run `docker compose up` again.
 
 ### Non-root docker image?
 


### PR DESCRIPTION
Fixes https://github.com/BerriAI/litellm/issues/26235

## Summary
The Getting Started Docker Compose tutorial told users to pull
`ghcr.io/berriai/litellm-database`, but `docker-compose.yml` uses
`docker.litellm.ai/berriai/litellm:main-stable` and `postgres:16`.

Removed the misleading Step 1 and renumbered the remaining Compose steps.

## Notes
Earlier PRs (#26236, #26259) were closed when temporary OSS staging
branches were deleted, so the fix never landed. Opening against
`litellm-docs` where the live docs live.