### PR TITLE
docs: fix broken links in policy_templates.md

### DIFF
--- a/docs/proxy/guardrails/policy_templates.md
+++ b/docs/proxy/guardrails/policy_templates.md
@@ -292,5 +292,5 @@ See the [full patterns list](https://github.com/BerriAI/litellm/blob/main/litell
 
 - [Guardrail Policies](./guardrail_policies)
 - [Policy Tags](./policy_tags)
-- [Content Filter Patterns](../hooks/content_filter)
-- [Custom Code Guardrails](../hooks/custom_code)
+- [Content Filter Patterns](litellm_content_filter)
+- [Custom Code Guardrails](custom_code_guardrail)


### PR DESCRIPTION
'../hooks/content_filter' and '../hooks/custom_code' pointed to a non-existent hooks/ folder. Fixed to the actual filenames in the same directory: litellm_content_filter.md and custom_code_guardrail.md.