### PR TITLE
docs(prometheus): document the saturation metrics and a reference query set

### DIFF
--- a/docs/proxy/prometheus.md
+++ b/docs/proxy/prometheus.md
@@ -667,6 +667,108 @@ litellm_settings:
 
 Both lists are validated at startup; an unknown metric or label name raises a configuration error so typos surface immediately. Exclusion always wins, so a metric named in `prometheus_exclude_metrics` is dropped even if a `prometheus_metrics_config` group enables it, and a label in `prometheus_exclude_labels` is removed even when a group's `include_labels` lists it.
 
+## Saturation Metrics
+
+Use these to answer why the proxy is slow rather than only that it is. They carry no api-key, team or user labels, so they stay cheap to scrape from every pod.
+
+### Database connection pool
+
+The Prisma query engine tracks pool occupancy, and separately how long a query spent waiting for a connection versus executing against the database. That split is what separates "the database is slow" from "we ran out of connections".
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `litellm_db_pool_connections_max` | Gauge | Configured pool size, summed across live workers |
+| `litellm_db_pool_connections_busy` | Gauge | Connections currently checked out by a query |
+| `litellm_db_pool_connections_idle` | Gauge | Pool capacity not currently checked out |
+| `litellm_db_pool_connections_open` | Gauge | Connections actually opened to the database |
+| `litellm_db_pool_pending_acquirers` | Gauge | Queries queued waiting for a free connection |
+| `litellm_db_pool_acquire_wait_seconds_total` | Counter | Cumulative seconds spent waiting for a connection, excluding query execution |
+| `litellm_db_pool_acquire_total` | Counter | Connection acquisitions, for the mean-wait ratio |
+| `litellm_db_query_duration_seconds_total` | Counter | Cumulative seconds executing against the database, excluding pool wait |
+| `litellm_db_query_total` | Counter | Queries executed |
+| `litellm_db_pool_timeouts_total` | Counter | Queries that gave up waiting for a connection (prisma `P2024`) |
+
+Pool size is set with `general_settings.database_connection_pool_limit` and the acquire timeout with `general_settings.database_connection_timeout`.
+
+These are sampled alongside real database work rather than by a timer, so they keep reporting during the event-loop saturation that would silence a periodic exporter. A proxy doing no database work samples less often, and one with no prometheus callback configured does not sample at all.
+
+### Scheduled background jobs
+
+Every job registered on the proxy scheduler is covered, including ones added by integrations.
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `litellm_scheduled_job_runs_total` | Counter | Runs by outcome. Labels: `"job_name"`, `"result"` where result is `success`, `error`, `missed` or `max_instances` |
+| `litellm_scheduled_job_duration_seconds` | Histogram | Wall-clock duration of a run. Labels: `"job_name"` |
+| `litellm_scheduled_job_last_run_timestamp` | Gauge | Unix timestamp of the last completed run. Labels: `"job_name"` |
+| `litellm_scheduled_job_items_processed_total` | Counter | Items a job reported processing. Labels: `"job_name"` |
+| `litellm_cronjob_lock_acquisitions_total` | Counter | Single-owner lock attempts. Labels: `"cronjob_id"`, `"result"` where result is `acquired`, `not_acquired` or `no_redis` |
+
+`result="max_instances"` means the previous run of that job had not finished when the next was due, which is how a job falling behind its schedule surfaces. `result="no_redis"` on the lock metric means no pod can be elected at all, which is a different state from losing the election.
+
+Each completed run also emits a structured log line at INFO:
+
+```
+scheduled_job_completed job=update_spend_job result=success duration_seconds=0.090 items_processed=25
+```
+
+### Per-pod request pressure
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `litellm_in_flight_requests` | Gauge | HTTP requests currently in flight, summed across live workers |
+| `litellm_requests_shed_total` | Counter | Responses where the proxy declined to serve. Labels: `"status"`, either `429` for a limit or `503` for the database being unavailable |
+| `litellm_global_max_parallel_requests_limit` | Gauge | Concurrency ceiling actually applied. `+Inf` means nothing bounds concurrency |
+
+A 500 is not counted as shed: that is the proxy failing rather than declining.
+
+`litellm_global_max_parallel_requests_limit` reports `+Inf` when `general_settings.global_max_parallel_requests` is unset, and also when it is set but the active rate limiter does not read it. Only the legacy limiter enforces that setting, enabled with `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`; the default limiter applies per-key, per-team and per-user limits instead. The proxy logs a warning at startup when the setting is configured but inert.
+
+### Reference queries
+
+Mean time waiting for a database connection, and mean time actually executing, side by side. A gap that opens on the first without the second is pool exhaustion rather than a slow database:
+
+```promql
+rate(litellm_db_pool_acquire_wait_seconds_total[5m]) / rate(litellm_db_pool_acquire_total[5m])
+rate(litellm_db_query_duration_seconds_total[5m]) / rate(litellm_db_query_total[5m])
+```
+
+Pool utilisation, and the alert that matters:
+
+```promql
+litellm_db_pool_connections_busy / litellm_db_pool_connections_max
+rate(litellm_db_pool_timeouts_total[5m]) > 0
+```
+
+A background job that has stopped running, or one that is falling behind:
+
+```promql
+time() - litellm_scheduled_job_last_run_timestamp > 900
+rate(litellm_scheduled_job_runs_total{result="max_instances"}[15m]) > 0
+rate(litellm_scheduled_job_runs_total{result="error"}[15m]) > 0
+```
+
+Job throughput and the p95 of how long each takes:
+
+```promql
+rate(litellm_scheduled_job_items_processed_total[5m])
+histogram_quantile(0.95, sum by (job_name, le) (rate(litellm_scheduled_job_duration_seconds_bucket[5m])))
+```
+
+A pod that never wins the single-owner lock, so its share of the work is never running:
+
+```promql
+rate(litellm_cronjob_lock_acquisitions_total{result="acquired"}[15m]) == 0
+```
+
+Whether to throttle upstream or add pods. Requests piling up against a real ceiling says throttle; piling up with no ceiling at all says the pod is unprotected:
+
+```promql
+litellm_in_flight_requests / litellm_global_max_parallel_requests_limit
+rate(litellm_requests_shed_total{status="429"}[5m])
+rate(litellm_requests_shed_total{status="503"}[5m])
+```
+
 ## Monitor System Health
 
 To monitor the health of litellm adjacent services (redis / postgres), do:

