### PR TITLE
docs(mcp): add MCP Server Usage section with Slack, Atlassian, and Linear guides

### DIFF
--- a/docs/mcp_servers/atlassian.md
+++ b/docs/mcp_servers/atlassian.md
@@ -1,25 +1,28 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Atlassian MCP server
 
-Connect Atlassian's hosted remote MCP server through the LiteLLM MCP Gateway for Jira issues, Confluence pages, and Compass components.
+> Connect Atlassian's hosted remote MCP server through the LiteLLM MCP Gateway for Jira issues, Confluence pages, and Compass components.
 
-Atlassian hosts and updates the server, so there is nothing to deploy. LiteLLM puts centralized auth, access control, and observability in front of it.
+Atlassian hosts and updates the server, so there is nothing to deploy or run yourself. LiteLLM adds centralized auth, access control by key and team, cost tracking per tool call, and one audit trail across every MCP server you expose.
 
 ## When should you use this server
 
-- Let an agent triage, create, or update Jira issues without a bespoke Jira integration
-- Give an agent Confluence context: summarize a page, find the doc behind a decision, draft a new one
-- Expose Jira and Confluence to a team under one gateway key instead of distributing Atlassian tokens
+- Let an agent triage, file, or update Jira issues without leaving the conversation
+- Pull Confluence pages in as context, or write findings back as a new page
+- Trace ownership and dependencies through Compass components
 
 ## Key features
 
-- One server covers Jira, Confluence, and Compass, including tools that link items across products
-- Hosted by Atlassian and open to all Atlassian Cloud customers with no special signup
-- Per-user auth: tools respect the signed-in user's existing product permissions, so an agent cannot open a project or space that person cannot
+- One server covers Jira, Confluence, and Compass, so a single registration reaches all three products
+- Hosted by Atlassian over Streamable HTTP; Cloud only, with no support for Server or Data Center
+- Dynamic client registration, so LiteLLM negotiates the OAuth client and there is no client ID or secret to manage
 
 ## Authentication
 
-- **Method:** OAuth 2.1 with user tokens, using dynamic client registration. LiteLLM registers itself, so there is no client ID or secret to create or rotate
-- **Atlassian site:** Atlassian Cloud only. Server and Data Center deployments are not covered
+- **Method:** OAuth 2.1 with user tokens, respecting each caller's existing Atlassian permissions. An agent cannot open a Jira project or Confluence space its user cannot already open.
+- **Atlassian app:** None to create. Atlassian supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), and the server is open to all Atlassian Cloud customers with no separate signup.
 
 ## Endpoint
 
@@ -29,31 +32,34 @@ Atlassian hosts and updates the server, so there is nothing to deploy. LiteLLM p
 https://mcp.atlassian.com/v1/mcp
 ```
 
----
+***
 
 ## Connect via LiteLLM MCP Gateway
 
-:::info
-Atlassian supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), so registration is the whole setup. There is no OAuth app to create first, unlike [Slack](./slack.md).
+:::warning Leave the client credentials out
+Do not set `client_id`, `client_secret`, or `token_url` on this server. Those switch it to a machine-to-machine identity shared by every caller, so Jira changes get attributed to one service account instead of the person who asked for them. Atlassian's dynamic registration makes them unnecessary.
 :::
 
 ### Step 1: Register the server in LiteLLM
 
-1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
-2. Set:
+<Tabs>
+<TabItem value="ui" label="LiteLLM UI">
 
-   | Field | Value |
-   |---|---|
-   | **Name** | `atlassian_mcp` |
-   | **Server URL** | `https://mcp.atlassian.com/v1/mcp` |
-   | **Transport** | HTTP |
-   | **Authentication** | OAuth |
-   | **OAuth flow type** | Interactive (PKCE) |
-   | **Client ID / Client Secret** | Leave blank |
+Navigate to **MCP Servers**, click **+ Add New MCP Server**, and set:
 
-3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm the connection. The first listing sends you through Atlassian sign-in and site selection.
+| Field | Value |
+|---|---|
+| **Server Name** | `atlassian_mcp` |
+| **Transport** | HTTP |
+| **Server URL** | `https://mcp.atlassian.com/v1/mcp` |
+| **Authentication** | OAuth |
+| **OAuth flow type** | Interactive (PKCE) |
+| **Client ID / Client Secret** | Leave blank |
 
-Or declare it in config instead of the UI:
+Click **Create MCP Server**, then open the server's **MCP Tools** tab to confirm the connection. The first listing sends you through Atlassian sign-in and site selection.
+
+</TabItem>
+<TabItem value="config" label="config.yaml">
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
@@ -65,25 +71,27 @@ mcp_servers:
     oauth2_flow: authorization_code
 ```
 
-`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it. Storing MCP servers also needs `store_model_in_db: true`, covered in [Prerequisites](../mcp.md#prerequisites).
 
-:::warning Leave the client credentials out
-Do not add `client_id`, `client_secret`, or `token_url`. Those switch the server to a machine-to-machine identity shared by every caller, so Jira changes get attributed to one service account instead of the person who asked for them. Dynamic registration makes them unnecessary.
-:::
+</TabItem>
+</Tabs>
 
-### Step 2: Check the OAuth callback origin
+### Step 2: Set the proxy's public origin
 
 If LiteLLM runs behind a TLS-terminating ingress, set `PROXY_BASE_URL` to the origin users see in their address bar so the OAuth callback validates:
 
-```
+```bash
 PROXY_BASE_URL=https://llm.example.com
 ```
 
-A mismatch surfaces as `400 Bad Request` with `{"detail":"invalid_request"}` when you click **Connect**. See [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration).
+A mismatch surfaces as `400 Bad Request` with `{"detail":"invalid_request"}` when you click **Connect**. Full rules are in [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration).
 
 ### Step 3: Connect from an agent
 
-The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `atlassian_mcp` is reachable at `http://localhost:4000/atlassian_mcp/mcp`.
+The gateway serves each server at `http://localhost:4000/{server_name}/mcp`, so `atlassian_mcp` is reachable at `http://localhost:4000/atlassian_mcp/mcp`.
+
+<Tabs>
+<TabItem value="cursor" label="Claude Desktop / Cursor">
 
 ```json title="Claude Desktop / Cursor" showLineNumbers
 {
@@ -98,33 +106,46 @@ The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `atla
 }
 ```
 
-For Claude Code, `claude mcp add --transport http atlassian http://localhost:4000/atlassian_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+</TabItem>
+<TabItem value="claude-code" label="Claude Code">
 
-The first call opens a browser to authorize and pick a site. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+```bash showLineNumbers
+claude mcp add --transport http atlassian http://localhost:4000/atlassian_mcp/mcp \
+  --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"
+```
 
----
+</TabItem>
+</Tabs>
+
+The first call opens a browser to authorize and pick a site. LiteLLM stores that user's token and refreshes it afterwards, so subsequent sessions connect without prompting.
+
+***
 
 ## Tools provided
 
 :::info
-Atlassian publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your site exposes and is the source of truth. See Atlassian's [Remote MCP server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/) for upstream details.
+Atlassian publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your site exposes; it lists the live tools and lets you call one with test arguments. See Atlassian's [MCP server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-mcp-server/) for upstream detail.
 :::
 
-| Product | Coverage |
+| Product | Capabilities |
 |---|---|
 | Jira | Issue search, issue creation and updates, bulk issue creation |
 | Confluence | Page reads and summaries, page creation, space navigation |
-| Compass | Component creation, bulk component and custom-field import, dependency queries |
-| Combined | Linking items across products, for example attaching a ticket to a page |
+| Compass | Component creation, bulk component and custom-field import from CSV or JSON, dependency queries |
+| Cross-product | Linking items across products, for example attaching a ticket to a page, or finding docs tied to a Compass component |
 
