### PR TITLE
docs(proxy): document actual dynamic rate limiter v3 behavior

### DIFF
--- a/docs/proxy/dynamic_rate_limit.md
+++ b/docs/proxy/dynamic_rate_limit.md
@@ -5,7 +5,7 @@ Prevent projects from gobbling too much tpm/rpm.
 
 **See Also:** [Request Prioritization](../scheduler.md) - Prioritize LLM API requests in high-traffic by adding them to a priority queue.
 
-Dynamically allocate TPM/RPM quota to api keys, based on active keys in that minute. [**See Code**](https://github.com/BerriAI/litellm/blob/9bffa9a48e610cc6886fc2dce5c1815aeae2ad46/litellm/proxy/hooks/dynamic_rate_limiter.py#L125)
+Share a model's TPM/RPM capacity across keys and teams. The limiter watches how saturated the model is: while recorded usage is below a configurable saturation threshold, any key may use idle capacity; once usage crosses the threshold, each priority level is held to its reserved share. [**See Code**](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/hooks/dynamic_rate_limiter_v3.py)
 
 ## Quick Start Usage
 
@@ -38,10 +38,11 @@ litellm --config /path/to/config.yaml
 
 ```python showLineNumbers title="test.py"
 """
-- Run 2 concurrent teams calling same model
+- Run 2 keys calling the same model
 - model has 60 TPM
 - Mock response returns 30 total tokens / request
-- Each team will only be able to make 1 request per minute
+- The model serves 2 requests in the window (2 x 30 = 60 tokens),
+  then 429s every key until the 60s window rolls
 """
 
 import requests
@@ -97,8 +98,10 @@ except RateLimitError as e:
 **Expected Response**
 
 ```
-This was rate limited b/c - Error code: 429 - {'error': {'message': {'error': 'Key=<hashed_token> over available TPM=0. Model TPM=0, Active keys=2'}, 'type': 'None', 'param': 'None', 'code': 429}}
+This was rate limited b/c - Error code: 429 - {'error': {'message': 'Model capacity reached for my-fake-model. Priority: None, Rate limit type: tokens, Model TPM: 60, Model RPM: not configured, Remaining: 0', 'type': 'throttling_error', 'param': None, 'code': '429'}}
 ```
+
+Tokens are recorded on the limiter's counters after each response completes, so the block fires on the first request after recorded usage reaches the model's TPM. Requests already in flight when the budget runs out are not blocked; see [How enforcement works](#how-enforcement-works) below.
 
 
 ## [BETA] Set Priority / Reserve Quota
@@ -168,7 +171,7 @@ general_settings:
   - Supported types: `"percent"`, `"rpm"`, `"tpm"`
 
 `priority_reservation_settings`: Object (Optional)
-- **default_priority (float)**: Weight/percentage (0.0 to 1.0) assigned to API keys that have no priority metadata set (defaults to 0.5)
+- **default_priority (float)**: Weight/percentage (0.0 to 1.0) assigned to API keys that have no priority metadata set (defaults to 0.25). All keys without an explicit priority share ONE pool of this size; it is not a per-key allocation. Two unlabeled teams therefore compete inside the same default pool with no floor between them
 - **saturation_threshold (float)**: Saturation level (0.0 to 1.0) at which strict priority enforcement begins for a model. Saturation is calculated as `max(current_rpm/max_rpm, current_tpm/max_tpm)`. Below this threshold, generous mode allows priority borrowing from unused capacity. Above this threshold, strict mode enforces normalized priority limits.
   - Example: When model usage is low, keys can use more than their allocated share. When model usage is high, keys are strictly limited to their allocated share.
 - **saturation_check_cache_ttl (int)**: TTL in seconds for local cache when reading saturation values from Redis (defaults to 60). In multi-node deployments, this controls how quickly nodes converge on the same saturation state. Lower values mean faster convergence but more Redis reads.
@@ -280,20 +283,58 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 ### Expected Behavior
 
-With the configuration above:
+A priority's reservation is a floor, not a ceiling. What a key can actually use depends on how saturated the model is:
 
-1. **Production keys** can make up to 9 requests per minute (90% of 10 RPM)
-2. **Development keys** can make up to 1 request per minute (10% of 10 RPM)
-3. **Keys without explicit priority** get the default_priority weight (0 = 0%), which allocates 0 requests per minute (0% of 10 RPM)
-4. Named priorities in `priority_reservation` and keys with `default_priority` operate independently
+1. **Below the saturation threshold (generous mode)**: only the model-wide capacity is enforced. Any key, regardless of priority, may use idle capacity beyond its own reservation
+2. **At or above the threshold (strict mode)**: each priority is held to its reserved share for the rest of the window. Keys whose priority pool is exhausted receive 429s while priorities still inside their reservation keep being served
+3. **Keys without explicit priority** share one pool weighted by `default_priority`. With the configuration above (`default_priority: 0`) they get nothing; with the default (`0.25`) all unlabeled keys together get 25%
+4. Capacity a key consumed while borrowing in generous mode is not taken back when strict mode engages. Floors protect capacity that has not been consumed yet, so a floor is only fully guaranteed if the protected priority sends traffic throughout the window
 
-**Rate Limit Error Example:**
+An important consequence of (1) and (2): saturation measures recorded usage, not how many keys are active. A key alone on an idle model still trips strict mode with its own traffic, so the most a single priority can use in one window is `max(its reservation, saturation_threshold) x model capacity`, plus at most one in-flight request. A lone key never reaches 100% of the model unless its reservation or the threshold allows it.
+
+#### Worked example
+
+Model with `tpm: 1000`, `priority_reservation: {"team_a": 0.5, "team_b": 0.5}`, `saturation_threshold: 0.5`. Team A demands more than full capacity every minute; team B demands what the row says. Each row is one fresh 60s window:
+
+| Window | A demands | B demands | A is served | B is served | Why |
+|---|---|---|---|---|---|
+| 1 | 100%+ | idle | ~500 | | A alone saturates the model to 50%, strict mode caps A at its own 500 floor |
+| 2 | 100%+ | 500 | ~500 | ~500 | strict mode splits capacity along the 50/50 floors |
+| 3 | 100%+ | 400 | ~500 | ~400 | B under its floor is fully served, zero 429s; A takes the rest |
+
+Raising `saturation_threshold` to `0.8` changes window 1 to ~800 (A borrows up to the threshold) but weakens window 2: A grabs ~600 in generous mode before strict engages, and B tops out around ~420 because A's borrowed capacity is not clawed back and the model-wide cap blocks the remainder.
+
+#### How enforcement works
+
+Request counts are checked and incremented before the LLM call, so RPM limits are exact. Token counts are only known after a response completes, so TPM enforcement is admission control against recorded usage: a request is admitted while recorded tokens are below the limit, and its own tokens land on the counter afterwards. Two consequences:
+
+1. Actual tokens served in a window can exceed the configured TPM by roughly one request's tokens per concurrently sending key. A burst of parallel requests admitted together can overshoot further; TPM is not a hard intra-minute cap
+2. If the configured TPM is smaller than a typical single response, a single request blows through the whole budget and enforcement degenerates to roughly one request per window. Size TPM well above your typical per-request token count when testing this feature
+
+Windows are rolling 60 seconds from the first request on the model, not calendar minutes. In multi-node deployments the saturation value is additionally cached locally for `saturation_check_cache_ttl` seconds, so strict mode can engage up to that many seconds late on nodes that did not serve the triggering traffic.
+
+**Rate Limit Error Examples:**
+
+Priority pool exhausted in strict mode:
+
 ```json
 {
   "error": {
-    "message": "Key=sk-dev-... over available RPM=0. Model RPM=10, Reserved RPM for priority 'dev'=1, Active keys=1",
-    "type": "rate_limit_exceeded",
-    "code": 429
+    "message": "Priority-based rate limit exceeded. Model: gpt-3.5-turbo, Priority: dev, Rate limit type: tokens, Model TPM: 1000, Model RPM: not configured, Remaining: 0, Model saturation: 52.8%",
+    "type": "throttling_error",
+    "code": "429"
+  }
+}
+```
+
+Model-wide capacity exhausted (any priority):
+
+```json
+{
+  "error": {
+    "message": "Model capacity reached for gpt-3.5-turbo. Priority: prod, Rate limit type: tokens, Model TPM: 1000, Model RPM: not configured, Remaining: 0",
+    "type": "throttling_error",
+    "code": "429"
   }
 }
 ```


### PR DESCRIPTION
## TLDR

The dynamic rate limiting page mixed prose from the old fair-share limiter with `dynamic_rate_limiter_v3` config examples, which set expectations v3 does not deliver. A customer built a test plan from this page expecting a lone team to use 100% of a model's TPM and saw very different numbers

What was wrong on the page: the intro said quota is allocated "based on active keys in that minute" and linked the v2 hook's code; the quick start promised each key one request per minute when v3 enforces a shared model-wide cap first come first served; both 429 examples showed the v2 message format that v3 never emits; `default_priority` was documented as defaulting to 0.5 when the code default is 0.25, without mentioning that all unlabeled keys share a single pool

What this PR documents, verified against a live proxy (measurements in [BerriAI/litellm#35422](https://github.com/BerriAI/litellm/pull/35422)): reservations are floors that harden into ceilings once model saturation crosses `saturation_threshold`; borrowing is bounded by the threshold, so a lone key tops out at `max(reservation, threshold) x capacity` and never reaches 100%; borrowed capacity is not clawed back within a window; unlabeled keys share one `default_priority` pool; TPM enforcement is admission control against post-call recorded usage, so a window can overshoot by roughly one in-flight request per sender and a TPM smaller than a single response degenerates to one request per window. Includes a worked two-team example table and current v3 429 messages

Note: TPM enforcement in v3 is broken on current releases for models configured with only `tpm` (no `rpm`); nothing is enforced at all. The behavior documented here is post-fix, landing in [BerriAI/litellm#35422](https://github.com/BerriAI/litellm/pull/35422)
