### PR TITLE
chore(compat-matrix): refresh for v1.93.0 + claude-code 2.1.126

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-11T06:11:54Z",
-  "litellm_version": "v1.91.1",
+  "generated_at": "2026-07-24T06:13:14Z",
+  "litellm_version": "v1.93.0",
   "claude_code_version": "2.1.126",
   "providers": [
     "anthropic",
@@ -29,7 +29,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -44,13 +45,15 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -72,7 +75,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -87,14 +91,14 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -116,7 +120,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -132,13 +137,14 @@
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -160,7 +166,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -182,7 +189,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -204,7 +212,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -226,7 +235,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -248,7 +258,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -263,13 +274,15 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     },
@@ -312,7 +325,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] tool_search probe failed: status 404: {\"error\":{\"message\":\"{\\\"error\\\":{\\\"code\\\":\\\"DeploymentNotFound\\\",\\\"message\\\":\\\"The API deployment claude-haiku-4-5 does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.\\\",\\\"details\\\":\\\"The API deployment claude-haiku-4-5 does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.\\\"}}. Received M"
         }
       }
     },
@@ -333,7 +347,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-sonnet-4-6-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-sonnet-4-6-azure). It may not exist or you may not have access to it. Run --model to pick a different model."
         }
       }
     }


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 16 green->red regression(s):
  - Basic messaging (non-streaming) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Basic messaging (streaming) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Basic messaging (streaming) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
  - Long context (1M) [azure]: pass -> fail ([claude-sonnet-4-6-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-sonnet-4-6-azure). It may not exist o)
  - PDF document input [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Prompt caching (1h TTL) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Prompt caching (5m TTL) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Structured outputs [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Structured outputs [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block)
  - Thinking [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Extended thinking + tool use [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Tool search (MCP discovery) [azure]: pass -> fail ([claude-haiku-4-5-azure] tool_search probe failed: status 404: {"error":{"message":"{\"error\":{\"code\":\"DeploymentNotFound\",\"message\":\"The API deployment)
  - Tool use [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Tool use (streaming / fine-grained) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Vision [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
  - Web search (server tool) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI failed: exit=1; api_status=404; text=There's an issue with the selected model (claude-haiku-4-5-azure). It may not exist or )
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.93.0` |
| claude_code_version | `2.1.126` |
| generated_at | `2026-07-24T01:57:04Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=fail
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=fail
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Thinking**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Structured outputs**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=pass, vertex_ai=pass, azure=fail
- **Long context (1M)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=fail

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.