### PR TITLE
docs(blog): tighten the Opus 5 post

### DIFF
--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -34,12 +34,12 @@ Sampling parameters (`temperature`, `top_p`, `top_k`), fixed thinking budgets, a
 
 ## Enabling Opus 5
 
-Opus 5 ships in the **`v1.95.0-dev.2`** image, but most proxies do not need to upgrade at all. On the default remote cost map, open the **Price Data** tab under **Models + Endpoints** in the UI and click **Reload Price Data** (or `POST /reload/model_cost_map` as a proxy admin). That refetches pricing and re-registers provider routing in one step, so `claude-opus-5` becomes available across Anthropic, Azure, Vertex AI, and Bedrock even on an older version.
+Opus 5 ships in the **`v1.95.0-dev.3`** image, cutting later today, but most proxies do not need to upgrade at all. On the default remote cost map, open the **Price Data** tab under **Models + Endpoints** in the UI and click **Reload Price Data** (or `POST /reload/model_cost_map` as a proxy admin). That refetches pricing and re-registers provider routing in one step, so `claude-opus-5` becomes available across Anthropic, Azure, Vertex AI, and Bedrock even on an older version.
 
-The exception is `LITELLM_LOCAL_MODEL_COST_MAP=true`, which bakes the cost map into the image and puts it out of the Reload button's reach. Pull `v1.95.0-dev.2` or later for the bundled Opus 5 metadata:
+The exception is `LITELLM_LOCAL_MODEL_COST_MAP=true`, which bakes the cost map into the image and puts it out of the Reload button's reach. Pull `v1.95.0-dev.3` or later for the bundled Opus 5 metadata:
 
 ```bash
-docker pull ghcr.io/berriai/litellm:v1.95.0-dev.2
+docker pull ghcr.io/berriai/litellm:v1.95.0-dev.3
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ docker run -d \
   -p 4000:4000 \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
   -v $(pwd)/config.yaml:/app/config.yaml \
-  ghcr.io/berriai/litellm:v1.95.0-dev.2 \
+  ghcr.io/berriai/litellm:v1.95.0-dev.3 \
   --config /app/config.yaml
 ```
 
@@ -92,7 +92,7 @@ docker run -d \
   -e AZURE_AI_API_KEY=$AZURE_AI_API_KEY \
   -e AZURE_AI_API_BASE=$AZURE_AI_API_BASE \
   -v $(pwd)/config.yaml:/app/config.yaml \
-  ghcr.io/berriai/litellm:v1.95.0-dev.2 \
+  ghcr.io/berriai/litellm:v1.95.0-dev.3 \
   --config /app/config.yaml
 ```
 
@@ -119,7 +119,7 @@ docker run -d \
   -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json \
   -v $(pwd)/config.yaml:/app/config.yaml \
   -v $(pwd)/credentials.json:/app/credentials.json \
-  ghcr.io/berriai/litellm:v1.95.0-dev.2 \
+  ghcr.io/berriai/litellm:v1.95.0-dev.3 \
   --config /app/config.yaml
 ```
 
@@ -150,7 +150,7 @@ docker run -d \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
   -v $(pwd)/config.yaml:/app/config.yaml \