--- a/docs/proxy/prometheus.md
+++ b/docs/proxy/prometheus.md
@@ -686,7 +686,7 @@ The Prisma query engine tracks pool occupancy, and separately how long a query s
 | `litellm_db_pool_acquire_total` | Counter | Connection acquisitions, for the mean-wait ratio |
 | `litellm_db_query_duration_seconds_total` | Counter | Cumulative seconds executing against the database, excluding pool wait |
 | `litellm_db_query_total` | Counter | Queries executed |
-| `litellm_db_pool_timeouts_total` | Counter | Queries that gave up waiting for a connection (prisma `P2024`) |
+| `litellm_db_pool_timeouts_total` | Counter | Queries that gave up waiting for a connection (prisma `P2024`), whether the pool was saturated or the database was unreachable |
 
 Pool size is set with `general_settings.database_connection_pool_limit` and the acquire timeout with `general_settings.database_connection_timeout`.
 
@@ -702,9 +702,11 @@ Every job registered on the proxy scheduler is covered, including ones added by 
 | `litellm_scheduled_job_duration_seconds` | Histogram | Wall-clock duration of a run. Labels: `"job_name"` |
 | `litellm_scheduled_job_last_run_timestamp` | Gauge | Unix timestamp of the last completed run. Labels: `"job_name"` |
 | `litellm_scheduled_job_items_processed_total` | Counter | Items a job reported processing. Labels: `"job_name"` |
-| `litellm_cronjob_lock_acquisitions_total` | Counter | Single-owner lock attempts. Labels: `"cronjob_id"`, `"result"` where result is `acquired`, `not_acquired` or `no_redis` |
+| `litellm_cronjob_lock_acquisitions_total` | Counter | Single-owner lock attempts. Labels: `"cronjob_id"`, `"result"` where result is `acquired`, `not_acquired`, `no_redis` or `error` |
 
