### PR TITLE
docs(blog): shorten the Auto Router benchmark post title

### DIFF
--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -1,6 +1,6 @@
 ---
 slug: auto-router-cost-quality-benchmark
-title: "Cut 75% Claude Code cost with near frontier model quality; Benchmarking Auto Router: 40-75% cheaper at 87-97% of frontier quality"
+title: "Cut 75% Claude Code cost with near frontier model quality"
 date: 2026-07-27T10:00:00
 authors:
   - tin


### PR DESCRIPTION
Trims the Auto Router benchmark post title to just the headline claim.

**Before**
> Cut 75% Claude Code cost with near frontier model quality; Benchmarking Auto Router: 40-75% cheaper at 87-97% of frontier quality

**After**
> Cut 75% Claude Code cost with near frontier model quality

Docusaurus renders this one string in the post H1, the blog list, the sidebar, and the `<title>`/`og:title` tags — the semicolon-joined form truncates in list views and reads as two competing headlines in search and social previews.

The dropped numbers aren't lost: the 40-75% / 87-97% figures already lead the post's "The results" section and remain in `description` and `keywords`, which feed the meta tags.

Frontmatter `title` only — one line changed. `slug`, `date`, `description`, `keywords`, and `tags` are untouched, so the published URL (`/blog/auto-router-cost-quality-benchmark`) stays the same.

## Relevant issues

- Follow-up to #692, which published this post
- No open issue; title-only editorial change

🤖 Generated with [Claude Code](https://claude.com/claude-code)