### PR TITLE
docs: fix broken link protocol typo in Softgen.md

### DIFF
--- a/docs/projects/Softgen.md
+++ b/docs/projects/Softgen.md
@@ -4,4 +4,4 @@
 LiteLLM helps `Softgen` users to choose and use different LLMs.
 
 - [Softgen](https://softgen.ai)
-- [Academy](hhttps://academy.softgen.ai)
+- [Academy](https://academy.softgen.ai)


### PR DESCRIPTION
'hhttps://academy.softgen.ai' -> 'https://academy.softgen.ai' (extra 'h' broke the link).