### PR TITLE
docs: use day names in spend log cleanup cron weekday examples

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -348,7 +348,7 @@ router_settings:
 | health_check_concurrency | integer | Maximum number of concurrent health check operations |
 | health_check_skip_disabled_background_models | boolean | If true, skips health probes for deployments with `model_info.disable_background_health_check: true` on on-demand `GET /health` and related health runs (not only the background loop). [Doc on health checks](health) |
 | health_check_staleness_threshold | integer | Maximum age in seconds for health check results before marking deployments as stale |
-| maximum_spend_logs_cleanup_cron | string | Cron expression for scheduling automatic spend log cleanup tasks |
+| maximum_spend_logs_cleanup_cron | string | Cron expression for scheduling automatic spend log cleanup tasks. Use day names (`sun`, `mon`, ...) rather than numbers in the weekday field: the scheduler numbers weekdays 0=Monday through 6=Sunday, unlike standard cron. See [spend log deletion](spend_logs_deletion) |
 | mcp_client_side_auth_header_name | string | HTTP header name for client-side MCP server credentials |
 | mcp_internal_ip_ranges | list | CIDR ranges considered internal for non-public MCP server access control |
 | mcp_required_fields | list | List of required field names for MCP server submissions |

--- a/docs/proxy/spend_logs_deletion.md
+++ b/docs/proxy/spend_logs_deletion.md
@@ -60,8 +60,14 @@ Schedule the cleanup using standard cron syntax. This takes precedence over `max
 
 Examples:
 - `"0 4 * * *"` – Run at 04:00 AM daily
-- `"0 0 * * 0"` – Run at midnight every Sunday
+- `"0 0 * * sun"` – Run at midnight every Sunday
 - `"*/30 * * * *"` – Run every 30 minutes
+
+:::warning Use day names in the weekday field
+
+Use day names (`sun`, `mon`, ...) instead of numbers in the weekday field. LiteLLM schedules the cleanup with APScheduler, which numbers weekdays 0=Monday through 6=Sunday, while standard cron uses 0=Sunday through 6=Saturday. Numeric weekday values are not translated between the two conventions, so `"0 0 * * 0"` fires on Monday, not Sunday. Day names mean the same thing in both conventions and always behave as expected.
+
+:::
 
 ## How it works
 


### PR DESCRIPTION
The spend log cleanup docs list "0 0 * * 0" as an example for running at midnight every Sunday. LiteLLM passes the expression to APScheduler's CronTrigger.from_crontab(), which numbers weekdays 0=Monday through 6=Sunday, unlike standard cron where 0=Sunday. Numeric weekday values are not translated, so that example actually fires on Monday. A customer followed the example and reported the weekly cleanup never running on the expected day

This updates the example to "0 0 * * sun", adds a warning explaining the numbering mismatch and recommending day names in the weekday field, and notes the same caveat on the maximum_spend_logs_cleanup_cron row in the config settings reference

Verified against apscheduler 3.11.2: CronTrigger.from_crontab("0 0 * * 0") next fires on a Monday, while "0 0 * * sun" fires on a Sunday
