### PR TITLE
docs(cloudflare): refresh endpoints and supported models

### DIFF
--- a/docs/providers/cloudflare_workers.md
+++ b/docs/providers/cloudflare_workers.md
@@ -1,58 +1,94 @@
 # Cloudflare Workers AI
-https://developers.cloudflare.com/workers-ai/models/text-generation/
 
-## API Key
-```python
-# env variable
-os.environ['CLOUDFLARE_API_KEY'] = "3dnSGlxxxx"
-os.environ['CLOUDFLARE_ACCOUNT_ID'] = "03xxxxx"
-```
+LiteLLM supports Cloudflare Workers AI chat completions, responses, embeddings, and reranking.
 
-## Sample Usage
+## API credentials
+
 ```python
-from litellm import completion
 import os
 
-os.environ['CLOUDFLARE_API_KEY'] = "3dnSGlxxxx"
-os.environ['CLOUDFLARE_ACCOUNT_ID'] = "03xxxxx"
+os.environ["CLOUDFLARE_API_KEY"] = "your-api-token"
+os.environ["CLOUDFLARE_ACCOUNT_ID"] = "your-account-id"
+```
+
+## Chat completion
+
+```python
+from litellm import completion
 
 response = completion(
-    model="cloudflare/@cf/meta/llama-2-7b-chat-int8", 
-    messages=[
-       {"role": "user", "content": "hello from litellm"}
-   ],
+    model="cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
 )
 print(response)
 ```
 
-## Sample Usage - Streaming
+### Streaming
+
 ```python
 from litellm import completion
-import os
-
-os.environ['CLOUDFLARE_API_KEY'] = "3dnSGlxxxx"
-os.environ['CLOUDFLARE_ACCOUNT_ID'] = "03xxxxx"
 
 response = completion(
-    model="cloudflare/@hf/thebloke/codellama-7b-instruct-awq", 
-    messages=[
-       {"role": "user", "content": "hello from litellm"}
-   ],
-    stream=True
+    model="cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
+    stream=True,
 )
 
 for chunk in response:
     print(chunk)
 ```
 
-## Supported Models
-All models listed here https://developers.cloudflare.com/workers-ai/models/text-generation/ are supported
+## Embeddings
 
-| Model Name                        | Function Call                                            |
-|-----------------------------------|----------------------------------------------------------|
-| @cf/meta/llama-2-7b-chat-fp16     | `completion(model="mistral/mistral-tiny", messages)`    |
-| @cf/meta/llama-2-7b-chat-int8     | `completion(model="mistral/mistral-small", messages)`   |
-| @cf/mistral/mistral-7b-instruct-v0.1 | `completion(model="mistral/mistral-medium", messages)` |
-| @hf/thebloke/codellama-7b-instruct-awq | `completion(model="codellama/codellama-medium", messages)` |
+```python
+from litellm import embedding
 
+response = embedding(
+    model="cloudflare/@cf/baai/bge-m3",
+    input=["Cloudflare Workers AI embeddings"],
+)
+print(response)
+```
 
+Embedding requests use Cloudflare's OpenAI-compatible
+`/accounts/{account_id}/ai/v1/embeddings` endpoint.
+
+## Reranking
+
+```python
+from litellm import rerank
+
+response = rerank(
+    model="cloudflare/@cf/baai/bge-reranker-base",
+    query="What is LiteLLM?",
+    documents=[
+        "LiteLLM is an LLM gateway.",
+        "Cloudflare operates a global network.",
+    ],
+    top_n=1,
+)
+print(response)
+```
+
+Reranking uses Cloudflare's native
+`/accounts/{account_id}/ai/run/{model}` endpoint. LiteLLM maps `documents` to
+Cloudflare `contexts` and `top_n` to `top_k`.
+
+## Supported models
+
+Use the `cloudflare/` prefix with a compatible model ID from the
+[Cloudflare Workers AI model catalog](https://developers.cloudflare.com/workers-ai/models/).
+The catalog is the source of truth for availability and deprecation status.
+
+Current examples by supported LiteLLM endpoint:
+
+| Endpoint | Example models |
+| --- | --- |
+| Chat completions and responses | `@cf/meta/llama-3.3-70b-instruct-fp8-fast`, `@cf/meta/llama-4-scout-17b-16e-instruct`, `@cf/openai/gpt-oss-120b` |
+| Embeddings | `@cf/baai/bge-base-en-v1.5`, `@cf/baai/bge-large-en-v1.5`, `@cf/baai/bge-m3`, `@cf/google/embeddinggemma-300m` |
+| Reranking | `@cf/baai/bge-reranker-base` |
+
+Image generation and audio are not yet exposed through this provider. Follow
+[the image support issue](https://github.com/BerriAI/litellm/issues/35055) and
+[the audio support issue](https://github.com/BerriAI/litellm/issues/35056) for
+implementation progress or to contribute.


### PR DESCRIPTION
## What changed

- replace deprecated Cloudflare model examples with current models
- document chat completion and streaming usage
- document embeddings and the OpenAI-compatible embeddings endpoint
- document reranking and the native Workers AI run endpoint
- link to Cloudflare's live model catalog as the source of truth
- clarify that image and audio integrations are still pending

## Why

The existing provider page listed deprecated models and did not cover the newly implemented embeddings and reranking support.

## Validation

- verified example model IDs against Cloudflare's current model catalog
- verified the documented endpoint shapes against Cloudflare's official API documentation

Related code PR: BerriAI/litellm#35054
Related to BerriAI/litellm#21115