-  ghcr.io/berriai/litellm:v1.95.0-dev.2 \
+  ghcr.io/berriai/litellm:v1.95.0-dev.3 \
   --config /app/config.yaml
 ```
 

--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -22,15 +22,20 @@ LiteLLM now supports [Claude Opus 5](https://www.anthropic.com/news/claude-opus-
 
 ## What's new in Opus 5
 
-Opus 5 holds Opus 4.8's price, $5 / MTok in and $25 / MTok out, and spends the generation on closing the gap to Fable 5. Anthropic reports it beats every other model on Frontier-Bench v0.1 at more than double Opus 4.8's score and a lower cost per task, triples the next-best score on ARC-AGI 3, and at `max` effort lands within 0.5% of Fable 5's peak CursorBench 3.2 result for half the cost per task ([details from Anthropic](https://www.anthropic.com/news/claude-opus-5)). If you route a tier of work to Fable 5 today purely because Opus 4.8 could not carry it, that split is now worth re-measuring.
+Key changes ([details from Anthropic](https://www.anthropic.com/news/claude-opus-5)):
 
-The specs are familiar: a 1M-token context window, up to 128K output tokens, and vision, PDF input, computer use, tool calling, prompt caching, and structured output on every provider LiteLLM supports. Two numbers did move. The knowledge cutoff is May 2026, the most recent of any Claude model, and the prompt cache minimum drops from 1,024 tokens to 512, which pulls shorter system prompts into the $0.50 / MTok read rate that previously did not qualify. Fast mode also got cheap enough to consider for interactive work: `speed: "fast"` on the Anthropic provider buys roughly 2.5x faster output at a 2x premium, down from 6x on Opus 4.6.
+- **Much better coding agents:** stronger at large refactors, debugging, multi-file features, and finishing end-to-end work without leaving stubs
+- **Better self-verification:** it checks and iterates on its own work more proactively
+- **Better vision and artifacts:** improved frontend replication, charts and documents, spreadsheets, and slide decks
+- **Same base API price as Opus 4.8:** $5 / MTok input and $25 / MTok output
+- **Thinking is on by default**
+- **Fast mode:** about 2.5x faster, but costs 2x
 
 ## Before you switch from Opus 4.8
 
 The swap is not free. Priority Tier and web fetch are both gone on Opus 5, so plan that capacity and that tooling separately. Opus 5's cybersecurity classifiers can also decline a request outright with `stop_reason: "refusal"` and a category in `stop_details`, which is worth handling explicitly or routing around with LiteLLM [fallbacks](../../docs/proxy/reliability).
 
-Sampling parameters (`temperature`, `top_p`, `top_k`), fixed thinking budgets, and assistant message prefill remain unsupported, same as Opus 4.8.
+Sampling parameters (`temperature`, `top_p`, `top_k`), fixed thinking budgets, and assistant message prefill remain unsupported, same as Opus 4.8. Anthropic's [Opus 5 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) has the full compatibility checklist.
 
 ## Enabling Opus 5
 

--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -26,7 +26,7 @@ Key changes ([details from Anthropic](https://www.anthropic.com/news/claude-opus
 
 - **Much better coding agents:** stronger at large refactors, debugging, multi-file features, and finishing end-to-end work without leaving stubs
 - **Better self-verification:** it checks and iterates on its own work more proactively
-- **Better vision and artifacts:** improved frontend replication (screenshots → website), charts and documents, spreadsheets, and slide decks
+- **Better vision and artifacts:** improved screenshots → website, charts and documents, spreadsheets, and slide decks
 - **Same base API price as Opus 4.8:** $5 / MTok input and $25 / MTok output
 - **Thinking is on by default**
 - **Fast mode:** about 2.5x faster, but costs 2x

--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -26,7 +26,7 @@ Key changes ([details from Anthropic](https://www.anthropic.com/news/claude-opus
 
 - **Much better coding agents:** stronger at large refactors, debugging, multi-file features, and finishing end-to-end work without leaving stubs
 - **Better self-verification:** it checks and iterates on its own work more proactively
-- **Better vision and artifacts:** improved frontend replication (turning screenshots into working websites), charts and documents, spreadsheets, and slide decks
+- **Better vision and artifacts:** improved frontend replication (screenshots → website), charts and documents, spreadsheets, and slide decks
 - **Same base API price as Opus 4.8:** $5 / MTok input and $25 / MTok output
 - **Thinking is on by default**
 - **Fast mode:** about 2.5x faster, but costs 2x

--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -26,7 +26,7 @@ Key changes ([details from Anthropic](https://www.anthropic.com/news/claude-opus
 
 - **Much better coding agents:** stronger at large refactors, debugging, multi-file features, and finishing end-to-end work without leaving stubs
 - **Better self-verification:** it checks and iterates on its own work more proactively
-- **Better vision and artifacts:** improved frontend replication, charts and documents, spreadsheets, and slide decks
+- **Better vision and artifacts:** improved frontend replication (turning screenshots into working websites), charts and documents, spreadsheets, and slide decks
 - **Same base API price as Opus 4.8:** $5 / MTok input and $25 / MTok output
 - **Thinking is on by default**
 - **Fast mode:** about 2.5x faster, but costs 2x

--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -22,37 +22,25 @@ LiteLLM now supports [Claude Opus 5](https://www.anthropic.com/news/claude-opus-
 
 ## What's new in Opus 5
 
-Opus 5 lands near Fable 5's frontier quality at half the price, and keeps Opus 4.8's per-token rates. A few things stand out for teams running it through a gateway:
+Opus 5 holds Opus 4.8's price, $5 / MTok in and $25 / MTok out, and spends the generation on closing the gap to Fable 5. Anthropic reports it beats every other model on Frontier-Bench v0.1 at more than double Opus 4.8's score and a lower cost per task, triples the next-best score on ARC-AGI 3, and at `max` effort lands within 0.5% of Fable 5's peak CursorBench 3.2 result for half the cost per task ([details from Anthropic](https://www.anthropic.com/news/claude-opus-5)). If you route a tier of work to Fable 5 today purely because Opus 4.8 could not carry it, that split is now worth re-measuring.
 
-- **Frontier coding at Opus prices.** Anthropic reports Opus 5 surpasses every other model on Frontier-Bench v0.1, more than doubling Opus 4.8's score at a lower cost per task, and lands within 0.5% of Fable 5's peak CursorBench 3.2 score at max effort for half the cost per task. It also scores three times the next-best model on ARC-AGI 3. ([details from Anthropic](https://www.anthropic.com/news/claude-opus-5))
-- **Thinking is on by default.** Requests that omit `thinking` now run with adaptive thinking, where the same request on Opus 4.8 ran without it. `max_tokens` still caps thinking plus response text together, so budget accordingly.
-- **The full effort ladder, per request.** `low`, `medium`, `high` (default), `xhigh`, and `max`, set per call via `reasoning_effort` or `output_config`. Anthropic recommends re-sweeping effort rather than carrying over an Opus 4.8 setting, and giving `xhigh` and `max` at least 64K `max_tokens`.
-- **$5 / MTok input and $25 / MTok output**, unchanged from Opus 4.8, with prompt caching at $0.50 / MTok (read) and $6.25 / MTok (5-minute write). The prompt cache minimum drops to 512 tokens, so shorter system prompts now qualify. On Bedrock, the `us.`, `eu.`, `au.`, and `jp.` inference profiles carry the usual 10% regional premium while `global.` stays at base price; LiteLLM tracks every variant automatically.
-- **Fast mode at 2x, not 6x.** Pass `speed: "fast"` on the Anthropic provider for roughly 2.5x faster output at $10 / MTok input and $50 / MTok output. LiteLLM sets the beta header and prices the premium for you.
-- **A May 2026 knowledge cutoff**, the most recent of any Claude model, with a 1M-token context window and up to 128K output tokens.
-- **One gateway, every surface.** Vision, PDF input, computer use, tool calling, prompt caching, adaptive thinking, and structured output, all available across Anthropic, Azure, Vertex AI, and Bedrock with unified spend tracking, logging, and fallbacks.
+The specs are familiar: a 1M-token context window, up to 128K output tokens, and vision, PDF input, computer use, tool calling, prompt caching, and structured output on every provider LiteLLM supports. Two numbers did move. The knowledge cutoff is May 2026, the most recent of any Claude model, and the prompt cache minimum drops from 1,024 tokens to 512, which pulls shorter system prompts into the $0.50 / MTok read rate that previously did not qualify. Fast mode also got cheap enough to consider for interactive work: `speed: "fast"` on the Anthropic provider buys roughly 2.5x faster output at a 2x premium, down from 6x on Opus 4.6.
 
 ## Before you switch from Opus 4.8
 
-Opus 5 is not a drop-in swap for every workload. Four behaviors change:
-
-- **Disabling thinking is capped at `high` effort.** `thinking: {type: "disabled"}` combined with `xhigh` or `max` returns a 400. Either drop the `thinking` field and let adaptive thinking run, or keep it disabled and stay at `high` or below.
-- **Priority Tier is not supported.** If you rely on it for Opus 4.8 capacity, plan that capacity separately.
-- **Web fetch is unavailable** on Opus 5; pick an alternative tool if your agents depend on it.
-- **Cybersecurity classifiers can decline a request** with `stop_reason: "refusal"` and a category in `stop_details`. Handle that stop reason, or use LiteLLM [fallbacks](../../docs/proxy/reliability) to route refused requests to another model.
+The swap is not free. Priority Tier and web fetch are both gone on Opus 5, so plan that capacity and that tooling separately. Opus 5's cybersecurity classifiers can also decline a request outright with `stop_reason: "refusal"` and a category in `stop_details`, which is worth handling explicitly or routing around with LiteLLM [fallbacks](../../docs/proxy/reliability).
 
 Sampling parameters (`temperature`, `top_p`, `top_k`), fixed thinking budgets, and assistant message prefill remain unsupported, same as Opus 4.8.
 
 ## Enabling Opus 5
 
-Opus 5 ships in the **`v1.95.0-dev.2`** image (and every release after it). How you pick it up depends on where your proxy reads pricing from:
+Opus 5 ships in the **`v1.95.0-dev.2`** image, but most proxies do not need to upgrade at all. On the default remote cost map, open the **Price Data** tab under **Models + Endpoints** in the UI and click **Reload Price Data** (or `POST /reload/model_cost_map` as a proxy admin). That refetches pricing and re-registers provider routing in one step, so `claude-opus-5` becomes available across Anthropic, Azure, Vertex AI, and Bedrock even on an older version.
 
-- **Default (remote cost map): no upgrade needed.** In the LiteLLM UI, open the **Price Data** tab under **Models + Endpoints** and click **Reload Price Data** (or, as a proxy admin, `POST /reload/model_cost_map`). This refetches the latest pricing from LiteLLM's cost map **and** re-registers provider routing in one step, so `claude-opus-5` becomes available across Anthropic, Azure, Vertex AI, and Bedrock, even if you're on an older proxy version.
-- **Running `LITELLM_LOCAL_MODEL_COST_MAP=true`?** The cost map is baked into the image, so the Reload button won't reach it. Pull `v1.95.0-dev.2` or later to get the bundled Opus 5 metadata:
+The exception is `LITELLM_LOCAL_MODEL_COST_MAP=true`, which bakes the cost map into the image and puts it out of the Reload button's reach. Pull `v1.95.0-dev.2` or later for the bundled Opus 5 metadata:
 
-  ```bash
-  docker pull ghcr.io/berriai/litellm:v1.95.0-dev.2
-  ```
+```bash
+docker pull ghcr.io/berriai/litellm:v1.95.0-dev.2
+```
 
 ## Usage
 
@@ -188,154 +176,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 }'
 ```
 
