### PR TITLE
docs: add a SigNoz card to the observability grids

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -17,6 +17,12 @@ Track, debug, and analyze LLM calls with observability platforms.
 columns={3}
 items={[
   {
+    icon: "🧭",
+    title: "SigNoz",
+    description: "OpenTelemetry-native traces, logs, and metrics.",
+    to: "/docs/observability/signoz",
+  },
+  {
     icon: "🪢",
     title: "Langfuse",
     description: "LLM observability and analytics.",

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -17,7 +17,7 @@ Track, debug, and analyze LLM calls with observability platforms.
 columns={3}
 items={[
   {
-    icon: "🧭",
+    icon: "👁️",
     title: "SigNoz",
     description: "OpenTelemetry-native traces, logs, and metrics.",
     to: "/docs/observability/signoz",

--- a/docs/integrations/observability_index.md
+++ b/docs/integrations/observability_index.md
@@ -13,6 +13,7 @@ import NavigationCards from '@site/src/components/NavigationCards';
 <NavigationCards
 columns={3}
 items={[
+  { icon: "🧭", title: "SigNoz", description: "OpenTelemetry-native traces, logs, and metrics.", to: "/docs/observability/signoz" },
   { icon: "🪢", title: "Langfuse", description: "LLM observability and analytics.", to: "/docs/observability/langfuse_integration" },
   { icon: "🐶", title: "Datadog", description: "Metrics, traces, and dashboards.", to: "/docs/observability/datadog" },
   { icon: "📡", title: "OpenTelemetry", description: "Vendor-neutral tracing.", to: "/docs/observability/opentelemetry_integration" },

--- a/docs/integrations/observability_index.md
+++ b/docs/integrations/observability_index.md
@@ -13,7 +13,7 @@ import NavigationCards from '@site/src/components/NavigationCards';
 <NavigationCards
 columns={3}
 items={[
-  { icon: "🧭", title: "SigNoz", description: "OpenTelemetry-native traces, logs, and metrics.", to: "/docs/observability/signoz" },
+  { icon: "👁️", title: "SigNoz", description: "OpenTelemetry-native traces, logs, and metrics.", to: "/docs/observability/signoz" },
   { icon: "🪢", title: "Langfuse", description: "LLM observability and analytics.", to: "/docs/observability/langfuse_integration" },
   { icon: "🐶", title: "Datadog", description: "Metrics, traces, and dashboards.", to: "/docs/observability/datadog" },
   { icon: "📡", title: "OpenTelemetry", description: "Vendor-neutral tracing.", to: "/docs/observability/opentelemetry_integration" },


### PR DESCRIPTION
SigNoz has a dedicated page at `docs/observability/signoz.md` and a sidebar entry under Infrastructure backends, but neither observability card grid links to it. Right now the only way to reach the page is the sidebar, so it is invisible to anyone who lands on the Observability overview and browses the cards.

This adds one card to each of the two grids that list observability platforms:

- `docs/integrations/observability_index.md`, the Observability overview reached from the Integrations tab
- `docs/integrations/index.md`, the Observability section of the top-level Integrations page


On placement: I put the card first in both grids. That is the most self-serving choice available to me, so please move it wherever you think it belongs; neither grid looks ordered by anything in particular, so I had no convention to follow. Description and icon follow the style of the existing cards, and the icon does not collide with one already in use.

`npm run build` passes and both cards render and link correctly. I diffed against a clean `main` build: both emit warnings for the same 11 paths with the same 25 minifier diagnostics, so this adds no new warnings.