### PR TITLE
docs(auto-routing): session affinity is now off by default

### DIFF
--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -19,7 +19,7 @@ Ships in **v1.94.x**. The earliest dev release cuts **Tuesday, 2026-07-14**. Sug
 | Classifier   | Embedding match on utterances     | Heuristic, LLM classifier, or lexical/semantic keyword rules               |
 | Tier value   | One model                         | One model, random pool, or adaptive (Thompson-sampled) pool                |
 | Latency      | ~100-500ms (embedding call)       | Sub-millisecond (heuristic/keyword) or one small classifier call (LLM)     |
-| Session pin  | No                                | Opt-in `session_affinity`, keyed by `session_id` from request metadata     |
+| Session pin  | No                                | Opt-in `session_affinity` (off by default), keyed by `session_id` metadata |
 | Log          | No routing-cause signal           | `cause=` marker per decision (scorer, literal, semantic, session_pin, LLM) |
 | Best for     | Intent-based routing              | Cost/quality tiering, hybrid rule + classifier setups, prompt-cache pinning |
 
@@ -96,7 +96,7 @@ Every knob v2 exposes. All fields on `complexity_router_config` are optional exc
       # Thompson-sample within the tier's pool
       adaptive: true
 
-      # Pin a session to its first-turn model to preserve prompt cache
+      # Pin a session to its first-turn model to preserve prompt cache (default false)
       session_affinity: true
       session_affinity_ttl_seconds: 3600
 
@@ -172,16 +172,24 @@ A tier value can be a single model name or a list.
 
 ## Session affinity
 
-On by default. Pins the first-turn model for a session and skips reclassification on later turns, so provider-side prompt caches keyed to that model do not get invalidated when a follow-up ("thanks!") would otherwise classify into a different tier. It also keeps a multi-turn session on a single model, which avoids provider errors when conversation history produced by one model (for example an Anthropic `thinking` block) is replayed to a different model on a later turn.
+Off by default: every turn is classified on its own merits, so each one lands on the cheapest tier adequate for it.
 
-Set `session_affinity: false` to reclassify every turn instead.
+Set `session_affinity: true` to pin the first-turn model for a session and skip reclassification on later turns. Turning it on buys two things. Provider-side prompt caches keyed to that model stop getting invalidated when a follow-up ("thanks!") would otherwise classify into a different tier. And a multi-turn session stays on a single model, which avoids provider errors when conversation history produced by one model (for example an Anthropic `thinking` block) is replayed to a different model on a later turn.
+
+The trade is that the whole session inherits the first turn's tier. A conversation that opens with one hard question then continues with simple follow-ups keeps paying the expensive tier for all of them.
 
 ```yaml
-session_affinity: true   # default; set false to reclassify every turn
+session_affinity: true          # default false; set true to pin a session to its first-turn model
 session_affinity_ttl_seconds: 3600
 ```
 
-`session_id` is read from request metadata; when no `session_id` is resolvable the router classifies every turn as usual. When `adaptive: true` is also set, a pinned turn still stamps the adaptive bandit's chosen-model metadata key so reward feedback keeps working.
+`session_id` is read from request metadata; when no `session_id` is resolvable the router classifies every turn as usual, whatever this is set to. When `adaptive: true` is also set, a pinned turn still stamps the adaptive bandit's chosen-model metadata key so reward feedback keeps working. `session_affinity` is ignored when `plugins` are configured, so a mid-session policy change still applies on later turns rather than being skipped by a cached pin.
+
+:::info Changed default
+
+`session_affinity` used to default to `true`. Routers created before that changed have no `session_affinity` key stored, so they pick up the new `false` default and start reclassifying every turn. Add `session_affinity: true` to any router that should keep pinning.
+
+:::
 
 ## Custom technical keywords
 
@@ -259,6 +267,8 @@ response = await router.acompletion(
 Models + Endpoints > Add Model > Auto Router tab. Router Type defaults to "Auto-Router v2 [Recommended]". Configure the four tier model groups, optionally enable Semantic Keyword Matching, LLM Classifier, or Adaptive, then click **Test Connection**. Test Connection runs a minimal `/v1/chat/completions` or `/v1/embeddings` per distinct tier model group, so a green row means the tier is genuinely reachable and a red row shows the real provider error.
 
 Tier and classifier dropdowns exclude embedding-mode models; the semantic embedding dropdown lists only embedding-mode models. All four tiers are required on submit; missing tiers are flagged inline.
+
+**Advanced > Session Affinity** holds the session pin, off to match the config default. Both the create tab and the edit modal write the value explicitly, so a router built in the UI records what it does rather than inheriting whatever the default happens to be.
 
 ## Claude Code and Claude Desktop
 


### PR DESCRIPTION
## What changed

`session_affinity` on the complexity router now defaults to `false` (BerriAI/litellm branch `litellm_autorouter_session_affinity_toggle`, LIT-5134). The Auto Routing page documented the opposite, so the "Session affinity" section is rewritten around pinning as the opt-in rather than the opt-out.

The section now states what turning it on buys (provider prompt caches survive a follow-up that would classify into a different tier; a multi-turn session stays on one model, so history produced by one model isn't replayed to another) and what it costs (the whole session inherits its first turn's tier, so a hard opener followed by simple follow-ups keeps paying the expensive tier).

Three smaller fixes on the same page. The "When to use" table said "Opt-in `session_affinity`" while the field was actually on by default; that row is now correct and says so explicitly. The full-config sample annotates the default next to the field. And a callout flags the migration: routers created before the change have no `session_affinity` key stored, so they pick up the new default and start reclassifying every turn, and need `session_affinity: true` added to keep pinning.

The UI section picks up the new **Advanced > Session Affinity** toggle on the create tab and edit modal.

## Related

- BerriAI/litellm branch `litellm_autorouter_session_affinity_toggle`
- LIT-5134

## Checks

Prose only; no code samples were changed beyond the inline default comment. The `:::info` callout follows the admonition style already used on `mcp_control.md` and `prompt_compression.md`