### PR TITLE
docs(tag-routing): document the & required-AND prefix and allow_fail_open

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -171,6 +171,7 @@ router_settings:
   disable_cooldowns: True                  # bool - Disable cooldowns for all models 
   enable_tag_filtering: True                # bool - Use tag based routing for requests
   tag_filtering_match_any: True             # bool - Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags
+  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive, skipping the known-tag-vocabulary heuristic. Unprefixed tags keep matching as today.
   retry_policy: {                          # Dict[str, int]: retry policy for different types of exceptions
     "AuthenticationErrorRetries": 3,
     "TimeoutErrorRetries": 3,
@@ -382,6 +383,7 @@ router_settings:
   disable_cooldowns: True                  # bool - Disable cooldowns for all models
   enable_tag_filtering: True                # bool - Use tag based routing for requests
   tag_filtering_match_any: True             # bool - Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags
+  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive, skipping the known-tag-vocabulary heuristic. Unprefixed tags keep matching as today.
   retry_policy: {                          # Dict[str, int]: retry policy for different types of exceptions
     "AuthenticationErrorRetries": 3,
     "TimeoutErrorRetries": 3,
@@ -414,6 +416,7 @@ router_settings:
 | enable_tag_filtering | boolean | If true, uses tag based routing for requests [Tag Based Routing](tag_routing) |
 | enable_weighted_failover | boolean | If true and `routing_strategy` is `simple-shuffle`, a retryable failure on one deployment re-picks (weighted) across other deployments in the same model group before cross-group fallbacks. Default: false. |
 | tag_filtering_match_any | boolean | Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags |
+| tag_routing_prefix | string | Default `""` (no-op). A request tag starting with this exact string is stripped and matched as an explicit, trusted routing directive, exempt from the heuristic that otherwise infers routing intent from deployment tag vocabulary. Unprefixed tags keep matching as today. [Tag Based Routing](tag_routing) |
 | cooldown_time | integer | The duration (in seconds) to cooldown a model if it exceeds the allowed failures. |
 | disable_cooldowns | boolean | If true, disables cooldowns for all models. [More information here](reliability) |
 | retry_policy | object | Specifies the number of retries for different types of exceptions. [More information here](reliability) |

--- a/docs/proxy/tag_routing.md
+++ b/docs/proxy/tag_routing.md
@@ -436,6 +436,73 @@ Falling back to the default-tagged pool can return the deployment the request tr
 | Scope | Only gates exhaustion caused by `!` or `&`. Plain-tag exhaustion keeps its existing behavior: fall back to the default pool if one exists, otherwise raise |
 | Fallback pool | The same default-tagged pool used for untagged and ban-only requests, without re-applying the request's own `!`/`&` constraints |
 
+## Per-Model-Group Tag Filtering (`enable_tag_filtering`)
+
+Set `enable_tag_filtering` in `model_info` to override `router_settings.enable_tag_filtering` for one model group only, in either direction. It is checked at the model-group level: the router looks at any deployment in the requested `model_name` group, and if that deployment's `model_info.enable_tag_filtering` is set, it replaces the router-wide default for every request to that group. Set it consistently on every deployment sharing the group, the same convention `allow_fail_open` already uses.
+
+This matters on a proxy that serves many unrelated model groups. Turning on `router_settings.enable_tag_filtering` globally to satisfy one group's `&`/`!`-driven compliance routing would expose every other group's requests to tag evaluation too. Setting `model_info.enable_tag_filtering: true` on just that group's deployments avoids that. The reverse works too: carve out one tag-immune catch-all or incident-response model group while the rest of the proxy enforces tag filtering everywhere else.
+
+### Quick example
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat-compliance",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["&provider:anthropic"]}
+  }'
+# router_settings.enable_tag_filtering is false, but chat-compliance opts in via
+# model_info.enable_tag_filtering: true, so the "&" constraint still applies
+```
+
+### Config example
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: chat-compliance
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+      tags: ["provider:anthropic"]
+    model_info:
+      enable_tag_filtering: true # opt in for this group only
+
+  - model_name: chat-compliance
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+      tags: ["provider:openai"]
+    model_info:
+      enable_tag_filtering: true
+
+  - model_name: incident-response
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      enable_tag_filtering: false # opt out for this group only
+
+router_settings:
+  enable_tag_filtering: false # router-wide default; chat-compliance overrides it
+
+general_settings:
+  master_key: sk-1234
+```
+
+With this config, `chat-compliance` evaluates tags on every request even though the router-wide default is off, while every other model group, including `incident-response`, ignores tags and falls back to ordinary load-balanced routing. Flip the router-wide default to `true` instead and `chat-compliance` still evaluates tags, unaffected, while `incident-response`'s explicit `enable_tag_filtering: false` keeps it exempt.
+
+### enable_tag_filtering semantics
+
+| Behavior | Detail |
+|----------|--------|
+| Location | `model_info.enable_tag_filtering`, not `litellm_params`. Set it on every deployment sharing the model group; the router checks any one member |
+| Precedence | Low to high: `router_settings.enable_tag_filtering` (router-wide default), then `model_info.enable_tag_filtering` if set on the requested group, which overrides the router default in either direction for that group alone, then request-level `enable_tag_filtering` from key/team settings |
+| Request-level escalation only | The request-level setting, set by the proxy from key/team settings, can only turn filtering on. A request-level `enable_tag_filtering=True` still wins over a group that opted itself out with `enable_tag_filtering: false`; there is no request-level way to turn filtering off over what the router and the model group already decided |
+| Default | Unset. The model group defers to `router_settings.enable_tag_filtering`, exactly as before this override existed |
+| Scope | Applies to the whole tag-filtering decision for the group, not just `&`/`!` handling. A group with filtering disabled ignores plain, negation, and required tags alike |
+
 ## Regex-based tag routing (`tag_regex`)
 
 Use `tag_regex` on a deployment to match incoming requests by their headers (e.g. `User-Agent`) — without requiring the client to send explicit tags. Patterns are operator-configured and compiled server-side, not supplied by callers.

--- a/docs/proxy/tag_routing.md
+++ b/docs/proxy/tag_routing.md
@@ -425,6 +425,8 @@ curl http://localhost:4000/v1/chat/completions \
 
 :::caution
 Falling back to the default-tagged pool can return the deployment the request tried to exclude. Only set `allow_fail_open` on a model group where a `!`/`&` constraint that can't be honored is acceptable to degrade rather than fail; do not set it on a group where the constraint is a hard compliance requirement (for example, "never route this account's traffic to Provider X").
+
+Request tags are merged with key/team tags into the same flat list before this logic runs, and nothing in that list records which tag came from where. An authenticated caller can add their own `&` tag that matches nothing, exhausting the pool on purpose, and the resulting fallback discards every constraint at once, including an inherited key/team-level requirement the caller never controlled and could not have satisfied. Do not set `allow_fail_open` on a group whose deployments carry a key/team-enforced constraint that must always hold.
 :::
 
 ### allow_fail_open semantics

--- a/docs/proxy/tag_routing.md
+++ b/docs/proxy/tag_routing.md
@@ -290,6 +290,152 @@ curl http://localhost:4000/v1/chat/completions \
 | Untagged deployments | Deployments with no `tags` field are never excluded by negation tags |
 | Header | Negation tags work via `x-litellm-tags` header too: `-H 'x-litellm-tags: !provider:anthropic'` |
 
+## Required Tags (AND)
+
+Prefix any tag with `&` to require it. A deployment must carry every `&`-prefixed tag in the request to be a candidate, unlike plain tags which need only one match. This is useful for combining independent constraints, for example "must be high-reasoning and specifically from Anthropic", where plain OR tags would instead match a low-reasoning Anthropic deployment or a high-reasoning non-Anthropic deployment.
+
+### Quick example
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["&reasoning_type:high", "&provider:anthropic"]}
+  }'
+```
+
+Only a deployment carrying both `reasoning_type:high` and `provider:anthropic` is eligible.
+
+### Config example
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: chat
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+      tags: ["reasoning_type:high", "provider:anthropic"]
+
+  - model_name: chat
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+      tags: ["reasoning_type:high", "provider:openai"]
+
+router_settings:
+  enable_tag_filtering: true
+
+general_settings:
+  master_key: sk-1234
+```
+
+### Combining required, negation, and plain tags
+
+`!` exclusion applies first, then `&` required tags narrow what's left, then plain tags apply the usual OR preference on the survivors:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["&reasoning_type:high", "provider:anthropic", "provider:openai", "!inference:cerebras"]}
+  }'
+# must be high-reasoning, AND (anthropic OR openai), AND not cerebras-hosted
+```
+
+### Required-AND semantics
+
+| Behavior | Detail |
+|----------|--------|
+| Matching | Exact tag string match, same as negation tags. Not regex |
+| Required-only request | If the request carries only `&` tags (no plain or negation tags), the base pool mirrors untagged-request behaviour: default-tagged deployments if any exist, otherwise all deployments. The required-tag filter is then applied on top of that pool |
+| Regex/header preference does not dilute a required-AND request | A required-AND-only request always returns every deployment satisfying the required tags, even if one of them also happens to match an unrelated `tag_regex`/User-Agent preference. It is never narrowed down to only the regex-matched deployment |
+| All eliminated | If required tags eliminate every candidate, the request fails with `no_deployments_with_tag_routing`, unless the model group opts into [`allow_fail_open`](#fail-open-fallback-allow_fail_open) |
+| Header | Required tags work via `x-litellm-tags` header too: `-H 'x-litellm-tags: &reasoning_type:high'` |
+
+## Fail-Open Fallback (`allow_fail_open`)
+
+By default, when `!` or `&` tags eliminate every deployment in a model group, the request fails with `no_deployments_with_tag_routing`. Set `allow_fail_open: true` in `model_info` on every deployment in the group to fall back to the default-tagged pool instead of failing the request.
+
+This is an explicit opt-in. Without it, behavior is unchanged: an unsatisfiable `!` or `&` constraint always raises, exactly as negation already does today.
+
+### Config example
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: chat
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+      tags: ["provider:anthropic"]
+    model_info:
+      allow_fail_open: true
+
+  - model_name: chat
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+      tags: ["provider:openai", "default"]
+    model_info:
+      allow_fail_open: true
+
+router_settings:
+  enable_tag_filtering: true
+
+general_settings:
+  master_key: sk-1234
+```
+
+### Without `allow_fail_open`
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["!provider:anthropic", "!provider:openai"]}
+  }'
+# both deployments banned, allow_fail_open unset -> fails with no_deployments_with_tag_routing
+```
+
+### With `allow_fail_open`
+
+Using the config above, the same request instead falls back to the default-tagged deployment, including the one the request tried to ban:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["!provider:openai"]}
+  }'
+# openai deployment banned; anthropic deployment is not "default"-tagged, so the
+# pool falls back to whichever deployment IS "default"-tagged (openai here) -> the
+# ban is treated as advisory rather than failing the request
+```
+
+:::caution
+Falling back to the default-tagged pool can return the deployment the request tried to exclude. Only set `allow_fail_open` on a model group where a `!`/`&` constraint that can't be honored is acceptable to degrade rather than fail; do not set it on a group where the constraint is a hard compliance requirement (for example, "never route this account's traffic to Provider X").
+:::
+
+### allow_fail_open semantics
+
+| Behavior | Detail |
+|----------|--------|
+| Location | `model_info.allow_fail_open`, not `litellm_params`. Set it on every deployment sharing the model group for consistent behavior; the router checks any one member |
+| Default | Unset (`false`). Existing `!` negation behavior is unchanged unless a group opts in |
+| Scope | Only gates exhaustion caused by `!` or `&`. Plain-tag exhaustion keeps its existing behavior: fall back to the default pool if one exists, otherwise raise |
+| Fallback pool | The same default-tagged pool used for untagged and ban-only requests, without re-applying the request's own `!`/`&` constraints |
+
 ## Regex-based tag routing (`tag_regex`)
 
 Use `tag_regex` on a deployment to match incoming requests by their headers (e.g. `User-Agent`) — without requiring the client to send explicit tags. Patterns are operator-configured and compiled server-side, not supplied by callers.

