### PR TITLE
docs(observability): redirect the remaining retired vendor pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,6 +131,26 @@ const config = {
             from: '/docs/observability/phoenix_integration',
             to: '/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets',
           },
+          {
+            from: '/docs/observability/langfuse_otel_integration',
+            to: '/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets',
+          },
+          {
+            from: '/docs/observability/langtrace_integration',
+            to: '/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets',
+          },
+          {
+            from: '/docs/observability/levo_integration',
+            to: '/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets',
+          },
+          {
+            from: '/docs/observability/agentops_integration',
+            to: '/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets',
+          },
+          {
+            from: '/docs/observability/telemetry',
+            to: '/docs/observability/opentelemetry_v2',
+          },
         ],
       },
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,6 +45,11 @@ const sidebars = {
           type: "category",
           label: "LLM observability platforms",
           items: [
+            {
+              type: "link",
+              label: "AgentOps",
+              href: "/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets",
+            },
             "observability/argilla",
             {
               type: "link",
@@ -64,6 +69,16 @@ const sidebars = {
             "observability/humanloop",
             "observability/langfuse_integration",
             "observability/langsmith_integration",
+            {
+              type: "link",
+              label: "Langtrace",
+              href: "/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets",
+            },
+            {
+              type: "link",
+              label: "Levo",
+              href: "/docs/observability/opentelemetry_v2#2-send-traces-to-a-specific-tool-presets",
+            },
             "observability/literalai_integration",
             "observability/logfire_integration",
             "observability/lunary_integration",


### PR DESCRIPTION
Stacked on #762; review that one first. This branch contains #762's commit, so the diff here will shrink to a single commit once #762 merges.

## Why

#762 covers Arize because that is the vendor who noticed and reported it. The same #434 consolidation retired five more pages the same way, and all five have been 404'ing since July 4: `langfuse_otel_integration`, `langtrace_integration`, `levo_integration`, `agentops_integration` and `telemetry`. Nobody has complained about these yet, which is the only reason they were not in the first PR.

## What changed

Five redirects pointing at the preset section of the OTel v2 guide, except `telemetry`, which was a stub with no vendor content and goes to the top of the guide.

Sidebar links for Langtrace, Levo and AgentOps under LLM observability platforms, placed to hold the category's alphabetical-by-label ordering. Langfuse already has its own page in the sidebar so `langfuse_otel` needs only the redirect, and `telemetry` had no vendor identity to restore.

## Notes for review

`npm run build` passes. All seven retired URLs across both PRs emit redirect pages with the correct meta refresh target, and the three new sidebar entries render.

Deliberately not included: flipping `onBrokenLinks` from `warn` to `throw`, which was the obvious guardrail to add here. The build currently reports 80 broken links and 95 broken anchors, nearly all of it pre-existing debt in archived release notes pointing at anchors like `docs/proxy/logging#prometheus`, so flipping it fails the build immediately and cleaning that up is its own piece of work. It would also not have caught this class of bug: Docusaurus runs the broken-link check before the redirects plugin emits its pages, so a correctly redirected URL still reports as broken.

The gap worth closing instead is that this repo has no CI at all, so nothing runs on any PR today and a consolidation that deletes pages gets no automated pushback. Happy to open that separately if we want it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->