### PR TITLE
docs: remove stale USE_PRISMA_MIGRATE guidance

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1214,7 +1214,7 @@ router_settings:
 | UPSTREAM_LANGFUSE_RELEASE | Release version identifier for upstream Langfuse
 | UPSTREAM_LANGFUSE_SECRET_KEY | Secret key for upstream Langfuse authentication
 | USE_AWS_KMS | Flag to enable AWS Key Management Service for encryption
-| USE_PRISMA_MIGRATE | Flag to use prisma migrate instead of prisma db push. Recommended for production environments.
+| USE_PRISMA_MIGRATE | Removed in [PR #13555](https://github.com/BerriAI/litellm/pull/13555); `prisma migrate deploy` is now the default. Setting this has no effect and it is safe to remove.
 | VANTAGE_API_KEY | API key for Vantage cost-import integration
 | VANTAGE_BASE_URL | Base URL for Vantage API. Default is `https://api.vantage.sh`
 | VANTAGE_EXPORT_FREQUENCY | Export frequency for Vantage — `hourly` (default), `daily`, or `interval`

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -246,11 +246,13 @@ To ensure only one service manages database migrations, use our [Helm PreSync ho
 
 ### Use prisma migrate deploy
 
-Use this to handle db migrations across LiteLLM versions in production:
+LiteLLM runs `prisma migrate deploy` on startup by default, so db migrations are handled across versions in production with no configuration. To stop a pod from running migrations at all, set `DISABLE_SCHEMA_UPDATE=true` as described in [Run migrations from the Helm PreSync hook](#run-migrations-from-the-helm-presync-hook).
 
-```bash
-USE_PRISMA_MIGRATE="True"
-```
+:::info
+
+Older versions gated this behind `USE_PRISMA_MIGRATE="True"`. That flag was removed in [PR #13555](https://github.com/BerriAI/litellm/pull/13555) when migrate deploy became the default, and this page continued to recommend it after the fact. Setting `USE_PRISMA_MIGRATE` today does nothing; it is safe to remove from your environment, and removing it does not change migration behavior
+
+:::
 
 The migrate deploy command:
 

--- a/docs/troubleshoot/rollback.md
+++ b/docs/troubleshoot/rollback.md
@@ -53,7 +53,7 @@ helm rollback <release-name> [revision-number]
 
 If you are rolling back to a version that did not have a specific migration, you may need to resolve the migration state in the database.
 
-> LiteLLM uses `prisma migrate deploy` for production (enabled via `USE_PRISMA_MIGRATE=True`). If a migration partially failed or you are reverting code that expects an older schema, you need to clean up the migration history in the `_prisma_migrations` table. See [Best Practices for Production](../proxy/prod#use-prisma-migrate-deploy).
+> LiteLLM uses `prisma migrate deploy` for production by default. If a migration partially failed or you are reverting code that expects an older schema, you need to clean up the migration history in the `_prisma_migrations` table. See [Best Practices for Production](../proxy/prod#use-prisma-migrate-deploy).
 
 ### Option A — Delete stale migration entries (recommended)
 


### PR DESCRIPTION
## TLDR

`USE_PRISMA_MIGRATE` was removed from LiteLLM in [PR #13555](https://github.com/BerriAI/litellm/pull/13555) when `prisma migrate deploy` became the default, but the production best practices page has kept recommending that operators set it. The variable is read nowhere in the codebase today

This is worse than a cosmetic staleness. An operator who sets it believes they have configured how migrations run, so when an upgrade leaves the schema half applied they have no reason to suspect their migration configuration is inert. It came up in a support case where a customer upgrading across several versions hit `column ... does not exist` errors, and their environment had `USE_PRISMA_MIGRATE` set because this page told them to set it

## Changes

Three references are corrected. `docs/proxy/prod.md` now states that migrate deploy is the default and needs no configuration, with an info admonition explaining that the flag was removed and is safe to delete from existing environments; `docs/proxy/config_settings.md` marks the env var table row as removed rather than recommending it; `docs/troubleshoot/rollback.md` drops the "enabled via `USE_PRISMA_MIGRATE=True`" aside

The `### Use prisma migrate deploy` heading is deliberately kept verbatim. Both `docs/troubleshoot/rollback.md` and `release_notes/v1.65.4-stable/index.md` link to the `#use-prisma-migrate-deploy` anchor, and renaming the heading would break them

The admonition keeps the removed name discoverable on purpose. Anyone who already has the variable set and searches the docs for it should land on an explanation rather than on silence

## Screenshots / Proof of Fix

`npm run build` completes successfully. Neither `#use-prisma-migrate-deploy` nor the newly added `#run-migrations-from-the-helm-presync-hook` link appears in the broken anchor report:

```bash
npm run build 2>&1 | grep -iE "prisma-migrate|presync|prod#|rollback"
```

returns no matches. The broken anchors the build does report are pre-existing and all in `release_notes/` pointing at `docs/proxy/logging#prometheus` and similar; none are touched here

## Type

📖 Documentation

## QA runbook

Build the site and open `/docs/proxy/prod#use-prisma-migrate-deploy`; the section should no longer instruct setting the variable, and the info box should explain that it was removed. Follow the link from `/docs/troubleshoot/rollback` to confirm the anchor still resolves. Search `/docs/proxy/config_settings` for `USE_PRISMA_MIGRATE` and confirm the row reads as removed
