### PR TITLE
feat(docs): add Nexus Shield provider doc

### DIFF
--- a/docs/providers/nexus_shield.md
+++ b/docs/providers/nexus_shield.md
@@ -1,0 +1,25 @@
+# Nexus Shield (Sub-10ms Guardrail Proxy)
+
+Nexus Shield is an in-RAM PII sanitization and security guardrail proxy designed for OpenAI/Anthropic APIs with sub-10ms overhead.
+
+## Usage with LiteLLM
+
+You can pass Nexus Shield as the custom `api_base` endpoint in your LiteLLM completion calls.
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="openai/gpt-4o",
+    messages=[{"role": "user", "content": "Hello, my phone is 555-0199"}],
+    api_base="https://api.nexusshield.ai/v1",
+    api_key="nx_live_YOUR_KEY",
+)
+
+print(response)
+```
+
+## Features
+
+- **Sub-10ms Latency:** Pattern matching evaluated directly in RAM before reaching LLMs.
+- **Zero-Log Infrastructure:** Redacts PII without writing raw payloads to disk.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1123,6 +1123,7 @@ const sidebars = {
         "providers/nlp_cloud",
         "providers/nano-gpt",
         "providers/novita",
+        "providers/nexus_shield",
         { type: "doc", id: "providers/nscale", label: "Nscale (EU Sovereign)" },
         {
           type: "category",


### PR DESCRIPTION
## Summary
Adds provider documentation and sidebar navigation entry for **Nexus Shield** — an in-RAM PII sanitization and security guardrail proxy with sub-10ms overhead.

## Changes Included
- Added `docs/providers/nexus_shield.md` with installation, features, and code examples.
- Updated `sidebars.js` to include Nexus Shield under the providers section.

## Usage Preview
```python
import litellm

response = litellm.completion(
    model="openai/gpt-4o",
    messages=[{"role": "user", "content": "Hello, my phone is 555-0199"}],
    api_base="[https://api.nexusshield.ai/v1](https://api.nexusshield.ai/v1)",
    api_key="nx_live_YOUR_KEY"
)

print(response)
Checklist
[x] Markdown formatting verified

[x] Added sidebar integration entry in sidebars.js

[x] Followed standard provider documentation guidelines