### PR TITLE
docs(bedrock): fix user keys documentation link

### DIFF
--- a/docs/proxy/guardrails/bedrock.md
+++ b/docs/proxy/guardrails/bedrock.md
@@ -48,7 +48,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Unsuccessful call" value = "not-allowed">


### PR DESCRIPTION
## Summary

- Fix the broken link to the LangChain and OpenAI SDK usage examples in the Bedrock guardrails documentation.
- Update the relative path so it correctly points to the user keys request format section.

https://docs.litellm.ai/docs/proxy/guardrails/bedrock
<img width="1883" height="774" alt="image" src="https://github.com/user-attachments/assets/319d55bc-cde9-41a5-bde3-e46862c2f4e4" />

Before(Not Found) : https://docs.litellm.ai/docs/proxy/proxy/user_keys#request-format
After : https://docs.litellm.ai/docs/proxy/user_keys#request-format