-LiteLLM prefixes tool names with the server name, so `getJiraIssue` is exposed as `atlassian_mcp-getJiraIssue`; see [Tool naming](../mcp_rest_api.md#tool-naming). The tool surface here is large, so [MCP Tool Search](../mcp_tool_search.md) and [semantic filtering](../mcp_semantic_filter.md) are worth enabling to keep the model's tool list small enough to be useful.
+LiteLLM prefixes tool names with the server name, so a tool named `getJiraIssue` is exposed to models as `atlassian_mcp-getJiraIssue`; see [Tool naming](../mcp_rest_api.md#tool-naming). This server's tool surface is large, so [MCP Tool Search](../mcp_tool_search.md) and [semantic filtering](../mcp_semantic_filter.md) are worth enabling to keep the model's tool list small enough to be useful.
 
----
+### Known limitations
 
-## Notes
+The server is in beta, and Atlassian applies its own hourly request quota that varies by plan. Bulk operations carry rate and format constraints, custom Jira fields may need manual configuration, and support is partial in some clients. A session is bound to one site, so a user who authorized against the wrong site has to disconnect and reconnect the server rather than switching in place.
 
-Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md). Atlassian applies its own hourly quota, so a per-key cap keeps one runaway agent from consuming the whole site's budget.
+***
 
-Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Atlassian's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics; a healthy call reports `x-mcp-debug-auth-resolution: oauth2-passthrough` against `https://mcp.atlassian.com/v1/mcp`. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+:::info Restrict who can use it
+Grant the server per key or per team with `object_permission`, and cap call volume per server with `mcp_rpm_limit`, both covered in [MCP Permission Management](../mcp_control.md). A per-key cap matters more here than on most servers, since Atlassian's beta quota is shared across the whole site and one runaway agent can exhaust it.
+:::
 
-A session cannot switch Atlassian sites once authorized, so a user who picked the wrong site has to disconnect and reconnect the server. Known beta limits include constraints on bulk operations, manual configuration for some custom Jira fields, and partial support in a few clients.
+:::warning Put the LiteLLM key in `x-litellm-api-key`
+Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and LiteLLM forwards your LiteLLM key to Atlassian, which rejects it. To diagnose, add `x-litellm-mcp-debug: true` and read the response headers; a healthy call reports `x-mcp-debug-auth-resolution: oauth2-passthrough` against `https://mcp.atlassian.com/v1/mcp`, while `SAME_AS_LITELLM_KEY` confirms this case and `m2m-client-credentials` means client credentials are set and every caller shares one identity. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+:::

--- a/docs/mcp_servers/atlassian.md
+++ b/docs/mcp_servers/atlassian.md
@@ -15,22 +15,27 @@ Atlassian hosts and updates the server, so there is nothing to deploy or run you
 
 ## Key features
 
-- One server covers Jira, Confluence, and Compass, so a single registration reaches all three products
+- One server spans Jira, Jira Service Management, Confluence, Bitbucket, and Compass, so a single registration reaches all of them
 - Hosted by Atlassian over Streamable HTTP; Cloud only, with no support for Server or Data Center
 - Dynamic client registration, so LiteLLM negotiates the OAuth client and there is no client ID or secret to manage
+
+Atlassian ships this as the **Rovo MCP Server**, which is the name to search for in their documentation.
 
 ## Authentication
 
 - **Method:** OAuth 2.1 with user tokens, respecting each caller's existing Atlassian permissions. An agent cannot open a Jira project or Confluence space its user cannot already open.
 - **Atlassian app:** None to create. Atlassian supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), and the server is open to all Atlassian Cloud customers with no separate signup.
+- **Alternative:** Atlassian also offers API token authentication, which an organization admin must first enable under Atlassian Administration. Tool coverage differs between the two methods, so check Atlassian's supported-tools page if a product you expect is missing.
 
 ## Endpoint
 
 **Remote MCP server:**
 
 ```
-https://mcp.atlassian.com/v1/mcp
+https://mcp.atlassian.com/v1/mcp/authv2
 ```
+
+Atlassian documents `authv2` for manually configured clients, which is what LiteLLM is. The older `https://mcp.atlassian.com/v1/mcp` form is still live and still handed out by Atlassian's one-click installers, so you may see it in existing setups; prefer `authv2` for new ones.
 
 ***
 
@@ -51,7 +56,7 @@ Navigate to **MCP Servers**, click **+ Add New MCP Server**, and set:
 |---|---|
 | **Server Name** | `atlassian_mcp` |
 | **Transport** | HTTP |
-| **Server URL** | `https://mcp.atlassian.com/v1/mcp` |
+| **Server URL** | `https://mcp.atlassian.com/v1/mcp/authv2` |
 | **Authentication** | OAuth |
 | **OAuth flow type** | Interactive (PKCE) |
 | **Client ID / Client Secret** | Leave blank |
@@ -64,7 +69,7 @@ Click **Create MCP Server**, then open the server's **MCP Tools** tab to confirm
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
   atlassian_mcp:
-    url: "https://mcp.atlassian.com/v1/mcp"
+    url: "https://mcp.atlassian.com/v1/mcp/authv2"
     transport: "http"
     description: "Jira, Confluence, and Compass"
     auth_type: oauth2
@@ -124,7 +129,7 @@ The first call opens a browser to authorize and pick a site. LiteLLM stores that
 ## Tools provided
 
 :::info
-Atlassian publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your site exposes; it lists the live tools and lets you call one with test arguments. See Atlassian's [MCP server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-mcp-server/) for upstream detail.
+Atlassian publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your site exposes; it lists the live tools and lets you call one with test arguments. See Atlassian's [MCP server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/) for upstream detail.
 :::
 
 | Product | Capabilities |
@@ -132,6 +137,8 @@ Atlassian publishes its tool definitions at runtime through `tools/list`, so nam
 | Jira | Issue search, issue creation and updates, bulk issue creation |
 | Confluence | Page reads and summaries, page creation, space navigation |
 | Compass | Component creation, bulk component and custom-field import from CSV or JSON, dependency queries |
+| Jira Service Management | Request and queue access |
+| Bitbucket | Repository and pull request access |
 | Cross-product | Linking items across products, for example attaching a ticket to a page, or finding docs tied to a Compass component |
 
 LiteLLM prefixes tool names with the server name, so a tool named `getJiraIssue` is exposed to models as `atlassian_mcp-getJiraIssue`; see [Tool naming](../mcp_rest_api.md#tool-naming). This server's tool surface is large, so [MCP Tool Search](../mcp_tool_search.md) and [semantic filtering](../mcp_semantic_filter.md) are worth enabling to keep the model's tool list small enough to be useful.
@@ -147,5 +154,5 @@ Grant the server per key or per team with `object_permission`, and cap call volu
 :::
 
 :::warning Put the LiteLLM key in `x-litellm-api-key`
-Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and LiteLLM forwards your LiteLLM key to Atlassian, which rejects it. To diagnose, add `x-litellm-mcp-debug: true` and read the response headers; a healthy call reports `x-mcp-debug-auth-resolution: oauth2-passthrough` against `https://mcp.atlassian.com/v1/mcp`, while `SAME_AS_LITELLM_KEY` confirms this case and `m2m-client-credentials` means client credentials are set and every caller shares one identity. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and LiteLLM forwards your LiteLLM key to Atlassian, which rejects it. To diagnose, add `x-litellm-mcp-debug: true` and read the response headers; a healthy call reports `x-mcp-debug-auth-resolution: oauth2-passthrough` against `https://mcp.atlassian.com/v1/mcp/authv2`, while `SAME_AS_LITELLM_KEY` confirms this case and `m2m-client-credentials` means client credentials are set and every caller shares one identity. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
 :::

--- a/docs/mcp_servers/atlassian.md
+++ b/docs/mcp_servers/atlassian.md
@@ -1,0 +1,130 @@
+# Atlassian MCP server
+
+Connect Atlassian's hosted remote MCP server through the LiteLLM MCP Gateway for Jira issues, Confluence pages, and Compass components.
+
+Atlassian hosts and updates the server, so there is nothing to deploy. LiteLLM puts centralized auth, access control, and observability in front of it.
+
+## When should you use this server
+
+- Let an agent triage, create, or update Jira issues without a bespoke Jira integration
+- Give an agent Confluence context: summarize a page, find the doc behind a decision, draft a new one
+- Expose Jira and Confluence to a team under one gateway key instead of distributing Atlassian tokens
+
+## Key features
+
+- One server covers Jira, Confluence, and Compass, including tools that link items across products
+- Hosted by Atlassian and open to all Atlassian Cloud customers with no special signup
+- Per-user auth: tools respect the signed-in user's existing product permissions, so an agent cannot open a project or space that person cannot
+
+## Authentication
+
+- **Method:** OAuth 2.1 with user tokens, using dynamic client registration. LiteLLM registers itself, so there is no client ID or secret to create or rotate
+- **Atlassian site:** Atlassian Cloud only. Server and Data Center deployments are not covered
+
+## Endpoint
+
+**Remote MCP server:**
+
+```
+https://mcp.atlassian.com/v1/mcp
+```
+
+---
+
+## Connect via LiteLLM MCP Gateway
+
+:::info
+Atlassian supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), so registration is the whole setup. There is no OAuth app to create first, unlike [Slack](./slack.md).
+:::
+
+### Step 1: Register the server in LiteLLM
+
+1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
+2. Set:
+
+   | Field | Value |
+   |---|---|
+   | **Name** | `atlassian_mcp` |
+   | **Server URL** | `https://mcp.atlassian.com/v1/mcp` |
+   | **Transport** | HTTP |
+   | **Authentication** | OAuth |
+   | **OAuth flow type** | Interactive (PKCE) |
+   | **Client ID / Client Secret** | Leave blank |
+
+3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm the connection. The first listing sends you through Atlassian sign-in and site selection.
+
+Or declare it in config instead of the UI:
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  atlassian_mcp:
+    url: "https://mcp.atlassian.com/v1/mcp"
+    transport: "http"
+    description: "Jira, Confluence, and Compass"
+    auth_type: oauth2
+    oauth2_flow: authorization_code
+```
+
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+
+:::warning Leave the client credentials out
+Do not add `client_id`, `client_secret`, or `token_url`. Those switch the server to a machine-to-machine identity shared by every caller, so Jira changes get attributed to one service account instead of the person who asked for them. Dynamic registration makes them unnecessary.
+:::
+
+### Step 2: Check the OAuth callback origin
+
+If LiteLLM runs behind a TLS-terminating ingress, set `PROXY_BASE_URL` to the origin users see in their address bar so the OAuth callback validates:
+
+```
+PROXY_BASE_URL=https://llm.example.com
+```
+
+A mismatch surfaces as `400 Bad Request` with `{"detail":"invalid_request"}` when you click **Connect**. See [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration).
+
+### Step 3: Connect from an agent
+
+The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `atlassian_mcp` is reachable at `http://localhost:4000/atlassian_mcp/mcp`.
+
+```json title="Claude Desktop / Cursor" showLineNumbers
+{
+  "mcpServers": {
+    "atlassian": {
+      "url": "http://localhost:4000/atlassian_mcp/mcp",
+      "headers": {
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY"
+      }
+    }
+  }
+}
+```
+
+For Claude Code, `claude mcp add --transport http atlassian http://localhost:4000/atlassian_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+
+The first call opens a browser to authorize and pick a site. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+
+---
+
+## Tools provided
+
+:::info
+Atlassian publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your site exposes and is the source of truth. See Atlassian's [Remote MCP server documentation](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/) for upstream details.
+:::
+
+| Product | Coverage |
+|---|---|
+| Jira | Issue search, issue creation and updates, bulk issue creation |
+| Confluence | Page reads and summaries, page creation, space navigation |
+| Compass | Component creation, bulk component and custom-field import, dependency queries |
+| Combined | Linking items across products, for example attaching a ticket to a page |
+
+LiteLLM prefixes tool names with the server name, so `getJiraIssue` is exposed as `atlassian_mcp-getJiraIssue`; see [Tool naming](../mcp_rest_api.md#tool-naming). The tool surface here is large, so [MCP Tool Search](../mcp_tool_search.md) and [semantic filtering](../mcp_semantic_filter.md) are worth enabling to keep the model's tool list small enough to be useful.
+
+---
+
+## Notes
+
+Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md). Atlassian applies its own hourly quota, so a per-key cap keeps one runaway agent from consuming the whole site's budget.
+
+Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Atlassian's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics; a healthy call reports `x-mcp-debug-auth-resolution: oauth2-passthrough` against `https://mcp.atlassian.com/v1/mcp`. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+
+A session cannot switch Atlassian sites once authorized, so a user who picked the wrong site has to disconnect and reconnect the server. Known beta limits include constraints on bulk operations, manual configuration for some custom Jira fields, and partial support in a few clients.

