### PR TITLE
docs: document the DCR bridge (gateway-hosted sign-in) for OAuth-only MCP clients

### DIFF
--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -412,4 +412,4 @@ The server has `client_id`/`client_secret`/`token_url` configured so LiteLLM is 
 
 ## Passthrough and Delegated Upstream OAuth
 
-For servers where the client already authenticates directly against the upstream's own OAuth issuer, LiteLLM can forward the client's upstream token instead of managing tokens itself. The transparent `auth_type: true_passthrough` mode, the admission-gated `auth_type: oauth_delegate` mode, and the legacy `delegate_auth_to_upstream` flag are covered in [MCP OAuth Passthrough](./mcp_oauth_passthrough.md).
+For servers where the client already authenticates directly against the upstream's own OAuth issuer, LiteLLM can forward the client's upstream token instead of managing tokens itself. The transparent `auth_type: true_passthrough` mode, the admission-gated `auth_type: oauth_delegate` mode, and the legacy `delegate_auth_to_upstream` flag are covered in [MCP OAuth Passthrough](./mcp_oauth_passthrough.md). That page also documents the `dcr_bridge` flag for OAuth-only clients such as OpenCode, Claude Code, Cursor, and Claude Desktop, where the gateway hosts registration and sign-in so the client can connect with a single OAuth flow.

--- a/docs/mcp_oauth_passthrough.md
+++ b/docs/mcp_oauth_passthrough.md
@@ -11,6 +11,8 @@ With `true_passthrough` LiteLLM performs no admission of its own and forwards th
 
 Both modes return the upstream's protected-resource metadata verbatim during discovery, so the client always authorizes against the real upstream issuer and the upstream validates the token audience.
 
