### PR TITLE
docs(parallel_ai): add LLM provider page, full search params, and env key reference

### DIFF
--- a/docs/providers/parallel_ai.md
+++ b/docs/providers/parallel_ai.md
@@ -1,0 +1,123 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Parallel AI
+https://parallel.ai
+
+Parallel AI provides web-research models. The chat models answer with built-in web grounding, and the `parallel` Responses API model runs multi-step web research with citations. API reference: [docs.parallel.ai](https://docs.parallel.ai/getting-started/overview)
+
+| Property | Details |
+|-------|-------|
+| Description | Web-research models grounded in Parallel's index of the web |
+| Provider Route on LiteLLM | `parallel_ai/` |
+| Supported Endpoints | `/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/search` |
+| API Reference | [Parallel AI docs](https://docs.parallel.ai/chat-api/chat-quickstart) |
+
+## API Key
+
+```python
+# env variable; PARALLEL_API_KEY is read as a fallback
+os.environ['PARALLEL_AI_API_KEY']
+```
+
+`PARALLEL_AI_API_BASE` overrides the default base URL (`https://api.parallel.ai`). When a request supplies its own `api_base` that is neither the default nor `PARALLEL_AI_API_BASE`, it must also supply an explicit `api_key`; the server-managed key is never sent to other hosts.
+
+## Chat Models
+
+| Model | Latency | Research basis |
+|-------|---------|----------------|
+| `parallel_ai/speed` | ~3s TTFT | No |
+| `parallel_ai/lite` | 10-60s | Yes |
+| `parallel_ai/base` | 15-100s | Yes |
+| `parallel_ai/core` | 60s-5min | Yes |
+
+The chat API supports `stream` and `response_format` (json_schema). Sampling parameters (temperature, top_p, penalties) and tool calling are not supported. Research models return a `basis` field with per-field citations, reasoning, and confidence, preserved on the LiteLLM response.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+os.environ['PARALLEL_AI_API_KEY'] = ""
+response = completion(
+    model="parallel_ai/core",
+    messages=[{"role": "user", "content": "What did Parallel Web Systems announce this year?"}]
+)
+print(response.choices[0].message.content)
+print(response.basis)  # citations, reasoning, confidence (research models)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: parallel-core
+    litellm_params:
+      model: parallel_ai/core
+      api_key: os.environ/PARALLEL_AI_API_KEY
+```
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "parallel-core",
+    "messages": [{"role": "user", "content": "What did Parallel Web Systems announce this year?"}]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Responses API
+
+The `parallel_ai/parallel` model is served through Parallel's OpenAI Responses-compatible endpoint. `reasoning.effort` selects the research tier: `low` (~5-10s), `medium` (~15-20s, default), or `high` (~30-60s). Web grounding is automatic, so `tools` is not supported; structured output via `text.format`, `instructions`, `stream`, and `previous_response_id` are.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import responses
+import os
+
+os.environ['PARALLEL_AI_API_KEY'] = ""
+response = responses(
+    model="parallel_ai/parallel",
+    input="What company acquired Windsurf in 2025?",
+    reasoning={"effort": "low"}
+)
+print(response.output_text)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: parallel-research
+    litellm_params:
+      model: parallel_ai/parallel
+      api_key: os.environ/PARALLEL_AI_API_KEY
+```
+
+```bash
+curl http://0.0.0.0:4000/v1/responses \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "parallel-research",
+    "input": "What company acquired Windsurf in 2025?",
+    "reasoning": {"effort": "low"}
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Search
+
+Parallel AI is also a search provider; see [Parallel AI Search](../search/parallel_ai).

--- a/docs/providers/parallel_ai.md
+++ b/docs/providers/parallel_ai.md
@@ -4,14 +4,14 @@ import TabItem from '@theme/TabItem';
 # Parallel AI
 https://parallel.ai
 
-Parallel AI provides web-research models. The chat models answer with built-in web grounding, and the `parallel` Responses API model runs multi-step web research with citations. API reference: [docs.parallel.ai](https://docs.parallel.ai/getting-started/overview)
+Parallel AI provides a web-research model through an OpenAI Responses-compatible endpoint: it answers questions using live multi-step web research and returns fully cited answers. API reference: [docs.parallel.ai](https://docs.parallel.ai/responses-api/responses-quickstart)
 
 | Property | Details |
 |-------|-------|
-| Description | Web-research models grounded in Parallel's index of the web |
+| Description | Web-research model grounded in Parallel's index of the web |
 | Provider Route on LiteLLM | `parallel_ai/` |
-| Supported Endpoints | `/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/search` |
-| API Reference | [Parallel AI docs](https://docs.parallel.ai/chat-api/chat-quickstart) |
+| Supported Endpoints | `/v1/responses` (native), `/chat/completions` and `/v1/messages` (via LiteLLM's responses bridge), `/v1/search` |
+| API Reference | [Parallel Responses API docs](https://docs.parallel.ai/responses-api/responses-quickstart) |
 
 ## API Key
 
@@ -22,60 +22,9 @@ os.environ['PARALLEL_AI_API_KEY']
 
 `PARALLEL_AI_API_BASE` overrides the default base URL (`https://api.parallel.ai`). When a request supplies its own `api_base` that is neither the default nor `PARALLEL_AI_API_BASE`, it must also supply an explicit `api_key`; the server-managed key is never sent to other hosts.
 
-## Chat Models
-
-| Model | Latency | Research basis |
-|-------|---------|----------------|
-| `parallel_ai/speed` | ~3s TTFT | No |
-| `parallel_ai/lite` | 10-60s | Yes |
-| `parallel_ai/base` | 15-100s | Yes |
-| `parallel_ai/core` | 60s-5min | Yes |
-
-The chat API supports `stream` and `response_format` (json_schema). Sampling parameters (temperature, top_p, penalties) and tool calling are not supported. Research models return a `basis` field with per-field citations, reasoning, and confidence, preserved on the LiteLLM response.
-
-<Tabs>
-<TabItem value="sdk" label="SDK">
-
-```python
-from litellm import completion
-import os
-
-os.environ['PARALLEL_AI_API_KEY'] = ""
-response = completion(
-    model="parallel_ai/core",
-    messages=[{"role": "user", "content": "What did Parallel Web Systems announce this year?"}]
-)
-print(response.choices[0].message.content)
-print(response.basis)  # citations, reasoning, confidence (research models)
-```
-
-</TabItem>
-<TabItem value="proxy" label="PROXY">
-
-```yaml
-model_list:
-  - model_name: parallel-core
-    litellm_params:
-      model: parallel_ai/core
-      api_key: os.environ/PARALLEL_AI_API_KEY
-```
-
-```bash
-curl http://0.0.0.0:4000/v1/chat/completions \
-  -H "Authorization: Bearer sk-1234" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "parallel-core",
-    "messages": [{"role": "user", "content": "What did Parallel Web Systems announce this year?"}]
-  }'
-```
-
-</TabItem>
-</Tabs>
-
 ## Responses API
 
-The `parallel_ai/parallel` model is served through Parallel's OpenAI Responses-compatible endpoint. `reasoning.effort` selects the research tier: `low` (~5-10s), `medium` (~15-20s, default), or `high` (~30-60s). Web grounding is automatic, so `tools` is not supported; structured output via `text.format`, `instructions`, `stream`, and `previous_response_id` are.
+The single `parallel_ai/parallel` model runs live web research per request. `reasoning.effort` selects the research tier: `low` (~5-10s), `medium` (~15-20s, default), or `high` (~30-60s). Web grounding is automatic, so `tools` is not supported; structured output via `text.format`, `instructions`, `stream`, and `previous_response_id` are.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
@@ -117,6 +66,22 @@ curl http://0.0.0.0:4000/v1/responses \
 
 </TabItem>
 </Tabs>
+
+## Chat Completions and Messages
+
+The same model also serves `/v1/chat/completions` and `/v1/messages` through LiteLLM's responses bridge, so OpenAI- and Anthropic-format clients work without changes:
+
+```python
+from litellm import completion
+import os
+
+os.environ['PARALLEL_AI_API_KEY'] = ""
+response = completion(
+    model="parallel_ai/parallel",
+    messages=[{"role": "user", "content": "What did Parallel Web Systems announce this year?"}]
+)
+print(response.choices[0].message.content)
+```
 
 ## Search
 

--- a/docs/providers/parallel_ai.md
+++ b/docs/providers/parallel_ai.md
@@ -26,6 +26,14 @@ os.environ['PARALLEL_AI_API_KEY']
 
 The single `parallel_ai/parallel` model runs live web research per request. `reasoning.effort` selects the research tier: `low` (~5-10s), `medium` (~15-20s, default), or `high` (~30-60s). Web grounding is automatic, so `tools` is not supported; structured output via `text.format`, `instructions`, `stream`, and `previous_response_id` are.
 
+The tier aliases pin the effort and bill at their own per-request rate, so spend tracking matches the tier you use:
+
+| Model | Effort | Price per request |
+|-------|--------|-------------------|
+| `parallel_ai/parallel-low` | low | $0.01 |
+| `parallel_ai/parallel` or `parallel_ai/parallel-medium` | medium | $0.05 |
+| `parallel_ai/parallel-high` | high | $0.25 |
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -729,7 +729,7 @@ router_settings:
 | OPENAI_PROJECT | OpenAI project ID sent on OpenAI requests, equivalent to passing `project`
 | OR_API_KEY | API key for OpenRouter, read after `OPENROUTER_API_KEY`
 | OVHCLOUD_API_BASE | Base URL for OVHcloud AI Endpoints
-| PARALLEL_AI_API_BASE | Base URL for the Parallel AI provider (search, chat, and Responses API)
+| PARALLEL_AI_API_BASE | Base URL for the Parallel AI provider (search and Responses API)
 | PARALLEL_AI_API_KEY | API key for Parallel AI
 | PARALLEL_API_KEY | API key for Parallel AI, read when `PARALLEL_AI_API_KEY` is unset
 | PERPLEXITY_API_BASE | Base URL for Perplexity. Default is https://api.perplexity.ai

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -729,7 +729,9 @@ router_settings:
 | OPENAI_PROJECT | OpenAI project ID sent on OpenAI requests, equivalent to passing `project`
 | OR_API_KEY | API key for OpenRouter, read after `OPENROUTER_API_KEY`
 | OVHCLOUD_API_BASE | Base URL for OVHcloud AI Endpoints
-| PARALLEL_AI_API_BASE | Base URL for the Parallel AI search provider
+| PARALLEL_AI_API_BASE | Base URL for the Parallel AI provider (search, chat, and Responses API)
+| PARALLEL_AI_API_KEY | API key for Parallel AI
+| PARALLEL_API_KEY | API key for Parallel AI, read when `PARALLEL_AI_API_KEY` is unset
 | PERPLEXITY_API_BASE | Base URL for Perplexity. Default is https://api.perplexity.ai
 | PG_VECTOR_API_BASE | Base URL for a pgvector vector store
 | PG_VECTOR_API_KEY | API key for a pgvector vector store

--- a/docs/search/parallel_ai.md
+++ b/docs/search/parallel_ai.md
@@ -57,19 +57,34 @@ curl http://0.0.0.0:4000/v1/search/parallel-search \
 
 ## Provider-specific Parameters
 
+Every parameter of Parallel's [v1 Search API](https://docs.parallel.ai/api-reference/search/search) can be passed. Flat parameters are mapped into the nested v1 request shape; anything else passes through to the request body as-is.
+
 ```python showLineNumbers title="Parallel AI Search with Provider-specific Parameters"
 import os
 from litellm import search
 
-os.environ["PARALLEL_AI_API_KEY"] = "..."
+os.environ["PARALLEL_AI_API_KEY"] = "..."  # PARALLEL_API_KEY works as a fallback
 
 response = search(
     query="latest developments in quantum computing",
     search_provider="parallel_ai",
     max_results=5,
-    # Parallel AI-specific parameters
-    processor="pro",                 # 'base' or 'pro'
-    max_chars_per_result=500         # Max characters per result
+    mode="advanced",                       # 'turbo', 'basic' (default), or 'advanced'
+    objective="find peer-reviewed research",  # natural-language search goal
+    include_domains=["arxiv.org"],         # restrict results to these domains
+    exclude_domains=["reddit.com"],        # drop results from these domains
+    after_date="2026-01-01",               # only content published on/after this date
+    location="us",                         # ISO 3166-1 alpha-2 geo-targeting
+    max_chars_per_result=500,              # max excerpt characters per result
+    max_chars_total=4000,                  # max excerpt characters across all results
+    fetch_policy={"max_age_seconds": 600}, # cached vs live-fetch behavior
+    session_id="session-123",              # ties related search/extract calls together
 )
 ```
+
+The legacy `processor` parameter still works: `'base'` maps to `mode='basic'` and `'pro'` to `mode='advanced'`.
+
+## Response
+
+Results follow LiteLLM's unified search format. Parallel's raw metadata is preserved on top: the response carries `search_id`, `session_id`, `parallel_usage` (billing SKUs), and `warnings`, and each result keeps its raw `excerpts` array alongside the joined `snippet`.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1181,6 +1181,7 @@ const sidebars = {
           type: "category",
           label: "Perplexity AI",
           items: [
+            "providers/parallel_ai",
             "providers/perplexity",
             "providers/perplexity_embedding",
           ]


### PR DESCRIPTION
Documents the Parallel AI LLM provider support landing in BerriAI/litellm#36704 and unblocks that PR's `documentation_test_env_keys` check, which fails on `PARALLEL_API_KEY` being read in code but mentioned nowhere in the docs

New `docs/providers/parallel_ai.md` covers the chat models (speed/lite/base/core, research `basis`), the Responses API model (`parallel`, `reasoning.effort` tiers), API key and trusted api_base behavior, plus SDK and proxy examples. The existing `docs/search/parallel_ai.md` gains the full v1 search parameter reference (mode, objective, domain and date filters, fetch_policy, session_id) and the preserved response metadata (`search_id`, `parallel_usage`, `warnings`, raw `excerpts`). `config_settings.md` gains PARALLEL_AI_API_KEY and PARALLEL_API_KEY rows next to the existing PARALLEL_AI_API_BASE entry
