### PR TITLE
docs(openai_codex): add Codex desktop app instructions

### DIFF
--- a/docs/tutorials/openai_codex.md
+++ b/docs/tutorials/openai_codex.md
@@ -156,7 +156,21 @@ codex
 
 <Image img={require('../../img/litellm_codex.gif')} />
 
-## 6. Advanced Options
+## 6. Using the Codex Desktop App
+
+The Codex desktop app reads the same `~/.codex/config.toml` as the CLI, so the configuration from step 4 works for the app with no extra LiteLLM setup. Set `model` and `model_provider` as shown above, then start the app and open a new session; requests are routed through your LiteLLM proxy.
+
+Two caveats specific to the app:
+
+**API key visibility.** The app resolves `env_key` from its own environment. On macOS, apps launched from Finder or the Dock do not inherit variables exported in your shell profile, so `LITELLM_API_KEY` can be missing even though `codex` works fine in your terminal. Either launch the app from a terminal or set the variable at the login session level and restart the app:
+
+```bash showLineNumbers
+launchctl setenv LITELLM_API_KEY sk-1234
+```
+
+**Model selection.** With a custom provider there is no UI for changing the model of a session in the app (see [openai/codex#15364](https://github.com/openai/codex/issues/15364)). A session uses whatever `model` was set in `config.toml` when the session was created. To use a different LiteLLM model, update `model` in `config.toml` and start a new session.
+
+## 7. Advanced Options
 
 ### Using Different Models
 


### PR DESCRIPTION
The OpenAI Codex tutorial only covered the Codex CLI, but the Codex desktop app reads the same ~/.codex/config.toml and speaks the same Responses API, so it already works with the LiteLLM proxy. This adds a section to the tutorial saying so, plus the two app-specific gotchas: env_key resolution for GUI-launched apps on macOS (shell profile exports are not inherited, launchctl setenv or launching from a terminal fixes it) and the lack of a UI to switch models mid-session with a custom provider (openai/codex#15364), where the workaround is editing config.toml and starting a new session

No LiteLLM-side changes are needed; this is documentation only