### PR TITLE
docs: document NIMBLE_API_BASE for the Nimble search provider

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -707,6 +707,7 @@ router_settings:
 | MODELSCOPE_API_KEY | API key for ModelScope
 | MORPH_API_BASE | Base URL for Morph. Default is https://api.morphllm.com/v1
 | NEBIUS_API_BASE | Base URL for Nebius. Default is https://api.studio.nebius.ai/v1
+| NIMBLE_API_BASE | Base URL for the Nimble search provider. Default is https://sdk.nimbleway.com/v2
 | NLP_CLOUD_API_BASE | Base URL for NLP Cloud. Default is https://api.nlpcloud.io/v1/gpu/
 | NOVITA_API_BASE | Base URL for Novita. Default is https://api.novita.ai/v3/openai
 | NSCALE_API_BASE | Base URL for Nscale


### PR DESCRIPTION
Adds the reference-table row for `NIMBLE_API_BASE`, the host override read by the Nimble search provider in BerriAI/litellm#36347.

That PR's `code-quality` and `documentation` jobs check out this repo and run `tests/documentation_tests/test_env_keys.py`, which fails with `Environment variables read under ./litellm but mentioned nowhere in the docs: ['NIMBLE_API_BASE']` until the row exists. Same one-line shape TinyFish and fastCRW added for their own base URLs

Disclosure: I work at Nimble