### PR TITLE
docs(proxy): document LITELLM_JOB_ROLE and the dedicated job worker topology

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1109,6 +1109,7 @@ router_settings:
 | LITELLM_KEY_ROTATION_CHECK_INTERVAL_SECONDS | Interval in seconds for how often to run job that auto-rotates keys. Default is 86400 (24 hours).
 | LITELLM_KEY_ROTATION_GRACE_PERIOD | Duration to keep old key valid after rotation (e.g. "24h", "2d"). Default is empty (immediate revoke). Used for scheduled rotations and as fallback when not specified in regenerate request.
 | LITELLM_KEY_ROTATION_LOCK_TTL_SECONDS | TTL in seconds for the distributed lock used by the key rotation job. Default is 600 (10 minutes).
+| LITELLM_JOB_ROLE | Which scheduled background jobs this process registers. `all` (the default when unset) and `worker` register every job; `serving` registers no single-owner job, so a serving deployment can leave budget resets, spend log cleanup, key rotation, usage exports and the other shared jobs to a dedicated worker deployment. Case insensitive; an unrecognized value falls back to `all` with a warning. See [Run background jobs on a dedicated worker](./prod.md#run-background-jobs-on-a-dedicated-worker).
 | LITELLM_LICENSE | License key for LiteLLM usage
 | LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS | Set to `True` to use the local bundled Anthropic beta headers config only, disabling remote fetching. Default is `False`
 | LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS | Comma-separated list of absolute directories from which the `oidc/file/` provider is permitted to read token files. Defaults to `/var/run/secrets,/run/secrets`.

--- a/docs/proxy/prod.md
+++ b/docs/proxy/prod.md
@@ -167,6 +167,116 @@ CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--num_workers"
 
 For packing multiple workers into one container, alternative servers (Gunicorn, Hypercorn, Granian), staggering recycles with jitter, hitless rolling restarts on Kubernetes, terminating TLS at the proxy, keepalive tuning, and loading `config.yaml` from S3 or GCS, see [Server Tuning](./server_tuning.md).
 
+### Run background jobs on a dedicated worker
+
+At startup the proxy registers a scheduler of background jobs, and it does that once per Uvicorn worker process rather than once per pod. A pod started with `--num_workers 4` runs four copies of every job, so a deployment of ten such replicas runs forty, and the amount of work multiplies by replicas times processes even though most of these jobs exist to happen once.
+
+Jobs whose effect is shared, resetting budgets or pruning spend logs or pushing a usage export, elect a single owner through Redis before doing anything. Where Redis is not configured there is nothing to elect through, so each of them runs unguarded on every process that registered it. `LITELLM_JOB_ROLE` lets you register those jobs on one deployment instead of on every replica serving traffic, and for a multi-pod deployment without Redis it is the only way to get single execution.
+
+| `LITELLM_JOB_ROLE` | What the process registers |
+| --- | --- |
+| unset, or `all` | Every job. This is the default and the behavior you already have |
+| `worker` | Every job, including the single-owner ones |
+| `serving` | No single-owner job |
+
+Parsing is case insensitive and ignores surrounding whitespace. An unrecognized value falls back to `all` and logs a warning, so a typo cannot silently stop a deployment's budget resets.
+
+A pod set to `serving` stops registering the budget reset job, spend log cleanup, key rotation, expired Admin UI session key cleanup, the PTU flat-cost rollup, the weekly and monthly spend reports, the Prometheus fallback stats, the batch and responses cost polls, and the CloudZero, Focus, Vantage, and Mavvrik usage exports.
+
+It keeps registering the spend flush, the daily tag spend flush, the gateway request counter flush, the periodic config reload, and the database model and credential reloads, because each of those drains that pod's own in-memory queues or refreshes that pod's own model registry rather than acting on state another pod could act on. A `serving` pod therefore keeps writing its own spend to the database and keeps picking up models added at runtime; the role changes which shared work it schedules, not whether it tracks what it served.
+
+Ownership is observable at runtime. The elected pod logs `<job name>: pod <id> owns this run` at INFO, and the `litellm_pod_lock_manager_size` Prometheus gauge carries a `<job>:<pod>` label naming the job and the pod holding its lock.
+
+#### Kubernetes reference topology
+
+Scale the serving Deployment as usual and keep the worker at one replica. Both point at the same database and the same Redis, which is what lets the worker take over the jobs the serving pods no longer register.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm-serving
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: litellm-serving
+  template:
+    metadata:
+      labels:
+        app: litellm-serving
+    spec:
+      containers:
+        - name: litellm
+          image: docker.litellm.ai/berriai/litellm:v1.98.0 # pin a version, do not use :latest
+          args: ["--config", "/app/proxy_server_config.yaml", "--num_workers", "1"]
+          ports:
+            - containerPort: 4000
+          env:
+            - name: LITELLM_JOB_ROLE
+              value: serving
+          envFrom:
+            - secretRef:
+                name: litellm-secrets # DATABASE_URL, REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, LITELLM_MASTER_KEY
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/proxy_server_config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 4000
+            initialDelaySeconds: 120
+            periodSeconds: 15
+      volumes:
+        - name: config-volume
+          configMap:
+            name: litellm-config-file
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm-jobs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm-jobs
+  template:
+    metadata:
+      labels:
+        app: litellm-jobs
+    spec:
+      containers:
+        - name: litellm
+          image: docker.litellm.ai/berriai/litellm:v1.98.0 # keep in lockstep with the serving image
+          args: ["--config", "/app/proxy_server_config.yaml", "--num_workers", "1"]
+          ports:
+            - containerPort: 4000
+          env:
+            - name: LITELLM_JOB_ROLE
+              value: worker
+          envFrom:
+            - secretRef:
+                name: litellm-secrets # the same secret, so both reach the same database and Redis
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/proxy_server_config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 4000
+            initialDelaySeconds: 120
+            periodSeconds: 15
+      volumes:
+        - name: config-volume
+          configMap:
+            name: litellm-config-file
+```
+
+Point your Service and Ingress at `app: litellm-serving` only, so the worker takes no request traffic. Give the worker one Uvicorn worker for the same reason the serving pods get one, since a second process would register a second copy of every job on the one deployment meant to run them once.
+
 ## Redis
 
 Run Redis (7.0 or newer) as soon as you run more than one proxy instance. It shares rate limit counters, router state, and the response cache across instances; without it, each instance enforces limits independently and cache hits stay local to the instance that served the request.


### PR DESCRIPTION
Documents `LITELLM_JOB_ROLE`, added in BerriAI/litellm#36618, which lets an operator run the proxy's single-owner background jobs on a dedicated worker deployment instead of on every replica serving traffic.

Goes into the existing "Sizing and workers" section of `prod.md` rather than a new page, because the section immediately above already tells an operator how many Uvicorn workers to run per pod, which is the fact that makes this feature necessary: the scheduler is registered once per worker process, not once per pod, so a deployment multiplies this work by replicas times processes. The "Redis" section immediately below is where the "without Redis these jobs run unguarded" point belongs, and `prod.md` already documents `litellm_pod_lock_manager_size`, so the observability note has a sibling instead of being orphaned.

Covers the three role values and the parsing behavior, the full list of jobs a serving pod stops registering, and an explicit paragraph on the ones it keeps, since an operator will otherwise assume a serving pod stops writing spend. It does not: the jobs that stay are the ones draining that pod's own in-memory queues and refreshing its own model registry. Ends with a Kubernetes reference topology, a scaled serving Deployment and a single-replica worker sharing one secret and one config map.

Adds the `LITELLM_JOB_ROLE` row to the `config_settings.md` reference table. The env-key gate (`tests/documentation_tests/test_env_keys.py`) accepts any `.md` mention so the prose alone would have satisfied it, but a new env var with no reference row is a discoverability gap.

Verified against the code at BerriAI/litellm#36618's head rather than from the PR description: the role parsing, each gate site, and the ownership log line all match what is documented.

## Merge order

Merge this before BerriAI/litellm#36618. That PR's `code-quality` and `documentation` jobs check out this repo's `main` with no ref, so they stay red on the undocumented env key until this lands, then need a rerun.

## Build

`npm ci` clean, `npm run build` exit 0. Warning count is identical to `origin/main` built with the same `node_modules` (527 lines either side), so no new warnings. The new heading renders at `#run-background-jobs-on-a-dedicated-worker` and the cross-page link from `config_settings` resolves to it.
