### PR TITLE
docs(router): document disable_mid_stream_continuation setting

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -413,6 +413,7 @@ router_settings:
 | fallbacks | array of objects | Specifies fallback models for all types of errors. [More information here](reliability) |
 | enable_tag_filtering | boolean | If true, uses tag based routing for requests [Tag Based Routing](tag_routing) |
 | enable_weighted_failover | boolean | If true and `routing_strategy` is `simple-shuffle`, a retryable failure on one deployment re-picks (weighted) across other deployments in the same model group before cross-group fallbacks. Default: false. |
+| disable_mid_stream_continuation | boolean | If true, a streaming fallback after a partial failure retries with the original conversation messages instead of appending an assistant prefill / continuation block. Useful for fallback models that reject assistant prefill (e.g. newer Claude models on Anthropic and Vertex AI). Default: false. |
 | tag_filtering_match_any | boolean | Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags |
 | cooldown_time | integer | The duration (in seconds) to cooldown a model if it exceeds the allowed failures. |
 | disable_cooldowns | boolean | If true, disables cooldowns for all models. [More information here](reliability) |


### PR DESCRIPTION
Adds the `disable_mid_stream_continuation` router setting to the router_settings reference table. This backs the litellm PR that introduces the flag (#36267).