### PR TITLE
docs(release_notes): promote v1.96.0 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.95.0 — Claude Opus 5, MCP Gateway DCR & Rust /v1/messages](/release_notes/v1.95.0/v1-95-0)
+### [v1.96.0 — MCP Entitlements, Redis Config Sync & Auto-Router Context](/release_notes/v1.96.0/v1-96-0)
 
-_August 1, 2026_
+_August 9, 2026_
 
-Day-0 support for the 1M-context Claude Opus 5 across Anthropic, Amazon Bedrock, Google Vertex AI, and Azure AI Foundry, joined by Gemini 3.6 Flash and Gemini 3.5 Flash Lite; an MCP gateway front door built on always-on aggregate DCR discovery, identity-only session tokens, RFC 8707 resource indicators, and a standalone `/connect` route; native Anthropic `/v1/messages` routed through the Rust axum gateway alongside a Responses API WebSockets port and SigV4 in `litellm-core`; SAML 2.0 SSO for the admin UI; roughly twenty dashboard routes completing the shadcn and shared DataTable migration; and a budget-reset correctness pass covering reset time of day, word-form durations, and NULL `budget_reset_at` repair. Note that user budgets are no longer enforced on team keys, reverting the `v1.94.0` change.
+An internal user's `object_permission` becomes a real MCP entitlement level that intersects the key, team, agent, and org scopes and is enforced at both `tools/list` and `tools/call`; a new `post_mcp_call` guardrail mode that finally lets a guardrail mask or reject the contents of an MCP tool result; config changes propagating to every pod through a coordination-Redis invalidation event instead of the 30s poll; OpenAI's GPT-5.6 price cut of 20% on terra and 80% on luna, mirrored onto Bedrock Mantle with new flex long-context rates; a complexity classifier that now sees prior and assistant turns and records its tier decision in spend logs; a generic `/management/v1` list contract with `GET /management/v1/budgets` on top of it; and operational hardening for large deployments covering DB statement and lock timeouts, `REPLICA IDENTITY FULL`, and an unreachable Redis that no longer blocks every request. Note that mock testing request params are now gated behind a config flag that is off by default.
 
 ---
 
@@ -22,6 +22,7 @@ Day-0 support for the 1M-context Claude Opus 5 across Anthropic, Amazon Bedrock,
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.96.0](/release_notes/v1.96.0/v1-96-0)   | Aug 9, 2026  | MCP entitlements, Redis config sync, auto-router context, GPT-5.6 price cut |
 | [v1.95.0](/release_notes/v1.95.0/v1-95-0)   | Aug 1, 2026  | Claude Opus 5, MCP gateway DCR, Rust `/v1/messages`, SAML 2.0 SSO |
 | [v1.94.0](/release_notes/v1.94.0/v1-94-0)   | Jul 28, 2026 | Router plugins & Auto-Router v2, MCP client-held credentials, shared DataTable UI |
 | [v1.93.0](/release_notes/v1.93.0/v1-93-0)   | Jul 18, 2026 | GPT-5.6, client-forwarded MCP credentials, Meta Model API provider |

