### PR TITLE
docs: fix link to renamed observability_index page

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -73,7 +73,7 @@ items={[
 ]}
 />
 
-[View all observability integrations →](/docs/integrations/observability_integrations)
+[View all observability integrations →](/docs/integrations/observability_index)
 
 ---
 

--- a/docs/integrations/letta.md
+++ b/docs/integrations/letta.md
@@ -924,5 +924,5 @@ for model in models:
 - [LiteLLM Proxy Documentation](/docs/simple_proxy)
 - [LiteLLM SDK Documentation](/docs/#litellm-python-sdk)
 - [Function Calling Guide](/docs/completion/function_call)
-- [Observability Setup](/docs/integrations/observability_integrations)
+- [Observability Setup](/docs/integrations/observability_index)
 - [Router Configuration](/docs/routing)


### PR DESCRIPTION
The page was renamed from observability_integrations.md to observability_index.md. Updated the stale references in integrations/letta.md and integrations/index.md.