### PR TITLE
docs(blog): Auto Router cost and quality benchmark

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -55,7 +55,7 @@ mateo:
 
 tin:
   name: Tin Lo
-  title: MCP Eng, LiteLLM
+  title: AI Engineer, LiteLLM
   image_url: https://media.licdn.com/dms/image/v2/D4E03AQH0K2Tx1GzBhQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1677601930841?e=1785369600&v=beta&t=-r46FiQh1uny60kMPAbGDtnINzyc3CZ72u6xt2UvMrc
 
 mubashir:

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -10,7 +10,7 @@ tags: [routing, complexity-router, cost, benchmarks, engineering]
 hide_table_of_contents: false
 ---
 
-Auto routing promises a smaller bill without a worse answer. We measured both halves against a baseline that sends every request to `claude-opus-5`: 8,619 graded prompts, about $111 of real API spend, and cost simulations over 14,000 real conversations.
+Auto routing promises a smaller bill without a worse answer. We measured both halves against a baseline that sends every request to `claude-opus-5`: 8,619 graded prompts and cost simulations over 14,000 real conversations.
 
 {/* truncate */}
 

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -32,8 +32,8 @@ Auto routing promises a smaller bill without a worse answer. We measured both ha
 
 - **Router arm:** one model group, four tiers. SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, COMPLEX and REASONING both to `claude-opus-5`, since Opus 5 already thinks by default. Heuristic classifier, no keyword rules, no adaptive sampling
 - **Baseline arm:** the same prompts sent straight to `claude-opus-5`, which is what most teams do today when they point a workload at one frontier model
-- **Cost savings:** `1 - cost(router) / cost(baseline)`, from measured token usage. The live-proxy leg reads each request's cost off the `x-litellm-response-cost` header; the simulations estimate tokens from conversation text
-- **Quality retained:** `pass(router) / pass(baseline)`, one pooled rate with no partial credit, identical prompts and grader on both arms
+- **Cost savings:** what the router spent against what the baseline spent. On the live proxy, LiteLLM reports the cost of every request back in a response header; on the other legs we price the tokens each request actually used
+- **Quality retained:** the router's pass rate against the baseline's, evaluating identical prompts with the same grader on both arms
 
 What counts as a pass:
 

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -126,30 +126,10 @@ One upstream finding is worth passing on to anyone else benchmarking on RouterAr
 
 ## Try it
 
-The config is the one at the top of this post; drop it into `config.yaml`, point a client at `smart-router`, and every response tells you where the request went:
+The config above is the whole setup; drop it into `config.yaml` and point a client at `smart-router`. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).
 
-```bash
-curl -i -X POST http://localhost:4000/v1/chat/completions \
-  -H "Authorization: Bearer $LITELLM_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
+:::info
 
-# x-litellm-model-name: anthropic/claude-haiku-4-5
-# x-litellm-response-cost: 0.0000418
-```
-
-Those two headers are all the instrumentation this study needed, and they are enough to reproduce the cost half of it on your own traffic in an afternoon. Set `classifier_type: llm` if you want quality back at a higher price, and tune `tier_boundaries` if the mix looks wrong for your workload. Full reference on the [Auto Routing docs page](/docs/proxy/auto_routing), and see [Auto Router v2](/blog/autorouter-v2) for keyword rules, tier pools, and session affinity.
-
-If you run this on your own traffic, we want the numbers. Post them on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
-
-## Come build the next version with us
-
-The remaining wins are the ones a benchmark cannot pick for us: embedding-based classification to fix the paraphrase instability above, tier boundaries tuned per traffic shape instead of one global default, and reporting that tells a platform team what routing actually saved them last month. We are choosing what to build from real workloads, so we are taking on a small number of design partners.
-
-If enough traffic runs through your gateway that a 40% to 65% cut is real money, we will sit down with your traffic mix, run this same evaluation against it, hand you the numbers, and ship the config that comes out of it.
-
-:::info Apply to be a design partner
-
-[Design partner application](https://cms49ctwm00026rv771kh8igo.zapier.app/application)
+If this is interesting, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application). Feedback, questions, and numbers from your own traffic go on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
 
 :::

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -35,17 +35,14 @@ Auto routing promises a smaller bill without a worse answer. We measured both ha
 - **Cost savings:** `1 - cost(router) / cost(baseline)`. On the live-proxy leg, each of the 440 requests reports its own cost in the `x-litellm-response-cost` header, which is LiteLLM's calculation over the usage Anthropic actually returned, including reasoning tokens. RouterArena costs come from measured token usage priced at list rates; the simulations estimate tokens from the conversation text
 - **Quality retained:** `pass(router) / pass(baseline)`, one pooled rate over all prompts with no partial credit and no per-dataset weighting, with identical prompts and grading on both arms so grader quirks largely cancel
 
-What counts as a pass depends on the dataset:
+What counts as a pass:
 
