### PR TITLE
docs(virtual_keys): document custom_key_update requirement for key edits

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -303,7 +303,8 @@ router_settings:
 | proxy_batch_polling_interval | int | Time (in seconds) to wait before polling a batch, to check if it's completed. **Default is 6000 seconds (1 hour)** |
 | proxy_config_reload_interval_seconds | int | How often each pod reloads config-in-DB objects (models, credentials, guardrails, etc.) from the database when `store_model_in_db` is enabled. Lower values speed up cross-pod convergence at the cost of more DB load; applied on proxy startup. Env: `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS`. **Default is 30 seconds** |
 | alerting_args | dict | Args for Slack Alerting [Doc on Slack Alerting](./alerting.md) |
-| custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom--key-generate) |
+| custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom-keygenerate) |
+| custom_key_update | str | Custom function for key updates. Required if `custom_key_generate` policies should also apply to key edits [Doc on custom key update](./virtual_keys.md#custom-keyupdate) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |
 | embedding_model | str | The default model to use for embeddings - ignores model set in request |
 | default_team_disabled | boolean | If true, users cannot create 'personal' keys (keys with no team_id). |

--- a/docs/proxy/virtual_keys.md
+++ b/docs/proxy/virtual_keys.md
@@ -536,6 +536,53 @@ general_settings:
   custom_key_generate: custom_auth.custom_generate_key_fn
 ```
 
+:::warning
+
+`custom_key_generate` only runs on `/key/generate`. Key edits (`/key/update`, `/key/bulk_update`, `/team/key/bulk_update`, and editing a key in the Admin UI, which calls `/key/update`) skip it, so a user can create a compliant key and then edit it out of compliance, e.g. remove its expiration date. Set [`custom_key_update`](#custom-keyupdate) as well if your policy should also hold on edits.
+
+:::
+
+### Custom /key/update
+
+If you enforce a policy with `custom_key_generate`, set `custom_key_update` to keep enforcing it when keys are edited. It runs on `/key/update`, `/key/bulk_update`, and `/team/key/bulk_update`. The Admin UI edit key flow calls `/key/update`, so this also covers edits made from the UI.
+
+#### 1. Write a custom `custom_update_key_fn`
+
+The input to the `custom_update_key_fn` function is a single parameter: `data` [(Type: UpdateKeyRequest)](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/_types.py)
+
+The output contract is the same as `custom_generate_key_fn`: return `{"decision": True}` to allow the update, or `{"decision": False, "message": "..."}` to reject it. Rejected updates fail with a `403`.
+
+Update requests only contain the fields being changed, so an unset field means "leave as is", not "clear". Use `data.model_fields_set` to tell an omitted field apart from one explicitly set to `None`. For example, the Admin UI sends `duration: null` when a key is edited to "Never expires", which the function below rejects.
+
+```python
+from litellm.proxy._types import UpdateKeyRequest
+
+
+async def custom_update_key_fn(data: UpdateKeyRequest) -> dict:
+    """
+    Asynchronous function that decides if a key update should be allowed.
+
+    Args:
+        data (UpdateKeyRequest): The requested changes to the key.
+
+    Returns:
+        dict: A dictionary containing the decision and an optional message.
+    """
+    if "duration" in data.model_fields_set and data.duration is None:
+        return {
+            "decision": False,
+            "message": "This violates LiteLLM Proxy Rules. Keys must keep an expiration date.",
+        }
+    return {"decision": True}
+```
+
+#### 2. Pass the filepath (relative to the config.yaml)
+
+```yaml
+general_settings:
+  custom_key_generate: custom_auth.custom_generate_key_fn
+  custom_key_update: custom_auth.custom_update_key_fn
+```
 
 ### Upperbound /key/generate params
 Use this, if you need to set default upperbounds for `max_budget`, `budget_duration` or any `key/generate` param per key. 


### PR DESCRIPTION
`custom_key_generate` only runs on `/key/generate`, so a key created under a compliant policy can later be edited out of compliance (for example removing its expiration date) because the update path never invokes that hook. The proxy has a separate `custom_key_update` hook for updates, but the docs never mention it, which led a customer to believe key editing silently bypasses their validation

This adds a warning to the Custom /key/generate section and a new Custom /key/update section documenting the hook's contract: `UpdateKeyRequest` input, the same decision/message output as `custom_generate_key_fn`, a 403 on rejection, and coverage of `/key/update`, `/key/bulk_update`, and `/team/key/bulk_update`, which also covers Admin UI edits. It explains how to tell omitted fields apart from explicitly cleared ones via `model_fields_set`, since the UI sends `duration: null` for "Never expires". It also adds a `custom_key_update` row to the config settings reference and fixes the broken `custom_key_generate` anchor there

Resolves LIT-3611