--- a/docs/mcp_servers/index.md
+++ b/docs/mcp_servers/index.md
@@ -1,0 +1,34 @@
+# MCP Server Usage
+
+Setup guides for connecting popular third-party MCP servers through the LiteLLM MCP Gateway. Each guide covers the server's endpoint, the auth LiteLLM needs, how to register it, and how to reach its tools from an agent.
+
+The gateway treats every server the same regardless of vendor: one endpoint for all clients, permissions by key, team, and organization, cost tracking per tool call, and a single audit trail. See [MCP Overview](../mcp.md) for the gateway itself and [Using your MCP](../mcp_usage.md) for the client-side patterns these guides build on.
+
+## Supported servers
+
+| Server | Endpoint | Auth | Covers |
+|--------|----------|------|--------|
+| [Slack](./slack.md) | `https://mcp.slack.com/mcp` | OAuth 2.1, your own Slack app | Search, channel and thread reads, messaging, canvases |
+| [Atlassian](./atlassian.md) | `https://mcp.atlassian.com/v1/mcp` | OAuth 2.1, dynamic registration | Jira issues, Confluence pages, Compass components |
+| [Linear](./linear.md) | `https://mcp.linear.app/mcp` | OAuth 2.1, dynamic registration | Issues, projects, cycles, documents, comments |
+
+Any other remote MCP server follows the same shape. Point `url` at its endpoint and pick the matching `auth_type`; the full list is in [MCP Overview](../mcp.md).
+
+## What these guides assume
+
+All three servers are hosted by their vendor and speak Streamable HTTP, so there is nothing to install or run yourself. All three authenticate per user with interactive OAuth, meaning each caller signs in once through their browser and the resulting tool calls carry that person's own permissions rather than a shared service identity.
+
+Storing MCP servers requires database storage on the proxy, covered in [Prerequisites](../mcp.md#prerequisites):
+
+```yaml title="config.yaml" showLineNumbers
+general_settings:
+  store_model_in_db: true
+```
+
+:::info Put the LiteLLM key in `x-litellm-api-key`
+Interactive OAuth needs the `Authorization` header free for the upstream token. A client that sends the LiteLLM API key as `Authorization: Bearer sk-...` blocks the OAuth flow entirely and forwards that key to Slack, Atlassian, or Linear, which rejects it. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth).
+:::
+
+## Related pages
+
+Access control by key and team lives in [MCP Permission Management](../mcp_control.md), the OAuth flows are documented in [MCP OAuth](../mcp_oauth.md), per-tool spend is in [MCP Cost Tracking](../mcp_cost.md), and connectivity failures are diagnosed in the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).

--- a/docs/mcp_servers/index.md
+++ b/docs/mcp_servers/index.md
@@ -9,7 +9,7 @@ Each guide covers the server's endpoint, the auth LiteLLM needs, how to register
 | Server | Endpoint | Auth | Covers |
 |---|---|---|---|
 | [Slack](./slack.md) | `https://mcp.slack.com/mcp` | OAuth 2.1, your own Slack app | Search, channel and thread reads, messaging, canvases |
-| [Atlassian](./atlassian.md) | `https://mcp.atlassian.com/v1/mcp` | OAuth 2.1, dynamic registration | Jira issues, Confluence pages, Compass components |
+| [Atlassian](./atlassian.md) | `https://mcp.atlassian.com/v1/mcp/authv2` | OAuth 2.1, dynamic registration | Jira, Confluence, Compass, Jira Service Management, Bitbucket |
 | [Linear](./linear.md) | `https://mcp.linear.app/mcp` | OAuth 2.1, dynamic registration | Issues, projects, cycles, documents, comments |
 
 Any other remote MCP server follows the same shape: point `url` at its endpoint and pick the matching `auth_type` from the auth table in [MCP Overview](../mcp.md).

--- a/docs/mcp_servers/index.md
+++ b/docs/mcp_servers/index.md
@@ -1,34 +1,32 @@
 # MCP Server Usage
 
-Setup guides for connecting popular third-party MCP servers through the LiteLLM MCP Gateway. Each guide covers the server's endpoint, the auth LiteLLM needs, how to register it, and how to reach its tools from an agent.
+> Setup guides for connecting popular third-party MCP servers through the LiteLLM MCP Gateway.
 
-The gateway treats every server the same regardless of vendor: one endpoint for all clients, permissions by key, team, and organization, cost tracking per tool call, and a single audit trail. See [MCP Overview](../mcp.md) for the gateway itself and [Using your MCP](../mcp_usage.md) for the client-side patterns these guides build on.
+Each guide covers the server's endpoint, the auth LiteLLM needs, how to register it, and how to reach its tools from an agent. The gateway treats every server the same regardless of vendor: one endpoint for all clients, permissions by key, team, and organization, cost tracking per tool call, and a single audit trail.
 
-## Supported servers
+## Servers
 
 | Server | Endpoint | Auth | Covers |
-|--------|----------|------|--------|
+|---|---|---|---|
 | [Slack](./slack.md) | `https://mcp.slack.com/mcp` | OAuth 2.1, your own Slack app | Search, channel and thread reads, messaging, canvases |
 | [Atlassian](./atlassian.md) | `https://mcp.atlassian.com/v1/mcp` | OAuth 2.1, dynamic registration | Jira issues, Confluence pages, Compass components |
 | [Linear](./linear.md) | `https://mcp.linear.app/mcp` | OAuth 2.1, dynamic registration | Issues, projects, cycles, documents, comments |
 
-Any other remote MCP server follows the same shape. Point `url` at its endpoint and pick the matching `auth_type`; the full list is in [MCP Overview](../mcp.md).
+Any other remote MCP server follows the same shape: point `url` at its endpoint and pick the matching `auth_type` from the auth table in [MCP Overview](../mcp.md).
 
 ## What these guides assume
 
