### PR TITLE
chore(compat-matrix): refresh for v1.95.0 + claude-code 2.1.220

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-11T06:11:54Z",
-  "litellm_version": "v1.91.1",
-  "claude_code_version": "2.1.126",
+  "generated_at": "2026-08-05T06:47:48Z",
+  "litellm_version": "v1.95.0",
+  "claude_code_version": "2.1.220",
   "providers": [
     "anthropic",
     "bedrock_invoke",
@@ -19,11 +19,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -41,10 +42,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -62,11 +65,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -84,11 +88,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -106,11 +111,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -128,11 +134,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -150,11 +157,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -172,11 +180,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -194,11 +203,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -216,11 +226,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -238,11 +249,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI failed: exit=1; text=API Error: Content block is not a text block"
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -260,10 +272,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -303,16 +317,18 @@
         },
         "bedrock_invoke": {
           "status": "fail",
-          "error": "[claude-haiku-4-5-bedrock-invoke] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"message\\\":\\\"tools.0: Input tag 'tool_search_tool_regex_20251119' found using 'type' does not match any of the expected tags: 'bash_20250124', 'custom', 'memory_20250818', 'text_editor_20250124', 'text_editor_20250429', 'text_editor_20250728', 'web_search_20250305'\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\""
+          "error": "[claude-haiku-4-5-bedrock-invoke] tool_search probe failed: status 403: {\"error\":{\"message\":\"{\\\"Message\\\":\\\"Authentication failed: Please make sure your API Key is valid.\\\"}. Received Model Group=claude-haiku-4-5-bedrock-invoke\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"403\"}}"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] tool_search probe failed: status 500: {\"error\":{\"message\":\"litellm.APIConnectionError: BedrockException - {\\\"Message\\\":\\\"Authentication failed: Please make sure your API Key is valid.\\\"}. Received Model Group=claude-haiku-4-5-bedrock-converse\\nAvailable Model Group Fallbacks=None\",\"type\":null,\"param\":null,\"code\":\"500\"}}"
         },
         "vertex_ai": {
           "status": "pass"
         },
         "azure": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-azure] tool_search probe failed: status 400: {\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"tool_search_server not supported in your workspace.\\\"},\\\"request_id\\\":\\\"req_011Cdj8xxH1K4SLQ77jfMJM8\\\"}. Received Model Group=claude-haiku-4-5-azure\\nAvailable Model Group Fallbacks=None\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}"
         }
       }
     },
@@ -324,10 +340,12 @@
           "status": "pass"
         },
         "bedrock_invoke": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-sonnet-4-6-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-sonnet-4-6-bedrock-invoke\nAvailable Model Group Fallbacks=None; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; api_status=500; text=API Error: 500 litellm.APIConnectionError: BedrockException - {\"Message\":\"Authentication failed: Please make sure your API Key is valid.\"}. Received Model Group=claude-sonnet-4-6-bedrock-converse\nAvailable Model Group Fallbacks=None. This is a server-side issue, usually temporary \u2014 try again in a moment. If it persists, check your inference gateway (127.0.0.1:4100).; stderr=\u26a0 claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login \u00b7 Unset it to load your organization's connectors"
         },
         "vertex_ai": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 18 green->red regression(s):
  - Basic messaging (non-streaming) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Basic messaging (streaming) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Basic messaging (streaming) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Long context (1M) [bedrock_converse]: pass -> fail ([claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; api_status=500; text=API Error: 500 litellm.APIConnectionError: BedrockException - {"Message":"A)
  - Long context (1M) [bedrock_invoke]: pass -> fail ([claude-sonnet-4-6-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Ple)
  - PDF document input [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Prompt caching (1h TTL) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Prompt caching (5m TTL) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Structured outputs [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Structured outputs [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Thinking [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Extended thinking + tool use [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Tool search (MCP discovery) [azure]: pass -> fail ([claude-haiku-4-5-azure] tool_search probe failed: status 400: {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\)
  - Tool search (MCP discovery) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] tool_search probe failed: status 500: {"error":{"message":"litellm.APIConnectionError: BedrockException - {\"Message\":\"Aut)
  - Tool use [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Tool use (streaming / fine-grained) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Vision [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
  - Web search (server tool) [bedrock_invoke]: pass -> fail ([claude-haiku-4-5-bedrock-invoke] claude CLI failed: exit=1; api_status=403; text=Failed to authenticate. API Error: 403 {"Message":"Authentication failed: Plea)
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.95.0` |
| claude_code_version | `2.1.220` |
| generated_at | `2026-08-05T06:47:48Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=fail
- **Long context (1M)**: anthropic=pass, bedrock_invoke=fail, bedrock_converse=fail, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.