### PR TITLE
docs: fix broken relative link to user_keys.md in guardrail docs

### DIFF
--- a/docs/proxy/guardrails/aporia_api.md
+++ b/docs/proxy/guardrails/aporia_api.md
@@ -71,7 +71,7 @@ litellm --config config.yaml --detailed_debug
 
 ## 4. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Unsuccessful call" value = "not-allowed">

--- a/docs/proxy/guardrails/azure_content_guardrail.md
+++ b/docs/proxy/guardrails/azure_content_guardrail.md
@@ -54,7 +54,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 ```shell
 curl -i http://localhost:4000/v1/chat/completions \

--- a/docs/proxy/guardrails/bedrock.md
+++ b/docs/proxy/guardrails/bedrock.md
@@ -48,7 +48,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Unsuccessful call" value = "not-allowed">

--- a/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/proxy/guardrails/custom_guardrail.md
@@ -186,7 +186,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 4. Test it 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Blocked Request" value = "blocked">

--- a/docs/proxy/guardrails/dynamoai.md
+++ b/docs/proxy/guardrails/dynamoai.md
@@ -48,7 +48,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 4. Test Request
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Successful Call" value="allowed">

--- a/docs/proxy/guardrails/enkryptai.md
+++ b/docs/proxy/guardrails/enkryptai.md
@@ -70,7 +70,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 4. Test Request
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Successful Call" value="allowed">

--- a/docs/proxy/guardrails/guardrails_ai.md
+++ b/docs/proxy/guardrails/guardrails_ai.md
@@ -39,7 +39,7 @@ litellm --config config.yaml --detailed_debug
 
 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 ```shell
 curl -i http://localhost:4000/v1/chat/completions \

--- a/docs/proxy/guardrails/javelin.md
+++ b/docs/proxy/guardrails/javelin.md
@@ -62,7 +62,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Prompt Injection Detection" value = "prompt-injection">

--- a/docs/proxy/guardrails/lakera_ai.md
+++ b/docs/proxy/guardrails/lakera_ai.md
@@ -56,7 +56,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Unsuccessful call" value = "not-allowed">

--- a/docs/proxy/guardrails/model_armor.md
+++ b/docs/proxy/guardrails/model_armor.md
@@ -54,7 +54,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 ```shell
 curl -i http://localhost:4000/v1/chat/completions \

--- a/docs/proxy/guardrails/pii_masking_v2.md
+++ b/docs/proxy/guardrails/pii_masking_v2.md
@@ -127,7 +127,7 @@ My credit card is 4111-1111-1111-1111 and my email is test@example.com.
 
 In order to apply a guardrail for a request send `guardrails=["presidio-pii"]` in the request body. 
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Masked PII call" value = "not-allowed">

--- a/docs/proxy/guardrails/qualifire.md
+++ b/docs/proxy/guardrails/qualifire.md
@@ -63,7 +63,7 @@ litellm --config config.yaml --detailed_debug
 
 ### 3. Test request
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 <Tabs>
 <TabItem label="Unsuccessful call" value = "not-allowed">

--- a/docs/proxy/guardrails/quick_start.md
+++ b/docs/proxy/guardrails/quick_start.md
@@ -132,7 +132,7 @@ litellm --config config.yaml --detailed_debug
 
 ## 3. Test request
 
-**[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
+**[Langchain, OpenAI SDK Usage Examples](../user_keys#request-format)**
 
 
 


### PR DESCRIPTION
'../proxy/user_keys' resolved to a non-existent docs/proxy/proxy/user_keys path from inside docs/proxy/guardrails/. Fixed to '../user_keys', which correctly resolves to docs/proxy/user_keys.md. Affects 13 guardrail pages.