### PR TITLE
docs(vector_stores): separate managed vector stores from provider CRUD and pass-through

### DIFF
--- a/docs/pass_through/vertex_ai_search_datastores.md
+++ b/docs/pass_through/vertex_ai_search_datastores.md
@@ -1,15 +1,18 @@
-# Vertex AI Search Datastores
+# Vertex AI Search Datastores (Pass-through)
 
-Call Vertex AI Discovery Engine Search API through LiteLLM.
+Call the Vertex AI Discovery Engine Search API through LiteLLM, using Google's native request and response shapes.
 
 Provider Doc: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.dataStores.servingConfigs/search
 
+:::tip Want the unified API instead?
+This page is the raw Google API through the proxy. If you want to query the datastore through the OpenAI-compatible `POST /v1/vector_stores/{id}/search` endpoint, or use it for RAG in `/chat/completions`, register it as a [managed vector store](../vector_stores/managed_vector_stores.md) (provider `vertex_ai/search_api`).
+:::
+
 ## What you get
 
-- Reference datastores by ID. LiteLLM finds the credentials.
-- No project/location in every request.
-- Configure credentials once, use everywhere.
-- Cost tracking works automatically.
+- The full Discovery Engine API surface, unchanged.
+- Configure credentials once on the proxy, use everywhere.
+- If the datastore id in the URL is registered as a [managed vector store](../vector_stores/managed_vector_stores.md), LiteLLM resolves its project and credentials from the registration automatically.
 
 ## Quick Start
 
@@ -40,30 +43,6 @@ curl -X POST \
   }'
 ```
 
-## Managed Vector Stores (Recommended)
-
-Register your datastore once. Reference it by ID.
-
-**In config.yaml:**
-
-```yaml
-vector_store_registry:
-  - vector_store_name: "vertex-ai-litellm-website-knowledgebase"
-    litellm_params:
-      vector_store_id: "my-datastore"
-      custom_llm_provider: "vertex_ai/search_api"
-      vertex_app_id: "test-litellm-app_1761094730750"
-      vertex_project: "test-vector-store-db"
-      vertex_location: "global"
-      vector_store_description: "Vertex AI vector store for the Litellm website knowledgebase"
-      vector_store_metadata:
-        source: "https://www.litellm.com/docs"
-```
-
-**How it works:**
-
-LiteLLM sees `dataStores/my-datastore` in your URL. It looks up the vector store. Uses the right project and credentials automatically.
-
 ## Endpoint
 
 `{PROXY_BASE_URL}/vertex_ai/discovery/{endpoint:path}`
@@ -71,19 +50,6 @@ LiteLLM sees `dataStores/my-datastore` in your URL. It looks up the vector store
 Routes to `https://discoveryengine.googleapis.com`
 
 ## Examples
-
-### Basic Search
-
-```bash
-curl -X POST \
-  "http://localhost:4000/vertex_ai/discovery/v1/projects/my-project/locations/global/collections/default_collection/dataStores/my-datastore/servingConfigs/default_config:search" \
-  -H "Content-Type: application/json" \
-  -H "x-litellm-api-key: Bearer sk-1234" \
-  -d '{
-    "query": "pricing",
-    "pageSize": 10
-  }'
-```
 
 ### Search with Filters
 
