### PR TITLE
docs(compat-matrix): prep the page for the 9 column e2e matrix

### DIFF
--- a/docs/claude_code_compatibility.md
+++ b/docs/claude_code_compatibility.md
@@ -9,9 +9,11 @@ import ClaudeCodeCompatibilityTable from '@site/src/components/ClaudeCodeCompati
 
 This table is regenerated daily by an automated populator that runs the
 [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) against
-the latest stable LiteLLM proxy across each supported provider, with
-Haiku 4.5, Sonnet 4.6, and Opus 4.7 in parallel. A cell goes green only
-if all three model tiers pass.
+the latest stable LiteLLM proxy across each supported provider. The
+Claude provider columns run Haiku 4.5, Sonnet 4.5, and Opus 4.7 in
+parallel; the GPT provider columns (OpenAI, Azure OpenAI, Bedrock
+Mantle) run GPT-5.6 Sol, Terra, and Luna. A cell goes green only if all
+three model tiers of its column family pass.
 
 <ClaudeCodeCompatibilityTable />
 
@@ -19,7 +21,7 @@ if all three model tiers pass.
 
 | Glyph | Meaning |
 | --- | --- |
-| ✅ | All three model tiers pass for this `(feature, provider)` cell. |
+| ✅ | All three model tiers of the column's family pass for this `(feature, provider)` cell. |
 | ❌ | At least one model tier failed. Hover for the upstream error. |
 | — | No test ran for this combination. |
 | n/a | Not applicable (e.g. provider doesn't expose this feature). Hover for the reason. |
@@ -49,5 +51,5 @@ the entry will be removed.
 The matrix JSON lives at
 [`src/data/compatibility-matrix.json`](https://github.com/BerriAI/litellm-docs/blob/main/src/data/compatibility-matrix.json).
 The populator is in
-[`tests/claude_code/cron_vm/`](https://github.com/BerriAI/litellm/tree/main/tests/claude_code/cron_vm)
+[`tests/e2e/claude_code/cron_vm/`](https://github.com/BerriAI/litellm/tree/litellm_internal_staging/tests/e2e/claude_code/cron_vm)
 on the main repo.

--- a/docs/claude_code_compatibility.md
+++ b/docs/claude_code_compatibility.md
@@ -11,7 +11,7 @@ This table is regenerated daily by an automated populator that runs the
 [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) against
 the latest stable LiteLLM proxy across each supported provider. The
 Claude provider columns run Haiku 4.5, Sonnet 4.5, and Opus 4.7 in
-parallel; the GPT provider columns (OpenAI, Azure OpenAI, Bedrock
+parallel. The GPT provider columns (OpenAI, Azure OpenAI, Bedrock
 Mantle) run GPT-5.6 Sol, Terra, and Luna. A cell goes green only if all
 three model tiers of its column family pass.
 

--- a/src/components/ClaudeCodeCompatibilityTable/index.tsx
+++ b/src/components/ClaudeCodeCompatibilityTable/index.tsx
@@ -6,8 +6,8 @@ import styles from "./styles.module.css";
  * Claude Code compatibility matrix table.
  *
  * Renders the JSON published daily by the populator
- * (`tests/claude_code/cron_vm/run_daily.sh` in BerriAI/litellm) into a
- * features-by-providers grid. Each cell shows pass / fail / not_tested /
+ * (`tests/e2e/claude_code/cron_vm/run_daily.sh` in BerriAI/litellm) into
+ * a features-by-providers grid. Each cell shows pass / fail / not_tested /
  * not_applicable; failure cells expose the upstream error on hover.
  *
  * The JSON is bundled at build time (no fetch), so the docs page works
@@ -44,6 +44,10 @@ const PROVIDER_LABELS: Record<string, string> = {
   bedrock_converse: "Bedrock (Converse)",
   vertex_ai: "Vertex AI",
   azure: "Azure (Foundry)",
+  openai: "OpenAI",
+  azure_openai: "Azure OpenAI",
+  bedrock_mantle: "Bedrock (Mantle)",
+  vertex_ai_gpt: "Vertex AI (GPT)",
 };
 
 const STATUS_GLYPH: Record<CellStatus, string> = {


### PR DESCRIPTION
Preps the compatibility page for the 9 column matrix that lands when the ported publisher (BerriAI/litellm#36465) takes over the daily run

The table itself renders providers and features straight from the JSON, so the new shape needs no structural change. What this fixes: the four GPT columns would render their raw ids in the header, so `PROVIDER_LABELS` gains OpenAI, Azure OpenAI, Bedrock (Mantle), and Vertex AI (GPT); the intro claimed every cell runs three Claude tiers, but the GPT columns run GPT-5.6 Sol, Terra, and Luna (and the e2e suite's Claude tiers are Haiku 4.5, Sonnet 4.5, Opus 4.7, not Sonnet 4.6); the populator path references pointed at the retired `tests/claude_code/cron_vm/` tree instead of `tests/e2e/claude_code/cron_vm/` on `litellm_internal_staging`

Hold merging until the VM cutover that follows litellm#36465, alongside repointing the service and setting the GPT column opt-in flags. The label additions are inert against today's 5 column JSON, but the path and prose changes only become true at cutover

The Known issues entries are left untouched; they describe the current 5 column baseline and will be rewritten against the first 9 column publish

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 49095bb6c5789ef344081a859cfabc42db3c2a82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->