### PR TITLE
docs(langfuse): note the v4 attribute names used by the langfuse_otel callback

### DIFF
--- a/docs/observability/langfuse_integration.md
+++ b/docs/observability/langfuse_integration.md
@@ -194,6 +194,14 @@ curl --location --request POST 'http://0.0.0.0:4000/chat/completions' \
 * `trace_user_id`  - User identifier for the trace, defaults to completion argument `user`
 * `tags`           - Tags for the trace, defaults to `None`
 
+:::note
+
+On the `langfuse_otel` callback, `trace_version` and `version` share a single Langfuse attribute, `langfuse.version`, because Langfuse exposes one version per observation. `trace_version` wins when both are set, matching the behaviour above. The `langfuse` callback keeps them separate
+
+That attribute was previously emitted under names Langfuse does not read, so version and release stayed empty on traces exported through `langfuse_otel`. If you were filtering on the raw span attributes rather than the Version and Release fields, the names changed: `langfuse.trace.version` and `langfuse.generation.version` are now `langfuse.version`, and `langfuse.trace.release` is now `langfuse.release`
+
+:::
+
 ##### Updatable Parameters on Continuation
 
 The following parameters can be updated on a continuation of a trace by passing in the following values into the `update_trace_keys` in the metadata of the completion.


### PR DESCRIPTION
Two corrections to the Langfuse page, both about the `langfuse_otel` callback.

The trace parameter list said `trace_version` and `version` are independently settable. That stays true for the `langfuse` callback, but Langfuse exposes a single version per observation, so on `langfuse_otel` the two share one attribute and `trace_version` wins when both are set.

Those values were also being emitted under attribute names Langfuse does not read, so Version and Release stayed empty on traces exported through `langfuse_otel`. BerriAI/litellm#36702 fixes that. Anyone who was filtering on the raw span attributes instead of the Version and Release fields needs the new names, so the note gives the old to new mapping.

Independent of BerriAI/litellm#36702; no merge order required.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->