-`result="max_instances"` means the previous run of that job had not finished when the next was due, which is how a job falling behind its schedule surfaces. `result="no_redis"` on the lock metric means no pod can be elected at all, which is a different state from losing the election.
+`result="max_instances"` means the previous run of that job had not finished when the next was due, which is how a job falling behind its schedule surfaces.
+
+The lock metric separates three states that all look like "did not run" from the outside. `no_redis` means no Redis is configured, so no pod can be elected at all. `error` means the attempt itself failed, which is what a Redis outage looks like. `not_acquired` means Redis answered and another pod simply won. Alert on `error`, not on `not_acquired`, since exactly one pod losing the election every cycle is the healthy case.
 
 Each completed run also emits a structured log line at INFO:
 
@@ -717,12 +719,15 @@ scheduled_job_completed job=update_spend_job result=success duration_seconds=0.0
 | Metric Name | Type | Description |
 |---|---|---|
 | `litellm_in_flight_requests` | Gauge | HTTP requests currently in flight, summed across live workers |
-| `litellm_requests_shed_total` | Counter | Responses where the proxy declined to serve. Labels: `"status"`, either `429` for a limit or `503` for the database being unavailable |
+| `litellm_requests_shed_total` | Counter | Responses where this proxy declined to serve. Labels: `"status"`, currently only `429` |
 | `litellm_global_max_parallel_requests_limit` | Gauge | Concurrency ceiling actually applied. `+Inf` means nothing bounds concurrency |
 
-A 500 is not counted as shed: that is the proxy failing rather than declining.
+A 500 is not counted as shed: that is the proxy failing rather than declining. Two other responses are deliberately excluded, because counting them would blur the throttle-or-scale decision this metric exists to inform:
 
-`litellm_global_max_parallel_requests_limit` reports `+Inf` when `general_settings.global_max_parallel_requests` is unset, and also when it is set but the active rate limiter does not read it. Only the legacy limiter enforces that setting, enabled with `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`; the default limiter applies per-key, per-team and per-user limits instead. The proxy logs a warning at startup when the setting is configured but inert.
+- Upstream rate limits. LiteLLM forwards a provider's 429 with the same status the proxy uses for its own limits, so only rejections this proxy originated are counted. A provider throttling you is not a reason to add pods
+- The 503s raised when `fail_closed_budget_enforcement` is on and spend cannot be verified against Redis or the database. That means a dependency is unreachable, not that this pod is at capacity
+
+`litellm_global_max_parallel_requests_limit` reports `+Inf` when `general_settings.global_max_parallel_requests` is unset, and also when it is set but the active rate limiter does not read it. Only the legacy limiter enforces that setting, enabled with `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`; the default limiter applies per-key, per-team and per-user limits instead. The proxy logs a warning at startup when the setting is configured but inert. The gauge reports the effective ceiling under either registration style, including `success_callback: ["prometheus"]`, where the logger is built on the first request rather than at startup.
 
 ### Reference queries
 
@@ -766,7 +771,6 @@ Whether to throttle upstream or add pods. Requests piling up against a real ceil
 ```promql
 litellm_in_flight_requests / litellm_global_max_parallel_requests_limit
 rate(litellm_requests_shed_total{status="429"}[5m])
-rate(litellm_requests_shed_total{status="503"}[5m])
 ```
 
 ## Monitor System Health


### PR DESCRIPTION
## TLDR

Documents the saturation metrics added by the LIT-5435 stack, and gives operators the PromQL to use them.

Covers three areas: the Prisma connection pool, scheduled background jobs, and per-pod request pressure. The reference queries are the ones that answer the questions the incidents raised: is pool wait or query execution the problem, has a background job stalled or fallen behind, and should we throttle upstream or add pods.

## Relevant issues

Documents the metrics added in BerriAI/litellm#36607, #36636 and #36639

## Linear ticket

Refs LIT-5435

## Type

📖 Documentation

## Caveats (if any)

No new environment variable is introduced by any of the three code PRs, so this is not a merge-order blocker for them and can land in either order.

Every metric name in the new section was checked against the code rather than transcribed: all 19 resolve to a real definition in `litellm/types/integrations/prometheus.py`, `litellm/integrations/prometheus.py` or the in-flight middleware.

The section calls out that `litellm_global_max_parallel_requests_limit` reports `+Inf` when `global_max_parallel_requests` is set but the active limiter does not read it, since only the legacy limiter enforces that setting. That gap is tracked separately as LIT-5460.

`npm run build` succeeds. The broken-anchor warnings it prints are pre-existing and all on old release-notes pages.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->