-## Advanced Features
-
-### Adaptive Thinking
-
-:::note
-When using `reasoning_effort` with Claude Opus 5, all values (`low`, `medium`, `high`, `xhigh`, `max`) are mapped to `thinking: {type: "adaptive"}`. Opus 5 only supports adaptive thinking; explicit budgets via `thinking: {type: "enabled", budget_tokens: ...}` are rejected by the Anthropic API with a 400 error. To control thinking depth, pair adaptive thinking with `output_config.effort` (see [Effort Levels](#effort-levels) below) rather than a fixed budget.
-:::
-
-<Tabs>
-<TabItem value="completions" label="/chat/completions">
-
-LiteLLM supports adaptive thinking through the `reasoning_effort` parameter:
-
-```bash
-curl --location 'http://0.0.0.0:4000/chat/completions' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer $LITELLM_KEY' \
---data '{
-  "model": "claude-opus-5",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Solve this complex problem: What is the optimal strategy for..."
-    }
-  ],
-  "reasoning_effort": "high"
-}'
-```
-
-</TabItem>
-<TabItem value="messages" label="/v1/messages">
-
-Use the `thinking` parameter with `type: "adaptive"` to enable adaptive thinking mode:
-
-```bash
-curl --location 'http://0.0.0.0:4000/v1/messages' \
---header 'x-api-key: sk-12345' \
---header 'content-type: application/json' \
---data '{
-    "model": "claude-opus-5",
-    "max_tokens": 16000,
-    "thinking": {
-        "type": "adaptive"
-    },
-    "messages": [
-        {
-            "role": "user",
-            "content": "Explain why the sum of two even numbers is always even."
-        }
-    ]
-}'
-```
-
-</TabItem>
-</Tabs>
-
-### Effort Levels
-
-Claude Opus 5 supports the full effort ladder: `low`, `medium`, `high` (default), `xhigh`, and `max`. These give you finer-grained control over how much reasoning the model applies to a task. Pass the effort level via the `output_config` parameter.
-
-<Tabs>
-<TabItem value="completions" label="/chat/completions">
-
-```bash
-curl --location 'http://0.0.0.0:4000/chat/completions' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer $LITELLM_KEY' \
---data '{
-  "model": "claude-opus-5",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Explain quantum computing"
-    }
-  ],
-  "output_config": {
-    "effort": "max"
-  }
-}'
-```
-
-**Using OpenAI SDK:**
-
-```python
-import openai
-
-client = openai.OpenAI(
-    api_key="your-litellm-key",
-    base_url="http://0.0.0.0:4000"
-)
-
-response = client.chat.completions.create(
-    model="claude-opus-5",
-    messages=[{"role": "user", "content": "Explain quantum computing"}],
-    extra_body={"output_config": {"effort": "max"}}
-)
-```
-
-**Using LiteLLM SDK:**
-
-```python
-from litellm import completion
-
-response = completion(
-    model="anthropic/claude-opus-5",
-    messages=[{"role": "user", "content": "Explain quantum computing"}],
-    output_config={"effort": "max"},
-)
-```
-
-</TabItem>
-<TabItem value="messages" label="/v1/messages">
-
-```bash
-curl --location 'http://0.0.0.0:4000/v1/messages' \
---header 'x-api-key: sk-12345' \
---header 'content-type: application/json' \
---data '{
-    "model": "claude-opus-5",
-    "max_tokens": 4096,
-    "messages": [
-        {
-            "role": "user",
-            "content": "Explain quantum computing"
-        }
-    ],
-    "output_config": {
-        "effort": "max"
-    }
-}'
-```
-
-</TabItem>
-</Tabs>
-
-**Effort level guide:**
-
-| Effort | When to use |
-|--------|-------------|
-| `low` | Short, fast responses for simple lookups, formatting, and classification |
-| `medium` | Balanced tradeoff for everyday Q&A and light reasoning |
-| `high` (default) | Complex reasoning, code generation, analysis |
-| `xhigh` | Hard problems like multi-step math, deep research, and agentic planning |
-| `max` | The hardest tasks where you want maximum reasoning depth regardless of latency |
-
-At `xhigh` or `max`, give the request at least 64K `max_tokens` so thinking and the final response both fit.
-
-### Fast Mode
+## Fast Mode
 
 :::info
 Fast mode is **only supported on the Anthropic provider** (`anthropic/claude-opus-5`). It is not available on Azure AI, Vertex AI, or Bedrock, and it cannot be combined with the Batch API.


### PR DESCRIPTION
Follow-up to #653, which merged before these edits landed on the branch.

Rewrites "What's new" as a short key-changes list covering what actually moved this generation (coding agents, self-verification, vision and artifacts, unchanged base price, thinking on by default, and fast mode at 2x for 2.5x speed), converts the upgrade-notes bullets to prose, and drops the effort levels and adaptive thinking sections entirely; both are table stakes across frontier models at this point and read as filler in a launch post. What's left is the key changes, the upgrade caveats, provider setup, and fast mode.

Also corrects the enablement section to point at v1.95.0-dev.3, the image cutting later today; the post previously named v1.95.0-dev.2, which was tagged before the Opus 5 cost map entry landed

The [announcement discussion](https://github.com/BerriAI/litellm/discussions/34517) has been updated to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only blog changes with no runtime or security impact.
> 
> **Overview**
> **Tightens the Claude Opus 5 launch post** so it reads like a short announcement instead of exhaustive API reference.
> 
> **What's new** is now a compact bullet list (coding agents, self-verification, vision/artifacts, unchanged base price, default thinking, fast mode) instead of long benchmark and pricing detail. **Upgrade notes** move from bullets to prose and fold in Priority Tier, web fetch, and refusal handling; the separate “disable thinking at xhigh/max” bullet is dropped. **Enablement** now points at **`v1.95.0-dev.3`** (remote reload vs local cost map) and all Docker examples use that tag instead of `v1.95.0-dev.2`.
> 
> The **Adaptive Thinking** and **Effort Levels** sections (curl/SDK examples and effort table) are removed entirely; **Fast Mode** stays as its own top-level section after Usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0baa2469e9e25ee1d8c3e8371bddfef9ad9445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->