### PR TITLE
docs(github-copilot): document configurable OAuth flow

### DIFF
--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -203,10 +203,13 @@ The token storage and endpoint settings are also configurable
 ```bash showLineNumbers title="Environment Variables"
 export GITHUB_COPILOT_TOKEN_DIR="~/.config/litellm/github_copilot"
 export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
+export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
 export GITHUB_COPILOT_API_BASE="https://copilot-api.example.com"
 export GITHUB_COPILOT_DEVICE_CODE_URL="https://github.example.com/login/device/code"
 export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://github.example.com/login/oauth/access_token"
 ```
+
+For compatibility with existing installations, when `GITHUB_COPILOT_API_BASE` is unset LiteLLM reads only `endpoints.api` from the legacy `api-key.json`. The cached exchanged token is ignored. `GITHUB_COPILOT_API_KEY_FILE` can locate a renamed legacy file. `GITHUB_COPILOT_API_KEY_URL` is no longer used and emits a warning when set
 
 For the proxy, put the same values in the `environment_variables` block
 

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -186,6 +186,7 @@ LiteLLM reads GitHub Copilot settings from the environment when each request is 
 | Variable | Default | Purpose |
 |---|---|---|
 | `GITHUB_COPILOT_CLIENT_ID` | `Iv1.b507a08c87ecfe98` | OAuth application client ID |
+| `GITHUB_COPILOT_USE_OAUTH_TOKEN` | Not set | Use the OAuth access token directly instead of exchanging it at `/copilot_internal/v2/token` |
 | `GITHUB_COPILOT_INTEGRATION_ID` | `vscode-chat` | `copilot-integration-id` header |
 | `GITHUB_COPILOT_EDITOR_VERSION` | `vscode/1.115.0` | `editor-version` header |
 | `GITHUB_COPILOT_EDITOR_PLUGIN_VERSION` | `copilot-chat/0.44.0` | `editor-plugin-version` header |
@@ -219,6 +220,18 @@ environment_variables:
   GITHUB_COPILOT_EDITOR_VERSION: "your-editor/1.0.0"
   GITHUB_COPILOT_EDITOR_PLUGIN_VERSION: "your-plugin/1.0.0"
   GITHUB_COPILOT_USER_AGENT: "YourClient/1.0.0"
+```
+
+OAuth clients that use their access token directly, such as OpenCode, must enable direct OAuth mode and omit the VS Code identity headers
+
+```yaml showLineNumbers title="OpenCode OAuth Identity"
+environment_variables:
+  GITHUB_COPILOT_CLIENT_ID: "Ov23li8tweQw6odWQebz"
+  GITHUB_COPILOT_USER_AGENT: "opencode/1.18.7"
+  GITHUB_COPILOT_INTEGRATION_ID: ""
+  GITHUB_COPILOT_EDITOR_VERSION: ""
+  GITHUB_COPILOT_EDITOR_PLUGIN_VERSION: ""
+  GITHUB_COPILOT_USE_OAUTH_TOKEN: "true"
 ```
 
 ### Request Headers

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -181,12 +181,11 @@ curl http://localhost:4000/v1/chat/completions \
 
 ### Environment Variables
 
-LiteLLM reads GitHub Copilot settings from the environment when each request is built. This also applies to the OAuth device-code, access-token, and Copilot token requests
+LiteLLM uses GitHub's OAuth device flow and sends the resulting access token directly to the trusted GitHub Copilot API base. Header and endpoint settings are read from the environment when each request is built
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `GITHUB_COPILOT_CLIENT_ID` | `Iv1.b507a08c87ecfe98` | OAuth application client ID |
-| `GITHUB_COPILOT_USE_OAUTH_TOKEN` | Not set | Use the OAuth access token directly instead of exchanging it at `/copilot_internal/v2/token` |
 | `GITHUB_COPILOT_INTEGRATION_ID` | `vscode-chat` | `copilot-integration-id` header |
 | `GITHUB_COPILOT_EDITOR_VERSION` | `vscode/1.115.0` | `editor-version` header |
 | `GITHUB_COPILOT_EDITOR_PLUGIN_VERSION` | `copilot-chat/0.44.0` | `editor-plugin-version` header |
@@ -204,11 +203,9 @@ The token storage and endpoint settings are also configurable
 ```bash showLineNumbers title="Environment Variables"
 export GITHUB_COPILOT_TOKEN_DIR="~/.config/litellm/github_copilot"
 export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
