### PR TITLE
docs(release_notes): add v1.94.1 and flag the v1.94.0 team-key budget issue

### DIFF
--- a/release_notes/v1.94.0/index.md
+++ b/release_notes/v1.94.0/index.md
@@ -43,9 +43,13 @@ pip install litellm==1.94.0
 </TabItem>
 </Tabs>
 
-:::danger Breaking Changes
+:::danger Known issue - fixed in v1.94.1
 
-**User budgets now apply on team keys by default.** A user's personal `max_budget` is now enforced whenever they call through a team key, so it stacks with the team and team-member budgets instead of being skipped as before. If you relied on personal budgets being ignored on team keys, set `general_settings.skip_user_budget_on_team_key: true` to restore the previous behavior. See [PR #32005](https://github.com/BerriAI/litellm/pull/32005).
+**A user's personal `max_budget` was enforced on their team keys, which could lock them out of the Admin UI.** Upgrade to [`v1.94.1`](/release_notes/v1.94.1/v1-94-1).
+
+Once a user's personal spend crossed their own budget, their team keys returned `429 ExceededBudget` even with team budget remaining. The check also runs on management routes, and the Admin UI session token is team-scoped, so the dashboard rendered empty for affected users.
+
+`v1.94.1` reverts this and removes the `general_settings.skip_user_budget_on_team_key` opt-out; remove it from your config if you set it.
 
 :::
 

--- a/release_notes/v1.94.1/index.md
+++ b/release_notes/v1.94.1/index.md
@@ -1,0 +1,60 @@
+---
+title: "v1.94.1 - Team Key Budget Enforcement Reverted"
+slug: "v1-94-1"
+date: 2026-07-30T21:45:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.94.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.94.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.94.1` is a patch release on top of [`v1.94.0`](/release_notes/v1.94.0/v1-94-0). It reverts the change that made a user's personal `max_budget` apply to their team keys.
+
+If you are on `v1.94.0`, upgrading to `v1.94.1` is recommended. Under `v1.94.0`, once a user's personal spend crossed their own `max_budget`, every request made with a team-scoped key belonging to that user was refused with `429 ExceededBudget`, even when the team had budget left. That check runs on management routes as well as LLM routes, and the Admin UI session token is itself team-scoped, so an affected user was also locked out of the dashboard: key lists, team lists, and most other panels returned `429` and the page rendered empty.
+
+A team-scoped key is once again governed by the team and team-member budgets alone. A user's personal `max_budget` continues to apply to their personal keys, unchanged.
+
+The `general_settings.skip_user_budget_on_team_key` flag that `v1.94.0` introduced as an opt-out is removed in this release. It existed only to switch the reverted behavior off, so it goes away with the behavior rather than remaining as a setting that does nothing. If you set it, remove it from your config; the hierarchy it restored is now the default.
+
+### What's Changed
+
+- revert(proxy): stop enforcing user budget on team keys - [PR #35271](https://github.com/BerriAI/litellm/pull/35271)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.94.0...v1.94.1


### PR DESCRIPTION
## What this does

Adds the `v1.94.1` release note and replaces the Breaking Changes admonition on the `v1.94.0` note with a known-issue warning

`v1.94.1` reverts the change that made a user's personal `max_budget` apply to their team keys. On `v1.94.0`, once a user's personal spend crossed their own budget, every request on their team-scoped keys was refused with `429 ExceededBudget` even when the team had budget left. That check also runs on management routes, and the Admin UI session token is itself team-scoped, so an affected user was locked out of the dashboard as well: key lists, team lists, and most other panels returned `429` and the page rendered empty

## Why the v1.94.0 note changes too

Its existing admonition presented the behavior as intended and told readers to set `general_settings.skip_user_budget_on_team_key: true` to opt out. That flag is removed in `v1.94.1` along with the behavior, so the advice no longer works. The block now leads with the upgrade instead

## Timing

`v1.94.1` is cut by [BerriAI/litellm#35277](https://github.com/BerriAI/litellm/pull/35277) and has not built yet. Do not merge this until that release actually ships, and update it if the release is re-cut to a different version