### PR TITLE
docs(blog): lead the auto-router v1.97 post with the hero image

### DIFF
--- a/blog/autorouter_context_and_benchmarks/index.md
+++ b/blog/autorouter_context_and_benchmarks/index.md
@@ -11,6 +11,10 @@ tags: [routing, complexity-router, cost, benchmarks, observability, product]
 hide_table_of_contents: false
 ---
 
+![LiteLLM Autorouter V2: routing accuracy on complex scenarios, 5.6x more accurate by reading the last N turns of the conversation before picking a model](./autorouter-v2-hero.png)
+
+<br /><br />
+
 :::info[🚀 Help shape the Auto-Router]
 
 Get early access, work directly with the LiteLLM team, and influence the roadmap with your production traffic.
@@ -22,8 +26,6 @@ Get early access, work directly with the LiteLLM team, and influence the roadmap
 Already testing it? Share your results in [discussion #32168](https://github.com/BerriAI/litellm/discussions/32168).
 
 :::
-
-![LiteLLM Autorouter V2: routing accuracy on complex scenarios, 5.6x more accurate by reading the last N turns of the conversation before picking a model](./autorouter-v2-hero.png)
 
 v1.97 makes three changes to the auto router.
 


### PR DESCRIPTION
## Relevant issues

- Moves the hero image above the "Apply to Become a Design Partner" callout on the v1.97 auto-router post, so the post opens on the graphic instead of the CTA
- Adds vertical spacing between the image and the callout
- Brings this post in line with the two earlier auto-router posts, which both open with their hero image

## Changes

`blog/autorouter_context_and_benchmarks/index.md` only. The `![...](./autorouter-v2-hero.png)` line moves above the `:::info[Help shape the Auto-Router]` admonition, with a `<br /><br />` between them. No copy, front matter, or asset changes.

Both the image and the callout stay above `{/* truncate */}`, so the blog list excerpt is unchanged.

## Testing

Rendered locally with `npm run start` and confirmed the order on the live page: hero graphic, gap, then the callout with the design-partner button, then the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)