### PR TITLE
docs(guardrails): document the Zscaler AI Guard timeout param

### DIFF
--- a/docs/proxy/guardrails/zscaler_ai_guard.md
+++ b/docs/proxy/guardrails/zscaler_ai_guard.md
@@ -24,6 +24,7 @@ guardrails:
       send_user_api_key_alias: os.environ/SEND_USER_API_KEY_ALIAS # Optional
       send_user_api_key_user_id: os.environ/SEND_USER_API_KEY_USER_ID # Optional
       send_user_api_key_team_id: os.environ/SEND_USER_API_KEY_TEAM_ID # Optional
+      timeout: 30                                       # Optional: seconds to wait for each scan. Defaults to 5
 
   - guardrail_name: "zscaler-ai-guard-post-guard"
     litellm_params:
@@ -100,6 +101,22 @@ In cases where encounter other errors when apply Zscaler AI Guard, return exampl
    }
 }
 ```
+
+Each scan waits up to 5 seconds by default. If requests fail with `litellm.Timeout: Connection timed out. Timeout passed=5.0`, the scan is taking longer than that, which is most common under load because the limit also covers waiting for a free connection. Raise it with the `timeout` param on the guardrail, in seconds:
+
+```yaml
+guardrails:
+  - guardrail_name: "zscaler-ai-guard-during-guard"
+    litellm_params:
+      guardrail: zscaler_ai_guard
+      mode: "during_call"
+      api_key: os.environ/ZSCALER_AI_GUARD_API_KEY
+      policy_id: os.environ/ZSCALER_AI_GUARD_POLICY_ID
+      timeout: 30
+```
+
+The value applies to each individual Zscaler AI Guard API call and can differ per guardrail, so a pre-call and a post-call guardrail can carry different limits. You can also set it from the Admin UI when adding or editing the guardrail. It must be positive; a zero or negative value is ignored and the 5 second default is used instead.
+
 ## 6. Sending User Information to Zscaler AI Guard (Optional)
 If you need to send end-user information to Zscaler AI Guard for analysis, you can set the configuration in the environment variables to True and include the relevant information in custom_headers on Zscaler AI Guard.
 

--- a/docs/proxy/guardrails/zscaler_ai_guard.md
+++ b/docs/proxy/guardrails/zscaler_ai_guard.md
@@ -102,20 +102,7 @@ In cases where encounter other errors when apply Zscaler AI Guard, return exampl
 }
 ```
 
-Each scan waits up to 5 seconds by default. If requests fail with `litellm.Timeout: Connection timed out. Timeout passed=5.0`, the scan is taking longer than that, which is most common under load because the limit also covers waiting for a free connection. Raise it with the `timeout` param on the guardrail, in seconds:
-
-```yaml
-guardrails:
-  - guardrail_name: "zscaler-ai-guard-during-guard"
-    litellm_params:
-      guardrail: zscaler_ai_guard
-      mode: "during_call"
-      api_key: os.environ/ZSCALER_AI_GUARD_API_KEY
-      policy_id: os.environ/ZSCALER_AI_GUARD_POLICY_ID
-      timeout: 30
-```
-
-The value applies to each individual Zscaler AI Guard API call and can differ per guardrail, so a pre-call and a post-call guardrail can carry different limits. You can also set it from the Admin UI when adding or editing the guardrail. It must be positive; a zero or negative value is ignored and the 5 second default is used instead.
+Each scan waits up to 5 seconds by default. If requests fail with `litellm.Timeout: Connection timed out. Timeout passed=5.0`, the scan is taking longer than that, which is most common under load because the limit also covers waiting for a free connection. Raise it with the `timeout` param shown above, in seconds. It applies to each individual Zscaler AI Guard API call and can differ per guardrail, so a pre-call and a post-call guardrail can carry different limits. You can also set it from the Admin UI when adding or editing the guardrail. It must be positive; a zero or negative value is ignored and the 5 second default is used instead.
 
 ## 6. Sending User Information to Zscaler AI Guard (Optional)
 If you need to send end-user information to Zscaler AI Guard for analysis, you can set the configuration in the environment variables to True and include the relevant information in custom_headers on Zscaler AI Guard.


### PR DESCRIPTION
Documents the `timeout` param on the Zscaler AI Guard guardrail, which is wired up in BerriAI/litellm#36110

Each scan waited 5 seconds with no documented way to change it, and a customer hitting timeouts under load had nothing to go on. The page now shows the param in the config example, explains the error string it fixes, and notes that the limit is per guardrail so a pre-call and post-call guardrail can differ

No merge-order dependency in either direction. The code PR adds no new env var, so `test_env_keys.py` is not involved and the two can land in any order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->