### PR TITLE
docs(guardrails/rubrik): document prompt and response moderation

### DIFF
--- a/docs/proxy/guardrails/rubrik.md
+++ b/docs/proxy/guardrails/rubrik.md
@@ -3,13 +3,15 @@ import TabItem from '@theme/TabItem';
 
 # Rubrik Guardrail
 
-Use Rubrik's tool blocking and logging integration to validate LLM tool calls against an external policy service and batch-log all LLM requests/responses.
+Use Rubrik's moderation and logging integration to screen prompts and responses against an external policy service and batch-log all LLM requests/responses.
 
 **Key features:**
 
-- **Tool blocking**: Validates tool calls against an external Rubrik service after LLM completion. Blocked tool calls trigger a policy violation response.
-- **Batch logging**: Logs all LLM requests and responses to Rubrik with configurable sampling and batching.
-- **Fail-open**: If the tool blocking service is unavailable, requests are allowed through unchanged.
+- **Prompt moderation** (`pre_call`): Screens the prompt before the LLM is called. Works for both OpenAI and Anthropic wire formats.
+- **Response moderation** (`post_call`): Screens the assistant's response text and tool calls after the LLM returns. Either can be blocked.
+- **Streaming**: The stream is buffered until the assembled response has been moderated, so no flagged chunk reaches the client before a block.
+- **Batch logging**: Logs all LLM requests and responses to Rubrik with configurable sampling and batching. Blocks are always logged, regardless of sampling.
+- **Fail-open**: If the Rubrik service is unavailable, requests are allowed through unchanged.
 
 ---
 
@@ -33,7 +35,7 @@ guardrails:
   - guardrail_name: "rubrik"
     litellm_params:
       guardrail: rubrik
-      mode: "post_call"
+      mode: ["pre_call", "post_call"]
       api_key: "your-rubrik-api-key"
       api_base: "https://your-rubrik-service.example.com"
       default_on: true
@@ -46,7 +48,7 @@ guardrails:
   - guardrail_name: "rubrik"
     litellm_params:
       guardrail: rubrik
-      mode: "post_call"
+      mode: ["pre_call", "post_call"]
       api_key: os.environ/RUBRIK_API_KEY
       api_base: os.environ/RUBRIK_WEBHOOK_URL
       default_on: true
@@ -75,7 +77,7 @@ guardrails:
   - guardrail_name: "rubrik"
     litellm_params:
       guardrail: rubrik
