### PR TITLE
docs(proxy): correct internal_user_view_only to internal_user_viewer in SSO role list

### DIFF
--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -266,7 +266,7 @@ Use `GENERIC_USER_ROLE_ATTRIBUTE` to specify which attribute in the SSO token co
 - `proxy_admin` - Admin over the platform
 - `proxy_admin_viewer` - Can login, view all keys, view all spend (read-only)
 - `internal_user` - Can login, view/create/delete their own keys, view their spend
-- `internal_user_view_only` - Can login, view their own keys, view their own spend
+- `internal_user_viewer` - Can login, view their own keys, view their own spend
 
 Nested attribute paths are supported (e.g., `claims.role` or `attributes.litellm_role`).
 


### PR DESCRIPTION
## Relevant issues

Fixes #33690

## What changed

The Generic SSO provider section of `docs/proxy/admin_ui_sso.md` listed `internal_user_view_only` as a supported `GENERIC_USER_ROLE_ATTRIBUTE` value. That string is not a valid LiteLLM role. The proxy only accepts `internal_user_viewer`, which is the string value of the `INTERNAL_USER_VIEW_ONLY` enum member in `litellm/proxy/_types.py`:

```python
class LitellmUserRoles(str, enum.Enum):
    INTERNAL_USER_VIEW_ONLY = "internal_user_viewer"
```

Role validation in `litellm/proxy/management_endpoints/types.py::is_valid_litellm_user_role` is an exact, case-insensitive match against `LitellmUserRoles._value2member_map_`, with no aliasing. So an admin who copied `internal_user_view_only` straight from the docs got a silent wrong role (the claim failed to match and the user fell back to their existing DB role or the `internal_user_viewer` default for new users).

The same page already used the correct `internal_user_viewer` in the Azure App Roles section further down, so the page contradicted itself. This change makes the Generic SSO section consistent with both the Azure section and the code.

## Proof of fix

The role string the proxy accepts (litellm main):

```
$ grep -n 'INTERNAL_USER_VIEW_ONLY =' litellm/proxy/_types.py
127:    INTERNAL_USER_VIEW_ONLY = "internal_user_viewer"
```

Both role lists on the page now use the correct value:

```
$ gh api repos/rajamanohar/litellm-docs/contents/docs/proxy/admin_ui_sso.md?ref=litellm-fix-sso-role-docs --jq .content | base64 -d | grep -n 'internal_user_view'
269:- `internal_user_viewer` - Can login, view their own keys, view their own spend
567:- `internal_user_viewer` - Can view own keys (read-only)
```

Line 269 is the Generic SSO section (previously `internal_user_view_only`); line 567 is the Azure App Roles section (already correct).