--- a/release_notes/v1.96.0/index.md
+++ b/release_notes/v1.96.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.96.0rc1 - MCP Entitlements, Redis Config Sync & Auto-Router Context"
-slug: "v1-96-0-rc-1"
-date: 2026-08-03T12:53:08
+title: "v1.96.0 - MCP Entitlements, Redis Config Sync & Auto-Router Context"
+slug: "v1-96-0"
+date: 2026-08-09T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,22 +30,28 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.96.0-rc.1
+docker.litellm.ai/berriai/litellm:1.96.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.96.0rc1
+pip install litellm==1.96.0
 ```
 
 </TabItem>
 </Tabs>
 
-## Key Highlights
+:::danger Breaking Changes
 
-`v1.96.0rc1` is the current release candidate for 1.96.0.
+**Mock testing request params are gated behind one config flag.** Six `mock_*` request params previously had three different behaviors, and a dropped param returned a normal success, so a fallback drill could pass without ever running. All six now reject with a 400 naming the params and the key unless an admin sets `general_settings.dangerously_allow_mock_testing_request_params: true` in `config.yaml`; the flag cannot be changed from the Admin UI or the API. See [PR #35423](https://github.com/BerriAI/litellm/pull/35423).
+
+**Keyless gateway OAuth now admits session bearers at any MCP scope.** Session-bearer admission and RFC 9728 `WWW-Authenticate` challenges fire on per-server MCP URL paths, not only the aggregate `/mcp/` scope, so a per-server path that previously fell through to a plain rejection now issues a challenge. See [PR #34856](https://github.com/BerriAI/litellm/pull/34856).
+
+:::
+
+## Key Highlights
 
 - **MCP entitlements reach the person, not just the key** - an internal user's `object_permission` now acts as an MCP entitlement level that intersects the key, team, agent, and org scopes, is read at both `tools/list` and `tools/call` time, is persisted by `/user/new` and `/user/update`, returned by `/v2/user/info`, and editable from the internal user page.
 - **Guardrails can finally see MCP tool results** - a new `post_mcp_call` mode routes tool result text through the unified `apply_guardrail` seam, so a guardrail can mask values inside a result or reject it outright; previously a tool returning sensitive data bypassed every guardrail.
@@ -54,12 +60,6 @@ pip install litellm==1.96.0rc1
 - **The auto-router learns what it is actually routing** - the complexity classifier now sees prior turns and assistant turns, rates what a short reply approves, closes its rubric on the window it was given, and records its tier decision, request body, and its own classifier calls in spend logs and the log drawer.
 - **Budgets become a first-class management surface** - a generic `/management/v1` list contract lands with `GET /management/v1/budgets` on top of it, and the budgets page gains sorting, filtering, and search.
 - **Operational hardening for large deployments** - opt-in `database_statement_timeout` and `database_lock_timeout`, opt-in `REPLICA IDENTITY FULL` re-asserted after every migration, pod-hardening and migration-Job knobs on the componentized Helm chart, and an unreachable Redis that no longer blocks every request.
-
-### Breaking changes
-
-- **Mock testing params are gated behind one config flag** - six mock testing request params previously had three different behaviors, and a dropped param returned a normal success, so a fallback drill could pass without ever running. All six are now gated by a single config flag that is unset by default and rejects with a 400 naming the params and the key - [PR #35423](https://github.com/BerriAI/litellm/pull/35423)
-- **User budgets are no longer enforced on team keys** - reverts [PR #32005](https://github.com/BerriAI/litellm/pull/32005), which caused team keys to reject on the key owner's personal budget; team keys use team budgets only and the `skip_user_budget_on_team_key` opt-out flag is removed - [PR #35271](https://github.com/BerriAI/litellm/pull/35271)
-- **Keyless gateway OAuth admits session bearers at any MCP scope** - session-bearer admission and RFC 9728 `WWW-Authenticate` challenges now fire on per-server MCP URL paths, not only the aggregate `/mcp/` scope - [PR #34856](https://github.com/BerriAI/litellm/pull/34856)
 
 ## New Models / Updated Models
 
@@ -297,4 +297,4 @@ This window added 18 test-only PRs, 10 of them against the live e2e suite. New a
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.95.0-rc.1...v1.96.0-rc.1
+https://github.com/BerriAI/litellm/compare/v1.95.0...v1.96.0


### PR DESCRIPTION
Promotes the v1.96.0 release candidate notes to stable, following the shape of [PR #744](https://github.com/BerriAI/litellm-docs/pull/744).

Renames `release_notes/v1.96.0rc1` to `release_notes/v1.96.0` and swaps the title, slug, date, Docker tag, pip version, and Full Changelog range onto the stable form. The changelog landing page now leads with v1.96.0 and gains its row in the recent-releases table.

Two edits beyond the mechanical rename. The breaking changes move from a `### Breaking changes` subsection into a `:::danger` admonition placed between the deploy block and Key Highlights, which is what this repo's CLAUDE.md asks for and what the v1.95.0 stable notes already do. The team-key budget revert (PR #35271) drops out of that list because it shipped in v1.95.0 by backport, so the v1.95.0 notes already carry it in their own callout and announcing it twice would read as two separate changes. Ancestry alone reports it as absent from v1.95.0 since the backport carries a different SHA, so this was confirmed by code instead: `skip_user_budget_on_team_key` is already gone at that tag. The other two breaking changes were checked the same way and do first ship here.

One thing to know before merging: the `v1.96.0` git tag and GitHub release do not exist yet, so the Full Changelog compare link will 404 until the tag is cut. The stable image is published and resolves on GHCR, built from the `rc/1.96.0` tip.

Not included, since the ask was a rename. The line picked up two content PRs after the rc tag, PR #35835 and PR #35844, plus a dependency-pin refresh, all through PR #36294. The v1.95.0 promotion folded its equivalent two PRs into the notes and moved the roll-up total. Happy to do the same here if you want the roll-up to read 153 instead of 151.