+Both `auth_type` values also take an orthogonal `dcr_bridge` flag that changes where an OAuth-only client discovers its authorization server. Turn it on when the client cannot register with the upstream IdP on its own or cannot send two separate credentials, which is the case for OpenCode, Claude Code, Cursor, and Claude Desktop. See [Gateway-hosted sign-in (DCR bridge)](#gateway-hosted-sign-in-dcr-bridge) below.
+
 ## true_passthrough
 
 LiteLLM acts as a transparent proxy. It runs no admission check, mints and stores nothing, and forwards the client's `Authorization` header to the upstream unchanged. This is the mode to reach for when the upstream server is the source of truth for who can access it and you do not want LiteLLM gating the route a second time.
@@ -126,6 +128,124 @@ Unlike `true_passthrough`, `oauth_delegate` keeps LiteLLM in the auth and observ
 | `url` | Yes | The upstream MCP server URL. |
 
 At request time the caller sends admission in `x-litellm-api-key` and the upstream token in `Authorization: Bearer <upstream-token>` (or `x-mcp-<alias>-authorization` when addressing a specific server in an aggregate request).
+
+## Gateway-hosted sign-in (DCR bridge) {#gateway-hosted-sign-in-dcr-bridge}
+
+OAuth-only MCP clients such as OpenCode, Claude Code, Cursor, and Claude Desktop connect to a remote server by running one Dynamic Client Registration (RFC 7591) plus PKCE flow against whatever authorization server the server's discovery metadata advertises. They hold no client credential pre-provisioned with the upstream IdP, and they cannot send a separate LiteLLM credential alongside an upstream token, so neither the plain `true_passthrough` request nor the two-header `oauth_delegate` request fits them. The `dcr_bridge` flag closes that gap. When it is on, LiteLLM advertises itself as the authorization server during discovery and hosts the register, authorize, and token endpoints at `/{server_name}/register`, `/{server_name}/authorize`, and `/{server_name}/token`, so the client registers and signs in through the gateway while LiteLLM runs the upstream OAuth behind those endpoints. When it is off, LiteLLM relays the upstream server's own OAuth metadata verbatim, which suits clients already registered with the upstream IdP or capable of running DCR directly against it.
+
+`dcr_bridge` is meaningful only on the two client-forwarded token modes (`true_passthrough` and `oauth_delegate`) and is rejected on any other `auth_type` at create, update, and config load. In the Admin UI it is the "Gateway-hosted sign-in (DCR bridge)" switch on the MCP server form, defaulted on for those two modes; in config it is a boolean field.
+
+### true_passthrough with the bridge
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  miro:
+    url: "https://mcp.miro.com/"
+    transport: http
+    auth_type: true_passthrough
+    dcr_bridge: true
+```
+
+The client discovers the gateway as its authorization server, registers through `POST /{server_name}/register`, and runs PKCE against `GET /{server_name}/authorize` and `POST /{server_name}/token`. LiteLLM performs the upstream registration and token exchange behind those endpoints; where the upstream supports Dynamic Client Registration LiteLLM relays the client's registration to it, and where the server carries no stored `client_id` LiteLLM mints an ephemeral client for the flow and persists nothing. No LiteLLM sign-in is involved, and as with `true_passthrough` generally LiteLLM records no caller identity or spend. This is the transparent option for OAuth-only clients.
+
+### oauth_delegate with the bridge
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  miro:
+    url: "https://mcp.miro.com/"
+    transport: http
+    auth_type: oauth_delegate
+    dcr_bridge: true
+```
+
+This is the combination that keeps LiteLLM in the observability path for OAuth-only clients, so spend, rate limits, audit, and per-tool-call attribution all resolve. Reach for it when you want to see in LiteLLM which server a caller used and which tools it invoked.
+
+An OAuth-only client cannot present a LiteLLM key inline, so the gateway takes the caller's identity from a LiteLLM browser session instead. During the authorize step LiteLLM looks for a LiteLLM UI session cookie; when the browser has none it redirects to LiteLLM login (`/sso/key/generate`) first. After the user signs in and re-initiates the connection, LiteLLM seals that identity together with the upstream token into a gateway-bound credential that the client stores and replays on every later request, and admission, spend, and audit resolve against it.
+
+Two prerequisites follow from that. The gateway must have a working sign-in the user can complete in a browser, whether SSO or username/password; without one there is no identity to bind and the authorize step cannot proceed, which is the usual reason an `oauth_delegate` bridge connection stalls at the login page. And the client's OAuth flow must run in an interactive browser session, which OpenCode, Claude Code, Cursor, and Claude Desktop all do. If your intent is fully scripted, non-interactive delegation, leave `dcr_bridge` off and use the two-header `oauth_delegate` request described above (a LiteLLM key in `x-litellm-api-key` plus the upstream token in `Authorization`) instead.
+
+```mermaid
+sequenceDiagram
+    participant Client as OAuth-only client
+    participant Browser
+    participant LiteLLM as LiteLLM Proxy
+    participant MCP as Upstream MCP Server
+    participant Auth as Upstream OAuth Server
+
+    Client->>LiteLLM: MCP request (no credential)
+    LiteLLM-->>Client: 401 + WWW-Authenticate (gateway is the authorization server)
+    Client->>LiteLLM: POST /{server}/register (DCR)
+    Client->>Browser: open /{server}/authorize
+    Browser->>LiteLLM: GET /{server}/authorize
+    Note over LiteLLM: no LiteLLM session cookie
+    LiteLLM-->>Browser: redirect to LiteLLM login
+    Browser->>LiteLLM: sign in (SSO / username-password)
+    Browser->>LiteLLM: GET /{server}/authorize (with session)
+    LiteLLM->>Auth: authorize upstream, capture code at /callback
+    Auth-->>LiteLLM: upstream authorization code
+    LiteLLM-->>Browser: gateway code, redirect back to client
+    Client->>LiteLLM: POST /{server}/token
+    Note over LiteLLM: seal LiteLLM identity + upstream token into one gateway-bound credential
+    LiteLLM-->>Client: gateway-bound credential
+    Client->>LiteLLM: MCP request + gateway-bound credential
+    Note over LiteLLM: admit, record spend / rate limit / audit / tool calls
+    LiteLLM->>MCP: forward request + upstream token (identity credential stripped)
+    MCP-->>LiteLLM: MCP response
+    LiteLLM-->>Client: MCP response
+```
+
+### Choosing the flag
+
+| Situation | `dcr_bridge` |
+|-----------|--------------|
+| An OAuth-only client (OpenCode, Claude Code, Cursor, Claude Desktop, ChatGPT) that holds no upstream `client_id` and cannot send two credentials | `true` |
+| A client already registered with the upstream IdP, or one that runs DCR directly against the upstream | `false` |
+| A scripted, non-interactive caller that can send `x-litellm-api-key` plus an upstream `Authorization` bearer | `false`, with `auth_type: oauth_delegate` (two-header form) |
+
+### Connecting a client
+
+Point the client at the gateway's server URL, `https://<gateway-host>/<server_name>/mcp`, and let it discover OAuth from there. Do not configure a `client_id` or secret on the client; the gateway handles registration and the token exchange. For a `true_passthrough` bridge server the browser flow authorizes only with the upstream, and for an `oauth_delegate` bridge server it signs in to LiteLLM first and then authorizes with the upstream. The snippets below show the gateway URL in each client's remote-MCP config; follow each client's own MCP documentation for the exact field names, which change over time.
+
+Claude Code registers and runs the browser flow on first use:
+
+```bash
+claude mcp add --transport http miro https://<gateway-host>/miro/mcp
+```
+
+Cursor reads remote MCP servers from `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "miro": {
+      "url": "https://<gateway-host>/miro/mcp"
+    }
+  }
+}
+```
+
+OpenCode reads them from `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "miro": {
+      "type": "remote",
+      "url": "https://<gateway-host>/miro/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Config Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `auth_type` | Yes | Must be `true_passthrough` or `oauth_delegate`; `dcr_bridge` is rejected on any other value. |
+| `url` | Yes | The upstream MCP server URL. |
+| `dcr_bridge` | Yes | Set to `true` so the gateway hosts sign-in for OAuth-only clients. Off relays the upstream's own OAuth metadata instead. |
 
 ## Delegate Auth to Upstream (PKCE Passthrough) {#delegate-auth-to-upstream-pkce-passthrough}
 

--- a/docs/mcp_oauth_passthrough.md
+++ b/docs/mcp_oauth_passthrough.md
@@ -1,21 +1,21 @@
 # MCP OAuth Passthrough
 
-Some MCP servers run their own OAuth issuer and expect the client (Claude Code, Cursor, ChatGPT, etc.) to authenticate directly against it. For those servers LiteLLM can let the client's own upstream token flow through instead of minting, storing, or refreshing anything itself. Two `auth_type` values cover this, and they differ in one thing: whether LiteLLM still authenticates the caller at its own edge.
+Some MCP servers run their own OAuth issuer and expect the client (Claude Code, Cursor, ChatGPT, etc.) to authenticate directly against it. For those servers LiteLLM can let the client's own upstream token flow through instead of minting, storing, or refreshing anything itself.
 
-With `true_passthrough` LiteLLM performs no admission of its own and forwards the client's `Authorization` header to the upstream verbatim. With `oauth_delegate` LiteLLM still admits the caller (LiteLLM API key, SSO, or JWT) and then forwards a *separate* upstream bearer the caller supplies alongside that admission, so spend tracking, rate limits, and audit continue to run.
+Two `auth_type` values cover this. They differ in one thing: whether LiteLLM still authenticates the caller at its own edge.
 
 | Mode | LiteLLM admission | Credential forwarded upstream | Spend / rate limits / audit | Use when |
 |------|-------------------|-------------------------------|-----------------------------|----------|
 | `true_passthrough` | None; anonymous at the LiteLLM layer | The client's `Authorization`, verbatim | Not recorded | LiteLLM should add zero auth and the upstream is the sole gate |
 | `oauth_delegate` | Required (LiteLLM key / SSO / JWT) | A distinct upstream bearer the caller sends alongside admission | Recorded, keyed on the admission identity | You want LiteLLM to keep gating and observing the route while the upstream owns tool authorization |
 
-Both modes return the upstream's protected-resource metadata verbatim during discovery, so the client always authorizes against the real upstream issuer and the upstream validates the token audience.
+Both modes return the upstream's protected-resource metadata verbatim during discovery, so the client always authorizes against the real upstream issuer.
 
-Both `auth_type` values also take an orthogonal `dcr_bridge` flag that changes where an OAuth-only client discovers its authorization server. Turn it on when the client cannot register with the upstream IdP on its own or cannot send two separate credentials, which is the case for OpenCode, Claude Code, Cursor, and Claude Desktop. See [Gateway-hosted sign-in (DCR bridge)](#gateway-hosted-sign-in-dcr-bridge) below.
+Both also take an orthogonal `dcr_bridge` flag that changes where an OAuth-only client discovers its authorization server. Turn it on for clients that cannot register with the upstream IdP themselves or cannot send two separate credentials, such as OpenCode, Claude Code, Cursor, and Claude Desktop. See [Gateway-hosted sign-in (DCR bridge)](#gateway-hosted-sign-in-dcr-bridge).
 
 ## true_passthrough
 
-LiteLLM acts as a transparent proxy. It runs no admission check, mints and stores nothing, and forwards the client's `Authorization` header to the upstream unchanged. This is the mode to reach for when the upstream server is the source of truth for who can access it and you do not want LiteLLM gating the route a second time.
+LiteLLM acts as a transparent proxy: no admission check, nothing minted or stored, and the client's `Authorization` forwarded unchanged. Reach for it when the upstream is the source of truth for access and you do not want LiteLLM gating the route twice.
 
 ### Setup
 
@@ -26,11 +26,14 @@ mcp_servers:
     auth_type: true_passthrough
 ```
 
-That is the entire configuration. The mode carries no client credentials or token endpoints because LiteLLM never participates in the token exchange.
+That is the entire configuration. No client credentials or token endpoints, because LiteLLM never participates in the token exchange.
 
 ### How It Works
 
-The client sends its MCP request with no LiteLLM API key. When no upstream token is present yet, LiteLLM relays the upstream's own `401` and `WWW-Authenticate` so the client runs OAuth directly against the upstream issuer. The client completes the flow, retries with `Authorization: Bearer <upstream-token>`, and LiteLLM forwards that request untouched.
+- The client sends its MCP request with no LiteLLM API key.
+- With no upstream token yet, LiteLLM relays the upstream's own `401` and `WWW-Authenticate`.
+- The client runs OAuth directly against the upstream issuer.
+- The client retries with `Authorization: Bearer <upstream-token>`, and LiteLLM forwards it untouched.
 
 ```mermaid
 sequenceDiagram
@@ -54,17 +57,19 @@ sequenceDiagram
 
 ### Fail-Closed Behavior
 
-The transparent path only fires when every target the request resolves to is `true_passthrough`. It falls back to normal LiteLLM admission in any of these cases:
+The transparent path fires only when every target resolves to `true_passthrough`. It falls back to normal LiteLLM admission when:
 
-- The server's `auth_type` is anything other than `true_passthrough`.
-- The request targets multiple servers (`x-mcp-servers: a,b`) and any one of them is not `true_passthrough`.
+- The server's `auth_type` is anything else.
+- The request targets multiple servers (`x-mcp-servers: a,b`) and any one is not `true_passthrough`.
 - The target server cannot be resolved from the URL path or the `x-mcp-servers` header.
 
 ### Security Trade-offs
 
-This mode turns the MCP route into an unauthenticated ingress at the LiteLLM layer. Spend tracking, per-key rate limits, and any guardrails that depend on `user_api_key_auth.user_id` do not run for these requests, and LiteLLM cannot tell who the caller is, so per-user auditing must come from the upstream MCP server's own logs. Only enable it on servers whose upstream OAuth issuer you trust to enforce access control.
-
-Because the caller is anonymous at the LiteLLM layer by design, setting `available_on_public_internet: false` does not add authentication here; it mainly controls IP-based discovery ([see guide](./mcp_public_internet.md)). Enforce access at the upstream IdP and the network edge.
+- The MCP route becomes an unauthenticated ingress at the LiteLLM layer.
+- Spend tracking, per-key rate limits, and any guardrail depending on `user_api_key_auth.user_id` do not run.
+- LiteLLM cannot tell who the caller is, so per-user auditing must come from the upstream server's logs.
+- `available_on_public_internet: false` adds no authentication here; it mainly controls IP-based discovery ([see guide](./mcp_public_internet.md)).
+- Only enable it on servers whose upstream OAuth issuer you trust to enforce access control.
 
 ### Config Reference
 
@@ -75,7 +80,7 @@ Because the caller is anonymous at the LiteLLM layer by design, setting `availab
 
 ## oauth_delegate
 
-LiteLLM still admits the caller with its usual LiteLLM API key, SSO, or JWT check, then forwards a separate upstream bearer that the caller supplies alongside admission. LiteLLM mints nothing and never forwards the admission credential upstream. Use this when the upstream owns tool-level authorization but you still want LiteLLM to gate the route and keep spend, rate-limit, and audit attribution.
+LiteLLM still admits the caller (LiteLLM API key, SSO, or JWT), then forwards a separate upstream bearer the caller supplies. LiteLLM mints nothing and never forwards the admission credential upstream. Use it when the upstream owns tool-level authorization but you still want LiteLLM gating the route and keeping spend, rate-limit, and audit attribution.
 
 ### Setup
 
@@ -86,11 +91,14 @@ mcp_servers:
     auth_type: oauth_delegate
 ```
 
-The mode carries no client credentials for the same reason as `true_passthrough`: LiteLLM does not run the token exchange. What changes is the request: the caller sends two credentials.
+No client credentials, for the same reason as `true_passthrough`. What changes is the request: the caller sends two credentials.
 
 ### How It Works
 
-The caller admits with a LiteLLM credential in `x-litellm-api-key` and carries the upstream token in `Authorization` (or in a per-server `x-mcp-<alias>-authorization` header for aggregate requests). LiteLLM validates admission, then forwards only the separate upstream bearer to the upstream, never the admission credential. When admission succeeds but no upstream token is present yet, LiteLLM issues a `401` at the gateway pointing the client at the gateway's `oauth-protected-resource` well-known, which proxies the upstream metadata verbatim so the client authorizes against the real upstream issuer.
+- The caller admits with a LiteLLM credential in `x-litellm-api-key`.
+- The upstream token rides in `Authorization` (or `x-mcp-<alias>-authorization` for aggregate requests).
+- LiteLLM validates admission, then forwards only the upstream bearer, never the admission credential.
+- With no upstream token yet, LiteLLM returns a `401` pointing at the gateway's `oauth-protected-resource` well-known, which proxies the upstream metadata verbatim.
 
 ```mermaid
 sequenceDiagram
@@ -114,11 +122,17 @@ sequenceDiagram
     LiteLLM-->>Client: MCP response
 ```
 
-The one thing to get right is keeping the two credentials in separate headers. If a caller sends a single credential in `Authorization` with no `x-litellm-api-key`, LiteLLM treats that `Authorization` as the admission credential (a virtual key, an IdP JWT, or an SSO session token) and never forwards it upstream, which is the leak defense that keeps a LiteLLM or IdP token from reaching a third-party MCP server.
+:::warning Keep the two credentials in separate headers
+
+If a caller sends a single credential in `Authorization` with no `x-litellm-api-key`, LiteLLM treats it as the admission credential (virtual key, IdP JWT, or SSO session token) and never forwards it upstream. That is the leak defense keeping a LiteLLM or IdP token from reaching a third-party MCP server.
+
+:::
 
 ### Security Trade-offs
 
-Unlike `true_passthrough`, `oauth_delegate` keeps LiteLLM in the auth and observability path. Admission always runs, so there is no anonymous ingress, and spend, rate limits, and audit resolve against the admission identity. The upstream token is a distinct credential that LiteLLM forwards without inspecting, so the upstream remains responsible for tool-level authorization and token validation.
+- Admission always runs, so there is no anonymous ingress.
+- Spend, rate limits, and audit resolve against the admission identity.
+- LiteLLM forwards the upstream token without inspecting it, so the upstream still owns tool-level authorization and token validation.
 
 ### Config Reference
 
@@ -127,13 +141,25 @@ Unlike `true_passthrough`, `oauth_delegate` keeps LiteLLM in the auth and observ
 | `auth_type` | Yes | Must be `oauth_delegate`. |
 | `url` | Yes | The upstream MCP server URL. |
 
-At request time the caller sends admission in `x-litellm-api-key` and the upstream token in `Authorization: Bearer <upstream-token>` (or `x-mcp-<alias>-authorization` when addressing a specific server in an aggregate request).
+At request time: admission in `x-litellm-api-key`, upstream token in `Authorization: Bearer <upstream-token>` (or `x-mcp-<alias>-authorization` for a specific server in an aggregate request).
 
 ## Gateway-hosted sign-in (DCR bridge) {#gateway-hosted-sign-in-dcr-bridge}
 
-OAuth-only MCP clients such as OpenCode, Claude Code, Cursor, and Claude Desktop connect to a remote server by running one Dynamic Client Registration (RFC 7591) plus PKCE flow against whatever authorization server the server's discovery metadata advertises. They hold no client credential pre-provisioned with the upstream IdP, and they cannot send a separate LiteLLM credential alongside an upstream token, so neither the plain `true_passthrough` request nor the two-header `oauth_delegate` request fits them. The `dcr_bridge` flag closes that gap. When it is on, LiteLLM advertises itself as the authorization server during discovery and hosts the register, authorize, and token endpoints at `/{server_name}/register`, `/{server_name}/authorize`, and `/{server_name}/token`, so the client registers and signs in through the gateway while LiteLLM runs the upstream OAuth behind those endpoints. When it is off, LiteLLM relays the upstream server's own OAuth metadata verbatim, which suits clients already registered with the upstream IdP or capable of running DCR directly against it.
+OAuth-only MCP clients (OpenCode, Claude Code, Cursor, Claude Desktop) connect by running a single Dynamic Client Registration (RFC 7591) plus PKCE flow against whatever authorization server the discovery metadata advertises. They:
 
-`dcr_bridge` is meaningful only on the two client-forwarded token modes (`true_passthrough` and `oauth_delegate`) and is rejected on any other `auth_type` at create, update, and config load. In the Admin UI it is the "Gateway-hosted sign-in (DCR bridge)" switch on the MCP server form, defaulted on for those two modes; in config it is a boolean field.
+- Hold no client credential pre-provisioned with the upstream IdP.
+- Cannot send a separate LiteLLM credential alongside an upstream token.
+
+So neither the plain `true_passthrough` request nor the two-header `oauth_delegate` request fits them. The `dcr_bridge` flag closes that gap:
+
+- **On:** LiteLLM advertises itself as the authorization server during discovery and hosts `/{server_name}/register`, `/{server_name}/authorize`, and `/{server_name}/token`. The client registers and signs in through the gateway while LiteLLM runs the upstream OAuth behind those endpoints.
+- **Off:** LiteLLM relays the upstream server's own OAuth metadata verbatim. Suits clients already registered with the upstream IdP, or able to run DCR directly against it.
+
+Where to set it:
+
+- Valid only on `true_passthrough` and `oauth_delegate`; rejected on any other `auth_type` at create, update, and config load.
+- In the Admin UI it is the "Gateway-hosted sign-in (DCR bridge)" switch on the MCP server form, defaulted on for those two modes.
+- In config it is a boolean field.
 
 ### true_passthrough with the bridge
 
@@ -146,7 +172,13 @@ mcp_servers:
     dcr_bridge: true
 ```
 
-The client discovers the gateway as its authorization server, registers through `POST /{server_name}/register`, and runs PKCE against `GET /{server_name}/authorize` and `POST /{server_name}/token`. LiteLLM performs the upstream registration and token exchange behind those endpoints; where the upstream supports Dynamic Client Registration LiteLLM relays the client's registration to it, and where the server carries no stored `client_id` LiteLLM mints an ephemeral client for the flow and persists nothing. No LiteLLM sign-in is involved, and as with `true_passthrough` generally LiteLLM records no caller identity or spend. This is the transparent option for OAuth-only clients.
+The transparent option for OAuth-only clients:
+
+- The client discovers the gateway as its authorization server and registers through `POST /{server_name}/register`.
+- It runs PKCE against `GET /{server_name}/authorize` and `POST /{server_name}/token`.
+- Where the upstream supports DCR, LiteLLM relays the client's registration to it.
+- Where the server has no stored `client_id`, LiteLLM mints an ephemeral client for the flow and persists nothing.
+- No LiteLLM sign-in is involved, and no caller identity or spend is recorded.
 
 ### oauth_delegate with the bridge
 
@@ -159,11 +191,24 @@ mcp_servers:
     dcr_bridge: true
 ```
 
-This is the combination that keeps LiteLLM in the observability path for OAuth-only clients, so spend, rate limits, audit, and per-tool-call attribution all resolve. Reach for it when you want to see in LiteLLM which server a caller used and which tools it invoked.
+This combination keeps LiteLLM in the observability path for OAuth-only clients, so spend, rate limits, audit, and per-tool-call attribution all resolve. Reach for it when you want to see in LiteLLM which server a caller used and which tools it invoked.
 
-An OAuth-only client cannot present a LiteLLM key inline, so the gateway takes the caller's identity from a LiteLLM browser session instead. During the authorize step LiteLLM looks for a LiteLLM UI session cookie; when the browser has none it redirects to LiteLLM login (`/sso/key/generate`) first. After the user signs in and re-initiates the connection, LiteLLM seals that identity together with the upstream token into a gateway-bound credential that the client stores and replays on every later request, and admission, spend, and audit resolve against it.
+An OAuth-only client cannot present a LiteLLM key inline, so identity comes from a LiteLLM browser session instead:
 
-Two prerequisites follow from that. The gateway must have a working sign-in the user can complete in a browser, whether SSO or username/password; without one there is no identity to bind and the authorize step cannot proceed, which is the usual reason an `oauth_delegate` bridge connection stalls at the login page. And the client's OAuth flow must run in an interactive browser session, which OpenCode, Claude Code, Cursor, and Claude Desktop all do. If your intent is fully scripted, non-interactive delegation, leave `dcr_bridge` off and use the two-header `oauth_delegate` request described above (a LiteLLM key in `x-litellm-api-key` plus the upstream token in `Authorization`) instead.
+- At the authorize step LiteLLM looks for a LiteLLM UI session cookie.
+- With no cookie, it redirects to LiteLLM login (`/sso/key/generate`) first.
+- After sign-in the user re-initiates the connection.
+- LiteLLM seals that identity plus the upstream token into a gateway-bound credential.
+- The client stores that credential and replays it on every later request; admission, spend, and audit resolve against it.
+
+:::warning Two prerequisites
+
+- **The gateway needs a working browser sign-in** (SSO or username/password). Without one there is no identity to bind and the authorize step cannot proceed. A missing gateway sign-in is the usual reason an `oauth_delegate` bridge connection stalls at the login page.
+- **The client's OAuth flow must run in an interactive browser session.** OpenCode, Claude Code, Cursor, and Claude Desktop all do.
+
+For fully scripted, non-interactive delegation, leave `dcr_bridge` off and use the two-header `oauth_delegate` request instead.
+
+:::
 
 ```mermaid
 sequenceDiagram
@@ -205,7 +250,12 @@ sequenceDiagram
 
 ### Connecting a client
 
-Point the client at the gateway's server URL, `https://<gateway-host>/<server_name>/mcp`, and let it discover OAuth from there. Do not configure a `client_id` or secret on the client; the gateway handles registration and the token exchange. For a `true_passthrough` bridge server the browser flow authorizes only with the upstream, and for an `oauth_delegate` bridge server it signs in to LiteLLM first and then authorizes with the upstream. The snippets below show the gateway URL in each client's remote-MCP config; follow each client's own MCP documentation for the exact field names, which change over time.
+- Point the client at `https://<gateway-host>/<server_name>/mcp` and let it discover OAuth from there.
+- Do not configure a `client_id` or secret on the client; the gateway handles registration and the token exchange.
+- On a `true_passthrough` bridge server the browser flow authorizes only with the upstream.
+- On an `oauth_delegate` bridge server it signs in to LiteLLM first, then authorizes with the upstream.
+
+Follow each client's own MCP documentation for exact field names, which change over time.
 
 Claude Code registers and runs the browser flow on first use:
 
@@ -245,7 +295,7 @@ OpenCode reads them from `opencode.json`:
 |-------|----------|-------------|
 | `auth_type` | Yes | Must be `true_passthrough` or `oauth_delegate`; `dcr_bridge` is rejected on any other value. |
 | `url` | Yes | The upstream MCP server URL. |
-| `dcr_bridge` | Yes | Set to `true` so the gateway hosts sign-in for OAuth-only clients. Off relays the upstream's own OAuth metadata instead. |
+| `dcr_bridge` | Yes | `true` so the gateway hosts sign-in for OAuth-only clients. Off relays the upstream's own OAuth metadata instead. |
 
 ## Delegate Auth to Upstream (PKCE Passthrough) {#delegate-auth-to-upstream-pkce-passthrough}
 
@@ -255,9 +305,7 @@ OpenCode reads them from `opencode.json`:
 
 :::
 
-For OAuth2 MCP servers where the client (Claude Code, Cursor, ChatGPT, etc.) already authenticates directly against the upstream server's own OAuth issuer, you can opt the route into **upstream-delegated auth**: LiteLLM stops checking its own API key / SSO and lets the client's PKCE flow run end-to-end with the upstream MCP server.
-
-Use this when the upstream server is the source of truth for who can access it and you don't want LiteLLM to gate the route a second time.
+For OAuth2 MCP servers where the client already authenticates directly against the upstream server's own OAuth issuer, you can opt the route into **upstream-delegated auth**: LiteLLM stops checking its own API key / SSO and lets the client's PKCE flow run end-to-end with the upstream MCP server.
 
 ### Setup
 
@@ -270,7 +318,7 @@ mcp_servers:
     delegate_auth_to_upstream: true
 ```
 
-That's the entire change. Delegated servers are interactive, so they take `oauth2_flow: authorization_code`. The flag is honored **only** when `auth_type: oauth2`; setting it on any other auth type is silently ignored.
+Delegated servers are interactive, so they take `oauth2_flow: authorization_code`. The flag is honored **only** when `auth_type: oauth2`; setting it on any other auth type is silently ignored.
 
 :::warning Internal-only (`available_on_public_internet: false`) **and** upstream PKCE delegation
 
@@ -312,17 +360,17 @@ sequenceDiagram
 
 ### Fail-Closed Behavior
 
-The bypass only fires when **every** target the request resolves to opts in. It fails closed and runs normal LiteLLM auth in any of these cases:
+The bypass fires only when **every** target opts in. It fails closed and runs normal LiteLLM auth when:
 
 - The server's `auth_type` is anything other than `oauth2`.
 - `delegate_auth_to_upstream` is not explicitly `true`.
-- The request targets multiple servers (`x-mcp-servers: a,b`) and any one of them is not delegated.
+- The request targets multiple servers (`x-mcp-servers: a,b`) and any one is not delegated.
 - The target server cannot be resolved from the URL path or `x-mcp-servers` header.
 
 ### Security Trade-offs
 
-- This flag turns the MCP route into an **unauthenticated** ingress at the LiteLLM layer. Spend tracking, per-key rate limits, and any guardrails that depend on `user_api_key_auth.user_id` will not run for these requests.
-- LiteLLM cannot tell who the caller is — that's the entire point — so per-user auditing must come from the upstream MCP server's own logs.
+- The MCP route becomes an **unauthenticated** ingress at the LiteLLM layer. Spend tracking, per-key rate limits, and guardrails depending on `user_api_key_auth.user_id` do not run.
+- LiteLLM cannot tell who the caller is by design, so per-user auditing must come from the upstream MCP server's own logs.
 - Only enable this on servers whose upstream OAuth issuer you trust to enforce access control.
 
 ### Config Reference


### PR DESCRIPTION
Documents the `dcr_bridge` flag, which had no coverage anywhere in the docs despite being a config field and an Admin UI toggle that customers are actively using.

OAuth-only MCP clients such as OpenCode, Claude Code, Cursor, and Claude Desktop connect by running a single Dynamic Client Registration plus PKCE flow against whatever authorization server the discovery metadata advertises. They hold no client credential pre-provisioned with the upstream IdP and cannot send a separate LiteLLM credential alongside an upstream token, so neither the plain `true_passthrough` request nor the two-header `oauth_delegate` request fits them. With the bridge on, LiteLLM advertises itself as the authorization server during discovery and hosts the register, authorize, and token endpoints, then runs the upstream OAuth behind them; with it off, LiteLLM relays the upstream server own OAuth metadata verbatim.

The new section in `docs/mcp_oauth_passthrough.md` explains both combinations. `true_passthrough` with the bridge is transparent, relaying upstream DCR or minting an ephemeral client when the server has no stored `client_id`, and records no identity or spend. `oauth_delegate` with the bridge keeps LiteLLM in the observability path so spend, rate limits, audit, and per-tool-call attribution resolve; because an OAuth-only client cannot present a LiteLLM key inline, the gateway takes identity from a LiteLLM browser session, redirecting to LiteLLM login when the browser has no session cookie and then sealing that identity together with the upstream token into a gateway-bound credential the client replays.

That last flow has two prerequisites the section calls out explicitly, since a missing gateway sign-in is the usual reason a delegate bridge connection stalls at the login page: the gateway needs a working browser sign-in (SSO or username/password), and the client OAuth flow has to run in an interactive browser session. Callers wanting fully scripted delegation are pointed back at the two-header form with the bridge off.

The section closes with a flag-selection table and gateway-URL connect snippets for Claude Code, Cursor, and OpenCode. The main MCP OAuth page links to it from its passthrough summary.

Rebased onto main after the MCP OAuth Passthrough page landed in #635 and #636, so this PR now carries only the bridge section. The new mermaid diagram uses commas rather than semicolons in `Note over` lines, per the fix in #636.