### PR TITLE
docs: repair broken image tag and chart links on the deployment pages

### DIFF
--- a/docs/learn/enterprise_quickstart.md
+++ b/docs/learn/enterprise_quickstart.md
@@ -205,7 +205,7 @@ Your LiteLLM Gateway is now running on `http://0.0.0.0:4000`.
 
 <TabItem value="helm" label="Helm">
 
-The chart is published to an OCI registry, so Helm installs it directly; there is no need to clone the repo. It can provision Postgres for you (`db.deployStandalone: true`) or point at an existing database (`db.useExisting`). See the [chart README](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/README.md) and the full [values.yaml](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/values.yaml).
+The chart is published to an OCI registry, so Helm installs it directly; there is no need to clone the repo. It can provision Postgres for you (`db.deployStandalone: true`) or point at an existing database (`db.useExisting`). See the [chart README](https://github.com/BerriAI/litellm/blob/main/helm/litellm-helm/README.md) and the full [values.yaml](https://github.com/BerriAI/litellm/blob/main/helm/litellm-helm/values.yaml).
 
 #### Step 1. Create a Secret for your license + provider keys
 

--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -239,7 +239,7 @@ spec:
     spec:
       containers:
       - name: litellm
-        image: docker.litellm.ai/berriai/litellm:main-v1.90.2 # pin a version, do not use :latest
+        image: docker.litellm.ai/berriai/litellm:v1.90.2 # pin a version, do not use :latest
         args:
           - "--config"
           - "/app/proxy_server_config.yaml"


### PR DESCRIPTION
## TLDR

Two broken references on the deployment pages. A reader copy-pasting the Kubernetes manifest cannot pull the image, and a reader following the enterprise quickstart to the chart reference gets a 404.

Problem this solves:

- `docs/proxy/deploy.md` tells readers to pull `docker.litellm.ai/berriai/litellm:main-v1.90.2`, and no `main-` prefixed tag exists for that release, so the pull fails
- `docs/learn/enterprise_quickstart.md` links the chart README and `values.yaml` under `deploy/charts/litellm-helm`, a directory that does not exist in the litellm repo

How it solves it:

- pins the manifest image to `v1.90.2`, which resolves
- repoints both chart links at `helm/litellm-helm`, where the chart actually lives

## Verification

The `main-` prefix is a real scheme that was retired rather than a typo, which is worth recording since the old form still works for older releases and looks valid:

```
main-v1.63.11-stable -> 200      main-v1.90.2-stable -> 404
main-v1.72.2-stable  -> 200      main-v1.90.2        -> 404
                                 main-v1.95.0        -> 404
                                 v1.90.2             -> 200
                                 v1.95.0             -> 200
```

Checked against ghcr manifests with an anonymous pull token, and reproduced identically through `docker.litellm.ai`, whose auth realm is `ghcr.io/token` and which is therefore a pass-through in front of the same registry.

Pinned `v1.90.2` was chosen over `main-latest`, which also resolves, because the page teaches pinning: line 47 says to pin a version tag rather than a moving one, the `values.yaml` example higher up already uses `tag: "v1.90.2"`, and the broken line's own trailing comment reads "pin a version, do not use :latest". Using a moving tag would contradict the page it sits on.

For the chart links, `helm/litellm-helm/README.md` and `helm/litellm-helm/values.yaml` were both confirmed present on `main` before repointing. `deploy/` does not exist in the repo at all.

The 19 `main-v...-stable` references under `release_notes/` are deliberately untouched. Those are historical records of what was current at publication, and most still resolve.

## Relevant issues

## Linear ticket

Resolves LIT-5177

## Pre-Submission checklist

- [ ] I have added meaningful tests (docs-only; validated with a full site build and the registry probes above)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

📖 Documentation

## Changes

`docs/proxy/deploy.md` and `docs/learn/enterprise_quickstart.md`, one line each.

## QA runbook

Docs-only. `npm ci && npm run build` passes with exit 0, with the same 95 pre-existing broken-anchor pages the other docs branches report and neither changed file among them. To confirm the substance rather than the build:

```bash
TOK=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:berriai/litellm:pull" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
for t in main-v1.90.2 v1.90.2; do
  printf "%-16s %s\n" "$t" "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOK" \
    -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json' \
    "https://ghcr.io/v2/berriai/litellm/manifests/$t")"
done
```

Expect `main-v1.90.2 404` and `v1.90.2 200`. The two repointed links can be opened directly: https://github.com/BerriAI/litellm/blob/main/helm/litellm-helm/README.md and https://github.com/BerriAI/litellm/blob/main/helm/litellm-helm/values.yaml
