### PR TITLE
docs(cursor): agent mode support, model variant resolution, Cloud Agents cross-link

### DIFF
--- a/docs/pass_through/cursor.md
+++ b/docs/pass_through/cursor.md
@@ -34,6 +34,8 @@ Just replace `https://api.cursor.com` with `LITELLM_PROXY_BASE_URL/cursor` 🚀
 
 Navigate to **Models + Endpoints → LLM Credentials** and click **Add Credential**. Select **Cursor** from the provider dropdown — you'll see the Cursor logo. Enter your API key from [cursor.com/settings](https://cursor.com/settings).
 
+Alternatively, set the `CURSOR_API_KEY` environment variable on the proxy.
+
 <Image img={require('../../img/cursor_add_credential.png')} alt="Add Cursor credential with logo" style={{maxWidth: '800px'}} />
 
 ### 2. Launch a Cursor Agent

--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -5,7 +5,7 @@ import Image from '@theme/IdealImage';
 Route Cursor IDE requests through LiteLLM for unified logging, budget controls, and access to any model.
 
 :::info
-**Supported modes:** Ask, Plan. Agent mode doesn't support custom API keys yet.
+**Supported modes:** Ask, Plan, Agent. Agent mode requires LiteLLM v1.97.0+, which translates the Responses API request shapes Cursor's agent sends to the chat completions path. Cursor gates custom API keys by mode and model on its side, so coverage follows what Cursor enables.
 :::
 
 ## Quick Reference
@@ -66,6 +66,10 @@ Paste the name in Cursor and enable the toggle.
 
 ![](https://ajeuwbhvhr.cloudimg.io/https://colony-recorder.s3.amazonaws.com/files/2025-12-13/5ab35f93-d417-423f-a359-9811ce18e2c3/ascreenshot.jpeg?tl_px=352,26&br_px=1728,795&force_format=jpeg&q=100&width=1120.0&wat=1&wat_opacity=0.7&wat_gravity=northwest&wat_url=https://colony-recorder.s3.us-west-1.amazonaws.com/images/watermarks/FB923C_standard.png&wat_pad=786,277)
 
+:::tip Model variants
+Cursor's model picker can emit thinking and fast variants of a model name, e.g. `claude-opus-5-thinking`. LiteLLM v1.97.0+ resolves these suffixes to the underlying model automatically, so key scopes and per-model budgets apply to the resolved model and you don't need separate `model_list` entries for the variants.
+:::
+
 ### 4. Test
 
 Open **Ask** mode with `Cmd+L` / `Ctrl+L` and select your model.
@@ -106,10 +110,14 @@ For official instructions on configuring MCP integration with Cursor, please ref
 
 <Image img={require('../../img/cursor_mcp_installed.png')} />
 
+## Cursor Cloud Agents
+
+LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api.cursor.com` get the same credential management and logging. See [Cursor Cloud Agents](../pass_through/cursor.md).
+
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | Model not responding | Check base URL ends with `/cursor` and key has model access |
 | Auth errors | Regenerate key; ensure it starts with `sk-` |
-| Agent mode not working | Expected—only Ask and Plan modes support custom keys |
+| Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |


### PR DESCRIPTION
## Summary

The Cursor tutorial still said agent mode doesn't support custom API keys, which stopped being true when [BerriAI/litellm#14c97ba](https://github.com/BerriAI/litellm/commit/14c97ba8db1cb4172e3276ba191c962be8a1cc11) made `/cursor/chat/completions` translate the Responses API shapes Cursor's agent sends, shipping in v1.97.0. This PR updates the supported-modes info box and the troubleshooting row accordingly, documents the thinking/fast model variant resolution from [BerriAI/litellm#35554](https://github.com/BerriAI/litellm/pull/35554) (key scopes and per-model budgets bind to the resolved model, per [BerriAI/litellm#35834](https://github.com/BerriAI/litellm/pull/35834)), and cross-links the tutorial to the Cursor Cloud Agents pass-through page from [BerriAI/litellm#34029](https://github.com/BerriAI/litellm/pull/34029). The pass-through page also gains the `CURSOR_API_KEY` environment variable alternative the endpoint's credential lookup supports

`npm run build` passes with no warnings referencing either page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior impact.
> 
> **Overview**
> **Cursor IDE integration** docs now list **Agent** alongside Ask and Plan, with a v1.97.0+ requirement for Responses API → chat completions translation, and troubleshooting updated from “agent unsupported” to upgrade/version and Cursor-side model gating.
> 
> Adds a **model variants** tip: thinking/fast suffixes (e.g. `-thinking`) resolve to the base model for key scopes and budgets without extra `model_list` entries. New **Cursor Cloud Agents** section in the tutorial links to the pass-through guide.
> 
> On **Cursor Cloud Agents** pass-through docs, documents **`CURSOR_API_KEY`** as an alternative to UI credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8445aca0943c23097b1df09088563bf7b14c3769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->