### PR TITLE
docs(troubleshoot): document the prisma query engine override for non-root uids

### DIFF
--- a/docs/troubleshoot/prisma_migrations.md
+++ b/docs/troubleshoot/prisma_migrations.md
@@ -1,6 +1,6 @@
 # Troubleshooting Prisma Migration Errors
 
-Common Prisma migration issues encountered when upgrading or downgrading LiteLLM proxy versions, and how to fix them.
+Common Prisma migration issues encountered when upgrading or downgrading LiteLLM proxy versions, plus the query engine resolution failure that can stop the proxy before any migration runs, and how to fix them.
 
 For a full guide on safely reverting your LiteLLM version, see the **[Safe Rollback Guide](rollback)**.
 
@@ -115,3 +115,29 @@ LIMIT 20;
 ```bash
 DATABASE_URL="<your_database_url>" prisma db push
 ```
+
+---
+
+### 4. `PermissionError` while resolving the query engine
+
+**Example error:**
+
+```
+PermissionError: [Errno 13] Permission denied:
+'/usr/local/lib/python3.11/site-packages/prisma/binaries/prisma-query-engine-debian-openssl-3.0.x'
+```
+
+**Cause:** before Prisma can talk to your database it has to decide which query engine binary to run, and it does that by walking the engine paths the Prisma CLI recorded when the client was generated. A generated client carries five of them, one per supported platform, so the walk always runs. It tests each candidate with `Path.exists()`, which reports a missing file as `False` but re-raises `PermissionError` when a directory on the way to the candidate denies the running uid; it only swallows `ENOENT`, `ENOTDIR`, `EBADF` and `ELOOP`. An image that generates the client as one uid and runs as another, or that installs the client somewhere the runtime uid cannot traverse, therefore dies at startup rather than moving on to the next candidate. Python 3.14 returns `False` here and is unaffected; every other interpreter LiteLLM supports, 3.10 through 3.13, raises.
+
+**How to fix:** point Prisma at an engine the runtime uid can read, setting both variables together. `PRISMA_QUERY_ENGINE_BINARY` on its own does not clear this, because the walk that raises runs before Prisma reads that variable. `PRISMA_BINARY_PLATFORM` is the one that short-circuits the walk, before any candidate is tested, so neither variable substitutes for the other:
+
+```bash
+export PRISMA_BINARY_PLATFORM=debian-openssl-3.0.x
+export PRISMA_QUERY_ENGINE_BINARY=/opt/prisma/binaries/prisma-query-engine-debian-openssl-3.0.x
+```
+
+`PRISMA_BINARY_PLATFORM` has to name a platform the client was actually generated for. Prisma looks the name up directly in the generated paths, so naming one you did not generate trades the `PermissionError` for a `KeyError`. `PRISMA_QUERY_ENGINE_BINARY` has to point at an engine file the runtime uid can both read and execute. Set both in the environment rather than patching `BINARY_PATHS` at import time: `PRISMA_BINARY_PLATFORM` is a declared Prisma config option and `PRISMA_QUERY_ENGINE_BINARY` is read from the environment directly, so neither depends on Prisma internals that a version bump can move.
+
+The official images already avoid the condition by baking the Prisma CLI and engines at a fixed, world-readable `/opt/prisma`, so any uid can resolve them. `v1.95.0` is the first stable release carrying that for both image variants. The standard image has had it since `v1.94.0`, but the whole `1.94.x` line lacks it for `litellm-non_root`, so a non-root deployment on `v1.94.1` or earlier still needs the two variables above. Custom images and plain `pip install` deployments are outside both fixes and always need them.
+
+Images are published to `ghcr.io/berriai` and mirrored at `docker.litellm.ai/berriai`; `ghcr.io/berriai/litellm-non_root:v1.95.0` is the non-root variant.


### PR DESCRIPTION
## TLDR

A customer running as a non-root uid hit an uncaught `PermissionError` during Prisma query-engine resolution and worked around it by monkey-patching `BINARY_PATHS` from a `sitecustomize.py`. There is a supported override; it was simply undiscoverable, and the one environment variable that looks like the answer does not always work.