-| Dataset | What it tests | How a pass is decided |
-| --- | --- | --- |
-| [HumanEval](https://huggingface.co/datasets/openai/openai_humaneval) | code generation | the dataset's own unit tests run in a subprocess; pass only if every official assert passes |
-| [MBPP](https://huggingface.co/datasets/google-research-datasets/mbpp) | code generation | same, the dataset's official assertion tests are executed |
-| [GSM8K](https://huggingface.co/datasets/openai/gsm8k) | grade-school math | exact match on the extracted final number |
-| [MATH-500](https://huggingface.co/datasets/HuggingFaceH4/MATH-500) | competition math | LaTeX normalisation, then numeric comparison, then a SymPy equivalence fallback |
-| [MMLU-Pro](https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro) | 10-way multiple choice | exact match on the final answer letter |
-| [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | real GitHub issues | LLM as judge, comparing the named files, functions, and diff sketch against the patch upstream actually merged |
-| [RouterArena](https://github.com/RouteWorks/RouterArena) | 9 domains, 44 categories | RouterArena's own evaluator scores each answer; about 74% of queries are multiple choice matched on a `\boxed{X}` letter, the rest use per-dataset scorers (numeric or exact match, text overlap, code checks) |
+| Dataset | How a pass is decided |
+| --- | --- |
+| [HumanEval](https://huggingface.co/datasets/openai/openai_humaneval), [MBPP](https://huggingface.co/datasets/google-research-datasets/mbpp) | the datasets' own unit tests run in a subprocess; pass only if every official assert passes |
+| [GSM8K](https://huggingface.co/datasets/openai/gsm8k), [MATH-500](https://huggingface.co/datasets/HuggingFaceH4/MATH-500), [MMLU-Pro](https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro) | answer-key match: the extracted final number, LaTeX normalisation with a SymPy equivalence fallback, and the final answer letter |
+| [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | LLM as judge, comparing the named files, functions, and diff sketch against the patch upstream actually merged |
+| [RouterArena](https://github.com/RouteWorks/RouterArena) | RouterArena's own evaluator; about 74% of queries are multiple choice matched on a `\boxed{X}` letter, the rest use per-dataset scorers |
 
 :::note
 
@@ -80,9 +77,9 @@ Four classifiers on the same three-model pool, scored offline against a fully gr
 | Policy | Accuracy | Cost/1k | haiku/sonnet/opus |
 | --- | --- | --- | --- |
 | All-Haiku (floor) | 68.5% | $1.13 | 100/0/0 |
-| LiteLLM heuristic (keyword) | 69.9% | $2.04 | 80/16/3 |
+| **LiteLLM heuristic (keyword)** | **69.9%** | **$2.04** | **80/16/3** |
 | RouteLLM BERT at matched budget | 71.2% | $2.46 | 80/16/3 |
-| LiteLLM LLM classifier (Haiku) | 74.9% | $5.44 | 36/35/28 |
+| **LiteLLM LLM classifier (Haiku)** | **74.9%** | **$5.44** | **36/35/28** |
 | RouteLLM BERT at matched budget | 74.8% | $4.69 | 36/35/28 |
 | All-Sonnet-5 | 75.3% | $4.81 | 0/100/0 |
 | LiteLLM semantic (MiniLM tier exemplars) | 76.3% | $6.20 | 19/27/54 |

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -70,27 +70,6 @@ The split runs opposite to intuition:
 
 If nearly every request carries a large repo context, there is no cheap tier to route it to, and the lever to reach for is [prompt caching or compression](/blog/save-claude-code-costs-with-litellm) rather than model selection.
 
-## The classifier is the dial
-
-Four classifiers on the same three-model pool, scored offline against a fully graded 809-query grid, alongside a trained router and a cheapest-correct oracle:
-
-| Policy | Accuracy | Cost/1k | haiku/sonnet/opus |
-| --- | --- | --- | --- |
-| All-Haiku (floor) | 68.5% | $1.13 | 100/0/0 |
-| **LiteLLM heuristic (keyword)** | **69.9%** | **$2.04** | **80/16/3** |
-| RouteLLM BERT at matched budget | 71.2% | $2.46 | 80/16/3 |
-| **LiteLLM LLM classifier (Haiku)** | **74.9%** | **$5.44** | **36/35/28** |
-| RouteLLM BERT at matched budget | 74.8% | $4.69 | 36/35/28 |
-| All-Sonnet-5 | 75.3% | $4.81 | 0/100/0 |
-| LiteLLM semantic (MiniLM tier exemplars) | 76.3% | $6.20 | 19/27/54 |
-| All-Opus-5 | 80.6% | $8.38 | 0/0/100 |
-| Oracle (cheapest correct model) | 85.7% | $2.25 | n/a |
-
-- **A trained router buys 1.3 points.** RouteLLM's BERT classifier beats the free keyword heuristic by that much at a matched budget, a small return for a model artifact you have to host and retrain
-- **An LLM classifier ties it.** `classifier_type: llm` with Haiku matches the trained router at a matched budget, so the cheapest path to a better router is a small model reading the prompt
-- **Classification is the bottleneck, not the pool.** The oracle beats all-Opus at roughly a quarter of its cost, so the headroom is in picking better, not in adding models
-- **The heuristic is unstable under paraphrase.** It picks the same model for only 50.7% of reworded queries, though 85% of the flips are upward, so the failure mode is paying too much rather than answering badly
-
 ## Try it
 
 :::info
@@ -127,4 +106,4 @@ model_list:
       complexity_router_default_model: claude-sonnet-5
 ```
 
-Point a client at `smart-router` and every response carries `x-litellm-model-name` and `x-litellm-response-cost`, which is all the instrumentation this study needed. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).
+Point a client at `smart-router` and every response carries `x-litellm-model-name` and `x-litellm-response-cost`, which is all the instrumentation this study needed. The heuristic classifier above is not the ceiling: switching to `classifier_type: llm`, where `claude-haiku-4-5` reads each prompt and picks the tier, scored about five accuracy points higher in our offline comparison, at roughly 2.5x the spend. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -1,0 +1,155 @@
+---
+slug: auto-router-cost-quality-benchmark
+title: "Benchmarking Auto Router: 40-75% cheaper at 87-97% of frontier quality"
+date: 2026-07-27T10:00:00
+authors:
+  - tin
+description: "Two independent evaluations of a three-tier Auto Router config against an all-frontier baseline: 8,619 graded prompts, 14,000 simulated real conversations, and what the cost and quality numbers actually depend on."
+keywords: [llm router benchmark, auto router, complexity router, llm cost savings, model routing, claude cost optimization, routerarena, litellm auto routing, cheaper llm inference]
+tags: [routing, complexity-router, cost, benchmarks, engineering]
+hide_table_of_contents: false
+---
+
+Auto routing is the cheapest cost lever on an AI gateway to turn on and the hardest one to trust. Sending every request to a frontier model has a known bill and known quality; sending some of them to a smaller model has an obvious bill and an unknown quality cost. So we measured it, twice, on a three-tier Claude configuration against a baseline of routing everything to `claude-opus-5`.
+
+Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut cost by **40.4%** on one evaluation and **74.5%** on the other, while retaining **97.1%** and **87.3%** of the baseline's answer quality. On simulations over 14,000 real conversations, savings land at roughly **65%**. The spread between those numbers is the interesting part, and it is almost entirely explained by how much of the traffic is genuinely simple.
+
+{/* truncate */}
+
+## What was measured
+
+We tested our auto-router using this configuration:
+
+```yaml title="config.yaml"
+model_list:
+  - model_name: claude-haiku-4-5           # $1 / $5 per 1M tokens
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-sonnet-5            # $3 / $15
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-5              # $5 / $25
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE:    claude-haiku-4-5
+          MEDIUM:    claude-sonnet-5
+          COMPLEX:   claude-opus-5
+          REASONING: claude-opus-5
+        classifier_type: heuristic         # local scoring, sub-millisecond, no API call
+      complexity_router_default_model: claude-sonnet-5
+```
+
+One model group over a three-model Claude pool, classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING pinned to the same model as COMPLEX because Opus 5 already thinks by default. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
+
+Quality retained is the ratio of the two pass rates, `pass(router) / pass(baseline)`. Cost savings is `1 - cost(router) / cost(baseline)`, computed from actual measured token usage on every request rather than from estimates.
+
+## Results
+
+| Evaluation | Prompts | Quality retained | Cost savings | Router routing mix (haiku/sonnet/opus) |
+| --- | --- | --- | --- | --- |
+| Live proxy, six public benchmarks | 220 | **97.1%** (91.8% vs 94.5% pass) | **40.4%** ($10.47 vs $17.57 per 1k) | 27% / 70% / 3% |
+| RouterArena full set, paired | 8,399 | **87.3%** (68.6% vs 78.5% accuracy) | **74.5%** ($2.15 vs $8.45 per 1k) | 79% / 17% / 4% |
+| Real-traffic simulation, WildChat + DevGPT | 14,056 conversations | not measured | **~65%** | 48-76% simple |
+
+The first leg ran through a live LiteLLM proxy on `localhost:4000`, 440 real requests to `POST /v1/chat/completions`, with per-request cost read from the `x-litellm-response-cost` header and the routed model read from `x-litellm-model-name`. Five of the six datasets are graded objectively against their own answer keys or test suites; only [SWE-bench Lite](https://www.swebench.com/) needs a judge, and every SWE-bench answer was judged twice, once by `claude-opus-5` and once by `gemini-3.6-flash`, to rule out self-preference. The second judge is stricter in absolute terms and leaves the retention ratio effectively unchanged at 96.6%.
+
+The second leg ran the full 8,400-query set from [RouterArena](https://github.com/RouteWorks/RouterArena), the public router benchmark, paired against an all-Opus arm on the same queries with RouterArena's own automated evaluator.
+
+The two legs disagree on both axes, and they disagree for one reason. The heuristic classifier keys mostly off length, code presence, and reasoning markers, so RouterArena's short academic questions score SIMPLE and 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers. Both numbers are real, and which one resembles your bill depends entirely on your traffic.
+
+## Where the savings come from, and what they cost
+
+Per-dataset, from the live-proxy leg:
+
+| Dataset | Auto Router pass | Opus-5 pass | Auto Router $/1k | Opus-5 $/1k | Savings |
+| --- | --- | --- | --- | --- | --- |
+| GSM8K | 98% (39/40) | 98% (39/40) | 1.08 | 5.68 | 81% |
+| HumanEval | 100% (40/40) | 98% (39/40) | 2.85 | 8.16 | 65% |
+| MMLU-Pro | 85% (34/40) | 88% (35/40) | 4.21 | 11.70 | 64% |
+| MATH-500 | 90% (36/40) | 98% (39/40) | 5.70 | 13.16 | 57% |
+| MBPP | 95% (38/40) | 98% (39/40) | 2.20 | 5.01 | 56% |
+| SWE-bench Lite | 75% (15/20) | 85% (17/20) | 83.08 | 105.83 | 21% |
+| **Blended** | **91.8%** | **94.5%** | **10.47** | **17.57** | **40%** |
+
+The split runs opposite to intuition. Short, cheap traffic saves the most at no measurable quality cost: grade-school math is identical at a fifth of the price, and HumanEval came out one prompt ahead of the frontier baseline. Repo-level work saves the least, because those prompts are long enough to dominate absolute spend and the classifier correctly declines to send them to Haiku. The two places quality is actually given up are MATH-500, where Haiku took 19 of the 40 prompts and the arm finished three behind the baseline, and SWE-bench Lite.
+
+That also sets the ceiling on what routing can do for a coding-agent workload. If nearly every request carries a large repo context, there is no cheap tier to route it to, and the lever to reach for is [prompt caching or compression](/blog/save-claude-code-costs-with-litellm) rather than model selection.
+
+## The classifier is the dial
+
+Cost and quality trade against each other through one component, so we put four classifiers on the same three-model pool and scored them offline against a fully graded 809-query grid, alongside a trained router and a cheapest-correct oracle:
+
+| Policy | Accuracy | Cost/1k | haiku/sonnet/opus |
+| --- | --- | --- | --- |
+| All-Haiku (floor) | 68.5% | $1.13 | 100/0/0 |
+| LiteLLM heuristic (keyword) | 69.9% | $2.04 | 80/16/3 |
+| RouteLLM BERT at matched budget | 71.2% | $2.46 | 80/16/3 |
+| LiteLLM LLM classifier (Haiku) | 74.9% | $5.44 | 36/35/28 |
+| RouteLLM BERT at matched budget | 74.8% | $4.69 | 36/35/28 |
+| All-Sonnet-5 | 75.3% | $4.81 | 0/100/0 |
+| LiteLLM semantic (MiniLM tier exemplars) | 76.3% | $6.20 | 19/27/54 |
+| All-Opus-5 | 80.6% | $8.38 | 0/0/100 |
+| Oracle (cheapest correct model) | 85.7% | $2.25 | n/a |
+
+Three things fall out of that table. A trained BERT router beats the free keyword heuristic by only 1.3 points at a matched budget, which is a small return for a model artifact you have to host and retrain. Setting `classifier_type: llm` with a Haiku classifier ties the trained router at a matched budget, so the cheapest path to a better router is a small model reading the prompt rather than a bespoke trained one. And the oracle beats all-Opus at roughly a quarter of its cost, so the model pool is not the bottleneck; classification is, and there is a lot of headroom left in it.
+
+The weak spot in today's heuristic is stability. On RouterArena's robustness metric it picks the same model for only 50.7% of paraphrased queries, though 85% of the flips are upward, so the failure mode is paying too much rather than answering badly. Embedding-based classification largely fixes this, and it is the next thing we want to measure.
+
+## What to expect on production traffic
+
+Benchmark prompts are deliberately difficulty-dense, so the third leg simulated the same router over real conversations, classifying the first user turn and pinning that model for the whole conversation the way `session_affinity` does:
+
+| Traffic | Sample | Tier split (simple/medium/complex) | Savings vs all-Opus-5 |
+| --- | --- | --- | --- |
+| General consumer chat | WildChat-1M, 12,000 conversations | 76 / 14 / 10 | **64.9%** |
+| Developer chat | DevGPT, 2,056 conversations | 48 / 27 / 25 | **65.4%** |
+| Code-in-prompt heavy | WildChat code-filtered, 993 conversations | 13 / 34 / 53 | 20.0% |
+
+Two very different populations both land near 65%, because in both cases roughly half to three quarters of requests are short enough that a frontier model is wasted on them. The honest range is 20% at the most code-saturated end to 75% at the shortest-query end, centered around 65% for ordinary chat and developer traffic.
+
+## Keeping the numbers honest
+
+The 220-prompt leg is small enough that differences under about five points are sampling noise, and it ran one sample per prompt with no tool use, no system prompts, and no prompt caching. Quality was measured only on ground-truth-checkable benchmark traffic, which is the defensible floor rather than the expected case; on production-shaped traffic where most requests are genuinely easy, retention should be higher, but nothing here measures that directly because WildChat and DevGPT have no answer key. The real-traffic legs estimate tokens as characters divided by four and do not model prompt caching, and the benchmark legs price Sonnet 5 at list ($3/$15) rather than the introductory rate, which moves savings by one to two points.
+
+Savings are always measured against routing everything to `claude-opus-5`, so they describe what routing recovers from an all-frontier workload rather than what it does against a pool you have already tuned by hand.
+
+One upstream finding is worth passing on to anyone else benchmarking on RouterArena. Its Anthropic handler read `response.content[0]` only, so a model that returns a thinking block first, which Opus 5 does by default, was graded on a stringified `ThinkingBlock` and scored near zero. Our fork joins the text blocks instead, and any existing Claude entry on the public leaderboard is likely depressed by this until the same fix lands upstream.
+
+## Try it
+
+The config is the one at the top of this post; drop it into `config.yaml`, point a client at `smart-router`, and every response tells you where the request went:
+
+```bash
+curl -i -X POST http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
+
+# x-litellm-model-name: anthropic/claude-haiku-4-5
+# x-litellm-response-cost: 0.0000418
+```
+
+Those two headers are all the instrumentation this study needed, and they are enough to reproduce the cost half of it on your own traffic in an afternoon. Set `classifier_type: llm` if you want quality back at a higher price, and tune `tier_boundaries` if the mix looks wrong for your workload. Full reference on the [Auto Routing docs page](/docs/proxy/auto_routing), and see [Auto Router v2](/blog/autorouter-v2) for keyword rules, tier pools, and session affinity.
+
+If you run this on your own traffic, we want the numbers. Post them on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
+
+## Come build the next version with us
+
+The remaining wins are the ones a benchmark cannot pick for us: embedding-based classification to fix the paraphrase instability above, tier boundaries tuned per traffic shape instead of one global default, and reporting that tells a platform team what routing actually saved them last month. We are choosing what to build from real workloads, so we are taking on a small number of design partners.
+
+If enough traffic runs through your gateway that a 40% to 65% cut is real money, we will sit down with your traffic mix, run this same evaluation against it, hand you the numbers, and ship the config that comes out of it.
+
+:::info Apply to be a design partner
+
+[Design partner application](https://cms49ctwm00026rv771kh8igo.zapier.app/application)
+
+:::

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -47,7 +47,11 @@ What counts as a pass depends on the dataset:
 | [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | real GitHub issues | LLM as judge, comparing the named files, functions, and diff sketch against the patch upstream actually merged |
 | [RouterArena](https://github.com/RouteWorks/RouterArena) | 9 domains, 44 categories | RouterArena's own evaluator scores each answer; about 74% of queries are multiple choice matched on a `\boxed{X}` letter, the rest use per-dataset scorers (numeric or exact match, text overlap, code checks) |
 
-Five of the six live-proxy datasets are graded against their own answer keys or test suites, so no model opinion is involved. SWE-bench Lite is the only judged slice, and since it drives most of the spread between models, every answer was judged twice, once by `claude-opus-5` and once by `gemini-3.6-flash`, to rule out self-preference. The Gemini judge is stricter in absolute terms (Auto Router 90.9%, baseline 94.1%) and leaves retention at 96.6%, so the ratio does not depend on the judge. The simulated legs have no answer key, so they report cost only.
+:::note
+
+SWE-bench Lite is the only slice scored by LLM as judge; everything else is checked against the dataset's own answer key or test suite. Every SWE-bench answer was judged twice, by `claude-opus-5` and by `gemini-3.6-flash`, and retention holds at 96.6% under the stricter judge.
+
+:::
 
 ## Where the savings come from, and what they cost
 

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -106,4 +106,4 @@ model_list:
       complexity_router_default_model: claude-sonnet-5
 ```
 
-Point a client at `smart-router` and every response carries `x-litellm-model-name` and `x-litellm-response-cost`, which is all the instrumentation this study needed. The heuristic classifier above is not the ceiling: switching to `classifier_type: llm`, where `claude-haiku-4-5` reads each prompt and picks the tier, scored about five accuracy points higher in our offline comparison, at roughly 2.5x the spend. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).
+Point a client at `smart-router` and every response carries `x-litellm-model-name` and `x-litellm-response-cost`, which is all the instrumentation this study needed. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -4,13 +4,13 @@ title: "Benchmarking Auto Router: 40-75% cheaper at 87-97% of frontier quality"
 date: 2026-07-27T10:00:00
 authors:
   - tin
-description: "Two independent evaluations of a three-tier Auto Router config against an all-frontier baseline: 8,619 graded prompts, 14,000 simulated real conversations, and what the cost and quality numbers actually depend on."
+description: "Two independent evaluations of a four-tier Auto Router config against an all-frontier baseline: 8,619 graded prompts, 14,000 simulated real conversations, and what the cost and quality numbers actually depend on."
 keywords: [llm router benchmark, auto router, complexity router, llm cost savings, model routing, claude cost optimization, routerarena, litellm auto routing, cheaper llm inference]
 tags: [routing, complexity-router, cost, benchmarks, engineering]
 hide_table_of_contents: false
 ---
 
-Auto routing is the cheapest cost lever on an AI gateway to turn on and the hardest one to trust. Sending every request to a frontier model has a known bill and known quality; sending some of them to a smaller model has an obvious bill and an unknown quality cost. So we measured it, twice, on a three-tier Claude configuration against a baseline of routing everything to `claude-opus-5`.
+Auto routing is the cheapest cost lever on an AI gateway to turn on and the hardest one to trust. Sending every request to a frontier model has a known bill and known quality; sending some of them to a smaller model has an obvious bill and an unknown quality cost. So we measured it, twice, on a four-tier Claude configuration against a baseline of routing everything to `claude-opus-5`.
 
 Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut cost by **40.4%** on one evaluation and **74.5%** on the other, while retaining **97.1%** and **87.3%** of the baseline's answer quality. On simulations over 14,000 real conversations, savings land at roughly **65%**. The spread between those numbers is the interesting part, and it is almost entirely explained by how much of the traffic is genuinely simple.
 
@@ -18,21 +18,25 @@ Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut co
 
 ## The results
 
-| Evaluation | Prompts | Quality retained | Cost savings | Router routing mix (haiku/sonnet/opus) |
+| Evaluation | Sample | Quality retained vs Opus-5 | Cost savings vs Opus-5 | Routing mix (haiku/sonnet/opus) |
 | --- | --- | --- | --- | --- |
-| Live proxy, six public benchmarks | 220 | **97.1%** (91.8% vs 94.5% pass) | **40.4%** ($10.47 vs $17.57 per 1k) | 27% / 70% / 3% |
-| RouterArena full set, paired | 8,399 | **87.3%** (68.6% vs 78.5% accuracy) | **74.5%** ($2.15 vs $8.45 per 1k) | 79% / 17% / 4% |
-| Real-traffic simulation, WildChat + DevGPT | 14,056 conversations | not measured | **~65%** | 48-76% simple |
+| Live proxy, six public benchmarks | 220 prompts | **97.1%** (Auto Router 91.8% pass, Opus-5 94.5%) | **40.4%** (Auto Router $10.47 / 1k, Opus-5 $17.57) | 27% / 70% / 3% |
+| [RouterArena](https://github.com/RouteWorks/RouterArena) full set, paired | 8,399 prompts | **87.3%** (Auto Router 68.6% accuracy, Opus-5 78.5%) | **74.5%** (Auto Router $2.15 / 1k, Opus-5 $8.45) | 79% / 17% / 4% |
+| Simulation, general consumer chat ([WildChat-1M](https://huggingface.co/datasets/allenai/WildChat-1M)) | 12,000 conversations | not measured | **64.9%** | 76% / 14% / 10% |
+| Simulation, developer chat ([DevGPT](https://github.com/NAIST-SE/DevGPT)) | 2,056 conversations | not measured | **65.4%** | 48% / 27% / 25% |
+| Simulation, code-in-prompt heavy ([WildChat](https://huggingface.co/datasets/allenai/WildChat-1M) code-filtered) | 993 conversations | not measured | **20.0%** | 13% / 34% / 53% |
 
 The first leg ran through a live LiteLLM proxy on `localhost:4000`, 440 real requests to `POST /v1/chat/completions`, with per-request cost read from the `x-litellm-response-cost` header and the routed model read from `x-litellm-model-name`. Five of the six datasets are graded objectively against their own answer keys or test suites; only [SWE-bench Lite](https://www.swebench.com/) needs a judge, and every SWE-bench answer was judged twice, once by `claude-opus-5` and once by `gemini-3.6-flash`, to rule out self-preference. The second judge is stricter in absolute terms and leaves the retention ratio effectively unchanged at 96.6%.
 
 The second leg ran the full 8,400-query set from [RouterArena](https://github.com/RouteWorks/RouterArena), the public router benchmark, paired against an all-Opus arm on the same queries with RouterArena's own automated evaluator.
 
-The two legs disagree on both axes, and they disagree for one reason. The heuristic classifier keys mostly off length, code presence, and reasoning markers, so RouterArena's short academic questions score SIMPLE and 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers. Both numbers are real, and which one resembles your bill depends entirely on your traffic.
+The last three rows are cost-only simulations over real conversations, classifying the first user turn and pinning that model for the rest of the conversation the way `session_affinity` does. Neither corpus has an answer key, so quality is not measured there. Two very different populations both land near 65%, because in both cases roughly half to three quarters of requests are short enough that a frontier model is wasted on them; the code-filtered slice sets the floor at 20%.
+
+The two graded legs disagree on both axes, and they disagree for one reason. The heuristic classifier keys mostly off length, code presence, and reasoning markers, so RouterArena's short academic questions score SIMPLE and 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers. Both numbers are real, and which one resembles your bill depends entirely on your traffic.
 
 ## How it was measured
 
-One model group over a three-model Claude pool (`claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-5`), classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING pinned to the same model as COMPLEX because Opus 5 already thinks by default. The full config is at the bottom of this post. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
+One model group with four tiers, SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, and COMPLEX and REASONING both to `claude-opus-5`, classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING shares a model with COMPLEX because Opus 5 already thinks by default. The full config is at the bottom of this post. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
 
 Quality retained is the ratio of the two pass rates, `pass(router) / pass(baseline)`. Cost savings is `1 - cost(router) / cost(baseline)`, computed from actual measured token usage on every request rather than from estimates.
 
@@ -42,12 +46,12 @@ Per-dataset, from the live-proxy leg:
 
 | Dataset | Auto Router pass | Opus-5 pass | Auto Router $/1k | Opus-5 $/1k | Savings |
 | --- | --- | --- | --- | --- | --- |
-| GSM8K | 98% (39/40) | 98% (39/40) | 1.08 | 5.68 | 81% |
-| HumanEval | 100% (40/40) | 98% (39/40) | 2.85 | 8.16 | 65% |
-| MMLU-Pro | 85% (34/40) | 88% (35/40) | 4.21 | 11.70 | 64% |
-| MATH-500 | 90% (36/40) | 98% (39/40) | 5.70 | 13.16 | 57% |
-| MBPP | 95% (38/40) | 98% (39/40) | 2.20 | 5.01 | 56% |
-| SWE-bench Lite | 75% (15/20) | 85% (17/20) | 83.08 | 105.83 | 21% |
+| [GSM8K](https://huggingface.co/datasets/openai/gsm8k) | 98% (39/40) | 98% (39/40) | 1.08 | 5.68 | 81% |
+| [HumanEval](https://huggingface.co/datasets/openai/openai_humaneval) | 100% (40/40) | 98% (39/40) | 2.85 | 8.16 | 65% |
+| [MMLU-Pro](https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro) | 85% (34/40) | 88% (35/40) | 4.21 | 11.70 | 64% |
+| [MATH-500](https://huggingface.co/datasets/HuggingFaceH4/MATH-500) | 90% (36/40) | 98% (39/40) | 5.70 | 13.16 | 57% |
+| [MBPP](https://huggingface.co/datasets/google-research-datasets/mbpp) | 95% (38/40) | 98% (39/40) | 2.20 | 5.01 | 56% |
+| [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | 75% (15/20) | 85% (17/20) | 83.08 | 105.83 | 21% |
 | **Blended** | **91.8%** | **94.5%** | **10.47** | **17.57** | **40%** |
 
 The split runs opposite to intuition. Short, cheap traffic saves the most at no measurable quality cost: grade-school math is identical at a fifth of the price, and HumanEval came out one prompt ahead of the frontier baseline. Repo-level work saves the least, because those prompts are long enough to dominate absolute spend and the classifier correctly declines to send them to Haiku. The two places quality is actually given up are MATH-500, where Haiku took 19 of the 40 prompts and the arm finished three behind the baseline, and SWE-bench Lite.
@@ -74,29 +78,13 @@ Three things fall out of that table. A trained BERT router beats the free keywor
 
 The weak spot in today's heuristic is stability. On RouterArena's robustness metric it picks the same model for only 50.7% of paraphrased queries, though 85% of the flips are upward, so the failure mode is paying too much rather than answering badly. Embedding-based classification largely fixes this, and it is the next thing we want to measure.
 
-## What to expect on production traffic
-
-Benchmark prompts are deliberately difficulty-dense, so the third leg simulated the same router over real conversations, classifying the first user turn and pinning that model for the whole conversation the way `session_affinity` does:
-
-| Traffic | Sample | Tier split (simple/medium/complex) | Savings vs all-Opus-5 |
-| --- | --- | --- | --- |
-| General consumer chat | WildChat-1M, 12,000 conversations | 76 / 14 / 10 | **64.9%** |
-| Developer chat | DevGPT, 2,056 conversations | 48 / 27 / 25 | **65.4%** |
-| Code-in-prompt heavy | WildChat code-filtered, 993 conversations | 13 / 34 / 53 | 20.0% |
-
-Two very different populations both land near 65%, because in both cases roughly half to three quarters of requests are short enough that a frontier model is wasted on them. The honest range is 20% at the most code-saturated end to 75% at the shortest-query end, centered around 65% for ordinary chat and developer traffic.
-
-## Keeping the numbers honest
-
-The 220-prompt leg is small enough that differences under about five points are sampling noise, and it ran one sample per prompt with no tool use, no system prompts, and no prompt caching. Quality was measured only on ground-truth-checkable benchmark traffic, which is the defensible floor rather than the expected case; on production-shaped traffic where most requests are genuinely easy, retention should be higher, but nothing here measures that directly because WildChat and DevGPT have no answer key. The real-traffic legs estimate tokens as characters divided by four and do not model prompt caching, and the benchmark legs price Sonnet 5 at list ($3/$15) rather than the introductory rate, which moves savings by one to two points.
-
-Savings are always measured against routing everything to `claude-opus-5`, so they describe what routing recovers from an all-frontier workload rather than what it does against a pool you have already tuned by hand.
-
-One upstream finding is worth passing on to anyone else benchmarking on RouterArena. Its Anthropic handler read `response.content[0]` only, so a model that returns a thinking block first, which Opus 5 does by default, was graded on a stringified `ThinkingBlock` and scored near zero. Our fork joins the text blocks instead, and any existing Claude entry on the public leaderboard is likely depressed by this until the same fix lands upstream.
-
 ## Try it
 
+:::info
+
 If this is interesting, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application). Try it yourself with the configuration below, and post any feedback, questions, or numbers from your own traffic on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
+
+:::
 
 ```yaml title="config.yaml"
 model_list:

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -28,21 +28,26 @@ Auto routing promises a smaller bill without a worse answer. We measured both ha
 | Simulation, developer chat ([DevGPT](https://github.com/NAIST-SE/DevGPT)) | 2,056 conversations | not measured | **65.4%** | 48% / 27% / 25% |
 | Simulation, code-in-prompt heavy ([WildChat](https://huggingface.co/datasets/allenai/WildChat-1M) code-filtered) | 993 conversations | not measured | **20.0%** | 13% / 34% / 53% |
 
-How each leg ran:
-
-- **Live proxy:** 440 real requests to `POST /v1/chat/completions`, per-request cost read from the `x-litellm-response-cost` header and the routed model from `x-litellm-model-name`
-- **Grading:** five of the six datasets score against their own answer keys or test suites; only [SWE-bench Lite](https://www.swebench.com/) needs a judge, so every SWE-bench answer was judged twice, by `claude-opus-5` and by `gemini-3.6-flash`, to rule out self-preference. The stricter judge leaves retention at 96.6%
-- **RouterArena:** the full 8,400-query set, paired against an all-Opus arm on the same queries and scored by RouterArena's own evaluator
-- **Simulations:** cost-only replays over real conversations, classifying the first user turn and pinning that model for the rest of the conversation the way `session_affinity` does. Neither corpus has an answer key, so quality is not measured there
-
-The two graded legs disagree because the heuristic classifier keys off length, code presence, and reasoning markers. RouterArena's short academic questions score SIMPLE, so 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers, and which number resembles your bill depends on your traffic.
-
 ## How it was measured
 
 - **Router arm:** one model group, four tiers. SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, COMPLEX and REASONING both to `claude-opus-5`, since Opus 5 already thinks by default. Heuristic classifier, no keyword rules, no adaptive sampling
 - **Baseline arm:** the same prompts sent straight to `claude-opus-5`, which is what most teams do today when they point a workload at one frontier model
-- **Quality retained:** `pass(router) / pass(baseline)`, with identical prompts and grader on both arms, so grader quirks largely cancel
-- **Cost savings:** `1 - cost(router) / cost(baseline)`, from measured token usage on every request rather than estimates
+- **Cost savings:** `1 - cost(router) / cost(baseline)`. On the live-proxy leg, each of the 440 requests reports its own cost in the `x-litellm-response-cost` header, which is LiteLLM's calculation over the usage Anthropic actually returned, including reasoning tokens. RouterArena costs come from measured token usage priced at list rates; the simulations estimate tokens from the conversation text
+- **Quality retained:** `pass(router) / pass(baseline)`, one pooled rate over all prompts with no partial credit and no per-dataset weighting, with identical prompts and grading on both arms so grader quirks largely cancel
+
+What counts as a pass depends on the dataset:
+
+| Dataset | What it tests | How a pass is decided |
+| --- | --- | --- |
+| [HumanEval](https://huggingface.co/datasets/openai/openai_humaneval) | code generation | the dataset's own unit tests run in a subprocess; pass only if every official assert passes |
+| [MBPP](https://huggingface.co/datasets/google-research-datasets/mbpp) | code generation | same, the dataset's official assertion tests are executed |
+| [GSM8K](https://huggingface.co/datasets/openai/gsm8k) | grade-school math | exact match on the extracted final number |
+| [MATH-500](https://huggingface.co/datasets/HuggingFaceH4/MATH-500) | competition math | LaTeX normalisation, then numeric comparison, then a SymPy equivalence fallback |
+| [MMLU-Pro](https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro) | 10-way multiple choice | exact match on the final answer letter |
+| [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | real GitHub issues | LLM as judge, comparing the named files, functions, and diff sketch against the patch upstream actually merged |
+| [RouterArena](https://github.com/RouteWorks/RouterArena) | 9 domains, 44 categories | RouterArena's own evaluator scores each answer; about 74% of queries are multiple choice matched on a `\boxed{X}` letter, the rest use per-dataset scorers (numeric or exact match, text overlap, code checks) |
+
+Five of the six live-proxy datasets are graded against their own answer keys or test suites, so no model opinion is involved. SWE-bench Lite is the only judged slice, and since it drives most of the spread between models, every answer was judged twice, once by `claude-opus-5` and once by `gemini-3.6-flash`, to rule out self-preference. The Gemini judge is stricter in absolute terms (Auto Router 90.9%, baseline 94.1%) and leaves retention at 96.6%, so the ratio does not depend on the judge. The simulated legs have no answer key, so they report cost only.
 
 ## Where the savings come from, and what they cost
 

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -10,13 +10,15 @@ tags: [routing, complexity-router, cost, benchmarks, engineering]
 hide_table_of_contents: false
 ---
 
-Auto routing is the cheapest cost lever on an AI gateway to turn on and the hardest one to trust. Sending every request to a frontier model has a known bill and known quality; sending some of them to a smaller model has an obvious bill and an unknown quality cost. So we measured it, twice, on a four-tier Claude configuration against a baseline of routing everything to `claude-opus-5`.
-
-Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut cost by **40.4%** on one evaluation and **74.5%** on the other, while retaining **97.1%** and **87.3%** of the baseline's answer quality. On simulations over 14,000 real conversations, savings land at roughly **65%**. The spread between those numbers is the interesting part, and it is almost entirely explained by how much of the traffic is genuinely simple.
+Auto routing promises a smaller bill without a worse answer. We measured both halves against a baseline that sends every request to `claude-opus-5`: 8,619 graded prompts, about $111 of real API spend, and cost simulations over 14,000 real conversations.
 
 {/* truncate */}
 
 ## The results
+
+- **40.4% cheaper at 97.1% of frontier quality**, on 220 prompts from six public benchmarks replayed through a live proxy
+- **74.5% cheaper at 87.3% of frontier quality**, on RouterArena's full 8,399-query set
+- **Around 65% cheaper** on simulated real chat and developer traffic, where most requests are short
 
 | Evaluation | Sample | Quality retained vs Opus-5 | Cost savings vs Opus-5 | Routing mix (haiku/sonnet/opus) |
 | --- | --- | --- | --- | --- |
@@ -26,23 +28,23 @@ Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut co
 | Simulation, developer chat ([DevGPT](https://github.com/NAIST-SE/DevGPT)) | 2,056 conversations | not measured | **65.4%** | 48% / 27% / 25% |
 | Simulation, code-in-prompt heavy ([WildChat](https://huggingface.co/datasets/allenai/WildChat-1M) code-filtered) | 993 conversations | not measured | **20.0%** | 13% / 34% / 53% |
 
-The first leg ran through a live LiteLLM proxy on `localhost:4000`, 440 real requests to `POST /v1/chat/completions`, with per-request cost read from the `x-litellm-response-cost` header and the routed model read from `x-litellm-model-name`. Five of the six datasets are graded objectively against their own answer keys or test suites; only [SWE-bench Lite](https://www.swebench.com/) needs a judge, and every SWE-bench answer was judged twice, once by `claude-opus-5` and once by `gemini-3.6-flash`, to rule out self-preference. The second judge is stricter in absolute terms and leaves the retention ratio effectively unchanged at 96.6%.
+How each leg ran:
 
-The second leg ran the full 8,400-query set from [RouterArena](https://github.com/RouteWorks/RouterArena), the public router benchmark, paired against an all-Opus arm on the same queries with RouterArena's own automated evaluator.
+- **Live proxy:** 440 real requests to `POST /v1/chat/completions`, per-request cost read from the `x-litellm-response-cost` header and the routed model from `x-litellm-model-name`
+- **Grading:** five of the six datasets score against their own answer keys or test suites; only [SWE-bench Lite](https://www.swebench.com/) needs a judge, so every SWE-bench answer was judged twice, by `claude-opus-5` and by `gemini-3.6-flash`, to rule out self-preference. The stricter judge leaves retention at 96.6%
+- **RouterArena:** the full 8,400-query set, paired against an all-Opus arm on the same queries and scored by RouterArena's own evaluator
+- **Simulations:** cost-only replays over real conversations, classifying the first user turn and pinning that model for the rest of the conversation the way `session_affinity` does. Neither corpus has an answer key, so quality is not measured there
 
-The last three rows are cost-only simulations over real conversations, classifying the first user turn and pinning that model for the rest of the conversation the way `session_affinity` does. Neither corpus has an answer key, so quality is not measured there. Two very different populations both land near 65%, because in both cases roughly half to three quarters of requests are short enough that a frontier model is wasted on them; the code-filtered slice sets the floor at 20%.
-
-The two graded legs disagree on both axes, and they disagree for one reason. The heuristic classifier keys mostly off length, code presence, and reasoning markers, so RouterArena's short academic questions score SIMPLE and 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers. Both numbers are real, and which one resembles your bill depends entirely on your traffic.
+The two graded legs disagree because the heuristic classifier keys off length, code presence, and reasoning markers. RouterArena's short academic questions score SIMPLE, so 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers, and which number resembles your bill depends on your traffic.
 
 ## How it was measured
 
-One model group with four tiers, SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, and COMPLEX and REASONING both to `claude-opus-5`, classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING shares a model with COMPLEX because Opus 5 already thinks by default. The full config is at the bottom of this post. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
-
-Quality retained is the ratio of the two pass rates, `pass(router) / pass(baseline)`. Cost savings is `1 - cost(router) / cost(baseline)`, computed from actual measured token usage on every request rather than from estimates.
+- **Router arm:** one model group, four tiers. SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, COMPLEX and REASONING both to `claude-opus-5`, since Opus 5 already thinks by default. Heuristic classifier, no keyword rules, no adaptive sampling
+- **Baseline arm:** the same prompts sent straight to `claude-opus-5`, which is what most teams do today when they point a workload at one frontier model
+- **Quality retained:** `pass(router) / pass(baseline)`, with identical prompts and grader on both arms, so grader quirks largely cancel
+- **Cost savings:** `1 - cost(router) / cost(baseline)`, from measured token usage on every request rather than estimates
 
 ## Where the savings come from, and what they cost
-
-Per-dataset, from the live-proxy leg:
 
 | Dataset | Auto Router pass | Opus-5 pass | Auto Router $/1k | Opus-5 $/1k | Savings |
 | --- | --- | --- | --- | --- | --- |
@@ -54,13 +56,17 @@ Per-dataset, from the live-proxy leg:
 | [SWE-bench Lite](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Lite) | 75% (15/20) | 85% (17/20) | 83.08 | 105.83 | 21% |
 | **Blended** | **91.8%** | **94.5%** | **10.47** | **17.57** | **40%** |
 
-The split runs opposite to intuition. Short, cheap traffic saves the most at no measurable quality cost: grade-school math is identical at a fifth of the price, and HumanEval came out one prompt ahead of the frontier baseline. Repo-level work saves the least, because those prompts are long enough to dominate absolute spend and the classifier correctly declines to send them to Haiku. The two places quality is actually given up are MATH-500, where Haiku took 19 of the 40 prompts and the arm finished three behind the baseline, and SWE-bench Lite.
+The split runs opposite to intuition:
 
-That also sets the ceiling on what routing can do for a coding-agent workload. If nearly every request carries a large repo context, there is no cheap tier to route it to, and the lever to reach for is [prompt caching or compression](/blog/save-claude-code-costs-with-litellm) rather than model selection.
+- **Short, cheap traffic saves the most at no quality cost.** GSM8K is identical at a fifth of the price, and HumanEval came out one prompt ahead of the frontier baseline
+- **Repo-level work saves the least.** Those prompts are long enough to dominate absolute spend, and the classifier correctly declines to send them to Haiku
+- **Quality is given up in two places.** MATH-500, where Haiku took 19 of the 40 prompts and the arm finished three behind, and SWE-bench Lite
+
+If nearly every request carries a large repo context, there is no cheap tier to route it to, and the lever to reach for is [prompt caching or compression](/blog/save-claude-code-costs-with-litellm) rather than model selection.
 
 ## The classifier is the dial
 
-Cost and quality trade against each other through one component, so we put four classifiers on the same three-model pool and scored them offline against a fully graded 809-query grid, alongside a trained router and a cheapest-correct oracle:
+Four classifiers on the same three-model pool, scored offline against a fully graded 809-query grid, alongside a trained router and a cheapest-correct oracle:
 
 | Policy | Accuracy | Cost/1k | haiku/sonnet/opus |
 | --- | --- | --- | --- |
@@ -74,9 +80,10 @@ Cost and quality trade against each other through one component, so we put four 
 | All-Opus-5 | 80.6% | $8.38 | 0/0/100 |
 | Oracle (cheapest correct model) | 85.7% | $2.25 | n/a |
 
-Three things fall out of that table. A trained BERT router beats the free keyword heuristic by only 1.3 points at a matched budget, which is a small return for a model artifact you have to host and retrain. Setting `classifier_type: llm` with a Haiku classifier ties the trained router at a matched budget, so the cheapest path to a better router is a small model reading the prompt rather than a bespoke trained one. And the oracle beats all-Opus at roughly a quarter of its cost, so the model pool is not the bottleneck; classification is, and there is a lot of headroom left in it.
-
-The weak spot in today's heuristic is stability. On RouterArena's robustness metric it picks the same model for only 50.7% of paraphrased queries, though 85% of the flips are upward, so the failure mode is paying too much rather than answering badly. Embedding-based classification largely fixes this, and it is the next thing we want to measure.
+- **A trained router buys 1.3 points.** RouteLLM's BERT classifier beats the free keyword heuristic by that much at a matched budget, a small return for a model artifact you have to host and retrain
+- **An LLM classifier ties it.** `classifier_type: llm` with Haiku matches the trained router at a matched budget, so the cheapest path to a better router is a small model reading the prompt
+- **Classification is the bottleneck, not the pool.** The oracle beats all-Opus at roughly a quarter of its cost, so the headroom is in picking better, not in adding models
+- **The heuristic is unstable under paraphrase.** It picks the same model for only 50.7% of reworded queries, though 85% of the flips are upward, so the failure mode is paying too much rather than answering badly
 
 ## Try it
 

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -16,43 +16,7 @@ Across 8,619 graded prompts and about $111 of real API spend, Auto Router cut co
 
 {/* truncate */}
 
-## What was measured
-
-We tested our auto-router using this configuration:
-
-```yaml title="config.yaml"
-model_list:
-  - model_name: claude-haiku-4-5           # $1 / $5 per 1M tokens
-    litellm_params:
-      model: anthropic/claude-haiku-4-5
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-sonnet-5            # $3 / $15
-    litellm_params:
-      model: anthropic/claude-sonnet-5
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-opus-5              # $5 / $25
-    litellm_params:
-      model: anthropic/claude-opus-5
-      api_key: os.environ/ANTHROPIC_API_KEY
-
-  - model_name: smart-router
-    litellm_params:
-      model: auto_router/complexity_router
-      complexity_router_config:
-        tiers:
-          SIMPLE:    claude-haiku-4-5
-          MEDIUM:    claude-sonnet-5
-          COMPLEX:   claude-opus-5
-          REASONING: claude-opus-5
-        classifier_type: heuristic         # local scoring, sub-millisecond, no API call
-      complexity_router_default_model: claude-sonnet-5
-```
-
-One model group over a three-model Claude pool, classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING pinned to the same model as COMPLEX because Opus 5 already thinks by default. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
-
-Quality retained is the ratio of the two pass rates, `pass(router) / pass(baseline)`. Cost savings is `1 - cost(router) / cost(baseline)`, computed from actual measured token usage on every request rather than from estimates.
-
-## Results
+## The results
 
 | Evaluation | Prompts | Quality retained | Cost savings | Router routing mix (haiku/sonnet/opus) |
 | --- | --- | --- | --- | --- |
@@ -65,6 +29,12 @@ The first leg ran through a live LiteLLM proxy on `localhost:4000`, 440 real req
 The second leg ran the full 8,400-query set from [RouterArena](https://github.com/RouteWorks/RouterArena), the public router benchmark, paired against an all-Opus arm on the same queries with RouterArena's own automated evaluator.
 
 The two legs disagree on both axes, and they disagree for one reason. The heuristic classifier keys mostly off length, code presence, and reasoning markers, so RouterArena's short academic questions score SIMPLE and 79% of them go to Haiku; the benchmark set with HumanEval, MBPP, and SWE-bench in it reads as code, so 70% goes to Sonnet 5. More Haiku means more savings and more missed answers. Both numbers are real, and which one resembles your bill depends entirely on your traffic.
+
+## How it was measured
+
+One model group over a three-model Claude pool (`claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-5`), classified by the heuristic scorer. No keyword rules, no LLM classifier, no adaptive sampling, and REASONING pinned to the same model as COMPLEX because Opus 5 already thinks by default. The full config is at the bottom of this post. The baseline arm sends the identical prompts to `claude-opus-5` directly, which is what most teams do today when they point a workload at one frontier model. Both arms use the same prompts, the same request format, and the same grader, so grader quirks affect both sides and largely cancel in the ratio.
+
+Quality retained is the ratio of the two pass rates, `pass(router) / pass(baseline)`. Cost savings is `1 - cost(router) / cost(baseline)`, computed from actual measured token usage on every request rather than from estimates.
 
 ## Where the savings come from, and what they cost
 
@@ -126,10 +96,34 @@ One upstream finding is worth passing on to anyone else benchmarking on RouterAr
 
 ## Try it
 
-The config above is the whole setup; drop it into `config.yaml` and point a client at `smart-router`. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).
+If this is interesting, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application). Try it yourself with the configuration below, and post any feedback, questions, or numbers from your own traffic on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
 
-:::info
+```yaml title="config.yaml"
+model_list:
+  - model_name: claude-haiku-4-5           # $1 / $5 per 1M tokens
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-sonnet-5            # $3 / $15
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-5              # $5 / $25
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
 
-If this is interesting, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application). Feedback, questions, and numbers from your own traffic go on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE:    claude-haiku-4-5
+          MEDIUM:    claude-sonnet-5
+          COMPLEX:   claude-opus-5
+          REASONING: claude-opus-5
+        classifier_type: heuristic         # local scoring, sub-millisecond, no API call
+      complexity_router_default_model: claude-sonnet-5
+```
 
-:::
+Point a client at `smart-router` and every response carries `x-litellm-model-name` and `x-litellm-response-cost`, which is all the instrumentation this study needed. Full reference, including the classifier and tier-boundary knobs, on the [Auto Routing docs page](/docs/proxy/auto_routing).

--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -32,8 +32,8 @@ Auto routing promises a smaller bill without a worse answer. We measured both ha
 
 - **Router arm:** one model group, four tiers. SIMPLE to `claude-haiku-4-5`, MEDIUM to `claude-sonnet-5`, COMPLEX and REASONING both to `claude-opus-5`, since Opus 5 already thinks by default. Heuristic classifier, no keyword rules, no adaptive sampling
 - **Baseline arm:** the same prompts sent straight to `claude-opus-5`, which is what most teams do today when they point a workload at one frontier model
-- **Cost savings:** `1 - cost(router) / cost(baseline)`. On the live-proxy leg, each of the 440 requests reports its own cost in the `x-litellm-response-cost` header, which is LiteLLM's calculation over the usage Anthropic actually returned, including reasoning tokens. RouterArena costs come from measured token usage priced at list rates; the simulations estimate tokens from the conversation text
-- **Quality retained:** `pass(router) / pass(baseline)`, one pooled rate over all prompts with no partial credit and no per-dataset weighting, with identical prompts and grading on both arms so grader quirks largely cancel
+- **Cost savings:** `1 - cost(router) / cost(baseline)`, from measured token usage. The live-proxy leg reads each request's cost off the `x-litellm-response-cost` header; the simulations estimate tokens from conversation text
+- **Quality retained:** `pass(router) / pass(baseline)`, one pooled rate with no partial credit, identical prompts and grader on both arms
 
 What counts as a pass:
 


### PR DESCRIPTION
Adds a blog post publishing the results of our Auto Router evaluation, at `/blog/auto-router-cost-quality-benchmark`.

## What it covers

Two evaluations of a four-tier Claude config (`claude-haiku-4-5` / `claude-sonnet-5` / `claude-opus-5` on `auto_router/complexity_router`, heuristic classifier) against a baseline that sends everything to `claude-opus-5`, plus cost simulations over real conversation traffic:

| Evaluation | Sample | Quality retained | Cost savings |
| --- | --- | --- | --- |
| Live proxy, six public benchmarks | 220 prompts | 97.1% | 40.4% |
| RouterArena full set, paired | 8,399 prompts | 87.3% | 74.5% |
| Simulations (WildChat, DevGPT) | 15,049 conversations | not measured | 20.0% to 65.4% |

The post is four sections: the results, how it was measured (including how a pass is decided per dataset and which slice used an LLM judge), a per-dataset breakdown of where the savings come from and what they cost, and a config to copy with a design-partner call to action.

Author entry for `tin` also updated from "MCP Eng" to "AI Engineer, LiteLLM".

## Verification

`npm run build` passes. The page renders at `/blog/auto-router-cost-quality-benchmark` with no build warnings attributable to it; the only warnings in the log are pre-existing broken anchors on old release-note pages. Every external dataset link (Hugging Face, RouterArena, DevGPT) was checked to resolve 200.
