### PR TITLE
docs(proxy): document LITELLM_SET_REPLICA_IDENTITY_FULL

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -979,6 +979,7 @@ router_settings:
 | LITELLM_RATE_LIMIT_WINDOW_SIZE | Rate limit window size for LiteLLM. Default is 60
 | LITELLM_REASONING_AUTO_SUMMARY | If set to "true", automatically enables detailed reasoning summaries (`summary: "detailed"`) for reasoning models across all translation paths (Anthropic adapter, Responses API, etc.). Default is "false"
 | LITELLM_SALT_KEY | Salt key for encryption in LiteLLM
+| LITELLM_SET_REPLICA_IDENTITY_FULL | Set to `true` to run `ALTER TABLE ... REPLICA IDENTITY FULL` on every LiteLLM table at the end of each migration run. Logical replication consumers such as Neon or lakehouse sync need FULL replica identity to read the old row of an UPDATE or DELETE; Prisma leaves new tables at the Postgres default. Requires the migration user to own the tables. Default is `false`
 | LITELLM_SENSITIVE_ROUTING_TTL | TTL in seconds for sticky sensitive-data routing decisions; controls how long a session stays pinned to the on-premise model selected by a routing guardrail. Default is 3600
 | LITELLM_SSL_CIPHERS | SSL/TLS cipher configuration for faster handshakes. Controls cipher suite preferences for OpenSSL connections.
 | LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE | AWS KMS encrypted license for LiteLLM

--- a/docs/proxy/db_info.md
+++ b/docs/proxy/db_info.md
@@ -74,3 +74,24 @@ If you need to migrate Databases the following Tables should be copied to ensure
 | LiteLLM_ErrorLogs | **Optional** Only migrate if you want historical data on LiteLLM UI |
 
 
+
+## Replicating the database with logical replication
+
+Postgres logical replication only carries the columns of the replica identity when a row is updated or deleted. Prisma creates every LiteLLM table at the Postgres default, which is the primary key, so a downstream consumer sees the new row but not the previous one. Sinks such as Neon's lakehouse sync require `REPLICA IDENTITY FULL` and reject tables that do not have it.
+
+Set `LITELLM_SET_REPLICA_IDENTITY_FULL=True` to have LiteLLM run
+
+```sql
+ALTER TABLE "LiteLLM_..." REPLICA IDENTITY FULL;
+```
+
+on every LiteLLM table at the end of each migration run, including tables that a future upgrade adds, so the setting survives upgrades instead of having to be re-applied by hand. Tables that are already `FULL` are skipped, and tables in the same schema that LiteLLM does not own are left alone.
+
+```bash
+export LITELLM_SET_REPLICA_IDENTITY_FULL=True
+litellm --config /path/to/config.yaml
+```
+
+The database user running the migrations has to own the tables. If it does not, the `ALTER` is rejected, LiteLLM logs the Postgres error and starts anyway, since replication metadata is not needed to serve requests.
+
+`REPLICA IDENTITY FULL` makes Postgres write the entire old row into the WAL for every `UPDATE` and `DELETE`, so leave it off unless a replication consumer needs it.


### PR DESCRIPTION
Documents the `LITELLM_SET_REPLICA_IDENTITY_FULL` env var added in BerriAI/litellm#35267

Postgres logical replication only carries the replica identity columns for an UPDATE or DELETE, and prisma leaves every LiteLLM table at the default, so sinks that need `REPLICA IDENTITY FULL` (Neon lakehouse sync and similar) reject them. The new env var re-asserts FULL at the end of each migration run

Adds a row to the environment variables reference and a short section to "What is stored in the DB" covering why the setting exists, what it costs, and the table-ownership requirement

Merge after BerriAI/litellm#35267
