### PR TITLE
docs(benchmarks): state the load generator think time and in-flight depth

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,6 +19,7 @@ Each machine deploying LiteLLM had the following specs:
 
 - Database: PostgreSQL
 - Redis: Not used
+- Load generator: Locust, 1000 users, each with 0.5s to 1s of think time between requests. See [Locust Settings](#locust-settings) before comparing these numbers against your own run.
 
 
 ### 2 Instance LiteLLM Proxy
@@ -130,7 +131,7 @@ End-to-end latency benchmarks for the `/realtime` endpoint tested against a fake
 
 | Category | Specification |
 |----------|---------------|
-| **Load Testing** | Locust: 1,000 concurrent users, 500 ramp-up |
+| **Load Testing** | Locust: 1,000 users with 0.5s to 1s think time, 500 ramp-up |
 | **System** | 4 vCPUs, 8 GB RAM, 4 workers, 4 instances |
 | **Database** | PostgreSQL (Redis unused) |
 
@@ -187,6 +188,15 @@ See [Production Configuration](./proxy/prod) for detailed best practices.
 
 - 1000 Users
 - 500 user Ramp Up
+- `wait_time = between(0.5, 1)`, so every user sleeps 0.5s to 1s between requests
+
+### Why the think time matters when you reproduce these numbers
+
+A Locust user spends its time either waiting on a response or sleeping. With a 0.75s mean think time and ~110ms responses, each of the 1000 users completes a request about every 0.86s, so the run offers ~1160 RPS and holds roughly **130 requests in flight** at any instant. That in-flight depth, not the user count, is what the latency columns above describe.
+
+A closed-loop client with no think time is measuring something else. 1000 concurrent workers that send the next request the moment the previous one returns hold **1000 requests in flight**, about 8x the queue depth of these runs. Once a gateway is saturated its throughput is fixed, and by Little's Law the latency each client observes is just `requests in flight / throughput`. So the same deployment, at the same RPS, reports roughly 8x the latency purely because the client queued 8x as much work into it. Latency and concurrency are not independent, and neither number means anything without the other.
+
+To compare against the tables above, either keep the 0.5s to 1s think time, or hold your client's in-flight request count near 130 and report it alongside the latency. It is also worth reporting RPS first: if your run shows higher RPS and higher latency than these tables, your gateway is faster than this benchmark and your client is simply queueing deeper.
 
 ## How to measure LiteLLM Overhead
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `docs/benchmarks.md` publishes latency tables but never states the load generator's think time next to them. "Locust Settings: 1000 Users, 500 user Ramp Up" reads as 1000 concurrent in-flight requests, and the `wait_time = between(0.5, 1)` that actually produced the numbers is 176 lines further down, inside a code sample under "How to measure LiteLLM Overhead" that is framed as an optional overhead snippet rather than as the harness
- A reader who reproduces the benchmark from that section builds a 1000-concurrency closed-loop test, holds about 8x the queue depth these runs held, and concludes the gateway is 5x slower than advertised. That has already happened on a support ticket
- The `/realtime` test setup table calls the same run "1,000 concurrent users", which is the phrasing that invites the mistake

How it solves it:

- States the think time in the Configuration bullets, in the `/realtime` test setup table, and in the Locust Settings list
- Adds a short subsection deriving the in-flight depth the published runs actually held (~130 requests) from the think time, and explaining why a zero-think-time client reports ~8x the latency on the same deployment at the same RPS
- Tells the reader how to make their own run comparable, and to read RPS before latency

## User Flow

Reader lands on the Benchmarks page, sees the harness stated alongside the numbers, and can reproduce them or correctly interpret a run of their own

## Relevant issues

## Linear ticket

Resolves LIT-5346

## Pre-Submission checklist

- [ ] I have added meaningful tests. Not applicable, this is a prose-only change to one page and adds no code path to test. The numbers it states are derived and then confirmed live under Proof of Fix
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests). `npm run build` succeeds, with only the pre-existing broken anchors on old release-notes pages
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

