### PR TITLE
docs: fix broken links in oauth2, request_headers and tag_management

### DIFF
--- a/docs/proxy/oauth2.md
+++ b/docs/proxy/oauth2.md
@@ -4,7 +4,7 @@ Use this if you want to use an Oauth2.0 token to make `/chat`, `/embeddings` req
 
 :::info
 
-This is an Enterprise Feature - [get in touch with us if you want a free trial to test if this feature meets your needs]((https://enterprise.litellm.ai/demo))
+This is an Enterprise Feature - [get in touch with us if you want a free trial to test if this feature meets your needs](https://enterprise.litellm.ai/demo)
 
 :::
 

--- a/docs/proxy/request_headers.md
+++ b/docs/proxy/request_headers.md
@@ -14,7 +14,7 @@ By default, LiteLLM does not forward client headers to LLM provider APIs. Howeve
 
 `x-litellm-enable-message-redaction`: Optional[bool]: Don't log the message content to logging integrations. Just track spend. [Learn More](./logging#redact-messages-response-content)
 
-`x-litellm-tags`: Optional[str]: A comma separated list (e.g. `tag1,tag2,tag3`) of tags to use for [tag-based routing](./tag_routing) **OR** [spend-tracking](./enterprise.md#tracking-spend-for-custom-tags).
+`x-litellm-tags`: Optional[str]: A comma separated list (e.g. `tag1,tag2,tag3`) of tags to use for [tag-based routing](./tag_routing) **OR** [spend-tracking](./cost_tracking#custom-tags).
 
 `x-litellm-num-retries`: Optional[int]: The number of retries for the request.
 

--- a/docs/tutorials/tag_management.md
+++ b/docs/tutorials/tag_management.md
@@ -140,6 +140,6 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 ## Additional Tag Features
 - [Sending tags in request headers](https://docs.litellm.ai/docs/proxy/tag_routing#calling-via-request-header)
 - [Tag based routing](https://docs.litellm.ai/docs/proxy/tag_routing)
-- [Track spend per tag](cost_tracking#-custom-tags)
-- [Setup Budgets per Virtual Key, Team](users)
+- [Track spend per tag](../proxy/cost_tracking#custom-tags)
+- [Setup Budgets per Virtual Key, Team](../proxy/users)
 


### PR DESCRIPTION
# What does this PR do?

Fixes several broken links in the docs:

1. **docs/proxy/oauth2.md**: remove a stray parenthesis in the enterprise trial link target (`]((https://...))` -> `](https://...)`).
2. **docs/proxy/request_headers.md**: the spend-tracking link pointed to `./enterprise.md#tracking-spend-for-custom-tags`, but the enterprise page moved to the docs root and has no such anchor. Point it to the Custom Tags section of `cost_tracking.md` instead (`./cost_tracking#custom-tags`).
3. **docs/tutorials/tag_management.md**: fix relative paths so `Track spend per tag` resolves to `proxy/cost_tracking#custom-tags` and `Setup Budgets` resolves to `proxy/users`.

All link targets were verified against the current file tree and their headings/anchors.