Problem this solves:

- Prisma resolves the query engine before it reads `PRISMA_QUERY_ENGINE_BINARY`, so a crash during resolution cannot be rescued by that variable alone
- the resolution tests candidate paths with `Path.exists()`, which returns `False` for a missing file but re-raises `PermissionError` when a directory on the way to the candidate denies the running uid, since pathlib only swallows `ENOENT`, `ENOTDIR`, `EBADF` and `ELOOP`
- an image that generates the client as one uid and runs as another therefore dies at startup rather than falling through to the next candidate, and nothing on the site documented the escape hatch

How it solves it:

- documents the working override, `PRISMA_BINARY_PLATFORM` paired with `PRISMA_QUERY_ENGINE_BINARY`, on the existing Prisma troubleshooting page
- states both constraints that make it work, including the sharp edge that naming a platform the client was not generated for trades the `PermissionError` for a `KeyError`
- records which images and releases already avoid the condition, so an operator can choose upgrading over configuring

## Verification

Everything above was verified by driving the real `prisma.engine.utils.ensure()` against a directory the running uid cannot traverse, not by reading the source alone.

The interpreter dependence is real and matters, because it decides whether a given deployment crashes at all:

```
3.10.20  exists() raised PermissionError
3.11.15  exists() raised PermissionError
3.12.13  exists() raised PermissionError
3.13.7   exists() raised PermissionError
3.14.6   exists() returned False
```

3.14 delegates to `os.path.exists()` and swallows the error; every earlier interpreter still runs `pathlib._ignore_error`, whose errno set excludes `EACCES`. `requires-python` is `>=3.10, <3.15`, so 3.14 is in range and unaffected while everything below it raises.

The override matrix, run against the five-target shape a generated client actually has:

```
no override                                    PermissionError
PRISMA_QUERY_ENGINE_BINARY alone               PermissionError
PRISMA_BINARY_PLATFORM + QUERY_ENGINE_BINARY   OK
```

The five targets are the reason the single-variable form is not offered as an option. `prisma generate` bakes one path per supported platform, confirmed on the installed client as `darwin-arm64`, `debian-openssl-1.1.x`, `debian-openssl-3.0.x`, `linux-musl` and `linux-musl-openssl-3.0.x`. The fast path that skips the walk fires only when there is exactly one target, so it never fires in practice and the raising check is always reached, before Prisma ever reads `PRISMA_QUERY_ENGINE_BINARY`.

A contrived single-target client is the one case where that variable alone suffices, and no shipped client has one, so the page documents the pair as a pair and offers no lighter-weight alternative that would only work in a configuration a reader cannot have.

Image and release provenance was resolved through `gh api` rather than local tags, which are stale in this checkout and understate what has shipped. v1.95.0 is `prerelease=false`, published after v1.94.1, and contains the non-root fix; both 1.94.x tags do not. `litellm`, `litellm-database` and `litellm-non_root` at `:v1.95.0` all return 200 on ghcr manifests. Only ghcr manifests were checked; no image was pulled or run, and nothing is asserted about the `docker.litellm.ai` mirror beyond it being a mirror.

## Relevant issues

## Linear ticket

Resolves LIT-5175

## Pre-Submission checklist

- [ ] I have added meaningful tests (docs-only; validated with a full site build and the live `ensure()` runs above)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

📖 Documentation

## Changes

`docs/troubleshoot/prisma_migrations.md`, one new section.

It goes on the existing page rather than a new one: it is the only Prisma troubleshooting page, every inbound link to it is page-level with no anchors, and no sidebar entry is needed. The page's one-line intro was widened by a clause, since a startup engine-resolution failure is not a migration error and the old framing did not cover it.

## QA runbook

Docs-only. `npm ci && npm run build` passes with exit 0. The build reports 95 pre-existing broken-anchor pages on old release notes and provider pages; `/docs/troubleshoot/prisma_migrations` is not among them. Rendered page to read: `/docs/troubleshoot/prisma_migrations`, section 4.