--- a/docs/proxy/tag_routing.md
+++ b/docs/proxy/tag_routing.md
@@ -424,9 +424,11 @@ curl http://localhost:4000/v1/chat/completions \
 ```
 
 :::caution
-Falling back to the default-tagged pool can return the deployment the request tried to exclude. Only set `allow_fail_open` on a model group where a `!`/`&` constraint that can't be honored is acceptable to degrade rather than fail; do not set it on a group where the constraint is a hard compliance requirement (for example, "never route this account's traffic to Provider X").
+Falling back to the default-tagged pool can still return a deployment the request explicitly tried to exclude, for any constraint attributable to the caller. Only set `allow_fail_open` on a model group where a `!`/`&` constraint that can't be honored is acceptable to degrade rather than fail; do not set it on a group where the constraint is a hard compliance requirement (for example, "never route this account's traffic to Provider X").
 
-Request tags are merged with key/team tags into the same flat list before this logic runs, and nothing in that list records which tag came from where. An authenticated caller can add their own `&` tag that matches nothing, exhausting the pool on purpose, and the resulting fallback discards every constraint at once, including an inherited key/team-level requirement the caller never controlled and could not have satisfied. Do not set `allow_fail_open` on a group whose deployments carry a key/team-enforced constraint that must always hold.
+A constraint inherited from key- or team-level policy is protected from being discarded. The proxy tracks which tags came from key/team metadata separately from what the request itself supplied (`metadata.inherited_tags`), so `allow_fail_open` only ever drops a constraint the caller controlled — even if the caller also resubmits the inherited tag's exact value alongside a conflicting one, a value-collision that plain set subtraction could not tell apart from an honest caller-only tag. If dropping the caller-controlled portion alone still leaves nothing to route to, the request raises instead of falling open.
+
+This protection requires the proxy layer. A direct SDK `Router` call that bypasses the proxy (no `metadata.inherited_tags` set) falls back to the fully-unconstrained default pool unconditionally, exactly as if every tag were caller-supplied — the same behavior `allow_fail_open` has always had outside the proxy.
 :::
 
 ### allow_fail_open semantics
@@ -437,6 +439,86 @@ Request tags are merged with key/team tags into the same flat list before this l
 | Default | Unset (`false`). Existing `!` negation behavior is unchanged unless a group opts in |
 | Scope | Only gates exhaustion caused by `!` or `&`. Plain-tag exhaustion keeps its existing behavior: fall back to the default pool if one exists, otherwise raise |
 | Fallback pool | The same default-tagged pool used for untagged and ban-only requests, without re-applying the request's own `!`/`&` constraints |
+| Inherited-tag protection | Discarding is based on tag provenance (`metadata.inherited_tags`, populated by the proxy from key/team policy), not on subtracting the caller's own tags from the total — a key/team-inherited constraint stays protected even if the caller separately submits the identical value |
+
+## Explicit Routing Directives (`tag_routing_prefix`)
+
+Tag-based routing infers "is this tag meant for routing" by checking whether some deployment's literal tag string happens to match. That heuristic is usually right, but a caller-invented `&`/`!` tag that matches nothing is treated as suspicious noise and can block `allow_fail_open`'s fallback (see above) even when the caller genuinely wanted an honest, if unsatisfiable, request. Configure `router_settings.tag_routing_prefix` to let a caller mark specific tags as trusted, unambiguous routing directives, removing that ambiguity entirely for the tags that use it.
+
+Any request tag starting with the configured prefix is stripped of the prefix and matched using the usual `!`/`&`/plain-tag logic, with no vocabulary check needed since the caller already declared routing intent explicitly. An unprefixed tag keeps going through today's existing handling unchanged, so adopting the prefix requires no migration.
+
+### Quick example
+
+With `tag_routing_prefix: "route:"` configured:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["feature:demo", "route:!provider:openai"]}
+  }'
+# feature:demo is untouched attribution, never meant for routing; route:!provider:openai
+# is stripped to !provider:openai and matched as an explicit ban
+```
+
+### Config example
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: chat
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+      tags: ["default", "provider:anthropic"]
+    model_info:
+      allow_fail_open: true
+
+  - model_name: chat
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+      tags: ["provider:openai"]
+
+router_settings:
+  enable_tag_filtering: true
+  tag_routing_prefix: "route:" # opt-in: enables the prefix mechanism
+
+general_settings:
+  master_key: sk-1234
+```
+
+### Prefixed tags and the unknown-tag fail-open guard
+
+A prefixed `&`/`!` tag counts as known to the [unknown-tag fail-open guard](#fail-open-fallback-allow_fail_open) regardless of whether any deployment's literal tags match it, since the caller has explicitly declared routing intent:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {"tags": ["route:&provider:anthropic", "route:&custom-routing-key"]}
+  }'
+# custom-routing-key matches no deployment's tags, but because it is prefix-marked
+# the caller has explicitly declared it a routing directive -- allow_fail_open still
+# proceeds to the default-tagged pool instead of being blocked by the "does an
+# invented tag hide a satisfiable answer" guard
+```
+
+### tag_routing_prefix semantics
+
+| Behavior | Detail |
+|----------|--------|
+| Location | `router_settings.tag_routing_prefix`, string, default `""` |
+| Default | `""`. `str.startswith("")` matches every string, so the mechanism is a full no-op until configured |
+| Matching | Exact literal prefix, no delimiter auto-appended. Configure a trailing delimiter yourself (e.g. `"route:"`, not `"route"`) — a prefix with no delimiter can coincidentally match an unrelated tag that happens to start with the same characters |
+| Stripping order | The prefix is stripped first, before `!`/`&` parsing, so `route:!provider:x` and `route:&provider:x` both work |
+| Unprefixed tags | Keep going through today's existing handling unchanged: the known-tag-vocabulary heuristic for plain tags, and the unknown-tag fail-open guard for `!`/`&` tags |
+| Interaction with fail-open | A prefixed `&`/`!` tag counts as known to `allow_fail_open`'s unknown-tag guard regardless of deployment tag vocabulary |
 
 ## Per-Model-Group Tag Filtering (`enable_tag_filtering`)
 
