### PR TITLE
docs(grafana): drop the collector claim from the intro

### DIFF
--- a/docs/observability/grafana_cloud.md
+++ b/docs/observability/grafana_cloud.md
@@ -1,6 +1,6 @@
 # Grafana Cloud
 
-Send LiteLLM traces and GenAI metrics to [Grafana Cloud](https://grafana.com/products/cloud/) over OTLP. One endpoint carries both signals, so there is no collector or agent to run
+Send LiteLLM traces and GenAI metrics to [Grafana Cloud](https://grafana.com/products/cloud/) over OTLP
 
 ## Prerequisites
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- The intro claims no collector or agent is needed
- The Prometheus section on the same page tells you to run Alloy

How it solves it:

- Removes the sentence

## Relevant issues

Follow-up to #713

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Documentation only, one sentence removed. `npm run build` passes.

## Type

📖 Documentation

## Changes

Drops "One endpoint carries both signals, so there is no collector or agent to run" from the intro line. The OTLP path needing no collector is already evident from the setup steps, and the claim read as contradictory next to the Prometheus section, which does require Grafana Alloy.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR