### PR TITLE
docs: add SigNoz as an OpenTelemetry destination

### DIFF
--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # OpenTelemetry v1
 
-OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as Jaeger, Zipkin, Datadog, New Relic, Traceloop, Levo AI and others.
+OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as Jaeger, Zipkin, Datadog, New Relic, SigNoz, Traceloop, Levo AI and others.
 
 <Image img={require('../../img/traceloop_dash.png')} />
 
@@ -87,6 +87,21 @@ OTEL_SERVICE_NAME="litellm-proxy"
 ```
 
 For **LiteLLM Proxy** setup, ingest token patterns, and trace verification, see **[Splunk Observability Cloud (OpenTelemetry)](/docs/observability/splunk_observability_cloud)**.
+
+</TabItem>
+
+<TabItem value="signoz" label="SigNoz">
+
+```shell
+OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
+OTEL_SERVICE_NAME="litellm-proxy"
+```
+
+Set `<region>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint). For a self-hosted instance, point `OTEL_EXPORTER_OTLP_ENDPOINT` at your own collector instead.
+
+For **LiteLLM SDK** and **LiteLLM Proxy** setup, logs and metrics as well as traces, and prebuilt dashboards, see **[SigNoz](/docs/observability/signoz)**.
 
 </TabItem>
 

--- a/docs/observability/opentelemetry_integration.md
+++ b/docs/observability/opentelemetry_integration.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # OpenTelemetry v1
 
-OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as Jaeger, Zipkin, Datadog, New Relic, SigNoz, Traceloop, Levo AI and others.
+OpenTelemetry is a CNCF standard for observability. It connects to any observability tool, such as SigNoz, Jaeger, Zipkin, Datadog, New Relic, Traceloop, Levo AI and others.
 
 <Image img={require('../../img/traceloop_dash.png')} />
 
@@ -32,6 +32,21 @@ Set the environment variables (different providers may require different variabl
 
 
 <Tabs>
+
+<TabItem value="signoz" label="SigNoz">
+
+```shell
+OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
+OTEL_SERVICE_NAME="litellm-proxy"
+```
+
+Set `<region>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint). For a self-hosted instance, point `OTEL_EXPORTER_OTLP_ENDPOINT` at your own collector instead.
+
+For **LiteLLM SDK** and **LiteLLM Proxy** setup, logs and metrics as well as traces, and prebuilt dashboards, see **[SigNoz](/docs/observability/signoz)**.
+
+</TabItem>
 
 <TabItem value="traceloop" label="Log to Traceloop Cloud">
 
@@ -87,21 +102,6 @@ OTEL_SERVICE_NAME="litellm-proxy"
 ```
 
 For **LiteLLM Proxy** setup, ingest token patterns, and trace verification, see **[Splunk Observability Cloud (OpenTelemetry)](/docs/observability/splunk_observability_cloud)**.
-
-</TabItem>
-
-<TabItem value="signoz" label="SigNoz">
-
-```shell
-OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
-OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
-OTEL_SERVICE_NAME="litellm-proxy"
-```
-
-Set `<region>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint). For a self-hosted instance, point `OTEL_EXPORTER_OTLP_ENDPOINT` at your own collector instead.
-
-For **LiteLLM SDK** and **LiteLLM Proxy** setup, logs and metrics as well as traces, and prebuilt dashboards, see **[SigNoz](/docs/observability/signoz)**.
 
 </TabItem>
 

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -881,6 +881,57 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 </TabItem>
 
+<TabItem value="SigNoz" label="Log to SigNoz">
+
+#### Quick Start - Log to SigNoz
+
+**Step 1:** Set callbacks and env vars
+
+Add the following to your env
+
+```shell
+OTEL_EXPORTER="otlp_grpc"
+OTEL_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
+OTEL_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
+```
+
+Set `<region>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint). For a self-hosted instance, point `OTEL_ENDPOINT` at your own collector instead.
+
+Add `otel` as a callback on your `litellm_config.yaml`
+
+```shell
+litellm_settings:
+  callbacks: ["otel"]
+```
+
+**Step 2**: Start the proxy, make a test request
+
+Start proxy
+
+```shell
+litellm --config config.yaml --detailed_debug
+```
+
+Test Request
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --data ' {
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+    }'
+```
+
+For logs and metrics as well as traces, plus prebuilt dashboards, see the full **[SigNoz](../observability/signoz)** guide.
+
+</TabItem>
+
 <TabItem value="traceloop" label="Log to Traceloop Cloud">
 
 #### Quick Start - Log to Traceloop

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -834,53 +834,6 @@ This is the Span from OTEL Logging
 
 </TabItem>
 
-<TabItem value="Honeycomb" label="Log to Honeycomb">
-
-#### Quick Start - Log to Honeycomb
-
-**Step 1:** Set callbacks and env vars
-
-Add the following to your env
-
-```shell
-OTEL_EXPORTER="otlp_http"
-OTEL_ENDPOINT="https://api.honeycomb.io/v1/traces"
-OTEL_HEADERS="x-honeycomb-team=<your-api-key>"
-```
-
-Add `otel` as a callback on your `litellm_config.yaml`
-
-```shell
-litellm_settings:
-  callbacks: ["otel"]
-```
-
-**Step 2**: Start the proxy, make a test request
-
-Start proxy
-
-```shell
-litellm --config config.yaml --detailed_debug
-```
-
-Test Request
-
-```shell
-curl --location 'http://0.0.0.0:4000/chat/completions' \
-    --header 'Content-Type: application/json' \
-    --data ' {
-    "model": "gpt-3.5-turbo",
-    "messages": [
-        {
-        "role": "user",
-        "content": "what llm are you"
-        }
-    ]
-    }'
-```
-
-</TabItem>
-
 <TabItem value="SigNoz" label="Log to SigNoz">
 
 #### Quick Start - Log to SigNoz
@@ -929,6 +882,53 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 ```
 
 For logs and metrics as well as traces, plus prebuilt dashboards, see the full **[SigNoz](../observability/signoz)** guide.
