### PR TITLE
docs(release_notes): add v1.90.6 and v1.92.1 release notes

### DIFF
--- a/release_notes/v1.90.6/index.md
+++ b/release_notes/v1.90.6/index.md
@@ -1,0 +1,54 @@
+---
+title: "v1.90.6 - Prisma Bake for Non-Root Migrations"
+slug: "v1-90-6"
+date: 2026-07-19T02:09:06
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.90.6
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.90.6
+```
+
+</TabItem>
+</Tabs>
+
+`v1.90.6` is a patch release on top of [`v1.90.5`](/release_notes/v1.90.5/v1-90-5). Where `v1.90.5` restored the `litellm-proxy-extras` source folder to the runtime images, this release makes those migration assets usable from any account: the prisma CLI and its engines are now baked at `/opt/prisma`, a fixed path every runtime uid can read. Deployments that run as a non-root user — kubernetes `runAsUser`, `docker --user`, and similar — previously had prisma fall back to downloading its engines into a home directory it could not write, so a fresh-database migration failed on hosts with no outbound network access. Migrations now run offline under any uid. The release also carries routine dependency maintenance updates to mcp, pypdf, pydantic-settings, python-multipart, and starlette in the image lockfile.
+
+### What's Changed
+
+- fix(docker): bake prisma CLI and engines at a fixed path so fresh-DB migrations work for any uid offline - [PR #33853](https://github.com/BerriAI/litellm/pull/33853)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.90.5...v1.90.6

--- a/release_notes/v1.92.1/index.md
+++ b/release_notes/v1.92.1/index.md
@@ -1,0 +1,59 @@
+---
+title: "v1.92.1 - Docker Migration Assets, Model Armor Attachments & Anthropic Passthrough"
+slug: "v1-92-1"
+date: 2026-07-19T03:07:45
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.92.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.92.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.92.1` is a patch release on top of [`v1.92.0`](/release_notes/v1.92.0/v1-92-0). It backports two Docker fixes onto the 1.92.x line: the runtime images regain the `/app/litellm-proxy-extras` source directory, so downstream jobs that point `prisma migrate deploy` at that path apply migrations again instead of exiting 0 with no schema applied; and the prisma CLI and engines are baked at `/opt/prisma`, a fixed path readable by any runtime uid, so fresh-database migrations work under kubernetes `runAsUser`, `docker --user`, and other non-root deployments with no outbound network access.
+
+Two provider fixes ride along. Model Armor no longer drops reference attachments — `skip_unscannable_attachments` restores them and the attachment count cap is removed. The Anthropic passthrough now drops an incompatible `temperature` when it downgrades adaptive thinking for pre-4.6 models, instead of forwarding a combination the upstream API rejects. The release also carries routine dependency maintenance updates to mcp and soupsieve in the image lockfile.
+
+### What's Changed
+
+- fix(docker): restore litellm-proxy-extras source dir in runtime images - [PR #33592](https://github.com/BerriAI/litellm/pull/33592)
+- fix(docker): bake prisma CLI and engines at a fixed path so fresh-DB migrations work for any uid offline - [PR #33853](https://github.com/BerriAI/litellm/pull/33853)
+- fix(model_armor): restore reference attachments via skip_unscannable_attachments and remove the attachment count cap - [PR #33554](https://github.com/BerriAI/litellm/pull/33554)
+- fix(anthropic/passthrough): drop incompatible temperature when downgrading adaptive thinking for pre-4.6 models - [PR #33244](https://github.com/BerriAI/litellm/pull/33244)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.92.0...v1.92.1


### PR DESCRIPTION
The last two stables from 2026-07-19 without notes. v1.90.5 (#596) and v1.91.4 (#606) merged; v1.93.0 is #603.

## Content

Derived from the actual commit ranges, anchored on the **release SHAs** rather than tags — these were cut from untagged stable-backport merges, so `git rev-list v1.90.6` finds nothing.

| Release | Range | Commits | Content PRs |
|---|---|---|---|
| v1.90.6 | `v1.90.5..5113f5d5` | 8 | 1 — #33853 |
| v1.92.1 | `v1.92.0..96baca0a` | 8 | 4 — #33592, #33853, #33554, #33244 |

The remaining commits in each range are the version bump, the `uv.lock` refresh, and dependency maintenance updates — summarized in prose rather than bulleted, matching the convention in v1.90.5 and v1.91.4.

**v1.90.6** builds on v1.90.5: that release restored the `litellm-proxy-extras` source folder to the runtime images; this one makes those assets usable from any account by baking the prisma CLI and engines at `/opt/prisma`, so fresh-database migrations run offline under non-root uids.

**v1.92.1** backports both Docker fixes onto the 1.92.x line, plus two provider fixes — Model Armor reference attachments, and dropping an incompatible `temperature` in the Anthropic passthrough when adaptive thinking is downgraded for pre-4.6 models.

## Verification

- **MDX compiles.** Both files checked with `@mdx-js/mdx` — the engine whose JSX extension broke the v1.93.0 build on an unescaped `<3.15`. Also scanned for bare `<`/`{` outside backticks: none.
- **Docker tags probed against GHCR, not derived.** `1.90.6` → 200, `1.92.1` → 200, `main-v*` → 404. Deploy blocks use the bare form accordingly.
- **PyPI confirmed**: `litellm==1.90.6` and `==1.92.1` both resolve.
- **Cross-links resolve**: `v1.90.5` and `v1.92.0` notes both exist on `main`.
- **`release_notes/index.md` intentionally untouched** — the landing page lists only minor releases; no patch note has ever been added to it (v1.90.4, v1.90.5, v1.91.1, v1.91.3, v1.91.4 are all absent), and #606 didn't touch it either.

## Known issue, not introduced here

The `## Full Changelog` compare links (`v1.90.5...v1.90.6`, `v1.92.0...v1.92.1`) will 404 until those tags are cut — **v1.90.6, v1.92.1 and v1.91.4 have no git tag in BerriAI/litellm**. I kept the tag-based form to match house convention and because the links resolve once tags exist; #606 has the same property. Flagging so it's a deliberate choice rather than a surprise.