### PR TITLE
docs(azure_sentinel): document sovereign cloud authority and audience settings

### DIFF
--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -123,6 +123,18 @@ You should see following logs in Azure Workspace.
 | `AZURE_SENTINEL_AUTHORITY_HOST` | Microsoft Entra authority host that issues the OAuth2 token | None (falls back to `AZURE_AUTHORITY_HOST`, then `https://login.microsoftonline.com`) | ❌ No |
 | `AZURE_SENTINEL_OAUTH_SCOPE` | OAuth2 scope requested for the Logs Ingestion API | The Azure Monitor audience matching the authority host | ❌ No |
 
+## Sovereign clouds
+
+Azure Government and Azure China use their own Entra authority and their own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host and LiteLLM derives the matching audience:
+
+| Cloud | Authority host | Derived audience |
+|-------|----------------|------------------|
+| Azure Public Cloud (default) | `https://login.microsoftonline.com` | `https://monitor.azure.com/.default` |
+| Azure Government | `https://login.microsoftonline.us` | `https://monitor.azure.us/.default` |
+| Azure China (21Vianet) | `https://login.partner.microsoftonline.cn`, or the legacy `https://login.chinacloudapi.cn` | `https://monitor.azure.cn/.default` |
+
+`AZURE_AUTHORITY_HOST` is shared with the `azure_storage` callback and Azure OpenAI OIDC; use `AZURE_SENTINEL_AUTHORITY_HOST` to scope it to Sentinel alone. For an authority host outside the table, LiteLLM falls back to the public-cloud audience and logs a warning, so set `AZURE_SENTINEL_OAUTH_SCOPE` explicitly there. These values are read when the callback is first used, so restart the proxy to apply a change
+
 ## How It Works
 
 The Azure Sentinel integration uses the [Azure Monitor Logs Ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview) to send logs to your Log Analytics workspace. The integration:

--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -142,6 +142,8 @@ If the ingestion endpoint and the resolved audience end up in different clouds, 
 
 `AZURE_AUTHORITY_HOST` is shared: LiteLLM already documents it for the `azure_storage` logging callback and for Azure OpenAI OIDC, and the Azure SDK reads it for any credential LiteLLM builds. If your Sentinel workspace lives in a different cloud than the rest of your Azure resources, set `AZURE_SENTINEL_AUTHORITY_HOST` to override it for Sentinel only.
 
+These settings are read once, when the callback is first used. Changing them from the Admin UI saves the new value but does not affect a logger that is already running, so restart the proxy to apply a change.
+
 ## How It Works
 
 The Azure Sentinel integration uses the [Azure Monitor Logs Ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview) to send logs to your Log Analytics workspace. The integration:

--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -123,27 +123,6 @@ You should see following logs in Azure Workspace.
 | `AZURE_SENTINEL_AUTHORITY_HOST` | Microsoft Entra authority host that issues the OAuth2 token | None (falls back to `AZURE_AUTHORITY_HOST`, then `https://login.microsoftonline.com`) | ❌ No |
 | `AZURE_SENTINEL_OAUTH_SCOPE` | OAuth2 scope requested for the Logs Ingestion API | The Azure Monitor audience matching the authority host | ❌ No |
 
-## Sovereign clouds (Azure Government, Azure China)
-
-Azure Government and Azure China use their own Entra authority and their own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host as well, and LiteLLM derives the matching audience for you:
-
-```bash
-AZURE_SENTINEL_ENDPOINT="https://your-dcr-endpoint.usgovarizona-1.ingest.monitor.azure.us"
-AZURE_AUTHORITY_HOST="https://login.microsoftonline.us"
-```
-
-| Cloud | Authority host | Derived audience |
-|-------|----------------|------------------|
-| Azure Public Cloud (default) | `https://login.microsoftonline.com` | `https://monitor.azure.com/.default` |
-| Azure Government | `https://login.microsoftonline.us` | `https://monitor.azure.us/.default` |
-| Azure China (21Vianet) | `https://login.partner.microsoftonline.cn`, or the legacy `https://login.chinacloudapi.cn` | `https://monitor.azure.cn/.default` |
-
-If the ingestion endpoint and the resolved audience end up in different clouds, LiteLLM logs a warning at startup naming both, since Azure would reject that combination. For an authority host that is not in the table above, LiteLLM logs a warning and falls back to the Azure Public Cloud audience, so set `AZURE_SENTINEL_OAUTH_SCOPE` explicitly in that case. The authority host must be an https origin with no path, because the client secret is posted to it.
-
-`AZURE_AUTHORITY_HOST` is shared: LiteLLM already documents it for the `azure_storage` logging callback and for Azure OpenAI OIDC, and the Azure SDK reads it for any credential LiteLLM builds. If your Sentinel workspace lives in a different cloud than the rest of your Azure resources, set `AZURE_SENTINEL_AUTHORITY_HOST` to override it for Sentinel only.
-
-These settings are read once, when the callback is first used. Changing them from the Admin UI saves the new value but does not affect a logger that is already running, so restart the proxy to apply a change.
-
 ## How It Works
 
 The Azure Sentinel integration uses the [Azure Monitor Logs Ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview) to send logs to your Log Analytics workspace. The integration:

--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -120,6 +120,27 @@ You should see following logs in Azure Workspace.
 | `AZURE_SENTINEL_TENANT_ID` | Azure Tenant ID for OAuth2 authentication | None (falls back to `AZURE_TENANT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_ID` | Application (client) ID for OAuth2 authentication | None (falls back to `AZURE_CLIENT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_SECRET` | Client secret for OAuth2 authentication | None (falls back to `AZURE_CLIENT_SECRET`) | ✅ Yes |
+| `AZURE_SENTINEL_AUTHORITY_HOST` | Microsoft Entra authority host that issues the OAuth2 token | None (falls back to `AZURE_AUTHORITY_HOST`, then `https://login.microsoftonline.com`) | ❌ No |
+| `AZURE_SENTINEL_OAUTH_SCOPE` | OAuth2 scope requested for the Logs Ingestion API | The Azure Monitor audience matching the authority host | ❌ No |
+
+## Sovereign clouds (Azure Government, Azure China)
+
+Azure Government and Azure China use their own Entra authority and their own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host as well, and LiteLLM derives the matching audience for you:
+
+```bash
+AZURE_SENTINEL_ENDPOINT="https://your-dcr-endpoint.usgovarizona-1.ingest.monitor.azure.us"
+AZURE_AUTHORITY_HOST="https://login.microsoftonline.us"
+```
+
+| Cloud | Authority host | Derived audience |
+|-------|----------------|------------------|
+| Azure Public Cloud (default) | `https://login.microsoftonline.com` | `https://monitor.azure.com/.default` |
+| Azure Government | `https://login.microsoftonline.us` | `https://monitor.azure.us/.default` |
+| Azure China (21Vianet) | `https://login.partner.microsoftonline.cn`, or the legacy `https://login.chinacloudapi.cn` | `https://monitor.azure.cn/.default` |
+
+If the ingestion endpoint and the resolved audience end up in different clouds, LiteLLM logs a warning at startup naming both, since Azure would reject that combination. For an authority host that is not in the table above, LiteLLM logs a warning and falls back to the Azure Public Cloud audience, so set `AZURE_SENTINEL_OAUTH_SCOPE` explicitly in that case. The authority host must be an https origin with no path, because the client secret is posted to it.
+
+`AZURE_AUTHORITY_HOST` is shared: LiteLLM already documents it for the `azure_storage` logging callback and for Azure OpenAI OIDC, and the Azure SDK reads it for any credential LiteLLM builds. If your Sentinel workspace lives in a different cloud than the rest of your Azure resources, set `AZURE_SENTINEL_AUTHORITY_HOST` to override it for Sentinel only.
 
 ## How It Works
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -560,6 +560,8 @@ router_settings:
 | AZURE_SENTINEL_ENDPOINT | Endpoint for Azure Sentinel logging
 | AZURE_SENTINEL_TENANT_ID | Tenant ID for Azure Sentinel authentication
 | AZURE_SENTINEL_CLIENT_ID | Client ID for Azure Sentinel authentication
+| AZURE_SENTINEL_AUTHORITY_HOST | Microsoft Entra authority host for Azure Sentinel logging, e.g. "https://login.microsoftonline.us" for Azure Government; falls back to AZURE_AUTHORITY_HOST, then to the Azure Public Cloud authority
+| AZURE_SENTINEL_OAUTH_SCOPE | OAuth2 scope requested for the Logs Ingestion API, defaults to the Azure Monitor audience matching the resolved authority host
 | AZURE_KEY_VAULT_URI | URI for Azure Key Vault
 | AZURE_OPERATION_POLLING_TIMEOUT | Timeout in seconds for Azure operation polling
 | AZURE_STORAGE_ACCOUNT_KEY | The Azure Storage Account Key to use for Authentication to Azure Blob Storage logging


### PR DESCRIPTION
## TLDR

The Azure Sentinel page documents only the commercial-cloud setup, so there was nothing telling an Azure Government or Azure China operator that pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own

Adds a "Sovereign clouds" section with the authority-host to audience table, plus rows for the two new settings, `AZURE_SENTINEL_AUTHORITY_HOST` and `AZURE_SENTINEL_OAUTH_SCOPE`, in both the Sentinel config table and the environment variable reference

## Merge order

This has to merge before BerriAI/litellm#36137, not after. `test_env_keys.py` checks out this repo at its default branch and fails any env var read under `litellm/` that is not mentioned anywhere in these docs, so the code PR's `documentation` and `code-quality` jobs stay red until this lands
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->