@@ -118,22 +84,4 @@ response = requests.post(url,
 for result in response.json().get("results", []):
     data = result["document"]["derivedStructData"]
     print(f"{data['title']}: {data['link']}")
-```
-
-### Use with Chat Completion
-
-```bash
-curl http://localhost:4000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $LITELLM_API_KEY" \
-  -d '{
-    "model": "claude-3-5-sonnet",
-    "messages": [{"role": "user", "content": "What is litellm?"}],
-    "tools": [
-        {
-            "type": "file_search",
-            "vector_store_ids": ["my-datastore"]
-        }
-    ]
-  }'
 ```

--- a/docs/vector_stores/create.md
+++ b/docs/vector_stores/create.md
@@ -18,6 +18,10 @@ Create a vector store which can be used to store and search document chunks for 
 
 The proxy also supports **retrieve**, **list**, **update**, and **delete** for vector stores (OpenAI-compatible). See [Vector store management and routing on the proxy](#vector-store-management-and-routing-on-the-proxy) for `curl` examples and provider routing.
 
+:::info Creating vs registering
+`POST /v1/vector_stores` (this page) creates a **new** store on the provider and only works for providers with a create implementation (see the [overview matrix](./index.md#provider-support)). If your store **already exists** on the provider (a Bedrock Knowledge Base, Vertex AI Search datastore, Azure AI Search index, ...), you want `POST /vector_store/new` instead, which registers it with LiteLLM so it can be searched through the unified API. See [Managed Vector Stores](./managed_vector_stores.md).
+:::
+
 ## Usage
 
 ### LiteLLM Python SDK

--- a/docs/vector_stores/index.md
+++ b/docs/vector_stores/index.md
@@ -1,0 +1,48 @@
+# Vector Stores - Overview
+
+LiteLLM has three distinct ways to work with vector stores. They are separate APIs with separate endpoints, and knowing which one you need saves a lot of confusion:
+
+1. **LiteLLM Managed Vector Stores**: you already have a vector store on a provider (a Bedrock Knowledge Base, a Vertex AI Search datastore, an Azure AI Search index, ...). You register it with LiteLLM once, and LiteLLM stores the provider, credentials, and id mapping. Every key on the proxy can then query it through one OpenAI-compatible endpoint, or attach it to `/chat/completions` and `/v1/responses` requests for RAG. Registration happens in `config.yaml`, over the [management API](./managed_vector_stores.md) (`POST /vector_store/new`), or in the Admin UI.
+
+2. **OpenAI-compatible vector store API**: create and manage vector stores *on the provider itself* through LiteLLM, using the OpenAI API shape. `POST /v1/vector_stores` creates a new store upstream, `/v1/vector_stores/{id}/files` manages its files, and `/rag/ingest` wraps upload, chunking, embedding, and store creation in one call.
+
+3. **Pass-through provider APIs**: call the provider's native API (native request and response shapes) through the proxy, for example `/vertex_ai/discovery/...` or `/bedrock/knowledgebases/...`. Use this when you need provider features the unified API does not expose.
+
+:::info Terminology
+A **managed vector store** in LiteLLM is a *registration*, not a new store: LiteLLM saves which provider a store lives on and how to authenticate to it, so requests can reference it by id. Nothing is created on the provider. Older docs call this concept a "knowledge base"; it is the same thing.
+:::
+
+## Which endpoint do I need?
+
+| You want to | Use | Docs |
+|---|---|---|
+| Query an existing provider store through one unified API | Register it, then `POST /v1/vector_stores/{id}/search` | [Managed Vector Stores](./managed_vector_stores.md) |
+| Give a model RAG context in `/chat/completions` | `tools: [{"type": "file_search", "vector_store_ids": [...]}]` with a registered store | [Using Vector Stores with Chat Completions](../completion/knowledgebase.md) |
+| Use `file_search` on `/v1/responses` | Registered store + the `file_search` tool | [File Search tutorial](../tutorials/file_search_responses_api.md) |
+| Create a brand new store on the provider | `POST /v1/vector_stores` | [Create](./create.md) |
+| Upload, chunk, embed, and store documents in one call | `POST /rag/ingest` | [RAG Ingest](../rag_ingest.md) |
+| Search plus rerank plus completion in one call | `POST /rag/query` | [RAG Query](../rag_query.md) |
+| Manage the files inside a store | `/v1/vector_stores/{id}/files` | [Files](../vector_store_files.md) |
+| Call the provider's native API directly | Pass-through routes | [Vertex AI Search](../pass_through/vertex_ai_search_datastores.md), [Azure AI (passthrough)](../providers/azure_ai/azure_ai_vector_stores_passthrough.md) |
+
+Note the two similarly named create endpoints. `POST /v1/vector_stores` (plural) creates a new store **on the provider**. `POST /vector_store/new` (singular) registers an **existing** store with LiteLLM. See [Managed Vector Stores](./managed_vector_stores.md) for the full management API.
+
+## Provider support
+
+Support for the unified endpoints varies by provider. `Search` is `POST /v1/vector_stores/{id}/search`; `Create` is `POST /v1/vector_stores`.
+
+| Provider (`custom_llm_provider`) | Search | Create | Notes |
+|---|---|---|---|
+| `openai` | Yes | Yes | Also supports the [files API](../vector_store_files.md) |
+| `azure` (Azure OpenAI) | Yes | Yes | |
+| `bedrock` (Knowledge Bases) | Yes | No | [Setup](../providers/bedrock_vector_store.md) |
+| `vertex_ai` (RAG Engine) | Yes | Yes | |
+| `vertex_ai/search_api` (Vertex AI Search) | Yes | No | Register the datastore as a [managed vector store](./managed_vector_stores.md) |
+| `azure_ai` (Azure AI Search) | Yes | No | [Setup](../providers/azure_ai_vector_stores.md) |
+| `gemini` (File Search) | Yes | Yes | [Setup](../providers/gemini_file_search.md) |
+| `milvus` | Yes | Yes | [Setup](../providers/milvus_vector_stores.md) |
+| `pg_vector` | Yes | Yes | Requires the [litellm-pgvector](../completion/knowledgebase.md) connector |
+| `s3_vectors` | Yes | No | |
+| `ragflow` | No | Yes | Dataset management only, [setup](../providers/ragflow_vector_store.md) |
+
+Retrieve, list, update, and delete (`GET`/`POST`/`DELETE /v1/vector_stores/{id}`) forward the OpenAI request shape as-is, so use them with providers that expose an OpenAI-shaped vector stores API (OpenAI, Azure OpenAI). See [Create](./create.md#vector-store-management-and-routing-on-the-proxy) for routing details.

--- a/docs/vector_stores/managed_vector_stores.md
+++ b/docs/vector_stores/managed_vector_stores.md
@@ -1,0 +1,128 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# LiteLLM Managed Vector Stores
+
+Register an existing provider vector store (Bedrock Knowledge Base, Vertex AI Search datastore, Azure AI Search index, Milvus collection, ...) with LiteLLM, so that every consumer of the proxy can use it through one OpenAI-compatible API without knowing the provider or holding its credentials.
+
+A managed vector store is a mapping, stored in `config.yaml` or in the LiteLLM database, of:
+
+| Field | Required | Description |
+|---|---|---|
+| `vector_store_id` | Yes | The id clients will reference, typically the provider's own store id (Knowledge Base id, datastore id, index name) |
+| `custom_llm_provider` | Yes | Which provider backend to route to, e.g. `bedrock`, `vertex_ai/search_api`, `azure_ai`, `milvus`, `gemini`, `openai`, `pg_vector` |
+| `vector_store_name` | No | Human readable name shown in the UI |
+| `vector_store_description` | No | Description shown in the UI |
+| `vector_store_metadata` | No | Free-form metadata object |
+| `litellm_credential_name` | No | Name of a [stored credential](../proxy/config_settings.md) to authenticate with |
+| `litellm_params` | No | Provider parameters, e.g. `vertex_project` and `vertex_location` for Vertex AI, `aws_region_name` for Bedrock |
+
+Registering does not create anything on the provider. To create a new store upstream, use [`POST /v1/vector_stores`](./create.md) instead.
+
+## Register a vector store
+
+<Tabs>
+<TabItem value="config" label="config.yaml">
+
+```yaml showLineNumbers title="config.yaml"
+vector_store_registry:
+  - vector_store_name: "docs-knowledgebase"
+    litellm_params:
+      vector_store_id: "T37J8R4WTM"
+      custom_llm_provider: "bedrock"
+      aws_region_name: "us-west-2"
+
+  - vector_store_name: "website-search"
+    litellm_params:
+      vector_store_id: "my-datastore_1234567890"
+      custom_llm_provider: "vertex_ai/search_api"
+      vertex_project: "my-gcp-project"
+      vertex_location: "global"
+```
+
+`vector_store_id` and `custom_llm_provider` are required inside `litellm_params`; the proxy fails to start without them.
+
+</TabItem>
+<TabItem value="api" label="Management API">
+
+```bash showLineNumbers title="Register a Vertex AI Search datastore"
+curl -X POST 'http://localhost:4000/vector_store/new' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "vector_store_id": "my-datastore_1234567890",
+    "custom_llm_provider": "vertex_ai/search_api",
+    "vector_store_name": "website-search",
+    "litellm_params": {
+      "vertex_project": "my-gcp-project",
+      "vertex_location": "global"
+    }
+  }'
+```
+
+The store is written to the LiteLLM database and is immediately usable; no restart needed. The response echoes the stored object with sensitive `litellm_params` values redacted.
+
+</TabItem>
+<TabItem value="ui" label="Admin UI">
+
+In the Admin UI go to **Tools > Vector Stores > Add new vector store**, pick the provider, and fill in the store id and provider parameters. The UI calls the same `POST /vector_store/new` endpoint. Screenshots are in the [chat completions guide](../completion/knowledgebase.md).
+
+</TabItem>
+</Tabs>
+
+## Use a registered store
+
+Search it through the unified endpoint. LiteLLM resolves the provider and credentials from the registration:
+
+```bash showLineNumbers title="Unified search"
+curl -X POST 'http://localhost:4000/v1/vector_stores/my-datastore_1234567890/search' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "How do I authenticate?"}'
+```
+
+The response is the OpenAI `vector_store.search_results.page` shape regardless of provider. See [Search](./search.md) for all request parameters.
+
+Or attach it to a chat completion, and LiteLLM will search the store and inject the results as context before calling the model:
+
+```bash showLineNumbers title="RAG in /chat/completions"
+curl -X POST 'http://localhost:4000/v1/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-5.6",
+    "messages": [{"role": "user", "content": "What is LiteLLM?"}],
+    "tools": [{"type": "file_search", "vector_store_ids": ["my-datastore_1234567890"]}]
+  }'
+```
+
+The request must reference the store explicitly (top-level `vector_store_ids` or inside `tools`); registering a store does not by itself change any chat completion. Details, citations, and streaming behavior: [Using Vector Stores with Chat Completions](../completion/knowledgebase.md).
+
+## Management API reference
+
+All endpoints require a LiteLLM key (`Authorization: Bearer ...`). Access can be restricted with `general_settings.disable_vector_stores_for_internal_users` and `allow_vector_stores_for_team_admins`; proxy admins always have access.
+
+| Endpoint | Method | Body / params |
+|---|---|---|
+| `/vector_store/new` | POST | The fields from the table above |
+| `/vector_store/list` | GET | `page`, `page_size` (also available as `/v1/vector_store/list`) |
+| `/vector_store/info` | POST | `{"vector_store_id": "..."}` |
+| `/vector_store/update` | POST | `vector_store_id` plus any of `custom_llm_provider`, `vector_store_name`, `vector_store_description`, `vector_store_metadata` |
+| `/vector_store/delete` | POST | `{"vector_store_id": "..."}` |
+
+`GET /vector_store/list` returns `{"object": "list", "data": [...], "total_count": n, "current_page": n, "total_pages": n}`. Stores registered via the API or UI are stamped with the creating key's `team_id` and `user_id`; stores created with a team are scoped to that team in list and search results (proxy admins see everything).
+
+## Restricting keys and teams to specific stores
+
+Set `object_permission.vector_stores` when creating a key or team to control which store ids its LLM requests may reference:
+
+```bash showLineNumbers title="Key limited to one store"
+curl -X POST 'http://localhost:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "object_permission": {"vector_stores": ["my-datastore_1234567890"]}
+  }'
+```
+
+A request through that key using any other registered store id in `vector_store_ids` is rejected. An empty or unset list means the key is not restricted. The same field works on teams.

--- a/docs/vector_stores/search.md
+++ b/docs/vector_stores/search.md
@@ -273,7 +273,7 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/vector_stores/vs_abc123/search' \
 
 ## Setting Up Vector Stores
 
-To use vector store search, configure your vector stores in the `vector_store_registry`. See the [Vector Store Configuration Guide](../completion/knowledgebase.md) for:
+To search a store that already exists on a provider, register it with LiteLLM first via `config.yaml`, `POST /vector_store/new`, or the Admin UI; see [Managed Vector Stores](./managed_vector_stores.md). For provider-specific configuration, see the [Vector Store Configuration Guide](../completion/knowledgebase.md):
 
 - Provider-specific configuration (Bedrock, OpenAI, Azure, Vertex AI, PG Vector)
 - Python SDK and Proxy setup examples  

--- a/sidebars.js
+++ b/sidebars.js
@@ -831,9 +831,19 @@ const sidebars = {
         "image_generation",
         "image_variations",
         "videos",
-        "vector_store_files",
-        "vector_stores/create",
-        "vector_stores/search",
+        {
+          type: "category",
+          label: "/vector_stores - Vector Stores",
+          items: [
+            "vector_stores/index",
+            "vector_stores/managed_vector_stores",
+            "vector_stores/create",
+            "vector_stores/search",
+            "vector_store_files",
+            "rag_ingest",
+            "rag_query",
+          ]
+        },
         {
           type: "category",
           label: "/mcp - Model Context Protocol",
@@ -902,8 +912,6 @@ const sidebars = {
             "proxy/pass_through_guardrails"
           ]
         },
-        "rag_ingest",
-        "rag_query",
         "realtime",
         "proxy/realtime_webrtc",
         "rerank",
@@ -1022,6 +1030,7 @@ const sidebars = {
             "providers/gemini",
             "providers/gemini/videos",
             "providers/gemini/music",
+            "providers/gemini_file_search",
             "providers/google_ai_studio/files",
             "providers/google_ai_studio/image_gen",
             "providers/google_ai_studio/realtime",
@@ -1152,6 +1161,7 @@ const sidebars = {
         "providers/predibase",
         "providers/pydantic_ai_agent",
         "providers/ragflow",
+        "providers/ragflow_vector_store",
         "providers/recraft",
         "providers/replicate",
         {


### PR DESCRIPTION
Resolves [LIT-3229](https://linear.app/litellm-ai/issue/LIT-3229/fix-vector-store-docs-separate-managed-from-pass-through-add-apiui)

## Why

LiteLLM has three different vector store surfaces: managed vector stores (register an existing provider store with LiteLLM, query it through the unified API), the OpenAI-compatible CRUD that creates stores on the provider, and raw pass-through routes. The docs never named this distinction. Vector store pages were spread across eight unrelated sidebar locations with no landing page, two pages (`providers/gemini_file_search`, `providers/ragflow_vector_store`) were on disk but in no sidebar, and the entire management API (`POST /vector_store/new`, `list`, `info`, `update`, `delete`), which is what the Admin UI itself uses, was undocumented apart from a single passing mention of `/vector_store/list`. This is how a customer ended up asking us to "add Vertex AI Search support on the API" when `POST /vector_store/new` with `custom_llm_provider: vertex_ai/search_api` already did exactly that

## What changed

New `docs/vector_stores/index.md` gives the three surfaces names, a "which endpoint do I need" table, and a per-provider support matrix for search and create. The matrix reflects what the code actually implements (for example bedrock, azure_ai, s3_vectors and vertex_ai/search_api raise NotImplementedError on create, so they are listed as search only; retrieve/list/update/delete forward the OpenAI shape as-is, so they are documented as OpenAI/Azure OpenAI only)

New `docs/vector_stores/managed_vector_stores.md` documents the management API for the first time: the `LiteLLM_ManagedVectorStore` fields, registration via config.yaml, `POST /vector_store/new` (with a working Vertex AI Search example) and the Admin UI, the five endpoints with their request and response shapes verified against `litellm/proxy/vector_store_endpoints/management_endpoints.py`, team scoping of API-created stores, and restricting keys and teams with `object_permission.vector_stores`

`docs/vector_stores/create.md` gets a callout disambiguating `POST /v1/vector_stores` (creates a store on the provider) from `POST /vector_store/new` (registers an existing store), which was the root cause of the confusion in the ticket. `docs/vector_stores/search.md` now points registration at the new page

`docs/pass_through/vertex_ai_search_datastores.md` is trimmed to pass-through only. The `vector_store_registry` YAML stanza moved to the managed page, and the `vertex_app_id` field is gone from all examples (`grep -rn vertex_app_id litellm/ tests/` returns zero hits in the code, so the field was silently ignored). The page keeps a note that registered datastore ids get their credentials resolved automatically, since `vertex_discovery_proxy_route` really does look the id up in the registry

`sidebars.js` now groups the vector store and RAG pages under one "/vector_stores - Vector Stores" category (overview, managed, create, search, files, rag_ingest, rag_query) and wires the two orphaned provider pages into their provider sections

## Notes for review

Claims in the new pages were checked against the code rather than existing docs, since the previous attempt (#222) was closed for misleading info. Deliberately not repeated from existing pages: the "Cost Tracking supported" claims (no provider bills through the unified search endpoint today) and org/customer level `object_permission.vector_stores` enforcement (the field is stored but only key and team level are enforced on LLM requests). Docusaurus build passes with no new broken links or anchors
