### PR TITLE
docs: fix broken link to contributing_code.md

### DIFF
--- a/docs/contribute_integration/custom_webhook_api.md
+++ b/docs/contribute_integration/custom_webhook_api.md
@@ -105,7 +105,7 @@ If you're adding a new integration, please add documentation for it under the `o
 
 5. File a PR! 
 
-- Review our contribution guide [here](../../extras/contributing_code)
+- Review our contribution guide [here](../extras/contributing_code)
 - Push your fork to your GitHub repo
 - Submit a PR from there
 


### PR DESCRIPTION
'../../extras/contributing_code' had one extra '../' and resolved outside the docs/ folder. Fixed to '../extras/contributing_code', which correctly resolves to docs/extras/contributing_code.md.