### PR TITLE
chore(compat-matrix): refresh for v1.94.0 + claude-code 2.1.220

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-11T06:11:54Z",
-  "litellm_version": "v1.91.1",
-  "claude_code_version": "2.1.126",
+  "generated_at": "2026-07-30T06:14:18Z",
+  "litellm_version": "v1.94.0",
+  "claude_code_version": "2.1.220",
   "providers": [
     "anthropic",
     "bedrock_invoke",
@@ -22,8 +22,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -65,8 +64,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -87,14 +85,14 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] claude CLI timed out after 120.0s"
         }
       }
     },
@@ -109,8 +107,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -153,8 +150,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -175,8 +171,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -198,7 +193,7 @@
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; api_status=400; text=API Error: 400 litellm.BadRequestError: BedrockException - {\"message\":\"A text block must be included when using documents. Add a text block and retry your request.\"}. Received Model Group=claude-haiku-4-5-bedrock-converse\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "vertex_ai": {
           "status": "pass"
@@ -219,8 +214,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -241,8 +235,7 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "status": "pass"
         },
         "vertex_ai": {
           "status": "pass"
@@ -312,7 +305,8 @@
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"tool_search_server not supported in your workspace.\\\"},\\\"request_id\\\":\\\"req_011CdXkAFVguVuRbvkFyS9ae\\\"}. Received Model Group=claude-haiku-4-5-azure\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
         }
       }
     },


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 2 green->red regression(s):
  - Prompt caching (5m TTL) [azure]: pass -> fail ([claude-haiku-4-5-azure] claude CLI timed out after 120.0s)
  - Tool search (MCP discovery) [azure]: pass -> fail ([claude-haiku-4-5-azure] tool_search probe failed: status 400: {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\)
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.94.0` |
| claude_code_version | `2.1.220` |
| generated_at | `2026-07-30T06:14:18Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=fail
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=pass, vertex_ai=pass, azure=fail
- **Long context (1M)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.