### PR TITLE
docs: add Opper provider page

### DIFF
--- a/docs/providers/opper.md
+++ b/docs/providers/opper.md
@@ -6,7 +6,9 @@ https://opper.ai
 
 **We support ALL Opper models, just set `opper/` as a prefix when sending completion requests**
 
-Opper is an EU-hosted LLM gateway with an OpenAI-compatible API, giving you access to 300+ models (Anthropic, OpenAI, Google, Mistral, open-weight models on EU infrastructure, and more) through a single API key. Model IDs follow the `provider/model` convention, e.g. `anthropic/claude-haiku-4-5`.
+Opper is an EU-hosted LLM gateway with an OpenAI-compatible API, giving you access to 500+ models (Anthropic, OpenAI, Google, Mistral, open-weight models on EU infrastructure, and more) through a single API key. Model IDs follow the `provider/model` convention, e.g. `anthropic/claude-haiku-4-5`.
+
+Opper is built for compliance-sensitive workloads: EU data residency, zero data retention (ZDR) available, and organization-level model allowlists so the models endpoint only returns what your compliance rules permit. It runs in production for everyone from single developers on the standard tier to enterprise deployments.
 
 Opper reports the actual request cost (USD) in `usage.cost` on every response; LiteLLM records it as the provider-reported response cost, so spend tracking reflects real gateway numbers instead of static price-map estimates.
 
@@ -79,4 +81,4 @@ model_list:
 
 ## Discovering models
 
-Opper's model list (with per-token pricing and compliance metadata) is available at `GET https://api.opper.ai/v3/compat/models`; the list is filtered to the models your key is permitted to use.
+Opper's model list (with per-token pricing) is available at `GET https://api.opper.ai/v3/compat/models`; the list is filtered to the models your organization's compliance rules permit your key to use.

--- a/docs/providers/opper.md
+++ b/docs/providers/opper.md
@@ -1,0 +1,82 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Opper
+https://opper.ai
+
+**We support ALL Opper models, just set `opper/` as a prefix when sending completion requests**
+
+Opper is an EU-hosted LLM gateway with an OpenAI-compatible API, giving you access to 300+ models (Anthropic, OpenAI, Google, Mistral, open-weight models on EU infrastructure, and more) through a single API key. Model IDs follow the `provider/model` convention, e.g. `anthropic/claude-haiku-4-5`.
+
+Opper reports the actual request cost (USD) in `usage.cost` on every response; LiteLLM records it as the provider-reported response cost, so spend tracking reflects real gateway numbers instead of static price-map estimates.
+
+## API Key
+```python
+# env variable
+os.environ['OPPER_API_KEY']
+```
+
+## Sample Usage
+```python
+from litellm import completion
+import os
+
+os.environ['OPPER_API_KEY'] = ""
+response = completion(
+    model="opper/anthropic/claude-haiku-4-5",
+    messages=[
+       {"role": "user", "content": "hello from litellm"}
+   ],
+)
+print(response)
+```
+
+## Sample Usage - Streaming
+```python
+from litellm import completion
+import os
+
+os.environ['OPPER_API_KEY'] = ""
+response = completion(
+    model="opper/anthropic/claude-haiku-4-5",
+    messages=[
+       {"role": "user", "content": "hello from litellm"}
+   ],
+    stream=True,
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+## Custom API Base
+For self-hosted or regional deployments, override the API base via the environment:
+```python
+# env variable
+os.environ['OPPER_API_BASE']  # defaults to https://api.opper.ai/v3/compat
+```
+
+## Usage with LiteLLM Proxy
+
+```yaml
+model_list:
+  - model_name: claude-haiku
+    litellm_params:
+      model: opper/anthropic/claude-haiku-4-5
+      api_key: os.environ/OPPER_API_KEY
+```
+
+Opper also accepts up to 8 usage-attribution tags per request via the `X-Opper-Tags` header (e.g. to split spend per downstream tenant in Opper's own analytics):
+
+```yaml
+model_list:
+  - model_name: claude-haiku
+    litellm_params:
+      model: opper/anthropic/claude-haiku-4-5
+      api_key: os.environ/OPPER_API_KEY
+      extra_headers: {"X-Opper-Tags": "tenant:acme"}
+```
+
+## Discovering models
+
+Opper's model list (with per-token pricing and compliance metadata) is available at `GET https://api.opper.ai/v3/compat/models`; the list is filtered to the models your key is permitted to use.

--- a/docs/providers/opper.md
+++ b/docs/providers/opper.md
@@ -81,4 +81,4 @@ model_list:
 
 ## Discovering models
 
-Opper's model list (with per-token pricing) is available at `GET https://api.opper.ai/v3/compat/models`; the list is filtered to the models your organization's compliance rules permit your key to use.
+Opper's model list (with per-token pricing and per-model compliance metadata such as region and zero data retention status) is available at `GET https://api.opper.ai/v3/compat/models`; the list is filtered to the models your organization's compliance rules permit your key to use.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1150,6 +1150,7 @@ const sidebars = {
         "providers/oci",
         "providers/ollama",
         "providers/openrouter",
+        "providers/opper",
         "providers/sarvam",
         "providers/ovhcloud",
         {


### PR DESCRIPTION
Adds a provider page for [Opper](https://opper.ai), an EU-hosted LLM gateway with an OpenAI-compatible API, documenting `OPPER_API_KEY` and `OPPER_API_BASE`, SDK + proxy usage, streaming, per-tenant tagging via the `x-opper-tags` header, and gateway-reported cost tracking.

Pairs with the code PR adding the `opper` provider to BerriAI/litellm (its `test_env_keys.py` CI check requires these env vars to be documented here, so this page needs to land first). Link to the code PR to follow in a comment.

Page follows the structure of the existing gateway provider pages (tencent/openrouter) and is registered in `sidebars.js` after openrouter.