### PR TITLE
docs(proxy): frame 4Gi as a memory floor and document chart autoscaling

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -144,7 +144,7 @@ proxy_config:
 helm install litellm oci://ghcr.io/berriai/litellm-helm -f values.yaml
 ```
 
-The chart lives at [`deploy/charts/litellm-helm`](https://github.com/BerriAI/litellm/tree/main/deploy/charts/litellm-helm); the published chart versions carry LiteLLM release numbers (for example `1.90.2`), and `helm show values oci://ghcr.io/berriai/litellm-helm` lists every knob. Beyond the values above it supports autoscaling (`autoscaling.*` or `keda.*`), PodDisruptionBudgets (`pdb.*`), a Prometheus ServiceMonitor (`serviceMonitor.*`), read replica routing (`db.readReplicaUrl`, see [Database Read Replica](./db_read_replica.md)), graceful drain on shutdown (`lifecycle`), and ArgoCD or Helm hooks for the migrations job (`migrationJob.hooks.*`, see [Helm PreSync hooks](./prod.md#run-migrations-from-the-helm-presync-hook)).
+The chart lives at [`helm/litellm-helm`](https://github.com/BerriAI/litellm/tree/main/helm/litellm-helm); the published chart versions carry LiteLLM release numbers (for example `1.90.2`), and `helm show values oci://ghcr.io/berriai/litellm-helm` lists every knob. Beyond the values above it supports [autoscaling](#autoscaling) (`autoscaling.*` or `keda.*`), PodDisruptionBudgets (`pdb.*`), a Prometheus ServiceMonitor (`serviceMonitor.*`), read replica routing (`db.readReplicaUrl`, see [Database Read Replica](./db_read_replica.md)), graceful drain on shutdown (`lifecycle`), and ArgoCD or Helm hooks for the migrations job (`migrationJob.hooks.*`, see [Helm PreSync hooks](./prod.md#run-migrations-from-the-helm-presync-hook)).
 
 </TabItem>
 <TabItem value="micro" label="Microservices (litellm)">
@@ -186,12 +186,41 @@ helm upgrade --install litellm \
   -f values.yaml
 ```
 
-This deploys `gateway`, `backend`, and `ui` as separate services with per-component autoscaling, so you can run many gateway replicas against a small fixed backend. It requires external Postgres and Redis (no bundled subcharts) and supports reader/writer database splits, IAM database auth, and Redis Cluster mode. Pin the chart to `1.89.0` or newer: the component images (`ghcr.io/berriai/litellm-gateway`, `-backend`, `-ui`, `-migrations`) are published to GHCR from `v1.89.0` onward, and each component's image tag defaults to the chart version, so older chart versions resolve to image tags that were never pushed. Every knob (per-component scaling and probes, read replica routing, Redis Cluster, migrations job, ingress) is documented in the [chart's values.yaml](https://github.com/BerriAI/litellm/blob/main/helm/litellm/values.yaml).
+This deploys `gateway`, `backend`, and `ui` as separate services with per-component autoscaling, so you can run many gateway replicas against a small fixed backend. It requires external Postgres and Redis (no bundled subcharts) and supports reader/writer database splits, IAM database auth, and Redis Cluster mode. Pin the chart to `1.89.0` or newer: the component images (`ghcr.io/berriai/litellm-gateway`, `-backend`, `-ui`, `-migrations`) are published to GHCR from `v1.89.0` onward, and each component's image tag defaults to the chart version, so older chart versions resolve to image tags that were never pushed. Every knob (per-component scaling and probes, read replica routing, Redis Cluster, migrations job, ingress) is documented in the [chart's values.yaml](https://github.com/BerriAI/litellm/blob/main/helm/litellm/values.yaml); see [Autoscaling](#autoscaling) for the scaling blocks.
 
 </TabItem>
 </Tabs>
 
 Both charts run the migrations job automatically and keep `DISABLE_SCHEMA_UPDATE=true` on the proxy pods. Expose the service through your cloud's ingress: the [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html) on EKS, [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) on GKE, or [Application Gateway Ingress (AGIC)](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview) on AKS, with health checks on `/health/readiness`, then point your DNS record at the resulting load balancer. For secrets, prefer your cloud's secret manager over plain Kubernetes secrets ([Key Vault CSI driver](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver) on AKS, for example); the charts consume whatever secret you mount.
+
+### Autoscaling
+
+Both charts can scale themselves, and both ship autoscaling off or conservative by default. For the thresholds to aim at, and why memory is not one of them, see [autoscaling in the production checklist](./prod.md#autoscaling).
+
+`litellm-helm` offers two mutually exclusive mechanisms. `autoscaling.*` renders a standard HorizontalPodAutoscaler, and `keda.*` renders a KEDA `ScaledObject` for scaling on queue depth, Prometheus queries, or anything else KEDA can read. Enabling both renders only the HPA, so pick one.
+
+```yaml
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage and behavior are also accepted
+
+keda:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  pollingInterval: 30   # seconds between trigger evaluations
+  cooldownPeriod: 300   # seconds of quiet before scaling back to minReplicas
+  triggers: []          # required; a ScaledObject with no triggers will not scale
+```
+
+`keda.triggers` is empty by default and has no useful default, so supply the trigger yourself; the chart's `values.yaml` carries a commented Prometheus example. `keda.fallback`, `keda.behavior`, and `keda.restoreToOriginalReplicaCount` are passed through for controlling what happens when the metric source is unavailable and how replicas settle after a scale event.
+
+The componentized chart scales each component on its own, under `gateway.hpa`, `backend.hpa`, and `ui.hpa`. The gateway and backend autoscale out of the box and the UI does not, with maximums sized to the shape of each component's traffic: the gateway defaults to `maxReplicas: 10` at 70 percent CPU and 80 percent memory, the backend to `maxReplicas: 4` at 70 percent CPU, and the UI to `maxReplicas: 3` at 80 percent CPU with `enabled: false`. Raising the gateway's ceiling is usually all you need, since it is the only component that sees LLM traffic.
+
+Whichever mechanism you use, set the maximum against what your database can serve. The connection pool is per worker, so the ceiling on replicas is also a ceiling on Postgres connections; `litellm-helm` defaults `maxReplicas` to 100, which at the default pool limit of 10 asks for roughly 1000 connections at full scale-out. See [bounding database connections](./prod.md#bound-database-connections).
 
 ### Kubernetes without Helm
 

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -69,6 +69,8 @@ Each instance multiplies your total connections: 3 instances × 4 workers × 10 
 
 :::
 
+Once an autoscaler owns the replica count, the instance count in that formula is `maxReplicas`, not the number of pods you are running today. The `litellm-helm` chart defaults `autoscaling.maxReplicas` and `keda.maxReplicas` to 100, so a deployment that scales out fully asks for roughly 1000 connections at the default pool limit of 10, which is far past what a stock Postgres accepts. Set `maxReplicas` from what your database can serve, and see [how to calculate the right value](./configs.md#configure-db-pool-limits--connection-timeouts) for the full division.
+
 ### Keep error logs out of the database
 
 LLM exceptions are written to the database by default. Under sustained provider errors this bloats the spend logs table; send exceptions to your logging stack (see [alerting](#turn-on-alerting) and [logging callbacks](./logging.md)) instead.
@@ -119,9 +121,7 @@ export LITELLM_SALT_KEY="sk-1234"
 
 ### Machine specifications
 
-For optimal performance in production, we recommend the following resource configuration.
-
-**1. Memory `requests` and `limits`**
+Give each pod 1 vCPU and 4Gi of memory, as both requests and limits, and scale both with the worker count if you run more than one worker per container.
 
 ```yaml
 resources:
@@ -133,20 +133,31 @@ resources:
     memory: "4Gi"
 ```
 
-**2. HPA thresholds**
+Both figures are per worker, so that multiplication is real rather than notional: a container running 8 workers wants 8 vCPU and 32Gi, not 1 vCPU and 4Gi. Sizing a multi-worker container from the single-worker numbers is a common way to end up under-provisioned, and it is the main reason to keep one worker per pod on Kubernetes and let replicas rather than workers carry the concurrency.
+
+4Gi is a floor rather than a target. The proxy's steady-state footprint is not a function of how many requests it is serving concurrently: Prisma runs the query engine as a separate process whose resident memory behaves as a high-water mark, growing to fit the largest single statement that engine has ever executed, and glibc does not hand that memory back to the operating system afterwards. A pod's floor therefore ratchets up to its worst-ever write and stays there for the life of the worker. Provision below 4Gi and a single large write is enough to push the pod past its limit and have the kernel OOM-kill it, which surfaces as a crash loop under traffic that looks unremarkable on every other metric.
+
+The largest statements come from spend logging with `store_prompts_in_spend_logs` enabled, because each row then carries a full prompt and response rather than counters. If you store prompts, treat 4Gi as the minimum and give the pod headroom above it.
+
+### Autoscaling
+
+Scale on CPU, and leave the memory target unset. Memory is not a usable scaling signal for the proxy: the query engine's resident memory reflects the largest write a pod has ever done rather than what it is doing now, so a memory target ratchets replicas up after one large write and never scales them back in. Provision memory as the floor above and let CPU drive the replica count.
 
 ```yaml
 targetCPUUtilizationPercentage: 60
-targetMemoryUtilizationPercentage: 80
 ```
+
+60 rather than a higher threshold because a replica is not useful the moment it is created. The `litellm-helm` startup probe allows up to 300 seconds for a pod to pass its first readiness check, so a replica added at 80 percent CPU arrives minutes after the saturation that triggered it. Both charts ship higher defaults, 80 on `litellm-helm` and 70 on the componentized chart's gateway, chosen so the charts install cleanly anywhere; lower them for production.
 
 ### Workers and scaling
 
-Run one Uvicorn worker per pod and scale horizontally (more pods) rather than vertically (more workers per pod). This is the default, so you only need `--num_workers 1`; one process per pod keeps latency predictable, lets the Horizontal Pod Autoscaler use the [thresholds above](#machine-specifications) accurately, and makes rolling restarts hitless because Kubernetes drains one pod at a time.
+On Kubernetes, or anywhere else a pod-level autoscaler is reading CPU, run one Uvicorn worker per pod and scale horizontally (more pods) rather than vertically (more workers per pod). This is the default, so you only need `--num_workers 1`; one process per pod keeps latency predictable, lets the Horizontal Pod Autoscaler read the [CPU threshold above](#autoscaling) against a single process, and makes rolling restarts hitless because Kubernetes drains one pod at a time.
 
 ```shell
 CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers", "1"]
 ```
+
+On a single VM or a bare container with nothing scaling it for you, the opposite applies: set `NUM_WORKERS` to the machine's vCPU count, since nothing else will put those cores to work. Sizing and connection limits are both per worker, so a machine running eight workers wants eight times the memory floor above and an eighth of the connection pool.
 
 If you see gradual memory growth under sustained load, recycle each worker after a fixed number of requests with `--max_requests_before_restart` to bound memory usage.
 
@@ -220,7 +231,7 @@ When `allow_requests_on_db_unavailable` is set to `true`, LiteLLM will handle er
 The Helm PreSync hook flow is in beta.
 :::
 
-To ensure only one service manages database migrations, use our [Helm PreSync hook for Database Migrations](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/templates/migrations-job.yaml). This ensures migrations are handled during `helm upgrade` or `helm install`, while LiteLLM pods explicitly disable migrations.
+To ensure only one service manages database migrations, use our [Helm PreSync hook for Database Migrations](https://github.com/BerriAI/litellm/blob/main/helm/litellm-helm/templates/migrations-job.yaml). This ensures migrations are handled during `helm upgrade` or `helm install`, while LiteLLM pods explicitly disable migrations.
 
 1. **Helm PreSync Hook**:
    - The Helm PreSync hook is configured in the chart to run database migrations during deployments.

--- a/docs/proxy/server_tuning.md
+++ b/docs/proxy/server_tuning.md
@@ -22,7 +22,7 @@ LiteLLM Proxy runs on [Uvicorn](https://uvicorn.dev/) by default. Passing `--run
 
 :::tip Recommendation
 
-On Kubernetes, run **one Uvicorn worker per pod** and scale **horizontally** (more pods) rather than vertically (more workers per pod). One process per pod keeps latency predictable under load, lets the Horizontal Pod Autoscaler use the [thresholds in the production checklist](./prod.md#machine-specifications) accurately, and makes rolling restarts hitless because Kubernetes drains one pod at a time. Reach for Gunicorn only when you must pack multiple workers into one container.
+On Kubernetes, run **one Uvicorn worker per pod** and scale **horizontally** (more pods) rather than vertically (more workers per pod). One process per pod keeps latency predictable under load, lets the Horizontal Pod Autoscaler use the [thresholds in the production checklist](./prod.md#autoscaling) accurately, and makes rolling restarts hitless because Kubernetes drains one pod at a time. Reach for Gunicorn only when you must pack multiple workers into one container.
 
 :::
 


### PR DESCRIPTION
## TLDR

A customer OOMKilled proxy pods at 2Gi, settled on 4Gi, and asked whether litellm publishes a minimum. We do publish 4Gi, but as a target rather than a floor, with nothing saying what happens below it. Three other things on these pages were wrong or missing in the same area.

Problem this solves:

- `prod.md` publishes `memory: "4Gi"` with no indication it is a floor and no statement of the failure mode below it
- the same block says `4*num_workers`, and nothing on the site says that following the vCPU worker advice on an 8-core box therefore means 32Gi
- three sources give three different HPA targets: `prod.md` 60/80, `litellm-helm` 80, the componentized chart 70/80
- `config_settings.md` says set `NUM_WORKERS` to the vCPU count while `prod.md` says one worker per pod, neither scoped to a deployment shape
- neither chart's autoscaling is documented; the classic chart's `autoscaling.*` and `keda.*` were one parenthetical in `deploy.md`, which was also the only KEDA mention on the entire site
- nothing connects `maxReplicas` to the Postgres connection ceiling it implies

How it solves it:

- frames 4Gi as a floor and explains the mechanism: the Prisma query engine is a separate process whose resident memory is a high-water mark of the largest single statement it has ever executed, and glibc does not return it, so a pod's floor ratchets to its worst-ever write and one large write OOMKills an undersized pod
- makes the per-worker multiplication explicit, and uses it to explain why one worker per pod is the default rather than asserting the rule separately
- resolves the HPA conflict rather than restating it, see below
- scopes both worker statements instead of picking a winner
- documents `autoscaling.*` and `keda.*` with real defaults, their mutual exclusivity, and the empty `triggers` default, plus the componentized chart's per-component `hpa` blocks
- ties `maxReplicas` to the connection ceiling and links the existing division formula

## How the two contradictions were resolved

**HPA thresholds.** Memory is dropped as a scaling signal entirely. A high-water mark reflects the largest write a pod has ever done rather than what it is doing now, so a memory target ratchets replicas up after one large write and never scales them back in; memory is a floor you provision, not a trigger. CPU stays at 60 against chart defaults of 80 and 70 because `litellm-helm`'s startup probe allows a pod up to 300 seconds (`failureThreshold: 30` x `periodSeconds: 10`) to pass its first readiness check, so a replica added at 80 percent arrives well after the saturation that triggered it. The chart defaults are named in the docs so a reader who sees them knows they are chart defaults rather than guidance.

**NUM_WORKERS.** Both statements are correct for different deployment shapes, so both are scoped rather than one being deleted. One worker per pod wherever a pod-level autoscaler reads CPU, since N workers behind one pod IP makes the CPU target ambiguous and breaks hitless rolling restarts. `NUM_WORKERS` at the vCPU count on a single VM or bare container, where nothing else will use the cores and the per-worker connection arithmetic already documented in `configs.md` applies. The `config_settings.md` half of this is being routed separately, since another change owns that file right now.

Also repoints two chart links from `deploy/charts/litellm-helm`, which does not exist in the litellm repo, at the real `helm/litellm-helm`. That is not incidental to the sizing work: those links are the documented route to the chart's values file, and an operator following them today gets a 404 instead of the file they would read a memory figure from. The dead link and the missing floor are the same failure reaching a reader from two directions.

## Relevant issues

## Linear ticket

Resolves LIT-5168

Also covers the documentation half of LIT-5167; the chart-side change for that ticket is a separate PR against the litellm repo, so this one does not close it

## Pre-Submission checklist

- [ ] I have added meaningful tests (docs-only; validated with a full site build instead, see QA runbook)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

📖 Documentation

## Changes

`docs/proxy/prod.md`, `docs/proxy/deploy.md`, `docs/proxy/server_tuning.md`

The `server_tuning.md` edit is a one-line anchor fix. It linked `prod#machine-specifications` for "the thresholds", and the thresholds moved to the new `#autoscaling` section, so leaving it would have pointed readers at a section that no longer contains them.

Note on the memory mechanism: this PR describes behavior that is live today and deliberately does not mention the bounded-batch work that limits it, which is merged to staging but carries no release tag. That gets a docs entry when it ships.

## QA runbook

Docs-only. `npm ci && npm run build` passes with exit 0. The build reports 95 pre-existing broken-anchor pages on old release notes and provider pages; none of the three files touched here appear among them, which is what confirms every anchor added or repointed resolves. Rendered pages to read: `/docs/proxy/prod#machine-specifications`, `/docs/proxy/prod#autoscaling`, `/docs/proxy/prod#workers-and-scaling`, and `/docs/proxy/deploy#autoscaling`.

Every figure traces to a file in the litellm repo: `helm/litellm-helm/values.yaml` for the classic chart's `autoscaling` and `keda` defaults and its startup probe, `helm/litellm/values.yaml` for the three per-component `hpa` blocks, and `litellm/proxy/proxy_cli.py` for the pool limit of 10.
