### PR TITLE
docs: add auto routing benchmark for same-family cost ladders

### DIFF
--- a/docs/proxy/auto_routing_benchmark.md
+++ b/docs/proxy/auto_routing_benchmark.md
@@ -1,0 +1,63 @@
+# Auto Routing Benchmark: Cost Ladders
+
+Auto routing is usually sold on a single promise: send easy requests to a cheap model, keep quality, cut the bill. This page reports what that promise measured out to on one concrete setup, a three-rung Gemini 3.x ladder, so you can calibrate what to expect and which strategy to reach for
+
+The short version is that routing by intent carried real signal, routing by rule-based complexity score did not, and the middle rung of the ladder was worse than the rung fourteen times cheaper than it
+
+## What was measured
+
+300 test prompts across three strata: 120 real chat turns from WildChat-1M, 90 verifiable problems from MATH-500 levels 4 and 5 plus MMLU-Pro, and 90 code tasks from BigCodeBench. A separate 100-prompt train slice, drawn from disjoint index ranges, was used for every fitting decision so no evaluation prompt ever informed a router's configuration
+
+Three rungs were generated once per prompt at temperature 0, giving a 3 x 300 response matrix. Every arm is a selection over that one matrix, so arms are exactly paired and no sampling noise separates them. Quality is blinded pairwise preference against the all-flagship arm, judged by a model from a different family, with every pair judged in both orders and disagreements resolved as ties. The 90 verifiable prompts also carry mechanical exact-match scoring with no model in the loop
+
+## Results
+
+| Arm | Win-rate vs flagship | 95% CI | Cost | Saving | Exact match |
+|---|---|---|---|---|---|
+| All-flagship (baseline) | 50.0% | | $9.320 | | 82/90 |
+| `auto_router`, threshold 0.3 | 48.2% | [45.8%, 50.5%] | $4.893 | 47.5% | 82/90 |
+| `auto_router`, threshold 0.2 | 46.8% | [44.0%, 49.5%] | $3.894 | 58.2% | 82/90 |
+| All-cheap | 43.7% | [40.0%, 47.5%] | $0.247 | 97.4% | 81/90 |
+| `complexity_router`, fitted | 41.5% | [38.0%, 45.0%] | $3.889 | 58.3% | 71/90 |
+| `complexity_router`, stock | 39.8% | [36.0%, 43.7%] | $2.053 | 78.0% | 76/90 |
+| Shuffled control | 39.2% | [35.7%, 42.7%] | $3.784 | 59.4% | 68/90 |
+
+A win-rate of 50% means indistinguishable from the flagship; ties count as half
+
+The cleanest comparison is the pair at matched cost. At 58.2% savings the semantic router scored 46.8%; at 58.3% savings the complexity router scored 41.5%. Same spend, five points of quality apart, and an eleven point gap on mechanically scored answers
+
+## The control arm
+
+The shuffled control takes the complexity router's exact tier assignments and permutes them across prompts with a fixed seed, so it costs the same by construction and differs only in whether the routing decision was informed. It is the arm that tells you whether a router is thinking or whether its tier mix is doing the work
+
+The semantic router beat it by 9.0 points [+5.3, +12.7] at threshold 0.3 and 7.7 points [+3.8, +11.5] at threshold 0.2. The complexity router beat it by 2.3 points [-0.2, +4.8] when fitted and 0.7 points [-2.5, +3.8] as shipped. Both complexity intervals span zero
+
+Any router benchmark without a control like this cannot separate a smart router from a cheap tier mix, and will read as a success either way
+
+## Why the complexity score did not separate
+
+Each train prompt was labelled by running flagship and cheap head to head and asking whether the cheap answer was worse. Against those labels, the complexity score's AUC was 0.524 pooled and 0.420 on the chat stratum, where below 0.5 means mildly inverted. Mean scores were identical to three decimals between prompts where the cheap model sufficed and prompts where it did not. No threshold beat always guessing "cheap"
+
+The cause is structural rather than a tuning failure. The default weights lean hardest on code presence and reasoning markers, so the scorer keys on what a prompt is about. On this setup 97% of chat scored into the cheapest tier and 97% of code into the middle one, while the labels said the cheap model sufficed on 90% of verifiable reasoning and only 50% of chat. The expensive rung should have been going to open ended chat, which is the one place the scorer never sent it
+
+This is a statement about same-family cost ladders, where every rung can attempt every request and the only question is whether the cheap one is good enough. It is not a claim about routing across heterogeneous models, which is a different problem
+
+## Check the rungs before blaming the router
+
+The middle rung, `gemini-3-flash-preview`, lists at a quarter of the flagship's output price and looked like an obvious intermediate. Measured end to end it cost 14.1x what `gemini-3.1-flash-lite` cost, won fewer pairings (37.5% against 43.7%), and answered 63 of 90 verifiable problems correctly against Flash-Lite's 81. Among prompts where exactly one was right, Flash-Lite won 20 to 2. There is no budget at which selecting it was correct
+
+Thinking tokens explain the cost half. That rung emitted 981,308 thinking tokens against the flagship's 581,883, so it thought 69% more than the model above it, and thinking bills as output. A list-price advantage of 4x realized as 2.7x. Flash-Lite emitted none at all, which is most of why it came in 37x cheaper than the flagship rather than the 8x list prices imply
+
+Both complexity arms routed most traffic into that rung, which is the mechanical reason they landed where they did. Before concluding a router is broken, price each rung on your own traffic with thinking tokens counted
+
+## Choosing a strategy
+
+For a cost ladder over one model family, reach for the semantic [Auto Router](./auto_routing_semantic.md) and build its routes from examples of requests you have already checked the cheap model on. What predicts "the cheap model suffices" in this setting is what kind of task it is, and matching against labelled examples captures that directly
+
+`score_threshold` deserves fitting rather than defaulting. Below it the router falls back to `auto_router_default_model`, so an untuned threshold quietly converts a routing config into an expensive-by-default one. At 0.3 the router sent 52% of traffic to the flagship and saved 47.5%; at 0.2 it sent 38% and saved 58.2%, trading roughly a point and a half of quality. Neither setting cleared both halves of a 45% quality floor and 50% savings target at once, so pick the corner of that frontier your workload actually needs. Deliberately not reported here is a threshold swept until it cleared both, because tuning on the evaluation set produces a number that means nothing
+
+## Scope
+
+One provider family, one ladder, one 300-prompt corpus, one judge model. The judge disagreed with itself on 32% of pairs when response order was swapped; those resolve to ties, which pulls every arm toward 50% and makes the reported gaps conservative rather than inflated. Judge verdicts agreed with mechanical ground truth 90% of the time. Code was judged rather than executed. Treat the direction of these results as portable and the magnitudes as specific to this setup
+
+The methodology is the part worth copying: pair your arms on one response matrix, include a cost-matched shuffled control, label a held-out train slice before fitting anything, count thinking tokens, and pre-register what would count as a pass