@@ -504,6 +586,7 @@ With this config, `chat-compliance` evaluates tags on every request even though 
 | Request-level escalation only | The request-level setting, set by the proxy from key/team settings, can only turn filtering on. A request-level `enable_tag_filtering=True` still wins over a group that opted itself out with `enable_tag_filtering: false`; there is no request-level way to turn filtering off over what the router and the model group already decided |
 | Default | Unset. The model group defers to `router_settings.enable_tag_filtering`, exactly as before this override existed |
 | Scope | Applies to the whole tag-filtering decision for the group, not just `&`/`!` handling. A group with filtering disabled ignores plain, negation, and required tags alike |
+| Health-independent | Resolved from every deployment configured for the model group, not just the ones currently healthy — a single deployment's cooldown can't silently disable (or enable) the whole group's tag policy by taking the only deployment carrying the override out of rotation |
 
 ## Regex-based tag routing (`tag_regex`)
 


### PR DESCRIPTION
Documents the "&" required-AND tag prefix and the model_info.allow_fail_open flag added in https://github.com/BerriAI/litellm/pull/36193.

Adds to docs/proxy/tag_routing.md:
- A "Required Tags (AND)" section: quick example, config example, combining with negation and plain tags, and a semantics table, matching the existing negation section's structure.
- A "Fail-Open Fallback (allow_fail_open)" section: config example, default (raises) vs opt-in (falls back to the default-tagged pool) behavior with curl examples, a caution about the fallback pool not re-applying the request's own ban, and a semantics table.

Verified with npm run build locally; no new broken links or anchors on the edited page.

---

**Update:** the source PR gained a third feature, `model_info.enable_tag_filtering`, since this docs PR was opened. Added a matching "Per-Model-Group Tag Filtering (enable_tag_filtering)" section (quick example, config example, semantics table) right after "Fail-Open Fallback" and before "Regex-based tag routing," documenting the per-model-group override of `router_settings.enable_tag_filtering` (overrides the router-wide default in either direction for one model group, while a request-level `enable_tag_filtering=True` still wins over both). Re-verified with npm run build locally; no new broken links or anchors on the edited page.