### PR TITLE
docs(router): document respect_retry_after_with_multiple_deployments

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -434,6 +434,7 @@ router_settings:
 | assistants_config | AssistantsConfig | Set on proxy via `assistant_settings`. [Further docs](../assistants.md) |
 | set_verbose | boolean | [DEPRECATED PARAM - see debug docs](./debugging) If true, sets the logging level to verbose. |
 | retry_after | int | Time to wait before retrying a request in seconds. Defaults to 0. If `x-retry-after` is received from LLM API, this value is overridden. |
+| respect_retry_after_with_multiple_deployments | bool | If true, honor an explicit `Retry-After` header from the LLM provider even when there are multiple healthy deployments in the model group. Defaults to False (instant retry against a healthy sibling deployment). Sibling deployments often share the same throttled upstream, so enabling this avoids hammering it. |
 | provider_budget_config | ProviderBudgetConfig | Provider budget configuration. Use this to set llm_provider budget limits. example $100/day to OpenAI, $100/day to Azure, etc. Defaults to None. [Further Docs](./provider_budget_routing.md) |
 | enable_pre_call_checks | boolean | If true, checks if a call is within the model's context window before making the call. **Required** for `model_info.max_input_tokens` enforcement. Default: false. [More information here](reliability) |
 | model_group_retry_policy | Dict[str, RetryPolicy] | [SDK-only arg] Set retry policy for model groups. |


### PR DESCRIPTION
Documents the new Router.__init__ opt-in flag `respect_retry_after_with_multiple_deployments`, added in BerriAI/litellm#34408.

This is needed to pass the `documentation_test_router_settings` CI check on that PR, which validates that every `Router.__init__` parameter is documented in this file.