-export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
 export GITHUB_COPILOT_API_BASE="https://copilot-api.example.com"
 export GITHUB_COPILOT_DEVICE_CODE_URL="https://github.example.com/login/device/code"
 export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://github.example.com/login/oauth/access_token"
-export GITHUB_COPILOT_API_KEY_URL="https://github.example.com/api/v3/copilot_internal/v2/token"
 ```
 
 For the proxy, put the same values in the `environment_variables` block
@@ -222,16 +219,17 @@ environment_variables:
   GITHUB_COPILOT_USER_AGENT: "YourClient/1.0.0"
 ```
 
-OAuth clients that use their access token directly, such as OpenCode, must enable direct OAuth mode and omit the VS Code identity headers
+OAuth applications can provide their own client identity without selecting a token mode. For example, these values match OpenCode's OAuth behavior
 
-```yaml showLineNumbers title="OpenCode OAuth Identity"
+```yaml showLineNumbers title="Custom OAuth Application"
 environment_variables:
   GITHUB_COPILOT_CLIENT_ID: "Ov23li8tweQw6odWQebz"
-  GITHUB_COPILOT_USER_AGENT: "opencode/1.18.7"
+  GITHUB_COPILOT_USER_AGENT: "opencode/<installed-version>"
   GITHUB_COPILOT_INTEGRATION_ID: ""
   GITHUB_COPILOT_EDITOR_VERSION: ""
   GITHUB_COPILOT_EDITOR_PLUGIN_VERSION: ""
-  GITHUB_COPILOT_USE_OAUTH_TOKEN: "true"
+  GITHUB_COPILOT_API_VERSION: "2026-06-01"
+  GITHUB_COPILOT_OPENAI_INTENT: "conversation-edits"
 ```
 
 ### Request Headers

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -203,12 +203,12 @@ The token storage and endpoint settings are also configurable
 ```bash showLineNumbers title="Environment Variables"
 export GITHUB_COPILOT_TOKEN_DIR="~/.config/litellm/github_copilot"
 export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
-export GITHUB_COPILOT_API_BASE="https://copilot-api.example.com"
-export GITHUB_COPILOT_DEVICE_CODE_URL="https://github.example.com/login/device/code"
-export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+export GITHUB_COPILOT_API_BASE="https://copilot-api.company.ghe.com"
+export GITHUB_COPILOT_DEVICE_CODE_URL="https://company.ghe.com/login/device/code"
+export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://company.ghe.com/login/oauth/access_token"
 ```
 
-Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Set `GITHUB_COPILOT_API_BASE` for a custom or Enterprise endpoint; it must be an HTTPS URL without embedded credentials, query parameters, or fragments. When unset, LiteLLM uses `https://api.githubcopilot.com`
+Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Official `*.githubcopilot.com` endpoints are trusted automatically. Standard Enterprise Copilot subdomains are trusted when their parent OAuth host is configured through `GITHUB_COPILOT_DEVICE_CODE_URL` or `GITHUB_COPILOT_ACCESS_TOKEN_URL`. Add exact comma-separated hostnames to `GITHUB_COPILOT_ALLOWED_API_HOSTS` only for nonstandard reverse proxies. Environment and deployment-level API bases use the same trust checks and must use HTTPS without embedded credentials, query parameters, or fragments
 
 For the proxy, put the same values in the `environment_variables` block
 

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -196,7 +196,7 @@ LiteLLM uses GitHub's OAuth device flow and sends the resulting access token dir
 | `GITHUB_COPILOT_OPENAI_INTENT` | Not set | Optional `openai-intent` header |
 | `GITHUB_COPILOT_USER_AGENT_LIBRARY_VERSION` | Not set | Optional `x-vscode-user-agent-library-version` header |
 
-Set a header environment variable to an empty string to omit that header. Request-level `extra_headers` take precedence over these values for model requests. Authentication requests use the environment variables because `extra_headers` are not available during OAuth
+Set a header environment variable to an empty string to omit that header. Request-level `extra_headers` take precedence for model requests. OAuth requests use the configured accept, content type, integration, editor, plugin, and user-agent values. API version, intent, and user-agent library version apply only to model requests
 
 The token storage and endpoint settings are also configurable
 
