### PR TITLE
docs(proxy): document PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1124,6 +1124,7 @@ router_settings:
 | PROXY_BATCH_POLLING_INTERVAL | Time in seconds to wait before polling a batch, to check if it's completed. Default is 6000s (1 hour)
 | PROXY_BATCH_POLLING_ENABLED | Set to `false` to disable the `CheckBatchCost` and `CheckResponsesCost` background polling jobs entirely. Useful for emergency mitigation on installs with large numbers of stale managed objects. Default is `true`
 | PROXY_CONFIG_RELOAD_INTERVAL_SECONDS | How often each pod reloads config-in-DB objects (models, credentials, guardrails, etc.) from the database when `store_model_in_db` is enabled. Lower values speed up cross-pod convergence at the cost of more DB load; applied on proxy startup. Default is 30
+| PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS | Per-step timeout in seconds for the final spend-buffer flush on proxy shutdown. The spend and daily-tag-spend queues are each drained once before Prisma disconnects; a step that exceeds this budget is abandoned so it cannot stall the rest of the shutdown sequence. Default is 10
 | MAX_OBJECTS_PER_POLL_CYCLE | Maximum number of managed objects (batches / responses) fetched per polling cycle. Prevents OOM on installs with many stale rows. Default is `50`
 | MANAGED_OBJECT_STALENESS_CUTOFF_DAYS | Managed objects older than this many days in a non-terminal state are marked `stale_expired` at the start of each poll cycle and skipped. Default is `7`
 | PROXY_BUDGET_RESCHEDULER_MAX_TIME | Maximum time in seconds to wait before checking database for budget resets. Default is 605


### PR DESCRIPTION
Adds the reference row for `PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS`, the env var introduced in BerriAI/litellm#34808.

Without this row the `documentation` job on that PR fails: `tests/documentation_tests/test_env_keys.py` diffs every `os.getenv(...)` under `litellm/` against the `### environment variables - Reference` table here, so a new key reads as undocumented.

Verified locally by staging this branch at `docs/my-website` in a litellm checkout carrying the new env var and running the gate:

```
$ python3 ./tests/documentation_tests/test_env_keys.py
All keys are documented in 'environment settings - Reference'.
exit 0
```

Placed with the other `PROXY_*` entries, immediately after `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS`.