-      mode: "post_call"
+      mode: ["pre_call", "post_call"]
       default_on: true
 ```
 
@@ -127,10 +129,10 @@ These are set under `guardrails.[].litellm_params` in your `config.yaml`:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `guardrail: rubrik` | Yes | Selects the Rubrik guardrail integration |
-| `mode: "post_call"` | Yes | Run after the LLM response is received |
+| `mode` | Yes | `"pre_call"` for prompt moderation, `"post_call"` for response moderation, or a list containing both |
 | `api_base` | Yes | Rubrik webhook base URL. Can use `os.environ/RUBRIK_WEBHOOK_URL`. Falls back to `RUBRIK_WEBHOOK_URL` env var if omitted. |
 | `api_key` | No | Rubrik API key. Can use `os.environ/RUBRIK_API_KEY`. Falls back to `RUBRIK_API_KEY` env var if omitted. |
-| `default_on` | No | When `true`, the guardrail runs on all requests without needing per-request opt-in |
+| `default_on` | No | When `true`, the guardrail runs on all requests. When omitted it resolves to `false` and callers opt in per request with `"guardrails": ["rubrik"]` |
 
 ### Environment Variables
 
@@ -140,28 +142,29 @@ These are optional fallbacks used when `api_base` / `api_key` are not set in the
 |----------|----------|---------|-------------|
 | `RUBRIK_WEBHOOK_URL` | Only if `api_base` not in config | — | Base URL of the Rubrik webhook service |
 | `RUBRIK_API_KEY` | No | — | Bearer token for authenticating with the Rubrik service |
-| `RUBRIK_SAMPLING_RATE` | No | `1.0` | Fraction of requests to **log** (0.0 to 1.0). Does not affect tool blocking, which always runs. Set to `0.5` to log ~50% of requests. |
+| `RUBRIK_SAMPLING_RATE` | No | `1.0` | Fraction of requests to **log** (0.0 to 1.0). Does not affect moderation, which always runs, and does not affect block logging. Set to `0.5` to log ~50% of requests. |
 | `RUBRIK_BATCH_SIZE` | No | `512` | Number of log entries to buffer before flushing. Logs are also flushed on a periodic interval. |
 
 ---
 
-## How Tool Blocking Works
+## How Moderation Works
 
-1. After the LLM returns a response with tool calls, the Rubrik guardrail sends them to the blocking service at `{api_base}/v1/after_completion/openai/v1`.
-2. The service evaluates each tool call against configured policies and returns the set of **allowed** tool calls.
-3. If any tool calls are blocked, the proxy returns the policy violation explanation as a response instead of the original LLM response.
-4. If the blocking service is unreachable or returns an error, the guardrail **fails open** — the original response is returned unchanged.
+On `pre_call`, the guardrail sends the normalized prompt to `{api_base}/v1/before_prompt/openai/v1` as a plain OpenAI chat completions request. The service returns `{}` to allow it, or a chat completion whose `choices[0].message.content` carries the refusal. On a refusal the LLM is never called.
+
+On `post_call`, the guardrail sends the assistant's text and tool calls to `{api_base}/v1/after_completion/openai/v1`. The service returns the moderated response; a removed tool call or replaced response text is treated as a block.
+
+A blocked request returns the policy explanation with `finish_reason: content_filter` instead of the original response. If either service is unreachable or returns an error, the guardrail **fails open** and the request proceeds unchanged.
 
 ### Request/Response format
 
-The guardrail sends a JSON envelope to the blocking service:
+On `post_call` the guardrail sends a JSON envelope:
 
 ```json
 {
   "request": {
     "messages": [...],
     "model": "gpt-4",
-    "proxy_server_request": {...}
+    "tools": [...]
   },
   "response": {
     "id": "chatcmpl-...",
@@ -169,6 +172,7 @@ The guardrail sends a JSON envelope to the blocking service:
     "choices": [{
       "message": {
         "role": "assistant",
+        "content": "...",
         "tool_calls": [...]
       }
     }]
@@ -176,7 +180,7 @@ The guardrail sends a JSON envelope to the blocking service:
 }
 ```
 
-The service should return an OpenAI chat completion format response containing only the **allowed** tool calls and an optional `content` field with the blocking explanation.
+`request.tools` carries the caller's declared tool list so the service can compare returned tool calls against it. The service should return an OpenAI chat completion containing only the **allowed** tool calls, with `content` carrying the replacement text or the blocking explanation.
 
 ---
 
@@ -185,5 +189,5 @@ The service should return an OpenAI chat completion format response containing o
 All LLM requests (successes and failures) are queued and sent in batches to `{api_base}/v1/litellm/batch`.
 
 - Logs are flushed when the queue reaches `RUBRIK_BATCH_SIZE` (default 512) or on a periodic interval (default 5 seconds). These defaults are inherited from LiteLLM's global settings.
-- Use `RUBRIK_SAMPLING_RATE` to reduce logging volume in high-traffic deployments. Sampling only affects logging - tool blocking always runs regardless of the sampling rate.
-- For Anthropic `/v1/messages` requests, the log ID is normalized to `litellm_call_id` for consistency across tool blocking and logging.
+- Use `RUBRIK_SAMPLING_RATE` to reduce logging volume in high-traffic deployments. Sampling only affects routine logging; moderation always runs, and blocks are always logged.
+- Log IDs are normalized to `litellm_call_id` across all providers, so the moderation log, the block log, and the batch log for one request share a correlation key.


### PR DESCRIPTION
Updates the Rubrik guardrail page for the behavior added in BerriAI/litellm#34019.

## What changed

Rubrik screens prompts on `pre_call` via `/v1/before_prompt/openai/v1`, and on `post_call` it now screens the assistant's response text in addition to tool calls. Streamed responses are buffered until end-of-stream moderation completes, so no flagged chunk reaches the client before a block. Blocks are logged regardless of the sampling rate.

The page previously described the integration as tool blocking only, and `mode` was documented as `post_call` required.

## Behavior changes

None in the docs repo. This describes behavior landing in BerriAI/litellm#34019.

## Correction

The `post_call` envelope example advertised a `proxy_server_request` field. The integration no longer sends it; the example now shows `tools` and `content`, which it does send.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->