@@ -222,7 +222,7 @@ environment_variables:
   GITHUB_COPILOT_USER_AGENT: "YourClient/1.0.0"
 ```
 
-OAuth applications can provide their own client identity without selecting a token mode. For example, these values match OpenCode's OAuth behavior
+OAuth applications use the same direct OAuth access-token flow and can provide their own client identity. For example, these values match OpenCode's OAuth behavior
 
 ```yaml showLineNumbers title="Custom OAuth Application"
 environment_variables:

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -203,13 +203,12 @@ The token storage and endpoint settings are also configurable
 ```bash showLineNumbers title="Environment Variables"
 export GITHUB_COPILOT_TOKEN_DIR="~/.config/litellm/github_copilot"
 export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
-export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
 export GITHUB_COPILOT_API_BASE="https://copilot-api.example.com"
 export GITHUB_COPILOT_DEVICE_CODE_URL="https://github.example.com/login/device/code"
 export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://github.example.com/login/oauth/access_token"
 ```
 
-For compatibility with existing installations, when `GITHUB_COPILOT_API_BASE` is unset LiteLLM reads only `endpoints.api` from the legacy `api-key.json`. The cached exchanged token is ignored. `GITHUB_COPILOT_API_KEY_FILE` can locate a renamed legacy file. `GITHUB_COPILOT_API_KEY_URL` is no longer used and emits a warning when set
+Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Set `GITHUB_COPILOT_API_BASE` for a custom or Enterprise endpoint; it must be an HTTPS URL without embedded credentials, query parameters, or fragments. When unset, LiteLLM uses `https://api.githubcopilot.com`
 
 For the proxy, put the same values in the `environment_variables` block
 

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -208,8 +208,7 @@ export GITHUB_COPILOT_DEVICE_CODE_URL="https://company.ghe.com/login/device/code
 export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://company.ghe.com/login/oauth/access_token"
 ```
 
-Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Official `*.githubcopilot.com` endpoints are trusted automatically. Standard Enterprise Copilot subdomains are trusted when their parent OAuth host is configured through `GITHUB_COPILOT_DEVICE_CODE_URL` or `GITHUB_COPILOT_ACCESS_TOKEN_URL`. Add exact comma-separated hostnames to `GITHUB_COPILOT_ALLOWED_API_HOSTS` only for nonstandard reverse proxies. Environment and deployment-level API bases use the same trust checks and must use HTTPS without embedded credentials, query parameters, or fragments
-
+Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Official `*.githubcopilot.com` endpoints are trusted automatically. Configuring an Enterprise OAuth host such as `company.ghe.com` trusts exactly `copilot-api.company.ghe.com`; other subdomains are not inferred. Add exact comma-separated hostnames to `GITHUB_COPILOT_ALLOWED_API_HOSTS` only for nonstandard reverse proxies. Environment and deployment-level API bases use the same trust checks and must use HTTPS without embedded credentials, query parameters, or fragments
 For the proxy, put the same values in the `environment_variables` block
 
 ```yaml showLineNumbers title="config.yaml"

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -181,38 +181,55 @@ curl http://localhost:4000/v1/chat/completions \
 
 ### Environment Variables
 
-You can customize token storage locations:
+LiteLLM reads GitHub Copilot settings from the environment when each request is built. This also applies to the OAuth device-code, access-token, and Copilot token requests
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GITHUB_COPILOT_CLIENT_ID` | `Iv1.b507a08c87ecfe98` | OAuth application client ID |
+| `GITHUB_COPILOT_INTEGRATION_ID` | `vscode-chat` | `copilot-integration-id` header |
+| `GITHUB_COPILOT_EDITOR_VERSION` | `vscode/1.115.0` | `editor-version` header |
+| `GITHUB_COPILOT_EDITOR_PLUGIN_VERSION` | `copilot-chat/0.44.0` | `editor-plugin-version` header |
+| `GITHUB_COPILOT_USER_AGENT` | `GitHubCopilotChat/0.44.0` | `user-agent` header |
+| `GITHUB_COPILOT_ACCEPT` | `application/json` | `accept` header |
+| `GITHUB_COPILOT_CONTENT_TYPE` | `application/json` | `content-type` header |
+| `GITHUB_COPILOT_API_VERSION` | Not set | Optional `x-github-api-version` header |
+| `GITHUB_COPILOT_OPENAI_INTENT` | Not set | Optional `openai-intent` header |
+| `GITHUB_COPILOT_USER_AGENT_LIBRARY_VERSION` | Not set | Optional `x-vscode-user-agent-library-version` header |
+
+Set a header environment variable to an empty string to omit that header. Request-level `extra_headers` take precedence over these values for model requests. Authentication requests use the environment variables because `extra_headers` are not available during OAuth
+
+The token storage and endpoint settings are also configurable
 
 ```bash showLineNumbers title="Environment Variables"
-# Optional: Custom token directory
 export GITHUB_COPILOT_TOKEN_DIR="~/.config/litellm/github_copilot"
