### PR TITLE
docs(deploy): show ingress.extraPaths on the componentized helm chart

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -177,6 +177,14 @@ ingress:
   enabled: true
   className: "<alb | gce | azure-application-gateway>"
   host: llm.example.com
+  # optional: routes the chart does not ship a rule for, e.g. a passthrough
+  # prefix added after this chart version or a custom
+  # general_settings.pass_through_endpoints path. Additive: every built-in
+  # UI, gateway, and backend path is still rendered
+  extraPaths:
+    - path: /watsonx
+      pathType: Prefix     # default; Exact and ImplementationSpecific also work
+      service: gateway     # default; backend and ui also work
 ```
 
 ```bash


### PR DESCRIPTION
Companion to BerriAI/litellm#35700, which adds `ingress.extraPaths` to the componentized helm chart

The componentized chart's Ingress renders a fixed path set, and the prefix list it routes to the gateway is a snapshot of the data plane at chart release time. A passthrough route the list omits falls into the backend catch-all and 404s, and a custom `general_settings.pass_through_endpoints` path has a name only the operator knows, so the chart can never ship a rule for it. `ingress.extraPaths` lets an operator add those paths from `values.yaml` without forking the template.

The helm tab's ingress example now shows the knob with its two selectors and their defaults, next to the values it already demonstrates

Merge after BerriAI/litellm#35700, since the knob does not exist until that lands

Validated with `npm ci && npm run build`; the only warnings are the pre-existing broken anchors on old release-notes pages
