### PR TITLE
docs(azure_storage): document AZURE_STORAGE_ENDPOINT_SUFFIX for sovereign clouds

### DIFF
--- a/docs/providers/google_ai_studio/files.md
+++ b/docs/providers/google_ai_studio/files.md
@@ -172,6 +172,9 @@ Configure your Azure Blob Storage account by setting the following environment v
 - `AZURE_STORAGE_FILE_SYSTEM` - The container/filesystem name where files will be stored
 - `AZURE_STORAGE_ACCOUNT_KEY` - Your account key
 
+**Optional Environment Variables:**
+- `AZURE_STORAGE_ENDPOINT_SUFFIX` - The storage endpoint suffix, e.g. `core.usgovcloudapi.net` for Azure Government. Defaults to `core.windows.net`
+
 ### Step 2: Pass Azure Blob Storage as Target Storage
 
 When uploading files, specify `target_storage: "azure_storage"` to use Azure Blob Storage instead of the default storage.

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -550,6 +550,7 @@ router_settings:
 | AZURE_STORAGE_TENANT_ID | The Application Tenant ID to use for Authentication to Azure Blob Storage logging
 | AZURE_STORAGE_CLIENT_ID | The Application Client ID to use for Authentication to Azure Blob Storage logging
 | AZURE_STORAGE_CLIENT_SECRET | The Application Client Secret to use for Authentication to Azure Blob Storage logging
+| AZURE_STORAGE_ENDPOINT_SUFFIX | The storage endpoint suffix to use for Azure Blob Storage logging, e.g. core.usgovcloudapi.net for Azure Government. Defaults to core.windows.net
 | AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY | Cost per GB per day for Azure Vector Store service
 | BACKGROUND_HEALTH_CHECK_MAX_TOKENS | Optional global default for `max_tokens` on proxy background health checks when a model has no `health_check_max_tokens`. If unset, non-wildcard models default to 5. Applies to wildcard routes when set. Default is unset
 | BACKGROUND_HEALTH_CHECK_MAX_TOKENS_REASONING | For **non-wildcard** reasoning models (`supports_reasoning(model)=true`), this takes precedence over `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` when set. If unset, reasoning models fall back to `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` (if set) or default behavior. Wildcard routes ignore this. Default is unset

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -1547,6 +1547,10 @@ AZURE_STORAGE_ACCOUNT_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 AZURE_STORAGE_TENANT_ID="985efd7cxxxxxxxxxx" # The Application Tenant ID to use for Authentication
 AZURE_STORAGE_CLIENT_ID="abe66585xxxxxxxxxx" # The Application Client ID to use for Authentication
 AZURE_STORAGE_CLIENT_SECRET="uMS8Qxxxxxxxxxx" # The Application Client Secret to use for Authentication
+
+# Sovereign Clouds (optional, defaults to the Azure commercial cloud)
+AZURE_STORAGE_ENDPOINT_SUFFIX="core.usgovcloudapi.net" # The storage endpoint suffix to use. Defaults to core.windows.net
+AZURE_AUTHORITY_HOST="https://login.microsoftonline.us" # The Entra ID login authority to use. Only needed with Option 2
 ```
 
 3. Start Proxy


### PR DESCRIPTION
Documents `AZURE_STORAGE_ENDPOINT_SUFFIX`, added in BerriAI/litellm#35806, which lets the `azure_storage` logging callback and the azure blob files backend reach storage accounts outside the Azure commercial cloud

Adds the env var to the reference table, to the Azure Blob Storage logging setup block alongside the existing auth options, and to the Gemini files backend page. `AZURE_AUTHORITY_HOST` is listed next to it because Azure Government also needs the Entra ID login authority moved when authenticating with tenant, client and secret; the OAuth scope is unchanged in every cloud

This should merge BEFORE BerriAI/litellm#35806. That repo's `documentation` and `code-quality` checks run `test_env_keys.py`, which checks out this repo's default branch into `docs/my-website` and requires every env var read in `litellm/` to have a row in `config_settings.md`, so the code PR stays red until this lands