### PR TITLE
docs(copilot): document the supported BYOK path for routing Copilot through LiteLLM

### DIFF
--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -11,6 +11,12 @@ https://docs.github.com/en/copilot
 
 :::
 
+:::info
+
+This page covers calling Copilot's models from LiteLLM. For the opposite direction, pointing Copilot itself at LiteLLM so its chat and agent traffic gets cost tracking and guardrails, see the [GitHub Copilot tutorial](../tutorials/github_copilot_integration.md).
+
+:::
+
 | Property | Details |
 |-------|-------|
 | Description | GitHub Copilot Chat API provides access to GitHub's AI-powered coding assistant. |

--- a/docs/tutorials/github_copilot_integration.md
+++ b/docs/tutorials/github_copilot_integration.md
@@ -7,185 +7,156 @@ import TabItem from '@theme/TabItem';
 
 # GitHub Copilot
 
-This tutorial shows you how to integrate GitHub Copilot with LiteLLM Proxy, allowing you to route requests through LiteLLM's unified interface.
+Route GitHub Copilot through LiteLLM using Copilot's bring your own key (BYOK) support. Copilot calls LiteLLM as an OpenAI-compatible provider, so chat and agent traffic gets cost tracking, per-developer attribution, guardrails, and PII masking before it reaches a model.
 
-:::info 
+:::info Direction matters
 
