### PR TITLE
docs(deepseek): fix proxy startup command for pip installs

### DIFF
--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -143,7 +143,7 @@ model_list:
 2. Run proxy
 
 ```bash
-python litellm/proxy/main.py
+litellm --config /path/to/config.yaml
 ```
 
 3. Test it!


### PR DESCRIPTION
The "Run Proxy" step on the DeepSeek provider page used
   `python litellm/proxy/main.py`, which only works from a source checkout
   and fails with "No such file or directory" for users who installed via pip.

   Replaced it with the installed `litellm --config /path/to/config.yaml` CLI
   command, matching the convention used across the other provider pages
   (anthropic.md and 20+ others).