### PR TITLE
docs(azure_sentinel): document AZURE_SENTINEL_AUTHORITY_HOST

### DIFF
--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -120,17 +120,18 @@ You should see following logs in Azure Workspace.
 | `AZURE_SENTINEL_TENANT_ID` | Azure Tenant ID for OAuth2 authentication | None (falls back to `AZURE_TENANT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_ID` | Application (client) ID for OAuth2 authentication | None (falls back to `AZURE_CLIENT_ID`) | ✅ Yes |
 | `AZURE_SENTINEL_CLIENT_SECRET` | Client secret for OAuth2 authentication | None (falls back to `AZURE_CLIENT_SECRET`) | ✅ Yes |
+| `AZURE_SENTINEL_AUTHORITY_HOST` | Microsoft Entra authority host that issues the OAuth2 token | None (falls back to `AZURE_AUTHORITY_HOST`, then `https://login.microsoftonline.com`) | ❌ No |
 
 ## Sovereign clouds
 
 Azure Government uses its own Entra authority and its own Azure Monitor audience, so pointing `AZURE_SENTINEL_ENDPOINT` at a sovereign ingestion endpoint is not enough on its own. Set the authority host and LiteLLM derives the matching audience:
 
-| Cloud | `AZURE_AUTHORITY_HOST` | Derived audience |
+| Cloud | Authority host | Derived audience |
 |-------|------------------------|------------------|
 | Azure Public Cloud (default) | `https://login.microsoftonline.com` | `https://monitor.azure.com/.default` |
 | Azure Government | `https://login.microsoftonline.us` | `https://monitor.azure.us/.default` |
 
-`AZURE_AUTHORITY_HOST` is shared with the `azure_storage` callback and Azure OpenAI OIDC, so setting it moves those to the same cloud. It is read when the callback is first used, so restart the proxy to apply a change
+`AZURE_AUTHORITY_HOST` is shared with the `azure_storage` callback and Azure OpenAI OIDC, so setting it moves those to the same cloud. Use `AZURE_SENTINEL_AUTHORITY_HOST` when your Sentinel workspace lives in a different cloud than the rest of your Azure resources; it takes precedence for Sentinel only. Both are read when the callback is first used, so restart the proxy to apply a change
 
 ## How It Works
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -560,6 +560,7 @@ router_settings:
 | AZURE_SENTINEL_ENDPOINT | Endpoint for Azure Sentinel logging
 | AZURE_SENTINEL_TENANT_ID | Tenant ID for Azure Sentinel authentication
 | AZURE_SENTINEL_CLIENT_ID | Client ID for Azure Sentinel authentication
+| AZURE_SENTINEL_AUTHORITY_HOST | Microsoft Entra authority host for Azure Sentinel logging, e.g. "https://login.microsoftonline.us" for Azure Government; falls back to AZURE_AUTHORITY_HOST, then to the Azure Public Cloud authority
 | AZURE_KEY_VAULT_URI | URI for Azure Key Vault
 | AZURE_OPERATION_POLLING_TIMEOUT | Timeout in seconds for Azure operation polling
 | AZURE_STORAGE_ACCOUNT_KEY | The Azure Storage Account Key to use for Authentication to Azure Blob Storage logging


### PR DESCRIPTION
## TLDR

BerriAI/litellm#36137 made Azure Sentinel follow `AZURE_AUTHORITY_HOST`, which is shared with Azure OpenAI and the `azure_storage` callback. The follow-up code PR adds `AZURE_SENTINEL_AUTHORITY_HOST` so a deployment whose Sentinel workspace lives in a different cloud than the rest of its Azure resources can scope it

This documents that variable and notes the precedence, editing the existing Sovereign clouds section in place

## Merge order

This must merge before the follow-up code PR. `tests/documentation_tests/test_env_keys.py` checks out this repo at its default branch and fails any env var read under `litellm/` that is not mentioned here

## Note on the Azure Government alias

An earlier revision also listed `login.usgovcloudapi.net`, which the Azure SDK treats as an Azure Government alias. It has been removed. That host resolves to genuine Azure Government identity infrastructure and behaves as Entra when certificate validation is disabled, returning `AADSTS90038`, but it presents no certificate covering its own name, so a normal TLS client cannot connect at all. Documenting it would advertise a configuration that cannot work