### PR TITLE
docs(auto_routing): document deployment_affinity for the auto-router

### DIFF
--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -19,7 +19,7 @@ Ships in **v1.94.x**. The earliest dev release cuts **Tuesday, 2026-07-14**. Sug
 | Classifier   | Embedding match on utterances     | Heuristic, LLM classifier, or lexical/semantic keyword rules               |
 | Tier value   | One model                         | One model, random pool, or adaptive (Thompson-sampled) pool                |
 | Latency      | ~100-500ms (embedding call)       | Sub-millisecond (heuristic/keyword) or one small classifier call (LLM)     |
-| Session pin  | No                                | Opt-in `session_affinity` (off by default), keyed by `session_id` metadata |
+| Session pin  | No                                | Opt-in `session_affinity` (off by default) pins the model; `deployment_affinity` (on by default) pins the deployment, both keyed by `session_id` metadata |
 | Log          | No routing-cause signal           | `cause=` marker per decision (scorer, literal, semantic, session_pin, LLM) |
 | Best for     | Intent-based routing              | Cost/quality tiering, hybrid rule + classifier setups, prompt-cache pinning |
 
@@ -262,6 +262,32 @@ session_affinity_ttl_seconds: 3600
 :::info Changed default
 
 `session_affinity` used to default to `true`. Routers created before that changed have no `session_affinity` key stored, so they pick up the new `false` default and start reclassifying every turn. Add `session_affinity: true` to any router that should keep pinning.
+
+:::
+
+## Deployment affinity
+
+`session_affinity` pins which model group a session routes to. `deployment_affinity` pins which deployment inside that group serves it, and the two are independent.
+
+The distinction matters when a model group fans out across several deployments of the same model, since provider prompt caches are per deployment. Without a deployment pin the router load-balances across the group on every turn, so a conversation that stays in one tier still lands on a different deployment roughly half the time and the cache it warmed goes unused.
+
+On by default, because re-shuffling a conversation across deployments of the same model discards that cache for no benefit. Set it to `false` to keep every turn load-balanced across the group, which is what a deployment set with tight per-deployment rate limits wants.
+
+```yaml
+deployment_affinity: true       # default; false keeps every turn load-balanced
+session_affinity: false         # default; independent of the above
+session_affinity_ttl_seconds: 3600
+```
+
+Pins are held per model group, so switching tiers does not disturb the pin left behind in the previous group. A session that classifies SIMPLE, escalates to COMPLEX on the next turn, then comes back down returns to the deployment it used the first time rather than being reshuffled. That is the combination `session_affinity` cannot express on its own, since pinning the model freezes the tier along with it.
+
+Do not confuse this with the router-level `deployment_affinity` listed under [`optional_pre_call_checks`](./config_settings.md), which pins on the caller's API key rather than the session and applies to every model group instead of the ones an auto-router targets. The setting on this page lives inside `complexity_router_config` and is keyed by session.
+
+`session_id` is read from request metadata exactly as it is for `session_affinity`; when none is resolvable there is nothing to key a pin on, so the router load-balances as usual and writes no pin. Pins are scoped by the caller's hashed API key, so two callers reusing the same client-supplied `session_id` cannot read or steer each other's pin. Like `session_affinity`, it is suppressed when `plugins` are configured. `session_affinity_ttl_seconds` bounds both pins, and it measures idle time rather than total session length, since every hit refreshes it.
+
+:::info Changed default
+
+`deployment_affinity` is new and defaults to `true`, so an auto-router whose callers send a `session_id` starts pinning deployments without any config change. Tiering, spend, and which model serves a turn are unaffected; only the choice among deployments of one model group changes. Set `deployment_affinity: false` to keep the previous load-balanced behavior.
 
 :::
 

--- a/release_notes/v1.96.0rc1/index.md
+++ b/release_notes/v1.96.0rc1/index.md
@@ -43,6 +43,14 @@ pip install litellm==1.96.0rc1
 </TabItem>
 </Tabs>
 
+:::danger Breaking Changes
+
+**Auto-routers now pin a session to one deployment inside each model group by default.** The new `complexity_router_config.deployment_affinity` defaults to `true`, so an auto-router whose callers send a session id (via `x-litellm-session-id`, `x-litellm-trace-id`, or any `x-<vendor>-session-id` header) stops load-balancing those turns across deployments of the same model group. Tiering, spend, and which model serves a turn are unaffected; only the choice among deployments of one group changes. Set `deployment_affinity: false` under `complexity_router_config` to keep the previous behavior. See [PR #36146](https://github.com/BerriAI/litellm/pull/36146).
+
+**Session deployment pins are now scoped by API key, so existing pins miss once on upgrade.** Callers using `optional_pre_call_checks: ["session_affinity"]` will see each active session take one load-balanced turn before re-pinning, because the cache key gained a hashed-API-key segment. No action is required and pins re-establish on the next request. The scoping closes a hole where two callers sending the same client-supplied session id shared one pin. See [PR #36146](https://github.com/BerriAI/litellm/pull/36146).
+
+:::
+
 ## Key Highlights
 
 `v1.96.0rc1` is the current release candidate for 1.96.0.


### PR DESCRIPTION
Documents the new `deployment_affinity` field on the auto-router config, added in [BerriAI/litellm#36146](https://github.com/BerriAI/litellm/pull/36146)

`session_affinity` pins which model group a session routes to; `deployment_affinity` pins which deployment inside that group serves it, and the two are independent. The new section covers the default-on behavior, the per-group pin semantics that let a session escalate a tier and come back to the deployment it used before, and the API key scoping on pins

Also disambiguates it from the router-level `deployment_affinity` under `optional_pre_call_checks`, which shares the name but keys on the caller's API key rather than the session

Resolves LIT-5305