### PR TITLE
docs(blog): use /v1 chat completions path and note Responses fast-mode gap

### DIFF
--- a/blog/claude_opus_5/index.md
+++ b/blog/claude_opus_5/index.md
@@ -190,10 +190,10 @@ Fast mode is **only supported on the Anthropic provider** (`anthropic/claude-opu
 Opus 5 runs roughly 2.5x faster with `speed: "fast"`, billed at $10 / MTok input and $50 / MTok output (2x the standard rate, down from the 6x premium on Opus 4.6). LiteLLM adds the `fast-mode-2026-02-01` beta header and tracks the premium in cost calculations automatically.
 
 <Tabs>
-<TabItem value="completions" label="/chat/completions">
+<TabItem value="completions" label="/v1/chat/completions">
 
 ```bash
-curl --location 'http://0.0.0.0:4000/chat/completions' \
+curl --location 'http://0.0.0.0:4000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer $LITELLM_KEY' \
 --data '{
@@ -228,6 +228,11 @@ curl --location 'http://0.0.0.0:4000/v1/messages' \
     ]
 }'
 ```
+
+</TabItem>
+<TabItem value="responses" label="/v1/responses">
+
+Fast mode on the Responses API is coming soon. The `speed` parameter is not yet forwarded on `/v1/responses`, so requests there run at standard speed and price until support lands.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- Point the Opus 5 fast-mode `/chat/completions` example at `/v1/chat/completions`.
- Add a `/v1/responses` tab noting that fast mode is not forwarded there yet.

## Test plan
- [ ] Preview the Opus 5 blog post and confirm the Fast mode tabs render correctly
- [ ] Confirm the completions curl uses `/v1/chat/completions`
- [ ] Confirm the Responses tab states fast mode is coming soon