### PR TITLE
docs: guidance on choosing GENERIC_USER_ID_ATTRIBUTE for generic SSO

### DIFF
--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -246,8 +246,8 @@ GENERIC_USERINFO_ENDPOINT = "http://localhost:9090/me"
 The following can be used to customize attribute names when interacting with the generic OAuth provider. We will read these attributes from the SSO Provider result
 
 ```shell
-GENERIC_USER_ID_ATTRIBUTE = "given_name"
-GENERIC_USER_EMAIL_ATTRIBUTE = "family_name"
+GENERIC_USER_ID_ATTRIBUTE = "sub"
+GENERIC_USER_EMAIL_ATTRIBUTE = "email"
 GENERIC_USER_DISPLAY_NAME_ATTRIBUTE = "display_name"
 GENERIC_USER_FIRST_NAME_ATTRIBUTE = "first_name"
 GENERIC_USER_LAST_NAME_ATTRIBUTE = "last_name"
@@ -258,6 +258,10 @@ GENERIC_CLIENT_STATE = "some-state" # if the provider needs a state parameter
 GENERIC_INCLUDE_CLIENT_ID = "false" # some providers enforce that the client_id is not in the body
 GENERIC_SCOPE = "openid profile email" # default scope openid is sometimes not enough to retrieve basic user info like first_name and last_name located in profile scope
 ```
+
+**Choosing `GENERIC_USER_ID_ATTRIBUTE`**
+
+LiteLLM stores this attribute's value as the user's identity and looks the user up by it on every subsequent login, so point it at a claim your provider guarantees is unique and never changes for the lifetime of the account. `sub` is the standard OIDC claim for this. Claims that a user can edit in their own profile, such as `preferred_username`, `email`, or `name`, will change out from under LiteLLM, and the next login is then treated as a different person with a separate set of keys, teams, and spend. When `GENERIC_USER_ID_ATTRIBUTE` is unset, LiteLLM reads `preferred_username`, so set it explicitly if your provider lets users change that value.
 
 **Assigning User Roles via SSO**
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -793,7 +793,7 @@ router_settings:
 | GENERIC_USER_EMAIL_ATTRIBUTE | Attribute for user's email in generic auth
 | GENERIC_USER_EXTRA_ATTRIBUTES | Comma-separated list of additional fields to extract from generic SSO provider response (e.g., "department,employee_id,groups"). Accessible via `CustomOpenID.extra_fields` in custom SSO handlers. Supports dot notation for nested fields
 | GENERIC_USER_FIRST_NAME_ATTRIBUTE | Attribute for user's first name in generic auth
-| GENERIC_USER_ID_ATTRIBUTE | Attribute for user ID in generic auth
+| GENERIC_USER_ID_ATTRIBUTE | Attribute for user ID in generic auth. Use a claim that is unique and immutable per account, such as `sub`; defaults to `preferred_username`
 | GENERIC_USER_LAST_NAME_ATTRIBUTE | Attribute for user's last name in generic auth
 | GENERIC_USER_PROVIDER_ATTRIBUTE | Attribute specifying the user's provider
 | GENERIC_USER_ROLE_ATTRIBUTE | Attribute specifying the user's role


### PR DESCRIPTION
The generic SSO page showed `GENERIC_USER_ID_ATTRIBUTE = "given_name"` as its worked example and never documented the `preferred_username` fallback, so there was nothing telling operators the attribute needs to be stable. LiteLLM stores that value as the user's identity and looks the user up by it on every subsequent login; if the claim changes, the next login resolves to a different user with a separate set of keys, teams, and spend.

This points the example at `sub`, adds a short paragraph on picking the attribute, and repeats the guidance in the env var reference table. The neighbouring `GENERIC_USER_EMAIL_ATTRIBUTE = "family_name"` example is corrected to `email` in the same block.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->