### PR TITLE
docs(proxy): document the Jina AI API key env vars

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -688,7 +688,9 @@ router_settings:
 | HYPERBOLIC_API_BASE | Base URL for Hyperbolic
 | INCEPTION_API_BASE | Base URL for Inception. Default is https://api.inceptionlabs.ai/v1
 | JINA_AI_API_BASE | Base URL for Jina AI embeddings. Default is https://api.jina.ai/v1
+| JINA_AI_API_KEY | API key for Jina AI
 | JINA_AI_TOKEN | Fallback for `JINA_AI_API_KEY`
+| JINA_API_KEY | Fallback for `JINA_AI_API_KEY`
 | LANGFLOW_API_BASE | Base URL for Langflow. Default is http://localhost:7860
 | LANGFLOW_API_KEY | API key for Langflow
 | LEMONADE_API_KEY | API key for Lemonade


### PR DESCRIPTION
The Jina AI embedding provider resolves its key from `JINA_AI_API_KEY`, falling back to `JINA_API_KEY` and then `JINA_AI_TOKEN`. Of those three only `JINA_AI_TOKEN` had a row in the environment variables reference; `JINA_AI_API_KEY` appeared solely as prose inside that row's description, and `JINA_API_KEY` was absent entirely.

This adds a row for each, in the alphabetical position and the style of the neighbouring entries.

`JINA_API_KEY` is the one a reader cannot currently find at all. The `JINA_AI_API_KEY` row is a reference-table improvement rather than a requirement: a variable a user has to set deserves its own entry instead of a passing mention inside a neighbouring variable's description.