-All three servers are hosted by their vendor and speak Streamable HTTP, so there is nothing to install or run yourself. All three authenticate per user with interactive OAuth, meaning each caller signs in once through their browser and the resulting tool calls carry that person's own permissions rather than a shared service identity.
-
-Storing MCP servers requires database storage on the proxy, covered in [Prerequisites](../mcp.md#prerequisites):
+All three servers are hosted by their vendor and speak Streamable HTTP, so there is nothing to install or run yourself. All three authenticate per user with interactive OAuth, meaning each caller signs in once through their browser and tool calls carry that person's own permissions rather than a shared service identity. Storing MCP servers requires `store_model_in_db: true` on the proxy, covered in [Prerequisites](../mcp.md#prerequisites).
 
 ```yaml title="config.yaml" showLineNumbers
 general_settings:
   store_model_in_db: true
 ```
 
-:::info Put the LiteLLM key in `x-litellm-api-key`
-Interactive OAuth needs the `Authorization` header free for the upstream token. A client that sends the LiteLLM API key as `Authorization: Bearer sk-...` blocks the OAuth flow entirely and forwards that key to Slack, Atlassian, or Linear, which rejects it. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth).
+:::warning Put the LiteLLM key in `x-litellm-api-key`
+Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and the proxy forwards your LiteLLM key to Slack, Atlassian, or Linear, which rejects it. This is the most common failure on all three servers. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth).
 :::
 
 ## Related pages
 
-Access control by key and team lives in [MCP Permission Management](../mcp_control.md), the OAuth flows are documented in [MCP OAuth](../mcp_oauth.md), per-tool spend is in [MCP Cost Tracking](../mcp_cost.md), and connectivity failures are diagnosed in the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+Client-side patterns are in [Using your MCP](../mcp_usage.md), access control by key and team in [MCP Permission Management](../mcp_control.md), the OAuth flows in [MCP OAuth](../mcp_oauth.md), per-tool spend in [MCP Cost Tracking](../mcp_cost.md), and connectivity failures in the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).

--- a/docs/mcp_servers/linear.md
+++ b/docs/mcp_servers/linear.md
@@ -1,25 +1,28 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Linear MCP server
 
-Connect Linear's hosted remote MCP server through the LiteLLM MCP Gateway for issues, projects, cycles, and documents.
+> Connect Linear's hosted remote MCP server through the LiteLLM MCP Gateway for issues, projects, cycles, and comments.
 
-Linear hosts and manages the server centrally, so there is nothing to deploy. LiteLLM puts centralized auth, access control, and observability in front of it.
+Linear hosts and manages the server centrally, so there is nothing to deploy or run yourself. LiteLLM adds centralized auth, access control by key and team, cost tracking per tool call, and one audit trail across every MCP server you expose.
 
 ## When should you use this server
 
-- Let an agent file, update, and triage Linear issues as part of a coding or planning workflow
-- Give an agent project context: what is in the current cycle, what a project's status is, what a document says
-- Expose Linear to a team under one gateway key instead of distributing Linear API keys
+- Let an agent file, triage, or update issues from wherever the work is discussed
+- Pull current cycle and project state in as context before planning or estimating
+- Give a coding agent the ticket it is implementing, then have it comment back with progress
 
 ## Key features
 
-- A dedicated read-only endpoint, so handing an agent Linear context without write access is a URL choice rather than a permissions exercise
-- Hosted by Linear, with Streamable HTTP as the primary transport
-- Per-user auth by default, with a Linear API key as an alternative for backend agents where no human is present to sign in
+- A dedicated read-only endpoint, so you can hand out Linear context without granting the ability to file or edit anything
+- Hosted by Linear over Streamable HTTP; the older SSE endpoint remains only as a deprecated fallback
+- Dynamic client registration for OAuth, plus an API key path for backend agents where no human is present to sign in
 
 ## Authentication
 
-- **Method:** OAuth 2.1 with user tokens, using dynamic client registration. LiteLLM registers itself, so there is no client ID or secret to create or rotate
-- **Alternative:** a Linear API key sent as a bearer token, useful for read-only context sources and unattended agents. Create it under **Settings > Security & access > Personal API keys**
+- **Method:** OAuth 2.1 with user tokens, respecting each caller's existing Linear permissions. Linear supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), so there is no client ID or secret to manage.
+- **Alternative:** A Linear API key sent as a bearer token. This is a single shared identity rather than per-user, so reserve it for read-only context sources and unattended backend agents.
 
 ## Endpoint
 
@@ -35,33 +38,36 @@ https://mcp.linear.app/mcp
 https://mcp.linear.app/mcp/readonly
 ```
 
-Linear also exposes `https://mcp.linear.app/sse`, a deprecated fallback for clients without Streamable HTTP support. Use `/mcp` for new setups.
+Linear also exposes `https://mcp.linear.app/sse` as a deprecated fallback for clients without Streamable HTTP support. Use the `/mcp` endpoint for new setups.
 
----
+***
 
 ## Connect via LiteLLM MCP Gateway
 
-:::info
-Linear supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), so registration is the whole setup. There is no OAuth app to create first, unlike [Slack](./slack.md).
+:::warning Leave the client credentials out
+Do not set `client_id`, `client_secret`, or `token_url` on the OAuth server. Those switch it to a machine-to-machine identity shared by every caller, so issues get filed by one service account instead of the person who asked. Linear's dynamic registration makes them unnecessary. If you actually want a shared identity, use the API key tab below, which is explicit about it.
 :::
 
 ### Step 1: Register the server in LiteLLM
 
-1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
-2. Set:
+<Tabs>
+<TabItem value="ui" label="LiteLLM UI">
 
-   | Field | Value |
-   |---|---|
-   | **Name** | `linear_mcp` |
-   | **Server URL** | `https://mcp.linear.app/mcp` |
-   | **Transport** | HTTP |
-   | **Authentication** | OAuth |
-   | **OAuth flow type** | Interactive (PKCE) |
-   | **Client ID / Client Secret** | Leave blank |
+Navigate to **MCP Servers**, click **+ Add New MCP Server**, and set:
 
-3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm the connection. The first listing sends you through Linear sign-in.
+| Field | Value |
+|---|---|
+| **Server Name** | `linear_mcp` |
+| **Transport** | HTTP |
+| **Server URL** | `https://mcp.linear.app/mcp` |
+| **Authentication** | OAuth |
+| **OAuth flow type** | Interactive (PKCE) |
+| **Client ID / Client Secret** | Leave blank |
 
-Or declare it in config instead of the UI:
+Click **Create MCP Server**, then open the server's **MCP Tools** tab to confirm the connection. The first listing sends you through Linear sign-in.
+
+</TabItem>
+<TabItem value="config" label="config.yaml">
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
@@ -73,15 +79,12 @@ mcp_servers:
     oauth2_flow: authorization_code
 ```
 
-`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it. Storing MCP servers also needs `store_model_in_db: true`, covered in [Prerequisites](../mcp.md#prerequisites).
 
-:::warning Leave the client credentials out
-Do not add `client_id`, `client_secret`, or `token_url`. Those switch the server to a machine-to-machine identity shared by every caller, so issues get filed by one service account instead of the person who asked. Dynamic registration makes them unnecessary.
-:::
+</TabItem>
+<TabItem value="api-key" label="config.yaml (API key)">
 
-### Step 2: Register a read-only server (optional)
-
-For a shared context source, or for a backend agent where no human is present to complete a browser sign-in, pair a read-scoped Linear API key with the read-only endpoint:
+For a shared read-only context source, or a backend agent with nobody present to complete a browser sign-in, authenticate with a Linear API key instead. Create it in Linear under **Settings > Security & access > Personal API keys** with only the Read permission enabled, then pair it with the read-only endpoint:
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
@@ -93,11 +96,27 @@ mcp_servers:
     auth_value: os.environ/LINEAR_API_KEY
 ```
 
-Create the key with only the Read permission enabled. Every caller shares this one identity, so tool calls are attributed to the key's owner rather than the end user. Prefer Step 1 for anything user-facing or anything that writes.
+Every caller shares this identity, so tool calls are attributed to the key's owner rather than the end user. Prefer OAuth for anything user-facing or anything that writes.
+
+</TabItem>
+</Tabs>
+
+### Step 2: Set the proxy's public origin
+
+If LiteLLM runs behind a TLS-terminating ingress, set `PROXY_BASE_URL` to the origin users see in their address bar so the OAuth callback validates:
+
+```bash
+PROXY_BASE_URL=https://llm.example.com
+```
+
+A mismatch surfaces as `400 Bad Request` with `{"detail":"invalid_request"}` when you click **Connect**. Full rules are in [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration).
 
 ### Step 3: Connect from an agent
 
-The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `linear_mcp` is reachable at `http://localhost:4000/linear_mcp/mcp`.
+The gateway serves each server at `http://localhost:4000/{server_name}/mcp`, so `linear_mcp` is reachable at `http://localhost:4000/linear_mcp/mcp`.
+
+<Tabs>
+<TabItem value="cursor" label="Claude Desktop / Cursor">
 
 ```json title="Claude Desktop / Cursor" showLineNumbers
 {
@@ -112,16 +131,25 @@ The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `line
 }
 ```
 
-For Claude Code, `claude mcp add --transport http linear http://localhost:4000/linear_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+</TabItem>
+<TabItem value="claude-code" label="Claude Code">
 
-The first call opens a browser for Linear sign-in. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+```bash showLineNumbers
+claude mcp add --transport http linear http://localhost:4000/linear_mcp/mcp \
+  --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"
+```
 
----
+</TabItem>
+</Tabs>
+
+The first call opens a browser for Linear sign-in. LiteLLM stores that user's token and refreshes it afterwards, so subsequent sessions connect without prompting.
+
+***
 
 ## Tools provided
 
 :::info
