### PR TITLE
docs: auto router setup for Claude Code and Claude Desktop (model name + org allowlist)

### DIFF
--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -262,7 +262,12 @@ Tier and classifier dropdowns exclude embedding-mode models; the semantic embedd
 
 ## Claude Code and Claude Desktop
 
-Claude clients apply two client-side checks before a router is selectable. The route's `model_name` has to read as an Anthropic model, meaning it contains `claude`, `anthropic`, or a family name such as `opus`, `sonnet`, or `haiku`, and carries no other vendor's name; `claude-auto` works, `smart-router` does not. That name also has to appear in your organization's `availableModels` allowlist. Miss either check and the router is greyed out in the Claude Desktop picker and rejected at CLI startup, with no request reaching the proxy. See [Auto Router with Claude Code and Claude Desktop](../tutorials/claude_code_autorouter.md).
+Two prerequisites before a router is selectable in a Claude client:
+
+1. **The router's `model_name` has to read as an Anthropic model.** It needs `claude`, `anthropic`, or a family name such as `opus`, `sonnet`, or `haiku` somewhere in it, and no other vendor's name, so `claude-auto` is accepted where `smart-router` is rejected.
+2. **On Claude for Teams or Enterprise, that name has to be on the organization's `availableModels` allowlist.** Anything missing from the allowlist is greyed out in the Claude Desktop picker and replaced at CLI startup with `restricted by your organization's settings`.
+
+Both checks run in the client, so a router that fails either one leaves nothing in the LiteLLM logs to explain itself. See [Auto Router with Claude Code and Claude Desktop](../tutorials/claude_code_autorouter.md).
 
 ## See also
 

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -260,6 +260,10 @@ Models + Endpoints > Add Model > Auto Router tab. Router Type defaults to "Auto-
 
 Tier and classifier dropdowns exclude embedding-mode models; the semantic embedding dropdown lists only embedding-mode models. All four tiers are required on submit; missing tiers are flagged inline.
 
+## Claude Code and Claude Desktop
+
+Claude clients apply two client-side checks before a router is selectable. The route needs an Anthropic-shaped `model_name` such as `claude-auto`, and that name has to appear in your organization's `availableModels` allowlist; otherwise the router is greyed out in the Claude Desktop picker and rejected at CLI startup without any request reaching the proxy. See [Auto Router with Claude Code and Claude Desktop](../tutorials/claude_code_autorouter.md).
+
 ## See also
 
 - Announcement post: [Auto Router v2: one router for complexity, semantic, and adaptive routing](/blog/autorouter-v2)

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -262,7 +262,7 @@ Tier and classifier dropdowns exclude embedding-mode models; the semantic embedd
 
 ## Claude Code and Claude Desktop
 
-Claude clients apply two client-side checks before a router is selectable. The route needs an Anthropic-shaped `model_name` such as `claude-auto`, and that name has to appear in your organization's `availableModels` allowlist; otherwise the router is greyed out in the Claude Desktop picker and rejected at CLI startup without any request reaching the proxy. See [Auto Router with Claude Code and Claude Desktop](../tutorials/claude_code_autorouter.md).
+Claude clients apply two client-side checks before a router is selectable. The route's `model_name` has to read as an Anthropic model, meaning it contains `claude`, `anthropic`, or a family name such as `opus`, `sonnet`, or `haiku`, and carries no other vendor's name; `claude-auto` works, `smart-router` does not. That name also has to appear in your organization's `availableModels` allowlist. Miss either check and the router is greyed out in the Claude Desktop picker and rejected at CLI startup, with no request reaching the proxy. See [Auto Router with Claude Code and Claude Desktop](../tutorials/claude_code_autorouter.md).
 
 ## See also
 

--- a/docs/tutorials/claude_code_autorouter.md
+++ b/docs/tutorials/claude_code_autorouter.md
@@ -12,7 +12,9 @@ Skip the allowlist step and the router is greyed out in the Claude Desktop model
 
 ## Name the router so Claude accepts it
 
-Claude's model pickers and Claude Desktop's third-party inference dialog expect Anthropic-shaped model names. A router called `smart-router`, `auto`, or a bare UUID is rejected in the client before any request is sent, while `claude-auto` or `claude-smart-router` is accepted. Avoid embedding another vendor's name in the router's `model_name`; a name containing `gpt`, `gemini`, `llama`, or similar is treated as non-Anthropic and filtered out.
+Claude's model pickers and Claude Desktop's third-party inference dialog only offer model names that read as Anthropic models. The `model_name` has to contain `claude` or `anthropic`, or a family name such as `opus`, `sonnet`, `haiku`, or `fable`, so `claude-auto`, `claude-smart-router`, and `opus-auto` are all accepted while `smart-router`, `auto`, and a bare UUID are rejected in the client before any request is sent. Another vendor's name anywhere in the string fails the check regardless, so `claude-vs-gpt` is filtered out as non-Anthropic despite the `claude`.
+
+Build the name on `claude` rather than on a family word. A family word changes how the allowlist in the next section treats the route: `opus-auto` counts as a specific Opus entry, which disables the `opus` family wildcard and leaves every Opus version you still want selectable to be listed by hand.
 
 ```yaml title="config.yaml"
 model_list:
@@ -41,8 +43,6 @@ Organizations on Claude for Teams or Claude for Enterprise restrict model select
 ```
 
 Owners set this in the claude.ai console at **Admin Settings > Claude Code > Managed settings**, which covers Claude Desktop and claude.ai sessions. Terminal sessions pointed at LiteLLM need the same list delivered through MDM or a managed settings file, because Claude Code skips the server-managed settings fetch whenever `ANTHROPIC_BASE_URL` points somewhere other than Anthropic. That file lives at `/Library/Application Support/ClaudeCode/managed-settings.json` on macOS, `/etc/claude-code/managed-settings.json` on Linux and WSL, and `C:\Program Files\ClaudeCode\managed-settings.json` on Windows.
-
-Prefer a router name that carries no model family in it. An entry such as `claude-sonnet-auto` counts as a specific Sonnet entry and disables the `sonnet` family wildcard, so every Sonnet version you still want selectable then has to be listed by hand.
 
 This allowlist is a separate control from the Enterprise admin console's per-model restrictions, which govern Anthropic's own models rather than custom gateway IDs. Both apply, so a router is selectable only when it is on `availableModels` and the models it routes to are not restricted for the organization.
 

--- a/docs/tutorials/claude_code_autorouter.md
+++ b/docs/tutorials/claude_code_autorouter.md
@@ -1,0 +1,91 @@
+---
+title: Auto Router with Claude Code and Claude Desktop
+sidebar_label: Auto Router
+description: Route Claude Code and Claude Desktop through a LiteLLM auto router, including the model name and organization allowlist requirements that decide whether the router is selectable at all.
+---
+
+# Auto Router with Claude Code and Claude Desktop
+
+A LiteLLM [auto router](../proxy/auto_routing.md) sends every Claude Code request to the smallest model that can handle it, which is where most of the savings on a Claude Code workload come from. Pointing Claude at one takes two things beyond the usual `ANTHROPIC_BASE_URL` setup: a router name Claude will accept, and that name on your organization's model allowlist.
+
+Skip the allowlist step and the router is greyed out in the Claude Desktop model picker, missing from `/model` in the CLI, and any attempt to select it by name starts the session on a different model with the notice `Model "<name>" is restricted by your organization's settings. Using <model> instead.` Nothing reaches your proxy, so the LiteLLM logs stay empty and the problem looks like a routing bug rather than a client-side policy check.
+
+## Name the router so Claude accepts it
+
+Claude's model pickers and Claude Desktop's third-party inference dialog expect Anthropic-shaped model names. A router called `smart-router`, `auto`, or a bare UUID is rejected in the client before any request is sent, while `claude-auto` or `claude-smart-router` is accepted. Avoid embedding another vendor's name in the router's `model_name`; a name containing `gpt`, `gemini`, `llama`, or similar is treated as non-Anthropic and filtered out.
+
+```yaml title="config.yaml"
+model_list:
+  - model_name: claude-auto
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE:    claude-haiku-4-5
+          MEDIUM:    claude-sonnet-5
+          COMPLEX:   claude-sonnet-5
+          REASONING: claude-opus-4-8
+      complexity_router_default_model: claude-sonnet-5
+```
+
+If API callers already use a non-Anthropic name, keep both by declaring a second `model_list` entry with the same `complexity_router_config` under the Claude-facing name. `router_settings.model_group_alias` does not work here, because alias resolution runs after auto-router dispatch and the aliased call fails with `Unmapped LLM provider`.
+
+## Add the router to your organization's allowlist
+
+Organizations on Claude for Teams or Claude for Enterprise restrict model selection with [`availableModels`](https://code.claude.com/docs/en/model-config#restrict-model-selection) in Claude Code managed settings. The list is an allowlist, and it is matched against a model family such as `sonnet`, a version prefix, or a full model ID, so a gateway-hosted router has to be listed by its exact `model_name`.
+
+```json
+{
+  "availableModels": ["claude-auto", "sonnet", "haiku"]
+}
+```
+
+Owners set this in the claude.ai console at **Admin Settings > Claude Code > Managed settings**, which covers Claude Desktop and claude.ai sessions. Terminal sessions pointed at LiteLLM need the same list delivered through MDM or a managed settings file, because Claude Code skips the server-managed settings fetch whenever `ANTHROPIC_BASE_URL` points somewhere other than Anthropic. That file lives at `/Library/Application Support/ClaudeCode/managed-settings.json` on macOS, `/etc/claude-code/managed-settings.json` on Linux and WSL, and `C:\Program Files\ClaudeCode\managed-settings.json` on Windows.
+
+Prefer a router name that carries no model family in it. An entry such as `claude-sonnet-auto` counts as a specific Sonnet entry and disables the `sonnet` family wildcard, so every Sonnet version you still want selectable then has to be listed by hand.
+
+This allowlist is a separate control from the Enterprise admin console's per-model restrictions, which govern Anthropic's own models rather than custom gateway IDs. Both apply, so a router is selectable only when it is on `availableModels` and the models it routes to are not restricted for the organization.
+
+## Point Claude at the router
+
+For the CLI, export the proxy URL, a virtual key, and the router name. `ANTHROPIC_MODEL` is read at startup, so set it before launching `claude`.
+
+```bash
+export ANTHROPIC_BASE_URL=https://your-litellm-proxy.com
+export ANTHROPIC_AUTH_TOKEN=sk-...
+export ANTHROPIC_MODEL=claude-auto
+```
+
+To get the router into the `/model` picker rather than only into the startup model, set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` and Claude Code populates the picker from the proxy's `/v1/models`. Where discovery is turned off, `ANTHROPIC_CUSTOM_MODEL_OPTION=claude-auto` adds the single entry instead.
+
+For Claude Desktop, enter the proxy URL and virtual key under **Developer > Configure Third-Party Inference**, then pick the router in the model list. The [Claude Desktop integration guide](./claude_desktop_cowork.md) walks the dialog screen by screen.
+
+## Scope the virtual key to the router
+
+Give Claude clients a key scoped to the router alone.
+
+```bash
+curl -X POST $LITELLM_PROXY_URL/key/generate \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"models": ["claude-auto"]}'
+```
+
+Model discovery lists whatever the key can reach, and Claude Desktop's **Test connection** then probes `/v1/messages` with one of the discovered models rather than with the one you selected. A broadly scoped key turns that into a connection failure on some unrelated deployment, which reads as a broken router. Scoping the key to `claude-auto` makes discovery return exactly one model and the probe hit the router itself. Wildcard route names are worth checking here too, since a literal `claude-*` entry in `model_list` is published verbatim in `/v1/models` and 404s when a client probes it.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+| Router greyed out in the Claude Desktop or claude.ai model picker | Router name is missing from `availableModels` | Add the exact `model_name` to the allowlist and restart the client |
+| `Model "<name>" is restricted by your organization's settings` at CLI startup | Same allowlist, delivered to the terminal | Deploy the list through MDM or `managed-settings.json`; the admin console channel does not reach sessions on `ANTHROPIC_BASE_URL` |
+| Claude Desktop rejects the name in the third-party inference dialog | Name is not Anthropic-shaped | Rename the route to something like `claude-auto` |
+| Test connection fails naming a model you never selected | Key discovers models beyond the router and the probe picks one of them | Scope the virtual key to the router |
+| Router missing from `/v1/models` and the Models page after an edit | Older builds did not relink the in-memory router registry when a deployment was replaced | Restart the proxy to reload it from the database, and upgrade to a release containing [PR #34564](https://github.com/BerriAI/litellm/pull/34564) |
+
+## Related
+
+- [Auto Routing](../proxy/auto_routing.md)
+- [Claude Code - Cut Costs](./claude_code_cut_costs.md)
+- [Claude Desktop integration](./claude_desktop_cowork.md)
+- [Virtual Keys](../proxy/virtual_keys.md)

--- a/docs/tutorials/claude_code_cut_costs.md
+++ b/docs/tutorials/claude_code_cut_costs.md
@@ -164,6 +164,8 @@ model_list:
       complexity_router_default_model: gpt-4o
 ```
 
+Name the router `claude-auto` (or another Anthropic-shaped name) and add that name to your organization's `availableModels` allowlist before rolling it out, otherwise Claude Code and Claude Desktop refuse to select it. [Auto Router with Claude Code and Claude Desktop](./claude_code_autorouter.md) covers both requirements.
+
 Learn more: [Complexity Router](../proxy/auto_routing#complexity-router), [Semantic Auto Routing](../proxy/auto_routing), and [Adaptive Router](../adaptive_router).
 
 ## Stacking the levers

--- a/docs/tutorials/claude_desktop_cowork.md
+++ b/docs/tutorials/claude_desktop_cowork.md
@@ -71,6 +71,7 @@ You can verify traffic is flowing by checking the LiteLLM Dashboard under **Usag
 
 ## Related
 
+- [Auto Router with Claude Code and Claude Desktop](claude_code_autorouter.md)
 - [LiteLLM Virtual Keys](../proxy/virtual_keys.md)
 - [Cursor Integration](cursor_integration.md)
 - [Claude Code Integration](claude_responses_api.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -233,6 +233,7 @@ const sidebars = {
           items: [
             "claude_code_compatibility",
             "tutorials/claude_code_cut_costs",
+            "tutorials/claude_code_autorouter",
             "tutorials/claude_responses_api",
             "tutorials/claude_code_max_subscription",
             "tutorials/claude_code_byok",


### PR DESCRIPTION
## Relevant issues

- [LIT-4636](https://linear.app/litellm-ai/issue/LIT-4636/claude-desktop-third-party-gateway-flow-cant-use-the-auto-router-model): Claude Desktop's third-party inference flow can't select a LiteLLM auto router. Two client-side checks decide this before any request reaches the proxy: the route name has to look Anthropic-shaped, and it has to be on the organization's `availableModels` allowlist.
- Customer report in `#tinder-litellm`: smart-router models show up greyed out in Claude Desktop and unavailable in Claude Code, with nothing in the LiteLLM logs to explain it. The allowlist is the usual cause, and it is currently documented nowhere on our side.
- [LIT-4664](https://linear.app/litellm-ai/issue/LIT-4664/model-group-alias-pointing-at-an-auto-router-400s-unmapped-llm): `model_group_alias` pointing at an auto router 400s with `Unmapped LLM provider`, so the guide tells people to declare a second `model_list` entry rather than an alias.

## What this adds

A new page, **Auto Router with Claude Code and Claude Desktop** (`docs/tutorials/claude_code_autorouter.md`), covering the setup that is specific to Claude clients:

- naming the router so Claude's model validators accept it (`claude-auto` rather than `smart-router` or a UUID), and keeping the old name as a second `model_list` entry for existing API callers
- adding the router's exact `model_name` to `availableModels`, including which delivery channel reaches which surface. The claude.ai admin console covers Desktop, but Claude Code skips the server-managed settings fetch entirely when `ANTHROPIC_BASE_URL` points at a gateway, so terminal fleets need the same list through MDM or `managed-settings.json`
- pointing the CLI and Desktop at the router, including gateway model discovery so it shows up in the picker
- scoping the virtual key to the router, so model discovery and Desktop's Test connection probe the router instead of some unrelated deployment
- a troubleshooting table mapping each symptom (greyed out, "restricted by your organization's settings", rejected in the Desktop dialog, test connection failing on a model you never picked) to its cause

Cross-linked from the Auto Routing reference, Claude Code - Cut Costs, and the Claude Desktop integration page, and added to the Claude Code section of the sidebar.