The numbers added to the page are derived, then confirmed against a live proxy.

**Derivation, checked against the published table.** The 4-instance row reports 1170 RPS at 111.73ms average. Locust users alternate between sleeping and waiting on a response, so with a 0.75s mean think time each of the 1000 users completes a request every 0.75 + 0.11173 = 0.86173s:

```
1000 / 0.86173 = 1160.5 RPS   vs   1170 RPS published   (99.2% agreement)
```

That agreement is what identifies `wait_time = between(0.5, 1)` as the harness behind the table. Little's Law then gives the in-flight depth:

```
L = X * R = 1170 * 0.11173 = 130.7 requests in flight
```

**Live confirmation.** One LiteLLM instance, 4 workers, `network_mock: true`, no DB, no Redis, no callbacks, on an 18 CPU host. Identical gateway on every row, 500 users/s ramp, 25s warm-up discarded, 30s measurement window. The only variable is the client's think time:

```
$ litellm --config benchmark_config.yaml --port 4536 --num_workers 4

$ python loadgen.py --users 1000 --mode think  --duration 30 --warmup 25
{"mode": "think",  "users": 1000, "rps": 1239.8, "mean_ms": 58.32,  "p50_ms": 29.02,  "p95_ms": 188.33, "p99_ms": 472.39, "inflight_L_littles_law": 72.3}

$ python loadgen.py --users 1000 --mode closed --duration 30 --warmup 25
{"mode": "closed", "users": 1000, "rps": 1381.4, "mean_ms": 721.37, "p50_ms": 645.86, "p95_ms": 978.80, "p99_ms": 1025.76, "inflight_L_littles_law": 996.5}

$ python loadgen.py --users 1000 --mode closed --duration 30 --warmup 25
{"mode": "closed", "users": 1000, "rps": 1496.7, "mean_ms": 665.14, "p50_ms": 595.07, "p95_ms": 913.28, "p99_ms": 953.72, "inflight_L_littles_law": 995.5}

$ python loadgen.py --users 1000 --mode think  --duration 30 --warmup 25
{"mode": "think",  "users": 1000, "rps": 1284.0, "mean_ms": 28.64,  "p50_ms": 17.64,  "p95_ms": 70.32,  "p99_ms": 308.87, "inflight_L_littles_law": 36.8}
```

Runs are order-balanced think / closed / closed / think. The A/A spread is 3.6% on RPS for think and 8.4% for closed, so the 12x to 22x latency gap is far outside noise. `inflight_L_littles_law` is `RPS * mean` computed from the measurements, and it lands on 72 and 37 for the think runs against ~996 for the closed runs, which is the ~8x queue depth the new prose describes.

**Saturation scan showing latency is queue depth, not gateway speed.** Same instance, closed loop:

```
users   50 -> {"rps":  788.0, "mean_ms":  63.6, "L":  50.1}
users  100 -> {"rps": 1016.3, "mean_ms":  98.1, "L":  99.7}
users  200 -> {"rps": 1138.6, "mean_ms": 173.7, "L": 197.8}
users  400 -> {"rps": 1152.5, "mean_ms": 349.2, "L": 402.5}
```

Throughput plateaus at ~1150 RPS from 200 users on. Past the knee each doubling of client concurrency doubles latency and buys no throughput, and L tracks the user count to within 1%.

## Type

📖 Documentation

## Changes

`docs/benchmarks.md` only. Three one-line disclosures of the think time plus one new subsection under Locust Settings. No published number is altered

## QA runbook

Open the Benchmarks page, confirm the Configuration bullets and the `/realtime` test setup table both name the think time, and that the "Why the think time matters" subsection renders under Locust Settings with a working link from the Configuration bullet. `npm run build` succeeds and reports no broken anchor for `/docs/benchmarks`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
