### PR TITLE
docs(release-notes): flag /v1/messages timeout enforcement as breaking in v1.94.0

### DIFF
--- a/release_notes/v1.94.0/index.md
+++ b/release_notes/v1.94.0/index.md
@@ -53,6 +53,12 @@ Once a user's personal spend crossed their own budget, their team keys returned 
 
 :::
 
+:::danger Breaking Changes
+
+**`timeout`, `stream_timeout`, and `request_timeout` in `litellm_params` are now enforced on `/v1/messages` traffic.** Earlier versions silently ignored these values for Anthropic Messages API calls, which always ran with the 600s client default. They now apply, and for streaming requests `stream_timeout` caps the wait between any two chunks of the stream, not only the first token. A low value that previously had no effect, such as `stream_timeout: 30`, will now fail long-running Claude streams mid-response with `ReadTimeout: Timeout on reading data from socket`. Review these values on your Anthropic and Bedrock Claude deployments before upgrading. See [PR #33418](https://github.com/BerriAI/litellm/pull/33418).
+
+:::
+
 ## Key Highlights
 
 - **Router plugin pipeline and Auto-Router v2** - a new `Router(plugins=[...])` extension point, resolvable from proxy YAML config, plus soft-floor adaptive mode, opt-in (now default) session affinity, multi-model tier random-pick, and user-triggered escalation keywords for the complexity router.


### PR DESCRIPTION
PR #33418 shipped in v1.94.0 and made /v1/messages honor timeout, stream_timeout, and request_timeout from litellm_params. Earlier versions silently ignored these values on that route, so configs carrying a latent low value started failing streams only after upgrading. The release notes listed the PR as a one-line bug fix with no behavior-change callout, which made the regression hard to trace during upgrade review

This adds a Breaking Changes admonition to the v1.94.0 release notes, matching the format used in v1.93.0. It spells out that stream_timeout caps the gap between any two stream chunks rather than time to first token, and calls out the failure mode a stale low value produces (mid-stream ReadTimeout on long Claude responses)

Context: a customer hit this in production as a Sev 1 after upgrading; their config had stream_timeout: 30 from before v1.94.0, when the value was inert on this route