### PR TITLE
docs: lead the auto router benchmark post with the design partner CTA

### DIFF
--- a/blog/autorouter_cost_quality_benchmark/index.md
+++ b/blog/autorouter_cost_quality_benchmark/index.md
@@ -14,6 +14,18 @@ Auto routing promises a smaller bill without a worse answer. We measured both ha
 
 {/* truncate */}
 
+:::info[🚀 Help shape the Auto-Router]
+
+Get early access, work directly with the LiteLLM team, and influence the roadmap with your production traffic.
+
+<a className="button button--primary button--lg" style={{background: '#2e8555', borderColor: '#2e8555', color: '#fff'}} href="https://cms49ctwm00026rv771kh8igo.zapier.app/application">Apply to Become a Design Partner</a>
+
+<br /><br />
+
+Already testing it? Share your results in [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
+
+:::
+
 ## The results
 
 - **40.4% cheaper at 97.1% of frontier quality**, on 220 prompts from six public benchmarks replayed through a live proxy
@@ -72,13 +84,18 @@ The split runs opposite to intuition:
 
 A question we keep hearing: do I have to choose between auto-routing and prompt caching?
 
-No. Session affinity already lets you keep a conversation on the model its first turn picked, so the cache holds. We are actively building out a solution to make the two work together. Stay tuned.
+No. Session affinity already lets you keep a conversation on the model its first turn picked, so the cache holds for the rest of that conversation. What it costs you is the routing decision on every turn after the first: once a session is pinned, a one-line follow-up stays on whatever model the opening turn earned. Closing that gap is the first item below.
+
+## What's next
+
+- **Prompt caching that survives a tier change.** Affinity pins a conversation today because switching models means a cold cache. We are testing a background refresher that keeps the prefix warm on every tier, so a session can move without paying the write cost twice
+- **Routing decisions you can inspect.** Surfacing why a request landed on the tier it did, not just which model served it. That same signal feeds back into the classifier, so it improves against real traffic rather than benchmarks
 
 ## Try it
 
 :::info
 
-If this is interesting, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application). Try it yourself with the configuration below, and post any feedback, questions, or numbers from your own traffic on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172).
+Try it yourself with the configuration below, and post any feedback, questions, or numbers from your own traffic on [discussion #32172](https://github.com/BerriAI/litellm/discussions/32172). If you want to work on this with us directly, [apply to be a design partner](https://cms49ctwm00026rv771kh8igo.zapier.app/application).
 
 :::
 


### PR DESCRIPTION
## Relevant issues

- Moves the design partner CTA from the bottom of the auto router benchmark post to the top, so readers who bounce after the headline numbers still see it
- Adds a short "What's next" section covering prompt cache warming across tiers and per-request routing explainability
- Trims the closing "Try it" admonition so it no longer repeats the design partner ask

## What this changes

Single file: `blog/autorouter_cost_quality_benchmark/index.md`.

The ask previously lived in the closing `Try it` admonition, below five result tables and the full YAML config. It now sits directly under the intro paragraph and above `## The results`, as an admonition with the headline, the early access blurb, a button linking to the application form, and the discussion #32172 pointer.

Placement detail: the CTA sits **below** the `{/* truncate */}` marker on purpose. Anything above that marker also renders on the blog index card, so putting a button there would leak it into the listing page. Below it, the CTA is the first thing in the article body.

Styling detail: the button carries inline `background` / `borderColor` / `color` rather than relying on Infima alone. `custom.css` sets `.blog-wrapper article .markdown a { color: #0ea5e9 }`, which overrides `button--primary`'s white label and renders it pale blue on green. The hardcoded `#2e8555` also keeps the button readable in dark mode, where `--ifm-color-primary` flips to teal.

`## What's next` is two bullets, placed between the prompt caching Q&A and `Try it`: keeping the prompt cache warm across tiers so a session can move without paying the write cost twice, and surfacing why a request landed on the tier it did so that signal can feed back into the classifier. The caching section's old "we are actively building out a solution, stay tuned" line is gone, since the first bullet now covers it.

## Testing

Rendered locally against `npm run start`. Docusaurus compiles clean with no MDX errors on this file; the warnings in the build log are pre-existing and about other posts. Verified the CTA and the new section in the rendered DOM, and checked button contrast in both light and dark mode.