### PR TITLE
docs(mcp): headless and remote machine paths for MCP OAuth

### DIFF
--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -161,6 +161,8 @@ MCP clients complete OAuth by listening on a loopback address (`http://localhost
 curl 'http://localhost:<port>/callback?code=...&state=...'
 ```
 
+Quote the URL for the shell you are in: the single-quoted form above is for bash and zsh; in PowerShell use double quotes; avoid cmd.exe, which treats neither form as full quoting
+
 The code on the page is single-use, bound to the client's PKCE verifier, and expires after 5 minutes, so it is useless to anyone who cannot also act as the waiting client. Requires a proxy build including [PR #34848](https://github.com/BerriAI/litellm/pull/34848)
 
 If you clicked Finish connecting without the checkbox, the laptop browser dead-ends on a connection error; the complete callback URL is still in the address bar and can be copied and delivered the same two ways

--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -151,7 +151,30 @@ The MCP proxy's `/v1/mcp/server/oauth/<server_id>/authorize` endpoint validates 
 
 `PROXY_BASE_URL` is the right escape hatch for ingressed deployments because the operator is declaring the proxy's true public origin out of band, rather than asking the proxy to infer it from headers an attacker might be able to set. The check itself is not relaxed.
 
-## Machine-to-Machine (M2M) Auth
+### Headless and remote machines (EC2, SSH boxes, containers) {#headless-and-remote-machines}
+
+MCP clients complete OAuth by listening on a loopback address (`http://localhost:<port>/callback`, per RFC 8252) and expecting the browser to deliver the authorization code there. That assumption breaks when the client runs on a machine with no browser: the client prints the authorize URL, you open it on your laptop, sign-in succeeds, and the final redirect then resolves `localhost` on the laptop instead of the machine running the client. The flow hangs with the client still waiting. The client registers and owns that redirect URI, so the gateway cannot send the code anywhere else; what it can do is hand the last hop to you
+
+**Manual code delivery (gateway aggregate `/mcp` flow).** When the OAuth client registered a loopback redirect URI, the connect page's "Finish connecting" banner shows a checkbox labeled "My client is on a remote or SSH machine". Check it before clicking Finish connecting. Instead of redirecting, the gateway renders the full callback URL on the page. Deliver it on the machine where the client runs, either by pasting it into the client (Claude Code 2.1.191 and later accepts a pasted callback URL while waiting for OAuth) or from that machine's terminal:
+
+```bash
+curl 'http://localhost:<port>/callback?code=...&state=...'
+```
+
+The code on the page is single-use, bound to the client's PKCE verifier, and expires after 5 minutes, so it is useless to anyone who cannot also act as the waiting client. Requires a proxy build including [PR #34848](https://github.com/BerriAI/litellm/pull/34848)
+
+If you clicked Finish connecting without the checkbox, the laptop browser dead-ends on a connection error; the complete callback URL is still in the address bar and can be copied and delivered the same two ways
+
+**Skip client OAuth with a virtual key.** A headless box never needs the browser dance if the MCP client authenticates with a LiteLLM key instead:
+
+```bash
+claude mcp add --transport http litellm "https://<your-gateway>/mcp/" \
+  --header "x-litellm-api-key: Bearer sk-<your-key>"
+```
+
+Upstream servers whose own auth is interactive OAuth still need a one-time connect from the gateway UI (any browser, any machine); the tokens are stored server side and resolved at call time by the key's user. The key must belong to the same user who connected the servers: a team or service key that carries no user identity resolves no stored token and receives the standard OAuth challenge, indistinguishable from a user who never connected
+
+SSH port-forwarding the callback is not a reliable alternative; clients pick an ephemeral callback port per flow, so there is no stable port to forward
 
 LiteLLM automatically fetches, caches, and refreshes OAuth2 tokens using the `client_credentials` grant. No manual token management required.
 

--- a/docs/tutorials/claude_mcp.md
+++ b/docs/tutorials/claude_mcp.md
@@ -59,6 +59,8 @@ The server name under `mcp_servers:` (e.g. `atlassian_mcp`, `github_mcp`) **must
 
 Since Claude Code needs a publicly accessible URL for the OAuth callback, expose your proxy via ngrok or a similar tool.
 
+If Claude Code runs on a machine without a browser (an EC2 instance, an SSH dev box, a container), the OAuth callback to `localhost` cannot reach it from the browser on your laptop; see [Headless and remote machines](../mcp_oauth#headless-and-remote-machines) for the supported paths.
+
 ```bash
 litellm --config /path/to/config.yaml
 


### PR DESCRIPTION
## Relevant issues

- Documents MCP OAuth from browserless machines (EC2, SSH boxes, containers): the loopback callback lands on the browser's machine, not the client's
- Covers the new manual code delivery checkbox on the gateway connect flow (BerriAI/litellm#34848), the address bar recovery, and the virtual key in headers path with its same-user constraint
- Adds a pointer from the Claude Code tutorial's callback section

## Linear ticket

Resolves LIT-4863

## Changes

New "Headless and remote machines" section in docs/mcp_oauth.md after the ingress section, plus a cross-link in docs/tutorials/claude_mcp.md. The companion feature PR is BerriAI/litellm#34848; the manual delivery paragraph names it as the required build