### PR TITLE
docs(xai): mention structured outputs in features

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -69,6 +69,7 @@ response = completion(
 - **Vision** = Image understanding
 - **Audio** = Audio input support
 - **Caching** = Prompt caching for cost savings
+- **Structured outputs** = JSON / schema-constrained responses
 - **Code generation** = Optimized for code tasks
 
 **Pricing:** See [xAI's pricing page](https://docs.x.ai/docs/models) for current rates.


### PR DESCRIPTION
Features list never mentioned structured outputs. xAI documents it for Grok 4.5 and LiteLLM has `supports_response_schema` set, so I added a bullet.