-This tutorial is based on [Sergio Pino's excellent guide](https://dev.to/spino327/calling-github-copilot-models-from-openhands-using-litellm-proxy-1hl4) for calling GitHub Copilot models through LiteLLM Proxy. This integration allows you to use any LiteLLM supported model through GitHub Copilot's interface.
+Copilot's own hosted models are not exposed as an OpenAI-compatible API, so LiteLLM cannot sit in front of Copilot as a passthrough gateway. There is no supported way to insert a gateway between the Copilot client and GitHub's model service. BYOK inverts the relationship instead: Copilot becomes the client and LiteLLM is the provider it calls. GitHub's [Copilot SDK BYOK docs](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok) name LiteLLM as a supported OpenAI-compatible endpoint.
 
 :::
 
-## Benefits of using GitHub Copilot with LiteLLM
+## What runs through LiteLLM
 
-When you use GitHub Copilot with LiteLLM you get the following benefits:
+BYOK covers model calls from Copilot Chat (Ask, Edit, Plan, and Agent modes) in VS Code, JetBrains IDEs, Eclipse, and Xcode, Copilot Chat on github.com, [Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models), the Copilot app, and the Copilot SDK. Editor utility calls such as chat titles and commit message generation go through the same path.
 
-**Developer Benefits:**
-- Universal Model Access: Use any LiteLLM supported model (Anthropic, OpenAI, Vertex AI, Bedrock, etc.) through the GitHub Copilot interface.
-- Higher Rate Limits & Reliability: Load balance across multiple models and providers to avoid hitting individual provider limits, with fallbacks to ensure you get responses even if one provider fails.
+Inline code completions (the grey ghost text), semantic search, and anything backed by embeddings stay on GitHub's infrastructure. BYOK does not apply to them, so plan for chat and agent traffic to flow through LiteLLM while completions continue to hit GitHub directly.
 
-**Proxy Admin Benefits:**
-- Centralized Management: Control access to all models through a single LiteLLM proxy instance without giving your developers API Keys to each provider.
-- Budget Controls: Set spending limits and track costs across all GitHub Copilot usage.
+## Requirements
 
-## Prerequisites
+Each model you expose to Copilot must support tool calling and streaming, otherwise Copilot rejects it; GitHub recommends a context window of 128k or more. `GET /v1/models` has to list the model, because the admin and editor flows fetch the model list from your endpoint. For enterprise-level BYOK, GitHub's Copilot API calls your endpoint server-side, so the proxy needs a publicly reachable URL and a valid TLS certificate; `localhost` only works for the per-developer setups.
 
-Before you begin, ensure you have:
-- GitHub Copilot subscription (Individual, Business, or Enterprise)
-- A running LiteLLM Proxy instance
-- A valid LiteLLM Proxy API key
-- VS Code or compatible IDE with GitHub Copilot extension
-
-## Quick Start Guide
-
-### Step 1: Install LiteLLM
-
-Install LiteLLM with proxy support:
-
-```bash
-uv tool install litellm[proxy]
-```
-
-### Step 2: Configure LiteLLM Proxy
-
-Create a `config.yaml` file with your model configurations:
+## Step 1: Configure LiteLLM
 
 ```yaml showLineNumbers title="config.yaml"
 model_list:
-  - model_name: gpt-4o
+  - model_name: claude-sonnet-5
     litellm_params:
-      model: gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-  
-  - model_name: claude-3-5-sonnet
-    litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
+      model: anthropic/claude-sonnet-5
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  - model_name: gpt-5
+    litellm_params:
+      model: openai/gpt-5
+      api_key: os.environ/OPENAI_API_KEY
+
 general_settings:
-  master_key: sk-1234567890 # Change this to a secure key
+  master_key: os.environ/LITELLM_MASTER_KEY
 ```
 
-### Step 3: Start LiteLLM Proxy
-
-Start the proxy server:
+Start the proxy:
 
 ```bash
 litellm --config config.yaml --port 4000
 ```
 
-### Step 4: Configure GitHub Copilot
+## Step 2: Create a virtual key per developer
 
-Configure GitHub Copilot to use your LiteLLM proxy. Add the following to your VS Code `settings.json`:
+Give each developer their own key so usage lands against the right user and team:
 
-```json
-{
-  "github.copilot.advanced": {
-    "debug.overrideProxyUrl": "http://localhost:4000",
-    "debug.testOverrideProxyUrl": "http://localhost:4000"
-  }
-}
+```bash
+curl -X POST "https://litellm.example.com/key/generate" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_alias": "copilot-emilio",
+    "user_id": "emilio@example.com",
+    "team_id": "platform-team",
+    "models": ["claude-sonnet-5", "gpt-5"]
+  }'
 ```
 
-### Step 5: Test the Integration
-
-Restart VS Code and test GitHub Copilot. Your requests will now be routed through LiteLLM Proxy, giving you access to LiteLLM's features like:
-- Request/response logging
-- Rate limiting
-- Cost tracking
-- Model routing and fallbacks
-
-## Advanced
-
-### Use Anthropic, OpenAI, Bedrock, etc. models with GitHub Copilot
-
-You can route GitHub Copilot requests to any provider by configuring different models in your LiteLLM Proxy config:
+## Step 3: Point Copilot at LiteLLM
 
 <Tabs>
-<TabItem value="anthropic" label="Anthropic">
+<TabItem value="vscode" label="VS Code">
 
-Route requests to Claude Sonnet:
+1. Open the Chat view, click the model picker, and select **Manage Language Models** (or run `Chat: Manage Language Models`).
+2. Choose **Add Models**, then **Custom Endpoint**, then the **Chat Completions** API type.
+3. Enter a group name and paste the developer's LiteLLM virtual key as the API key.
+4. VS Code opens `chatLanguageModels.json` for the model details:
 
-```yaml showLineNumbers title="config.yaml"
-model_list:
-  - model_name: claude-3-5-sonnet
-    litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
-      api_key: os.environ/ANTHROPIC_API_KEY
-
-general_settings:
-  master_key: sk-1234567890
+```json title="chatLanguageModels.json"
+[
+  {
+    "name": "LiteLLM",
+    "vendor": "customendpoint",
+    "apiKey": "${input:apiKey}",
+    "apiType": "chat-completions",
+    "models": [
+      {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5 (LiteLLM)",
+        "url": "https://litellm.example.com/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "maxInputTokens": 200000,
+        "maxOutputTokens": 64000
+      }
+    ]
+  }
+]
 ```
+
+Give the full endpoint path. VS Code uses the URL as-is when it already ends in `/chat/completions`, `/responses`, or `/messages`, so an explicit path avoids ambiguity about what it appends.
+
+On Copilot Business and Enterprise, the **Bring Your Own Language Model Key in VS Code** policy must stay enabled in Copilot policy settings on github.com. It is on by default.
 
 </TabItem>
-<TabItem value="openai" label="OpenAI">
+<TabItem value="jetbrains" label="JetBrains">
 
