### PR TITLE
docs(search): warn that Google PSE full-web search is being discontinued

### DIFF
--- a/docs/search/google_pse.md
+++ b/docs/search/google_pse.md
@@ -1,5 +1,13 @@
 # Google Programmable Search Engine (PSE)
 
+:::warning Google is sunsetting full-web search for PSE
+
+As of January 20, 2026, Google no longer offers the "Search the entire web" option for newly created Programmable Search Engines; new engines are limited to a hand-picked list of up to 50 sites. Existing engines that already have entire-web search enabled keep it only until January 1, 2027 ([announcement](https://programmablesearchengine.googleblog.com/2026/01/updates-to-our-web-search-products.html)).
+
+If you need full-web search, use a different LiteLLM search provider instead, e.g. [SearXNG](./searxng) (self-hosted), [Serper](./serper) or [SearchAPI](./searchapi) (Google results via API), or [Tavily](./tavily), [Brave](./brave), and [Exa](./exa_ai).
+
+:::
+
 **Get API Key:** [Google Cloud Console](https://console.cloud.google.com/apis/credentials)  
 **Create Search Engine:** [Programmable Search Engine](https://programmablesearchengine.google.com/)
 
@@ -8,7 +16,7 @@
 1. Go to [Google Developers Programmable Search Engine](https://programmablesearchengine.google.com/) and log in or create an account
 2. Click the **Add** button in the control panel
 3. Enter a search engine name and configure properties:
-   - Choose which sites to search (entire web or specific sites)
+   - Choose which sites to search (up to 50 specific sites for engines created after January 20, 2026)
    - Set language and other preferences
    - Verify you're not a robot
 4. Click **Create** button


### PR DESCRIPTION
Google stopped offering the "Search the entire web" option for newly created Programmable Search Engines on January 20, 2026; new engines are capped at a hand-picked list of 50 sites, and existing entire-web engines lose the option on January 1, 2027 (see https://programmablesearchengine.googleblog.com/2026/01/updates-to-our-web-search-products.html). A customer followed our Google PSE search doc and only discovered this wall after setting everything up

This adds a warning admonition at the top of the Google PSE page stating the deprecation timeline and pointing at the other LiteLLM search providers that still do full-web search (SearXNG, Serper, SearchAPI, Tavily, Brave, and Exa), and updates the setup step that still claimed new engines can search the entire web