### PR TITLE
Revert "docs(azure_sentinel): document sovereign cloud authority and audience settings"

### DIFF
--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -120,20 +120,17 @@ You should see following logs in Azure Workspace.
 | `AZURE_SENTINEL_TENANT_ID` | Azure Tenant ID for OAuth2 authentication | None (falls back to `AZURE_TENANT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_ID` | Application (client) ID for OAuth2 authentication | None (falls back to `AZURE_CLIENT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_SECRET` | Client secret for OAuth2 authentication | None (falls back to `AZURE_CLIENT_SECRET`) | ✅ Yes |
-| `AZURE_SENTINEL_AUTHORITY_HOST` | Microsoft Entra authority host that issues the OAuth2 token | None (falls back to `AZURE_AUTHORITY_HOST`, then `https://login.microsoftonline.com`) | ❌ No |
-| `AZURE_SENTINEL_OAUTH_SCOPE` | OAuth2 scope requested for the Logs Ingestion API | The Azure Monitor audience matching the authority host | ❌ No |
 
 ## Sovereign clouds
 
-Azure Government and Azure China use their own Entra authority and their own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host and LiteLLM derives the matching audience:
+Azure Government uses its own Entra authority and its own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host and LiteLLM derives the matching audience:
 
-| Cloud | Authority host | Derived audience |
-|-------|----------------|------------------|
+| Cloud | `AZURE_AUTHORITY_HOST` | Derived audience |
+|-------|------------------------|------------------|
 | Azure Public Cloud (default) | `https://login.microsoftonline.com` | `https://monitor.azure.com/.default` |
 | Azure Government | `https://login.microsoftonline.us` | `https://monitor.azure.us/.default` |
-| Azure China (21Vianet) | `https://login.partner.microsoftonline.cn`, or the legacy `https://login.chinacloudapi.cn` | `https://monitor.azure.cn/.default` |
 
-`AZURE_AUTHORITY_HOST` is shared with the `azure_storage` callback and Azure OpenAI OIDC; use `AZURE_SENTINEL_AUTHORITY_HOST` to scope it to Sentinel alone. For an authority host outside the table, LiteLLM falls back to the public-cloud audience and logs a warning, so set `AZURE_SENTINEL_OAUTH_SCOPE` explicitly there. These values are read when the callback is first used, so restart the proxy to apply a change
+`AZURE_AUTHORITY_HOST` is shared with the `azure_storage` callback and Azure OpenAI OIDC, so setting it moves those to the same cloud. It is read when the callback is first used, so restart the proxy to apply a change
 
 ## How It Works
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -560,8 +560,6 @@ router_settings:
 | AZURE_SENTINEL_ENDPOINT | Endpoint for Azure Sentinel logging
 | AZURE_SENTINEL_TENANT_ID | Tenant ID for Azure Sentinel authentication
 | AZURE_SENTINEL_CLIENT_ID | Client ID for Azure Sentinel authentication
-| AZURE_SENTINEL_AUTHORITY_HOST | Microsoft Entra authority host for Azure Sentinel logging, e.g. "https://login.microsoftonline.us" for Azure Government; falls back to AZURE_AUTHORITY_HOST, then to the Azure Public Cloud authority
-| AZURE_SENTINEL_OAUTH_SCOPE | OAuth2 scope requested for the Logs Ingestion API, defaults to the Azure Monitor audience matching the resolved authority host
 | AZURE_KEY_VAULT_URI | URI for Azure Key Vault
 | AZURE_OPERATION_POLLING_TIMEOUT | Timeout in seconds for Azure operation polling
 | AZURE_STORAGE_ACCOUNT_KEY | The Azure Storage Account Key to use for Authentication to Azure Blob Storage logging


### PR DESCRIPTION
Reverts #804, restoring the Azure Sentinel docs to their state before it.

BerriAI/litellm#36137 was cut back to the minimum needed to unblock a customer. It reads the existing `AZURE_AUTHORITY_HOST` and derives the Azure Monitor audience from it, and adds no environment variables, so the two settings #804 documented, `AZURE_SENTINEL_AUTHORITY_HOST` and `AZURE_SENTINEL_OAUTH_SCOPE`, do not exist. The sovereign cloud table also listed Azure China, which the shipped code does not map.

The revert is exact: the tree matches 63421b23 with no residue.

Note that Azure Government support is now undocumented. Operators have to set `AZURE_AUTHORITY_HOST` for it to take effect and nothing on the page says so, so a short note is worth adding separately if we want that discoverable