-Route requests to GPT-4o:
-
-```yaml showLineNumbers title="config.yaml"
-model_list:
-  - model_name: gpt-4o
-    litellm_params:
-      model: gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-
-general_settings:
-  master_key: sk-1234567890
-```
+JetBrains IDEs accept OpenAI-compatible custom endpoints with an API key, so configure the base URL `https://litellm.example.com/v1` and the developer's virtual key in the Copilot plugin's model settings. See the [changelog entry](https://github.blog/changelog/2026-07-14-github-copilot-for-jetbrains-expands-byok-capabilities/) for the current state of the feature.
 
 </TabItem>
-<TabItem value="bedrock" label="Bedrock">
+<TabItem value="cli" label="Copilot CLI">
 
-Route requests to Claude on Bedrock:
-
-```yaml showLineNumbers title="config.yaml"
-model_list:
-  - model_name: bedrock-claude
-    litellm_params:
-      model: bedrock/anthropic.claude-haiku-4-5-20251001:0
-      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
-      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-      aws_region_name: us-east-1
-
-general_settings:
-  master_key: sk-1234567890
+```bash
+export COPILOT_PROVIDER_BASE_URL="https://litellm.example.com/v1"
+export COPILOT_PROVIDER_API_KEY="sk-litellm-virtual-key"
+export COPILOT_MODEL="claude-sonnet-5"
+copilot
 ```
+
+`COPILOT_PROVIDER_TYPE` defaults to `openai`, so you only need it if you are pointing the CLI at a non-OpenAI wire format.
 
 </TabItem>
-<TabItem value="multi-provider" label="Multi-Provider Load Balancing">
+<TabItem value="sdk" label="Copilot SDK">
 
-All deployments with the same model_name will be load balanced. In this example we load balance between OpenAI and Anthropic:
-
-```yaml showLineNumbers title="config.yaml"
-model_list:
-  - model_name: gpt-4o
-    litellm_params:
-      model: gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-  - model_name: gpt-4o  # Same model name for load balancing
-    litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
-      api_key: os.environ/ANTHROPIC_API_KEY
-
-router_settings:
-  routing_strategy: simple-shuffle
-
-general_settings:
-  master_key: sk-1234567890
+```ts
+const provider = {
+  type: "openai",
+  baseUrl: "https://litellm.example.com/v1",
+  bearerToken: process.env.LITELLM_VIRTUAL_KEY,
+};
 ```
+
+The `model` parameter is required once BYOK is configured. LiteLLM also serves `wireApi: "responses"` if you prefer the Responses API shape.
+
+</TabItem>
+<TabItem value="enterprise" label="Enterprise or organization">
+
+Enterprise and organization owners can add the key centrally instead of asking each developer to configure their editor. In enterprise or organization settings, add a custom model key, choose the **OpenAI-compatible providers** option, supply a LiteLLM virtual key, and select the models to publish. Published models appear at the bottom of the model picker under the enterprise name, across Copilot Chat, Copilot CLI, and IDEs. See [Enabling custom models](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/enable-custom-models).
+
+GitHub's setup page spells out an explicit endpoint field only for Microsoft Foundry and fetches the model list from the provider for the other options, so confirm where your LiteLLM base URL goes in your own enterprise settings while the feature is in preview. If the form will not take an arbitrary base URL, fall back to the per-developer setups above, which document a base URL field on every surface.
+
+Because this path is server-side, every developer's traffic arrives on the one key you configured, so LiteLLM attributes it to that key rather than to individual developers. Add a separate key per GitHub organization if you want usage split by org, and use the editor and CLI setups above when you need per-developer attribution.
+
+Enterprise BYOK is in public preview.
 
 </TabItem>
 </Tabs>
 
-With this configuration, GitHub Copilot will automatically route requests through LiteLLM to your configured provider(s) with load balancing and fallbacks.
+## Tracking usage per developer and team
 
-## Troubleshooting
+With a virtual key per developer, spend and token usage roll up by user and by team in the LiteLLM UI at **Usage** and through `/spend/report`, letting teams compare how they are using models. Set budgets and rate limits on the same keys, and use `team_id` to group developers so team-level reporting matches your org structure. See [Cost tracking for coding assistants](./cost_tracking_coding.md).
 
-If you encounter issues:
+## Guardrails and PII masking
 
-1. **GitHub Copilot not using proxy**: Verify the proxy URL is correctly configured in VS Code settings and that LiteLLM proxy is running
-2. **Authentication errors**: Ensure your master key is valid and API keys for providers are correctly set
-3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000`
+Guardrails attach to the proxy, so they apply to Copilot's calls the same way they apply to any other client. Configure PII masking and any other pre-call checks once and they cover every surface pointed at LiteLLM. See the [guardrails quick start](../proxy/guardrails/quick_start.md).
 
-## Credits
+## Limitations
 
-This tutorial is based on the work by [Sergio Pino](https://dev.to/spino327) from his original article: [Calling GitHub Copilot models from OpenHands using LiteLLM Proxy](https://dev.to/spino327/calling-github-copilot-models-from-openhands-using-litellm-proxy-1hl4). Thank you for the foundational work! 
+Inline completions never traverse BYOK, so LiteLLM cannot see or mask that traffic. Enterprise BYOK is a public preview feature, and GitHub bills BYOK calls according to your provider's terms rather than counting them against Copilot usage quotas. If you need coverage of every model call a developer makes, pair BYOK with a coding assistant that supports a custom base URL for all of its traffic, such as [Claude Code](./claude_code_byok.md) or [Cursor](./cursor_integration.md).
+
+## Related
+
+Looking for the opposite direction, calling Copilot's models from LiteLLM with your Copilot subscription? See the [GitHub Copilot provider docs](../providers/github_copilot.md).


### PR DESCRIPTION
## TLDR

The GitHub Copilot tutorial told readers to set `github.copilot.advanced.debug.overrideProxyUrl`, an undocumented debug flag aimed at Copilot's completions proxy. That direction cannot work; Copilot's hosted models are not exposed as an OpenAI-compatible API, so LiteLLM has no supported way to sit in front of Copilot as a passthrough gateway. A customer asking how to get per-developer tracking, PII masking, and guardrails across company-wide Copilot usage would follow that page and get nowhere

This rewrites the page around the direction GitHub does support, where Copilot is the client and LiteLLM is the OpenAI-compatible provider it calls through bring your own key. GitHub's own [Copilot SDK BYOK docs](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok) name LiteLLM as a supported OpenAI-compatible endpoint, and no LiteLLM code changes are needed; it is config on both sides

## Changes

Covers setup per surface (VS Code custom endpoint with the full `/chat/completions` URL, JetBrains, Copilot CLI env vars, the Copilot SDK, and enterprise or organization custom models), a virtual key per developer so spend rolls up by `user_id` and `team_id`, and the requirements Copilot imposes on the provider: tool calling, streaming, and a model list served from `GET /v1/models`

Also states what BYOK never covers, since that shapes what we can promise. Inline ghost-text completions, semantic search, and embedding-backed features stay on GitHub's infrastructure on every surface, so LiteLLM sees chat, agent, and CLI traffic but not completions. On the enterprise path the traffic arrives on one centrally configured key, so attribution there is per organization rather than per developer; the page says so and points at the per-developer setups when user-level attribution is the goal

The enterprise section is deliberately hedged on one point: GitHub documents an explicit endpoint field only for Microsoft Foundry and fetches models from the provider for the other options, so the page tells admins to confirm where the LiteLLM base URL goes in their own settings while the feature is in preview, with the per-developer setups as the fallback. Every per-developer surface documents a base URL field, so that path is unambiguous

The provider page gets a pointer to the tutorial, since the two pages describe opposite directions and are easy to confuse

## Type

📖 Documentation

## Screenshots / Proof of Fix

`npm run build` passes with no broken links or MDX errors from these pages (the HTML minifier diagnostics and the one broken anchor in the log are pre-existing, on unrelated release-notes pages)

The Copilot-side claims are cited from GitHub's docs and changelogs rather than tested here: [BYOK concepts](https://docs.github.com/en/copilot/concepts/models/bring-your-own-key), [enable custom models](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/enable-custom-models), [Copilot CLI BYOK](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models), [Copilot SDK BYOK](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok), and [BYOK enhancements adding any OpenAI-compatible provider](https://github.blog/changelog/2026-01-15-github-copilot-bring-your-own-key-byok-enhancements/). The enterprise BYOK public preview announcement is the Nov 20, 2025 GitHub changelog entry titled "Enterprise bring your own key (BYOK) for GitHub Copilot is now in public preview"

An end-to-end run needs a Copilot Business or Enterprise seat plus a publicly reachable proxy, so the VS Code and CLI steps are worth walking once against a live proxy before this ships

## QA runbook

Start a proxy with a model that supports tool calling, create a virtual key with `user_id` and `team_id` set, then in VS Code open the Chat model picker, choose Manage Language Models, Add Models, Custom Endpoint, Chat Completions, paste the virtual key, and set the model `url` to `https://PROXY_HOST/v1/chat/completions`. Send a chat message and an agent-mode request, then confirm both appear at http://localhost:4000/ui/?page=logs attributed to that user and team. Repeat with `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`, and `COPILOT_MODEL` exported for Copilot CLI. Trigger an inline completion and confirm it does not appear in the logs, which is the documented gap
