### PR TITLE
docs(proxy): document proxy_config_reload_interval_seconds

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1120,6 +1120,7 @@ router_settings:
 | PROXY_BATCH_WRITE_AT | Time in seconds to wait before batch writing spend logs to the database. Default is 10
 | PROXY_BATCH_POLLING_INTERVAL | Time in seconds to wait before polling a batch, to check if it's completed. Default is 6000s (1 hour)
 | PROXY_BATCH_POLLING_ENABLED | Set to `false` to disable the `CheckBatchCost` and `CheckResponsesCost` background polling jobs entirely. Useful for emergency mitigation on installs with large numbers of stale managed objects. Default is `true`
+| PROXY_CONFIG_RELOAD_INTERVAL_SECONDS | How often each pod reloads config-in-DB objects (models, credentials, guardrails, etc.) from the database when `store_model_in_db` is enabled. Lower values speed up cross-pod convergence at the cost of more DB load; applied on proxy startup. Default is 30
 | MAX_OBJECTS_PER_POLL_CYCLE | Maximum number of managed objects (batches / responses) fetched per polling cycle. Prevents OOM on installs with many stale rows. Default is `50`
 | MANAGED_OBJECT_STALENESS_CUTOFF_DAYS | Managed objects older than this many days in a non-terminal state are marked `stale_expired` at the start of each poll cycle and skipped. Default is `7`
 | PROXY_BUDGET_RESCHEDULER_MAX_TIME | Maximum time in seconds to wait before checking database for budget resets. Default is 605

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -295,6 +295,7 @@ router_settings:
 | proxy_budget_rescheduler_max_time | int | The maximum time (in seconds) to wait before checking db for budget resets. **Default is 605 seconds** |
 | proxy_batch_write_at | int | Time (in seconds) to wait before batch writing spend logs to the db. **Default is 10 seconds** |
 | proxy_batch_polling_interval | int | Time (in seconds) to wait before polling a batch, to check if it's completed. **Default is 6000 seconds (1 hour)** |
+| proxy_config_reload_interval_seconds | int | How often each pod reloads config-in-DB objects (models, credentials, guardrails, etc.) from the database when `store_model_in_db` is enabled. Lower values speed up cross-pod convergence at the cost of more DB load; applied on proxy startup. Env: `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS`. **Default is 30 seconds** |
 | alerting_args | dict | Args for Slack Alerting [Doc on Slack Alerting](./alerting.md) |
 | custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom--key-generate) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -40,6 +40,18 @@ general_settings:
 
 Above roughly 1000 requests per second, also route these writes through Redis with the [Redis transaction buffer](#redis-transaction-buffer) to prevent connection exhaustion and deadlocks.
 
+### Tune config reload across pods
+
+With `store_model_in_db: true`, each pod keeps itself in sync with config added at runtime (models, credentials, guardrails, general settings, etc.) by polling the database on a background job. There is no cross-pod push; a pod converges within one polling interval of a change. That interval defaults to 30 seconds and is tunable, so if you need faster convergence you can lower it, and if you run many pods against a busy database you can raise it to shed load.
+
+```yaml
+general_settings:
+  store_model_in_db: true
+  proxy_config_reload_interval_seconds: 30
+```
+
+The value is read at startup, so a change takes effect once each pod restarts. It can also be set from the admin UI under Settings, and via the `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS` environment variable.
+
 ### Bound database connections
 
 Cap the connection pool per worker process so your instances cannot exhaust the database. Size it as `MAX_DB_CONNECTIONS / (instances × workers)`; the default is 10.


### PR DESCRIPTION
## Summary

Documents the new `proxy_config_reload_interval_seconds` general setting that ships in BerriAI/litellm#34130.

With `store_model_in_db: true`, each pod keeps itself in sync with config added at runtime by polling the database on a background job, and a pod converges within one polling interval of a change. That interval was previously hardcoded to 30s; the code PR makes it tunable. This adds the `general_settings` reference entry in `config_settings.md` and a "Tune config reload across pods" note under the production configuration guide in `prod.md`, covering config.yaml, the admin UI, and the `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS` env var.

## Changes

- `docs/proxy/config_settings.md`: reference row for `proxy_config_reload_interval_seconds`
- `docs/proxy/prod.md`: multi-pod convergence note and example under Configuration