--- a/sidebars.js
+++ b/sidebars.js
@@ -750,6 +750,7 @@ const sidebars = {
           items: [
             "proxy/auto_routing",
             "proxy/auto_routing_semantic",
+            "proxy/auto_routing_benchmark",
             "adaptive_router",
             {
               type: "link",
@@ -1242,6 +1243,7 @@ const sidebars = {
         "scheduler",
         "proxy/auto_routing",
         "proxy/auto_routing_semantic",
+        "proxy/auto_routing_benchmark",
         "proxy/load_balancing",
         "proxy/keys_teams_router_settings",
         "proxy/provider_budget_routing",


### PR DESCRIPTION
## TLDR

Problem this solves:

- We tell people auto routing saves money without keeping quality, but we have never published a number for it, so users have nothing to calibrate against
- The current guidance sends cost-optimization users to `complexity_router` and marks the semantic router deprecated. On a same-family cost ladder the measurement came out the other way, and nothing in the docs would warn a user about that
- Nobody checks whether the ladder itself is sane before blaming the router

How it solves it:

- Adds a benchmark page reporting a 300-prompt paired run over a 3-rung Gemini 3.x ladder, with blinded pairwise judging in both orders, mechanical exact-match on 90 prompts, and a cost-matched shuffled control
- States scope plainly so the direction is portable and the magnitudes are not read as universal
- Documents `score_threshold` as something to fit rather than default, since below it every request falls back to `auto_router_default_model`

## User Flow

A user picking a routing strategy for a cost ladder lands on Cost Optimization in the sidebar, reads what each strategy measured out to, and picks one with a number attached instead of a promise

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests. Docs-only change, no code paths to test. The numbers on the page come from a measured run whose scripts are reproducible; `sidebars.js` was validated with `node -e "require('./sidebars.js')"`
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests). Not yet verified, CI has not run at time of writing
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy on the `auto_router` config from the page, real Vertex calls, real billing. The proxy reports the deployment it picked in `x-litellm-model-name` and the price in `x-litellm-response-cost`.

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-bench-1234" -H "Content-Type: application/json" \
  -d '{"model":"bench-auto-router","messages":[{"role":"user","content":"Write a short, warm toast for my sister at her wedding. She is a marine biologist and we grew up on the coast."}]}' -D -
```

```
x-litellm-model-name: vertex_ai/gemini-3.1-pro-preview
x-litellm-response-cost: 0.014572
usage: {"completion_tokens": 1210, "completion_tokens_details": {"reasoning_tokens": 888}}
```

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-bench-1234" -H "Content-Type: application/json" \
  -d '{"model":"bench-auto-router","messages":[{"role":"user","content":"A train travels 60 miles in 45 minutes. At the same rate, how many miles does it travel in 2 hours? End your reply with the final answer on the last line as: ANSWER: <number>"}]}' -D -
```

```
x-litellm-model-name: vertex_ai/gemini-3.1-flash-lite
x-litellm-response-cost: 0.00047825
usage: {"completion_tokens": 311, "completion_tokens_details": {"text_tokens": 311}}
content ends: ANSWER: 160
```

Chat went to the flagship, math went to Flash-Lite at 30x less, and the math answer is correct. The same toast prompt forced to `gemini-cheap` costs $0.000413, so the router paid 35x more for that one request

To view the page: `npm run start` in this repo, then http://localhost:3000/docs/proxy/auto_routing_benchmark. It appears under Cost Optimization and under the Routing and Load Balancing group

## Type

📖 Documentation

## Changes

New page `docs/proxy/auto_routing_benchmark.md`, added to both sidebar locations that already list `proxy/auto_routing` and `proxy/auto_routing_semantic`. No existing page was edited

Headline numbers, all against an all-flagship baseline over the same 300 prompts:

| Arm | Win-rate | 95% CI | Saving | Exact match |
|---|---|---|---|---|
| `auto_router`, threshold 0.3 | 48.2% | [45.8%, 50.5%] | 47.5% | 82/90 |
| `auto_router`, threshold 0.2 | 46.8% | [44.0%, 49.5%] | 58.2% | 82/90 |
| All-cheap | 43.7% | [40.0%, 47.5%] | 97.4% | 81/90 |
| `complexity_router`, fitted | 41.5% | [38.0%, 45.0%] | 58.3% | 71/90 |
| `complexity_router`, stock | 39.8% | [36.0%, 43.7%] | 78.0% | 76/90 |
| Shuffled control | 39.2% | [35.7%, 42.7%] | 59.4% | 68/90 |

At matched cost, 58.2% against 58.3% savings, semantic scored 46.8% and complexity scored 41.5%

## QA runbook

Two things worth a maintainer's judgement rather than my own:

The page's conclusion sits in tension with the deprecation notice on `auto_routing_semantic.md`, which says `complexity_router` supersedes the semantic router. I deliberately did not touch that notice, because whether to revise product guidance off one benchmark is your call, not mine. If you want the notice softened or the page reframed, say so and I will follow

The complexity result is scoped to same-family cost ladders, where every rung can attempt every request and the only question is whether the cheap rung is good enough. It says nothing about routing across heterogeneous models, which is a different problem and may well be what that scorer is good at. The page states this, but it is the sentence most likely to be quoted out of context

Also worth knowing: the ladder's middle rung, `gemini-3-flash-preview`, measured strictly dominated. It cost 14.1x `gemini-3.1-flash-lite` and lost to it on both judged quality and exact match, with discordant pairs running 20 to 2 against it. It emitted 981k thinking tokens against the flagship's 582k, so it thought 69% more than the model above it while billing that as output. Both complexity arms routed most traffic into it, which is the mechanical reason they landed where they did

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR. Not applicable to a docs-only change; what stands in for it is that every number on the page is measured rather than asserted, the scope paragraph bounds what the result claims, and the run's limitations are stated on the page itself