+
+</TabItem>
+
+<TabItem value="Honeycomb" label="Log to Honeycomb">
+
+#### Quick Start - Log to Honeycomb
+
+**Step 1:** Set callbacks and env vars
+
+Add the following to your env
+
+```shell
+OTEL_EXPORTER="otlp_http"
+OTEL_ENDPOINT="https://api.honeycomb.io/v1/traces"
+OTEL_HEADERS="x-honeycomb-team=<your-api-key>"
+```
+
+Add `otel` as a callback on your `litellm_config.yaml`
+
+```shell
+litellm_settings:
+  callbacks: ["otel"]
+```
+
+**Step 2**: Start the proxy, make a test request
+
+Start proxy
+
+```shell
+litellm --config config.yaml --detailed_debug
+```
+
+Test Request
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --data ' {
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+    }'
+```
 
 </TabItem>
 


### PR DESCRIPTION
SigNoz has had a dedicated page since #18726 (on the old `docs/my-website` tree), but it is missing from both places that list where you can send OpenTelemetry data. Anyone wiring up OTLP export starts on one of those two pages, so the existing page is effectively undiscoverable from them.

This adds a SigNoz tab in both spots, following the tabs already there:

- `docs/observability/opentelemetry_integration.md`, alongside Traceloop, Laminar, and Splunk Observability Cloud. I used the Splunk tab as the model, since it pairs a short env-var block with a link out to its own page, which is the same shape SigNoz needs.
- `docs/proxy/logging.md`, in the OpenTelemetry section alongside Honeycomb, Traceloop, and the OTEL collectors. Matches the Honeycomb quickstart structure, including the config snippet and test request.

Also named SigNoz in the opening line of the OpenTelemetry page that lists the tools OTLP connects to (Jaeger, Zipkin, Datadog, New Relic, and so on).

The env vars use `OTEL_EXPORTER` / `OTEL_ENDPOINT` / `OTEL_HEADERS` as documented in the exporter reference table on that same page, and the endpoint and `signoz-ingestion-key` header match the existing `docs/observability/signoz.md` page so the two do not drift. Both tabs note the self-hosted case and link out for logs, metrics, and dashboards.

On tab order: I put SigNoz first on the OpenTelemetry integration page and second in the proxy logging guide, behind the console tab, which stays first so a quickstart still opens on the exporter that needs no account. Ordering is entirely yours to set, so please reorder or ask me to; none of these lists look alphabetical, so I had to pick something.

`npm run build` passes. I diffed the build against a clean `main` build: both emit warnings for the same 11 paths with the same 25 minifier diagnostics, so this adds no new warnings.