-Linear publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your workspace exposes and is the source of truth. See Linear's [MCP server documentation](https://linear.app/docs/mcp) for upstream details.
+Linear publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your workspace exposes; it lists the live tools and lets you call one with test arguments. See Linear's [MCP documentation](https://linear.app/docs/mcp) for upstream detail.
 :::
 
 | Area | Tools |
@@ -130,12 +158,15 @@ Linear publishes its tool definitions at runtime through `tools/list`, so names 
 | Issue metadata | `list_issue_statuses`, `get_issue_status`, `list_issue_labels` |
 | Projects | `list_projects`, `get_project`, `create_project`, `update_project` |
 | Comments | `list_comments`, `create_comment` |
-| Documents and cycles | `get_document`, `list_documents`, `list_cycles` |
+| Documents | `get_document`, `list_documents` |
+| Cycles | `list_cycles` |
 | Teams | `list_teams` |
 
-Issues, projects, and comments support reads and writes. Documents, cycles, teams, statuses, and labels are read-only.
+Writes are limited to issues, projects, and comments; documents, cycles, teams, statuses, and labels are read-only. LiteLLM prefixes tool names with the server name, so `create_issue` is exposed to models as `linear_mcp-create_issue`; see [Tool naming](../mcp_rest_api.md#tool-naming).
 
-LiteLLM prefixes tool names with the server name, so `create_issue` is exposed as `linear_mcp-create_issue`; see [Tool naming](../mcp_rest_api.md#tool-naming). To allow reads but not writes on the standard endpoint, list the write tools under `disallowed_tools`:
+### Reads without writes
+
+The read-only endpoint is the cleanest way to grant reads only. On the standard endpoint you can get the same result by declining the write scope at consent time, or by excluding the write tools in config:
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
@@ -147,12 +178,14 @@ mcp_servers:
     disallowed_tools: ["create_issue", "update_issue", "create_project", "update_project", "create_comment"]
 ```
 
----
+***
 
-## Notes
+:::info Restrict who can use it
+Grant the server per key or per team with `object_permission`, and cap call volume per server with `mcp_rpm_limit`, both covered in [MCP Permission Management](../mcp_control.md).
+:::
 
-Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md).
+:::warning Put the LiteLLM key in `x-litellm-api-key`
+Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and LiteLLM forwards your LiteLLM key to Linear, which rejects it. To diagnose, add `x-litellm-mcp-debug: true` and read the response headers: `SAME_AS_LITELLM_KEY` confirms this case, and `m2m-client-credentials` means client credentials are set and every caller shares one identity. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+:::
 
-Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Linear's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics; see [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
-
-An authorized session is scoped to one Linear workspace, and reconnecting alone does not switch it, so a second workspace needs its own MCP server entry in LiteLLM.
+An authorized session is bound to one Linear workspace, and reconnecting alone does not switch it, so a user who needs a second workspace has to register it as a separate MCP server entry.

--- a/docs/mcp_servers/linear.md
+++ b/docs/mcp_servers/linear.md
@@ -1,0 +1,158 @@
+# Linear MCP server
+
+Connect Linear's hosted remote MCP server through the LiteLLM MCP Gateway for issues, projects, cycles, and documents.
+
+Linear hosts and manages the server centrally, so there is nothing to deploy. LiteLLM puts centralized auth, access control, and observability in front of it.
+
+## When should you use this server
+
+- Let an agent file, update, and triage Linear issues as part of a coding or planning workflow
+- Give an agent project context: what is in the current cycle, what a project's status is, what a document says
+- Expose Linear to a team under one gateway key instead of distributing Linear API keys
+
+## Key features
+
+- A dedicated read-only endpoint, so handing an agent Linear context without write access is a URL choice rather than a permissions exercise
+- Hosted by Linear, with Streamable HTTP as the primary transport
+- Per-user auth by default, with a Linear API key as an alternative for backend agents where no human is present to sign in
+
+## Authentication
+
+- **Method:** OAuth 2.1 with user tokens, using dynamic client registration. LiteLLM registers itself, so there is no client ID or secret to create or rotate
+- **Alternative:** a Linear API key sent as a bearer token, useful for read-only context sources and unattended agents. Create it under **Settings > Security & access > Personal API keys**
+
+## Endpoint
+
+**Remote MCP server:**
+
+```
+https://mcp.linear.app/mcp
+```
+
+**Read-only:**
+
+```
+https://mcp.linear.app/mcp/readonly
+```
+
+Linear also exposes `https://mcp.linear.app/sse`, a deprecated fallback for clients without Streamable HTTP support. Use `/mcp` for new setups.
+
+---
+
+## Connect via LiteLLM MCP Gateway
+
+:::info
+Linear supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), so registration is the whole setup. There is no OAuth app to create first, unlike [Slack](./slack.md).
+:::
+
+### Step 1: Register the server in LiteLLM
+
+1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
+2. Set:
+
+   | Field | Value |
+   |---|---|
+   | **Name** | `linear_mcp` |
+   | **Server URL** | `https://mcp.linear.app/mcp` |
+   | **Transport** | HTTP |
+   | **Authentication** | OAuth |
+   | **OAuth flow type** | Interactive (PKCE) |
+   | **Client ID / Client Secret** | Leave blank |
+
+3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm the connection. The first listing sends you through Linear sign-in.
+
+Or declare it in config instead of the UI:
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  linear_mcp:
+    url: "https://mcp.linear.app/mcp"
+    transport: "http"
+    description: "Linear issues, projects, and cycles"
+    auth_type: oauth2
+    oauth2_flow: authorization_code
+```
+
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+
+:::warning Leave the client credentials out
+Do not add `client_id`, `client_secret`, or `token_url`. Those switch the server to a machine-to-machine identity shared by every caller, so issues get filed by one service account instead of the person who asked. Dynamic registration makes them unnecessary.
+:::
+
+### Step 2: Register a read-only server (optional)
+
+For a shared context source, or for a backend agent where no human is present to complete a browser sign-in, pair a read-scoped Linear API key with the read-only endpoint:
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  linear_readonly:
+    url: "https://mcp.linear.app/mcp/readonly"
+    transport: "http"
+    description: "Linear, read-only"
+    auth_type: bearer_token
+    auth_value: os.environ/LINEAR_API_KEY
+```
+
+Create the key with only the Read permission enabled. Every caller shares this one identity, so tool calls are attributed to the key's owner rather than the end user. Prefer Step 1 for anything user-facing or anything that writes.
+
+### Step 3: Connect from an agent
+
+The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `linear_mcp` is reachable at `http://localhost:4000/linear_mcp/mcp`.
+
+```json title="Claude Desktop / Cursor" showLineNumbers
+{
+  "mcpServers": {
+    "linear": {
+      "url": "http://localhost:4000/linear_mcp/mcp",
+      "headers": {
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY"
+      }
+    }
+  }
+}
+```
+
+For Claude Code, `claude mcp add --transport http linear http://localhost:4000/linear_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+
+The first call opens a browser for Linear sign-in. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+
+---
+
+## Tools provided
+
+:::info
+Linear publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your workspace exposes and is the source of truth. See Linear's [MCP server documentation](https://linear.app/docs/mcp) for upstream details.
+:::
+
+| Area | Tools |
+|---|---|
+| Issues | `get_issue`, `list_issues`, `create_issue`, `update_issue`, `list_my_issues` |
+| Issue metadata | `list_issue_statuses`, `get_issue_status`, `list_issue_labels` |
+| Projects | `list_projects`, `get_project`, `create_project`, `update_project` |
+| Comments | `list_comments`, `create_comment` |
+| Documents and cycles | `get_document`, `list_documents`, `list_cycles` |
+| Teams | `list_teams` |
+
+Issues, projects, and comments support reads and writes. Documents, cycles, teams, statuses, and labels are read-only.
+
+LiteLLM prefixes tool names with the server name, so `create_issue` is exposed as `linear_mcp-create_issue`; see [Tool naming](../mcp_rest_api.md#tool-naming). To allow reads but not writes on the standard endpoint, list the write tools under `disallowed_tools`:
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  linear_mcp:
+    url: "https://mcp.linear.app/mcp"
+    transport: "http"
+    auth_type: oauth2
+    oauth2_flow: authorization_code
+    disallowed_tools: ["create_issue", "update_issue", "create_project", "update_project", "create_comment"]
+```
+
+---
+
+## Notes
+
+Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md).
+
+Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Linear's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics; see [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+
+An authorized session is scoped to one Linear workspace, and reconnecting alone does not switch it, so a second workspace needs its own MCP server entry in LiteLLM.

--- a/docs/mcp_servers/linear.md
+++ b/docs/mcp_servers/linear.md
@@ -166,7 +166,7 @@ Writes are limited to issues, projects, and comments; documents, cycles, teams, 
 
 ### Reads without writes
 