-
-# Optional: Custom access token file name
 export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
-
-# Optional: Custom API key file name
 export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
-
-# Optional: Custom Copilot endpoints for authentication and usage
-# (needed when using GitHub Enterprise subscriptions with custom endpoints or self-hosted GitHub servers
-export GITHUB_COPILOT_API_BASE="https://copilot-api.my-company.ghe.com"
-export GITHUB_COPILOT_DEVICE_CODE_URL="https://my-company.ghe.com/login/device/code"
-export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://my-company.ghe.com/login/oauth/access_token"
-export GITHUB_COPILOT_API_KEY_URL="https://my-company.ghe.com/api/v3/copilot_internal/v2/token"
+export GITHUB_COPILOT_API_BASE="https://copilot-api.example.com"
+export GITHUB_COPILOT_DEVICE_CODE_URL="https://github.example.com/login/device/code"
+export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+export GITHUB_COPILOT_API_KEY_URL="https://github.example.com/api/v3/copilot_internal/v2/token"
 ```
 
-### Headers
+For the proxy, put the same values in the `environment_variables` block
 
-LiteLLM automatically injects the required GitHub Copilot headers (simulating VSCode). You don't need to specify them manually.
+```yaml showLineNumbers title="config.yaml"
+environment_variables:
+  GITHUB_COPILOT_CLIENT_ID: "your-oauth-client-id"
+  GITHUB_COPILOT_INTEGRATION_ID: "your-integration-id"
+  GITHUB_COPILOT_EDITOR_VERSION: "your-editor/1.0.0"
+  GITHUB_COPILOT_EDITOR_PLUGIN_VERSION: "your-plugin/1.0.0"
+  GITHUB_COPILOT_USER_AGENT: "YourClient/1.0.0"
+```
 
-If you want to override the defaults (e.g., to simulate a different editor), you can use `extra_headers`:
+### Request Headers
 
-```python showLineNumbers title="Custom Headers (Optional)"
-extra_headers = {
-    "editor-version": "vscode/1.85.1",           # Editor version
-    "editor-plugin-version": "copilot/1.155.0",  # Plugin version
-    "Copilot-Integration-Id": "vscode-chat",     # Integration ID
-    "user-agent": "GithubCopilot/1.155.0"        # User agent
-}
+Use `extra_headers` when a single model request needs additional headers or must override the environment defaults
+
+```python showLineNumbers title="Custom Request Headers"
+response = completion(
+    model="github_copilot/gpt-4",
+    messages=[{"role": "user", "content": "Hello"}],
+    extra_headers={"editor-version": "custom-editor/2.0.0"},
+)
 ```
 

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -208,7 +208,7 @@ export GITHUB_COPILOT_DEVICE_CODE_URL="https://company.ghe.com/login/device/code
 export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://company.ghe.com/login/oauth/access_token"
 ```
 
-Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. Official `*.githubcopilot.com` endpoints are trusted automatically. Configuring an Enterprise OAuth host such as `company.ghe.com` trusts exactly `copilot-api.company.ghe.com`; other subdomains are not inferred. Add exact comma-separated hostnames to `GITHUB_COPILOT_ALLOWED_API_HOSTS` only for nonstandard reverse proxies. Environment and deployment-level API bases use the same trust checks and must use HTTPS without embedded credentials, query parameters, or fragments
+Existing `access-token` files are reused without reauthentication. Legacy `api-key.json`, `GITHUB_COPILOT_API_KEY_FILE`, and `GITHUB_COPILOT_API_KEY_URL` are no longer used. `GITHUB_COPILOT_API_BASE` and deployment-level API bases remain explicit operator-controlled endpoint settings. They must use HTTPS without embedded credentials, query parameters, or fragments
 For the proxy, put the same values in the `environment_variables` block
 
 ```yaml showLineNumbers title="config.yaml"


### PR DESCRIPTION
## Summary

- Documents GitHub Copilot's unified OAuth access-token flow
- Lists every configurable OAuth and request header
- Explains how empty values omit default identity headers
- Adds a custom OAuth application example using OpenCode
- Documents secure custom API-base requirements

Existing authenticated users continue using their stored OAuth access token. Deployment and environment API bases retain their pre-existing role as operator-controlled settings and now require HTTPS without embedded credentials, query parameters, or fragments; otherwise LiteLLM uses the official default and does not read legacy `api-key.json`

## Companion implementation

https://github.com/BerriAI/litellm/pull/34889

## Verification

- Docusaurus production build completed successfully
- Existing repository-wide documentation warnings remain unchanged
