### PR TITLE
docs(a2a): document defining agents in config.yaml

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -47,7 +47,9 @@ You can add A2A-compatible agents through the LiteLLM Admin UI.
 
 The URL should be the invocation URL for your A2A agent (e.g., `http://localhost:10001`).
 
-Set `protocolVersion` in `agent_card_params` when registering via API or config:
+#### Define agents in config.yaml
+
+Agents can also be declared in `config.yaml` under the top-level `agents` key, which is useful when the gateway is deployed from a ConfigMap or another read-only source. `agent_name` and `agent_card_params` are both required; entries missing either one are skipped at startup.
 
 ```yaml title="config.yaml"
 agents:
@@ -58,6 +60,24 @@ agents:
       protocolVersion: "1.0"  # or "0.3"
 ```
 
+`protocolVersion` can be set the same way when registering through the API.
+
+Config-defined agents show up in the Agents tab and in `GET /v1/agents` alongside agents created in the UI, and they survive the periodic reload from the database. Verify them with:
+
+```shell
+curl -s http://localhost:4000/v1/agents \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY"
+```
+
+If an agent created in the UI already uses a name you then declare in `config.yaml`, the database record wins and the config entry with that name is skipped, so the name always resolves to the record you can edit. Delete the database agent and the config entry takes the name back on the next reload.
+
+:::info
+
+Agents declared in `config.yaml` are not stored in the database, so they cannot be edited or deleted from the Admin UI. Change the config file and restart the gateway instead.
+
+The `agents` key is read correctly starting in the next release (after `v1.95.0`). On earlier versions, use `agent_list`, and note that config-defined agents are dropped on gateways that have a database attached.
+
+:::
 
 ### Add Azure AI Foundry Agents
 


### PR DESCRIPTION
## What this changes

The A2A guide showed a `config.yaml` snippet under the `agents` key as an aside about `protocolVersion`, with nothing saying that declaring agents in config is a supported way to onboard them. Readers who deploy the gateway from a ConfigMap had no page telling them what the key is, which fields are required, or how to check that it worked

This adds a "Define agents in config.yaml" section under "Add A2A Agents" covering the required fields, the fact that config agents appear in the Agents tab and `GET /v1/agents` next to UI-created ones, a verification curl, and the caveat that they cannot be edited or deleted from the UI because they are not DB rows

## Merge order

Merge after BerriAI/litellm#35163, which makes the proxy actually read the documented `agents` key and stops config-defined agents from being dropped on a gateway with a database attached. Before that lands, this page documents behavior the shipped versions do not have

## Validation

`npm ci && npm run build` passes; the only warnings are the pre-existing broken anchors on old release-notes pages