-The read-only endpoint is the cleanest way to grant reads only. On the standard endpoint you can get the same result by declining the write scope at consent time, or by excluding the write tools in config:
+The read-only endpoint is the cleanest way to grant reads only, and the one to reach for by default. On the standard endpoint you can get the same result by declining the write scope at consent time, or by excluding the write tools in config. Confirm the names against your live tool list first, because a `disallowed_tools` entry that no longer matches a real tool fails silently and leaves that tool callable:
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:

--- a/docs/mcp_servers/slack.md
+++ b/docs/mcp_servers/slack.md
@@ -1,25 +1,28 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Slack MCP server
 
-Connect Slack's hosted MCP server through the LiteLLM MCP Gateway for search, channels, messaging, and workspace context.
+> Connect Slack's hosted MCP server through the LiteLLM MCP Gateway for workspace search, channel reads, and messaging.
 
-Slack hosts and manages the server, so there is nothing to deploy or keep running. LiteLLM puts centralized auth, access control, and observability in front of it.
+Slack hosts and maintains the server, so there is nothing to deploy or run yourself. LiteLLM adds centralized auth, access control by key and team, cost tracking per tool call, and one audit trail across every MCP server you expose.
 
 ## When should you use this server
 
-- Give an agent workspace context: what was decided in a channel, what a thread concluded, who owns something
-- Let an agent post updates, draft replies, or schedule messages without a custom Slack integration
-- Expose Slack to a team under one gateway key instead of handing out Slack tokens
+- Give an agent workspace context: what was decided in a channel, who said it, and when
+- Let an agent post updates, summaries, or alerts into Slack instead of only reporting back in chat
+- Search across messages, files, and canvases as a retrieval step before answering
 
 ## Key features
 
-- Tool surface depends on the OAuth scopes you grant, so a read-only rollout is a scope choice rather than a different setup
-- Hosted by Slack, so no local process, container, or token rotation to run yourself
-- Per-user auth: every tool call runs as the signed-in user and sees only what that person can already see in Slack
+- Tool surface depends on the OAuth scopes you grant, so a read-only rollout and a full read/write rollout use the same server with different consent
+- Hosted by Slack over Streamable HTTP; no local process, no bot token to rotate
+- Per-user auth, so every tool call runs as the signed-in person and only sees what they can already see in Slack
 
 ## Authentication
 
