### PR TITLE
docs: add Nadir provider page

### DIFF
--- a/docs/providers/nadir.md
+++ b/docs/providers/nadir.md
@@ -1,0 +1,129 @@
+# Nadir
+
+## Overview
+
+| Property | Details |
+|-------|-------|
+| Description | Nadir is an intelligent LLM router. A single virtual model, `auto`, is classified by complexity server-side and routed to the cheapest model that clears the quality bar. |
+| Provider Route on LiteLLM | `nadir/` |
+| Link to Provider Doc | [Nadir Documentation ↗](https://getnadir.com/docs) |
+| Base URL | `https://api.getnadir.com/v1` |
+| Supported Operations | `/chat/completions` |
+
+<br />
+
+Nadir speaks the OpenAI `/v1/chat/completions` dialect, so no request translation is required.
+
+## Required Variables
+
+```python showLineNumbers title="Environment Variables"
+os.environ["NADIR_API_KEY"] = ""  # your Nadir API key
+```
+
+## Optional Variables
+
+```python showLineNumbers title="Environment Variables"
+os.environ["NADIR_API_BASE"] = ""  # defaults to https://api.getnadir.com/v1
+```
+
+## Usage - LiteLLM Python SDK
+
+### Non-streaming
+
+```python showLineNumbers title="Nadir Non-streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["NADIR_API_KEY"] = "your-api-key"
+
+response = completion(
+    model="nadir/auto",
+    messages=[{"content": "Hello, how are you?", "role": "user"}],
+)
+print(response)
+```
+
+### Streaming
+
+```python showLineNumbers title="Nadir Streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["NADIR_API_KEY"] = "your-api-key"
+
+response = completion(
+    model="nadir/auto",
+    messages=[{"content": "Hello, how are you?", "role": "user"}],
+    stream=True,
+)
+for chunk in response:
+    print(chunk)
+```
+
+## Usage - LiteLLM Proxy
+
+Add the following to your LiteLLM Proxy configuration file:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: nadir-auto
+    litellm_params:
+      model: nadir/auto
+      api_key: os.environ/NADIR_API_KEY
+```
+
+Start your LiteLLM Proxy server:
+
+```bash showLineNumbers title="Start LiteLLM Proxy"
+litellm --config config.yaml
+```
+
+```bash showLineNumbers title="Nadir via Proxy - cURL"
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "nadir-auto",
+    "messages": [{"role": "user", "content": "Hello, how are you?"}]
+  }'
+```
+
+## Model
+
+Nadir exposes one virtual model. Send `nadir/auto` and the router picks the
+underlying model per request.
+
+| Model Name | Function Call |
+|------------|---------------|
+| auto | `completion(model="nadir/auto", messages=messages)` |
+
+## Cost tracking
+
+The `model` field on the response reports the model Nadir actually routed to.
+That is a vendor model name, so it has no `nadir/*` pricing entry for the shared
+cost calculator to look up. Nadir returns the cost it computed for the call
+instead, and LiteLLM uses that as the provider-reported cost:
+
+```python
+print(f"Request cost: ${response._hidden_params['additional_headers']['llm_provider-x-litellm-response-cost']}")
+```
+
+## Supported OpenAI Parameters
+
+Nadir validates requests against its own schema and drops anything outside it,
+so LiteLLM advertises only the parameters the endpoint honors:
+
+`frequency_penalty`, `max_tokens`, `presence_penalty`, `response_format`,
+`stream`, `temperature`, `top_p`
+
+`extra_headers` and `max_retries` are handled by the LiteLLM transport rather
+than sent in the request body.
+
+:::info
+
+`tools`, `tool_choice`, and `functions` are **not** supported. Function calling
+is not part of Nadir's request schema today.
+
+:::

--- a/sidebars.js
+++ b/sidebars.js
@@ -1136,6 +1136,7 @@ const sidebars = {
         "providers/minimax",
         "providers/moonshot",
         "providers/morph",
+        "providers/nadir",
         "providers/nebius",
         "providers/nlp_cloud",
         "providers/nano-gpt",


### PR DESCRIPTION
Adds a provider page for Nadir, the provider added to litellm in https://github.com/BerriAI/litellm/pull/33227.

**Disclosure: I work on Nadir.**

### Why this is needed

`tests/documentation_tests/test_env_keys.py` in the main repo fails on that PR:

```
Exception: Environment variables read under ./litellm but mentioned nowhere in the docs: ['NADIR_API_BASE', 'NADIR_API_KEY']
```

Since the docs moved to this repo, the `code-quality` and `documentation` jobs there clone `BerriAI/litellm-docs@main`, so that check cannot pass until a page here documents those two variables. `provider_endpoints_support.json` in the main repo also already links to `/docs/providers/nadir`, which is currently a dead link.

### What the page says

The page documents what the provider actually enforces, not the full OpenAI surface:

- One virtual model, `nadir/auto`; the concrete model is chosen server-side per request.
- `/chat/completions` only, matching the `provider_endpoints_support.json` entry.
- Only the 7 body params the endpoint honors, since Nadir validates into its own request schema and silently drops anything outside it. `extra_headers` and `max_retries` are noted as transport-side.
- An explicit callout that `tools` / `tool_choice` / `functions` are **not** supported.
- Cost tracking via `_hidden_params['additional_headers']['llm_provider-x-litellm-response-cost']`, the same mechanism and doc phrasing the OpenRouter page uses, because the routed model is a vendor name with no `nadir/*` pricing entry.

### Verification

- `npm run build` passes. The page produces no warnings; the 5 broken-anchor warnings are pre-existing on `release_notes/*` pages and unrelated.
- With this branch checked out into `docs/my-website`, all four documentation tests in the main repo pass, including the one currently failing: `Every environment variable read under ./litellm is documented`.
- `sidebars.js` entry added alongside the other providers.