-- **Method:** OAuth 2.1 with user tokens. Slack does not support dynamic client registration, so LiteLLM needs explicit client credentials from a Slack app you create
-- **Slack app:** create one at [api.slack.com/apps](https://api.slack.com/apps), add the LiteLLM callback as a redirect URL, grant user token scopes, and enable Model Context Protocol under **Agents & AI Apps**
+- **Method:** OAuth 2.1 with user tokens. Slack does not support dynamic client registration, so you create a Slack app and give LiteLLM its client credentials.
+- **Slack app:** Create one at [api.slack.com/apps](https://api.slack.com/apps). You will set a redirect URL, add user token scopes, and enable the Model Context Protocol toggle.
 
 ## Endpoint
 
@@ -29,12 +32,12 @@ Slack hosts and manages the server, so there is nothing to deploy or keep runnin
 https://mcp.slack.com/mcp
 ```
 
----
+***
 
 ## Connect via LiteLLM MCP Gateway
 
 :::info
-Slack needs `client_id` and `client_secret` supplied to LiteLLM because it has no dynamic client registration. Servers that do support it, such as [Atlassian](./atlassian.md) and [Linear](./linear.md), skip Steps 1 and 2 entirely.
+Slack is one of the servers that needs explicit client credentials. LiteLLM normally handles OAuth client setup for you through dynamic registration, as on the [Atlassian](./atlassian.md) and [Linear](./linear.md) servers, but Slack requires your own app.
 :::
 
 ### Step 1: Create a Slack OAuth app
@@ -47,14 +50,14 @@ Slack needs `client_id` and `client_secret` supplied to LiteLLM because it has n
    https://llm.example.com/ui/mcp/oauth/callback
    ```
 
-   Replace the origin with the one users see in their address bar. It must match `PROXY_BASE_URL`; see [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration) if LiteLLM sits behind an ingress.
-4. Under **User Token Scopes**, add scopes for the capabilities you want, for example `search:read`, `channels:read`, and `chat:write`. Match these to the table in [Tools provided](#tools-provided).
-5. From **Basic Information**, copy the **Client ID** and **Client Secret**.
+4. Replace `https://llm.example.com` with the origin users see in their address bar. It must match `PROXY_BASE_URL`; see [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration) if LiteLLM sits behind an ingress.
+5. Under **User Token Scopes**, add the scopes for the capabilities you want, matching the table in [Tools provided](#oauth-scopes-by-capability). Start read-only for a broad rollout and add write scopes for teams you trust.
+6. From **Basic Information**, copy the **Client ID** and **Client Secret**.
 
 ### Step 2: Enable MCP (Agents & AI Apps)
 
 :::warning
-The MCP endpoint sits behind a per-app toggle. Leave it off and the OAuth flow still succeeds while the tool list comes back empty, which reads like a LiteLLM permissions problem when it is not.
+The MCP endpoint sits behind a per-app toggle under **Agents & AI Apps**. If you leave it off, OAuth still succeeds and the tool list comes back empty or 403, which reads like a LiteLLM permissions problem when it is not.
 :::
 
 1. In the app settings, open **Agents & AI Apps**.
@@ -63,21 +66,24 @@ The MCP endpoint sits behind a per-app toggle. Leave it off and the OAuth flow s
 
 ### Step 3: Register the server in LiteLLM
 
-1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
-2. Set:
+<Tabs>
+<TabItem value="ui" label="LiteLLM UI">
 
-   | Field | Value |
-   |---|---|
-   | **Name** | `slack_mcp` |
-   | **Server URL** | `https://mcp.slack.com/mcp` |
-   | **Transport** | HTTP |
-   | **Authentication** | OAuth |
-   | **OAuth flow type** | Interactive (PKCE) |
-   | **Client ID / Client Secret** | From Step 1 |
+Navigate to **MCP Servers**, click **+ Add New MCP Server**, and set:
 
-3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm LiteLLM can list Slack's tools. The first listing triggers the browser sign-in.
+| Field | Value |
+|---|---|
+| **Server Name** | `slack_mcp` |
+| **Transport** | HTTP |
+| **Server URL** | `https://mcp.slack.com/mcp` |
+| **Authentication** | OAuth |
+| **OAuth flow type** | Interactive (PKCE) |
+| **Client ID / Client Secret** | From Step 1 |
 
-Or declare it in config instead of the UI:
+Click **Create MCP Server**, then open the server's **MCP Tools** tab to confirm LiteLLM can list Slack's tools. The first listing triggers the browser sign-in.
+
+</TabItem>
+<TabItem value="config" label="config.yaml">
 
 ```yaml title="config.yaml" showLineNumbers
 mcp_servers:
@@ -91,11 +97,17 @@ mcp_servers:
     client_secret: os.environ/SLACK_OAUTH_CLIENT_SECRET
 ```
 
-`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it. Storing MCP servers also needs `store_model_in_db: true`, covered in [Prerequisites](../mcp.md#prerequisites).
+
+</TabItem>
+</Tabs>
 
 ### Step 4: Connect from an agent
 
-The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `slack_mcp` is reachable at `http://localhost:4000/slack_mcp/mcp`.
+The gateway serves each server at `http://localhost:4000/{server_name}/mcp`, so `slack_mcp` is reachable at `http://localhost:4000/slack_mcp/mcp`.
+
+<Tabs>
+<TabItem value="cursor" label="Claude Desktop / Cursor">
 
 ```json title="Claude Desktop / Cursor" showLineNumbers
 {
@@ -110,19 +122,35 @@ The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `slac
 }
 ```
 
-For Claude Code, `claude mcp add --transport http slack http://localhost:4000/slack_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+</TabItem>
+<TabItem value="claude-code" label="Claude Code">
 
-The first call opens a browser for Slack sign-in. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+```bash showLineNumbers
+claude mcp add --transport http slack http://localhost:4000/slack_mcp/mcp \
+  --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"
+```
 
----
+</TabItem>
+</Tabs>
+
+The first call opens a browser for Slack sign-in. LiteLLM stores that user's token and refreshes it afterwards, so subsequent sessions connect without prompting.
+
+***
 
 ## Tools provided
 
 :::info
-Slack publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your workspace exposes and is the source of truth. See Slack's [MCP documentation](https://docs.slack.dev/) for upstream details.
+Slack publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your workspace exposes; it lists the live tools and lets you call one with test arguments. See Slack's [MCP documentation](https://docs.slack.dev/) for upstream detail.
 :::
 
-Coverage spans search across messages, files, channels, and users; reads of channels, threads, and user profiles; sending, drafting, and scheduling messages; and creating, reading, and updating canvases. Canvas tools require a paid Slack plan.
+| Area | Tools |
+|---|---|
+| Search | `search_public`, `search_public_and_private`, `search_channels`, `search_users` |
+| Read | `read_channel`, `read_thread`, `read_user_profile` |
+| Messaging | `send_message`, `send_message_draft`, `schedule_message` |
+| Canvases | `create_canvas`, `read_canvas`, `update_canvas` |
+
+Canvas tools require a paid Slack plan. LiteLLM prefixes tool names with the server name, so `search_public` is exposed to models as `slack_mcp-search_public`; see [Tool naming](../mcp_rest_api.md#tool-naming).
 
 ### OAuth scopes by capability
 
@@ -134,17 +162,16 @@ Coverage spans search across messages, files, channels, and users; reads of chan
 | Read direct messages | `im:history` |
 | Post messages | `chat:write` |
 | Resolve user profiles | `users:read` |
+| Read files | `files:read` |
 
-Slack documents the full list in [OAuth scopes](https://api.slack.com/scopes). Start read-only for a broad rollout and add write scopes for teams you trust.
+Slack documents the full list in [OAuth scopes](https://api.slack.com/scopes), and applies its own per-workspace rate limits on top of anything you configure in LiteLLM.
 
-LiteLLM prefixes tool names with the server name, so `search_public` is exposed as `slack_mcp-search_public`; see [Tool naming](../mcp_rest_api.md#tool-naming).
+***
 
----
+:::info Restrict who can use it
+Grant the server per key or per team with `object_permission`, and cap call volume per server with `mcp_rpm_limit`, both covered in [MCP Permission Management](../mcp_control.md). Grant the narrowest scope set that works for the audience; a key that only needs to summarize channels does not need `chat:write`.
+:::
 
-## Notes
-
-Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md).
-
-Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Slack's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics that name the exact failure; see [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
-
-Grant the narrowest scopes that do the job. Tools inherit the user's Slack permissions, so a broad scope grant widens what every agent connected through this server can read.
+:::warning Put the LiteLLM key in `x-litellm-api-key`
+Interactive OAuth needs the `Authorization` header free for the upstream token. If a client sends the LiteLLM API key as `Authorization: Bearer sk-...`, the OAuth flow never runs and LiteLLM forwards your LiteLLM key to Slack, which rejects it. To diagnose, add `x-litellm-mcp-debug: true` and read the response headers: `SAME_AS_LITELLM_KEY` confirms this case, and `m2m-client-credentials` means a `token_url` is set and every caller shares one identity. See [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+:::

--- a/docs/mcp_servers/slack.md
+++ b/docs/mcp_servers/slack.md
@@ -44,13 +44,13 @@ Slack is one of the servers that needs explicit client credentials. LiteLLM norm
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App**, then **From scratch**, and pick the workspace agents should reach.
 2. Open **OAuth & Permissions**.
-3. Under **Redirect URLs**, add your proxy's OAuth callback and click **Save URLs**:
+3. Under **Redirect URLs**, add `{PROXY_BASE_URL}/callback` and click **Save URLs**:
 
    ```
-   https://llm.example.com/ui/mcp/oauth/callback
+   https://llm.example.com/callback
    ```
 
-4. Replace `https://llm.example.com` with the origin users see in their address bar. It must match `PROXY_BASE_URL`; see [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration) if LiteLLM sits behind an ingress.
+4. Replace `https://llm.example.com` with the origin users see in their address bar. This is the value LiteLLM sends upstream as the `redirect_uri`, so a mismatch fails the flow at Slack's consent screen. See [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration) if LiteLLM sits behind an ingress.
 5. Under **User Token Scopes**, add the scopes for the capabilities you want, matching the table in [Tools provided](#oauth-scopes-by-capability). Start read-only for a broad rollout and add write scopes for teams you trust.
 6. From **Basic Information**, copy the **Client ID** and **Client Secret**.
 

--- a/docs/mcp_servers/slack.md
+++ b/docs/mcp_servers/slack.md
@@ -1,0 +1,150 @@
+# Slack MCP server
+
+Connect Slack's hosted MCP server through the LiteLLM MCP Gateway for search, channels, messaging, and workspace context.
+
+Slack hosts and manages the server, so there is nothing to deploy or keep running. LiteLLM puts centralized auth, access control, and observability in front of it.
+
+## When should you use this server
+
+- Give an agent workspace context: what was decided in a channel, what a thread concluded, who owns something
+- Let an agent post updates, draft replies, or schedule messages without a custom Slack integration
+- Expose Slack to a team under one gateway key instead of handing out Slack tokens
+
+## Key features
+
+- Tool surface depends on the OAuth scopes you grant, so a read-only rollout is a scope choice rather than a different setup
+- Hosted by Slack, so no local process, container, or token rotation to run yourself
+- Per-user auth: every tool call runs as the signed-in user and sees only what that person can already see in Slack
+
+## Authentication
+
+- **Method:** OAuth 2.1 with user tokens. Slack does not support dynamic client registration, so LiteLLM needs explicit client credentials from a Slack app you create
+- **Slack app:** create one at [api.slack.com/apps](https://api.slack.com/apps), add the LiteLLM callback as a redirect URL, grant user token scopes, and enable Model Context Protocol under **Agents & AI Apps**
+
+## Endpoint
+
+**Remote MCP server:**
+
+```
+https://mcp.slack.com/mcp
+```
+
+---
+
+## Connect via LiteLLM MCP Gateway
+
+:::info
+Slack needs `client_id` and `client_secret` supplied to LiteLLM because it has no dynamic client registration. Servers that do support it, such as [Atlassian](./atlassian.md) and [Linear](./linear.md), skip Steps 1 and 2 entirely.
+:::
+
+### Step 1: Create a Slack OAuth app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App**, then **From scratch**, and pick the workspace agents should reach.
+2. Open **OAuth & Permissions**.
+3. Under **Redirect URLs**, add your proxy's OAuth callback and click **Save URLs**:
+
+   ```
+   https://llm.example.com/ui/mcp/oauth/callback
+   ```
+
+   Replace the origin with the one users see in their address bar. It must match `PROXY_BASE_URL`; see [Reverse proxy and ingress configuration](../mcp_oauth.md#reverse-proxy-and-ingress-configuration) if LiteLLM sits behind an ingress.
+4. Under **User Token Scopes**, add scopes for the capabilities you want, for example `search:read`, `channels:read`, and `chat:write`. Match these to the table in [Tools provided](#tools-provided).
+5. From **Basic Information**, copy the **Client ID** and **Client Secret**.
+
+### Step 2: Enable MCP (Agents & AI Apps)
+
+:::warning
+The MCP endpoint sits behind a per-app toggle. Leave it off and the OAuth flow still succeeds while the tool list comes back empty, which reads like a LiteLLM permissions problem when it is not.
+:::
+
+1. In the app settings, open **Agents & AI Apps**.
+2. Enable **Model Context Protocol**.
+3. Install or reinstall the app to the workspace so the new scopes take effect.
+
+### Step 3: Register the server in LiteLLM
+
+1. In the LiteLLM UI, navigate to **MCP Servers** and click **+ Add New MCP Server**.
+2. Set:
+
+   | Field | Value |
+   |---|---|
+   | **Name** | `slack_mcp` |
+   | **Server URL** | `https://mcp.slack.com/mcp` |
+   | **Transport** | HTTP |
+   | **Authentication** | OAuth |
+   | **OAuth flow type** | Interactive (PKCE) |
+   | **Client ID / Client Secret** | From Step 1 |
+
+3. Click **Create MCP Server**, then open the **MCP Tools** tab to confirm LiteLLM can list Slack's tools. The first listing triggers the browser sign-in.
+
+Or declare it in config instead of the UI:
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  slack_mcp:
+    url: "https://mcp.slack.com/mcp"
+    transport: "http"
+    description: "Slack workspace search, channels, and messaging"
+    auth_type: oauth2
+    oauth2_flow: authorization_code
+    client_id: os.environ/SLACK_OAUTH_CLIENT_ID
+    client_secret: os.environ/SLACK_OAUTH_CLIENT_SECRET
+```
+
+`oauth2_flow: authorization_code` selects the interactive per-user flow and is required; the proxy refuses to start on an `auth_type: oauth2` server that omits it.
+
+### Step 4: Connect from an agent
+
+The gateway serves each server at `{proxy_base_url}/{server_name}/mcp`, so `slack_mcp` is reachable at `http://localhost:4000/slack_mcp/mcp`.
+
+```json title="Claude Desktop / Cursor" showLineNumbers
+{
+  "mcpServers": {
+    "slack": {
+      "url": "http://localhost:4000/slack_mcp/mcp",
+      "headers": {
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY"
+      }
+    }
+  }
+}
+```
+
+For Claude Code, `claude mcp add --transport http slack http://localhost:4000/slack_mcp/mcp --header "x-litellm-api-key: Bearer $LITELLM_API_KEY"`.
+
+The first call opens a browser for Slack sign-in. LiteLLM stores and refreshes that user's token afterwards, so the authorization is a one-time step per user.
+
+---
+
+## Tools provided
+
+:::info
+Slack publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI lists exactly what your workspace exposes and is the source of truth. See Slack's [MCP documentation](https://docs.slack.dev/) for upstream details.
+:::
+
+Coverage spans search across messages, files, channels, and users; reads of channels, threads, and user profiles; sending, drafting, and scheduling messages; and creating, reading, and updating canvases. Canvas tools require a paid Slack plan.
+
+### OAuth scopes by capability
+
+| Capability | User token scopes (examples) |
+|---|---|
+| Search messages and files | `search:read` |
+| Read public channels | `channels:read`, `channels:history` |
+| Read private channels | `groups:read`, `groups:history` |
+| Read direct messages | `im:history` |
+| Post messages | `chat:write` |
+| Resolve user profiles | `users:read` |
+
+Slack documents the full list in [OAuth scopes](https://api.slack.com/scopes). Start read-only for a broad rollout and add write scopes for teams you trust.
+
+LiteLLM prefixes tool names with the server name, so `search_public` is exposed as `slack_mcp-search_public`; see [Tool naming](../mcp_rest_api.md#tool-naming).
+
+---
+
+## Notes
+
+Access is granted per key and per team through `object_permission`, and call volume is capped per server with `mcp_rpm_limit`; both are covered in [MCP Permission Management](../mcp_control.md).
+
+Pass the LiteLLM API key as `x-litellm-api-key`, never as `Authorization`. Interactive OAuth needs the `Authorization` header free for Slack's token, and a client that occupies it blocks the flow and forwards your LiteLLM key upstream. Adding `x-litellm-mcp-debug: true` to a request returns masked diagnostics that name the exact failure; see [Debugging OAuth](../mcp_oauth.md#debugging-oauth) and the [MCP Troubleshooting Guide](../mcp_troubleshoot.md).
+
+Grant the narrowest scopes that do the job. Tools inherit the user's Slack permissions, so a broad scope grant widens what every agent connected through this server can read.

--- a/docs/mcp_servers/slack.md
+++ b/docs/mcp_servers/slack.md
@@ -22,7 +22,7 @@ Slack hosts and maintains the server, so there is nothing to deploy or run yours
 ## Authentication
 
 - **Method:** OAuth 2.1 with user tokens. Slack does not support dynamic client registration, so you create a Slack app and give LiteLLM its client credentials.
-- **Slack app:** Create one at [api.slack.com/apps](https://api.slack.com/apps). You will set a redirect URL, add user token scopes, and enable the Model Context Protocol toggle.
+- **Slack app:** Create one at [api.slack.com/apps](https://api.slack.com/apps). You will set a redirect URL, add user token scopes, and enable the Model Context Protocol toggle. Slack only permits MCP on internal apps and directory-published apps, so an app built in your own workspace qualifies.
 
 ## Endpoint
 
@@ -140,7 +140,7 @@ The first call opens a browser for Slack sign-in. LiteLLM stores that user's tok
 ## Tools provided
 
 :::info
-Slack publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your workspace exposes; it lists the live tools and lets you call one with test arguments. See Slack's [MCP documentation](https://docs.slack.dev/) for upstream detail.
+Slack publishes its tool definitions at runtime through `tools/list`, so names and fields can change without notice. The **MCP Tools** tab in the LiteLLM UI is the source of truth for what your workspace exposes; it lists the live tools and lets you call one with test arguments. See Slack's [Slack MCP server overview](https://docs.slack.dev/ai/slack-mcp-server) for upstream detail.
 :::
 
 | Area | Tools |
@@ -164,7 +164,7 @@ Canvas tools require a paid Slack plan. LiteLLM prefixes tool names with the ser
 | Resolve user profiles | `users:read` |
 | Read files | `files:read` |
 
-Slack documents the full list in [OAuth scopes](https://api.slack.com/scopes), and applies its own per-workspace rate limits on top of anything you configure in LiteLLM.
+Slack documents the full list in [OAuth scopes](https://api.slack.com/scopes). Rate limits are applied per tool, matching the tier of the equivalent Web API method, and stack on top of anything you configure in LiteLLM.
 
 ***
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -459,6 +459,16 @@ const sidebars = {
               items: [
                 "mcp",
                 "mcp_usage",
+                {
+                  type: "category",
+                  label: "MCP Server Usage",
+                  items: [
+                    "mcp_servers/index",
+                    "mcp_servers/slack",
+                    "mcp_servers/atlassian",
+                    "mcp_servers/linear",
+                  ],
+                },
                 "mcp_rest_api",
                 "mcp_openapi",
                 "mcp_oauth",
@@ -859,6 +869,16 @@ const sidebars = {
           items: [
             "mcp",
             "mcp_usage",
+            {
+              type: "category",
+              label: "MCP Server Usage",
+              items: [
+                "mcp_servers/index",
+                "mcp_servers/slack",
+                "mcp_servers/atlassian",
+                "mcp_servers/linear",
+              ],
+            },
             "mcp_rest_api",
             "mcp_openapi",
             "mcp_oauth",


### PR DESCRIPTION
## TLDR

Adds a "MCP Server Usage" section with setup guides for the three hosted MCP servers people ask about most, so connecting Slack, Atlassian, or Linear through the gateway stops being an exercise in reading `mcp_oauth.md` and inferring which auth shape applies

Each guide follows one format: what the server is good for, key features, authentication, endpoint, numbered setup steps with both the UI fields and the `config.yaml` equivalent, then a tools table. The index carries a server table so adding a fourth server later is a one row change

## Why the auth details are the substance here

All three servers are interactive per-user OAuth, and the failure modes are not obvious from the existing docs

Atlassian and Linear support dynamic client registration, so the correct config is the URL plus `auth_type: oauth2` plus `oauth2_flow: authorization_code` and nothing else. Adding `client_id` and `client_secret` there is the trap: it silently converts a per-user server into one shared machine identity, so Jira issues and Linear tickets get filed by a service account instead of the person who asked. Both pages carry an explicit warning against it

Slack is the opposite case. It has no dynamic client registration, so it genuinely needs your own app, plus a Model Context Protocol toggle under "Agents & AI Apps" that leaves the tool list empty if you miss it while OAuth still appears to succeed

Every YAML block includes `oauth2_flow` because the proxy refuses to start on an `auth_type: oauth2` server that omits it, and a config missing it looks perfectly plausible to a reader

All three pages also warn to pass the LiteLLM key as `x-litellm-api-key` rather than `Authorization`, since occupying that header blocks the OAuth flow entirely and forwards the LiteLLM key upstream

## Atlassian's endpoint has moved

Atlassian now documents `https://mcp.atlassian.com/v1/mcp/authv2` everywhere it spells out a URL for a manually configured client, which is what LiteLLM is. The shorter `https://mcp.atlassian.com/v1/mcp` form is still live but only survives inside their one click installer payloads, and it is the value currently in `mcp_oauth.md` and `mcp_troubleshoot.md`

The new page leads with `authv2` and notes the older form so existing setups still make sense. Those two existing pages are left alone in this PR to keep the scope isolated, and are worth a follow up

## User Flow

Reader lands on MCP Server Usage from the MCP Gateway sidebar, picks their vendor, follows the numbered steps, and ends up with a working server registered on the proxy that their agent can reach at `/{server_name}/mcp`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] My PR passes the docs build (`npm run build` succeeds, no warnings referencing the new pages)
- [x] My PR's scope is as isolated as possible; it only adds the new section and nests it in the existing MCP sidebar categories

## Screenshots / Proof of Fix

Docs only, so the proof is the rendered pages. Run `npm run start` and visit:

1. http://localhost:3000/docs/mcp_servers/
2. http://localhost:3000/docs/mcp_servers/slack
3. http://localhost:3000/docs/mcp_servers/atlassian
4. http://localhost:3000/docs/mcp_servers/linear

The section appears as "MCP Server Usage" nested under MCP Gateway in the sidebar, directly after "Using your MCP". MCP docs are listed in two places in `sidebars.js`, so it is added to both; adding it to only one would hide the pages from half the site's nav without failing the build

Screenshots of the Slack app setup and the LiteLLM Add New MCP Server form are still to be added, in Slack Step 1 and 2 and in Step 1 of each page

## Type

📖 Documentation

## Caveats (if any)

The tool tables name upstream tools, and all three vendors publish definitions at runtime through `tools/list`, so those names can drift. Every page says so and points at the MCP Tools tab in the UI as the source of truth rather than the table. This matters most in the Linear `disallowed_tools` example, where a name that no longer matches a real tool fails open and leaves the tool callable, so that example tells readers to confirm names against their live list first

Atlassian's server is in beta and its tool coverage differs between OAuth and API token auth, so the product table points at Atlassian's supported tools page rather than claiming to be exhaustive

## QA runbook

Register one server per page by following the steps, confirm the MCP Tools tab lists tools after the browser sign in, then connect from Claude Code or Cursor with the config block shown and call one read tool. For Atlassian, verify the `authv2` endpoint authorizes cleanly, since that is the value this PR changes relative to the rest of the docs

### Final Attestation

- [x] The pages describe the auth shapes the proxy actually enforces, including the two cases that fail quietly: a missing `oauth2_flow` (proxy refuses to start) and client credentials on a DCR server (per-user identity silently becomes shared)
