### PR TITLE
docs: document OPENCODE_* provider environment variables

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1232,6 +1232,11 @@ router_settings:
 | OPENAI_FILE_SEARCH_COST_PER_1K_CALLS | Cost per 1000 calls for OpenAI file search. Default is 0.0025
 | OPENAI_ORGANIZATION | Organization identifier for OpenAI
 | OPENAPI_URL | The path to the OpenAPI JSON endpoint. **By default this is "/openapi.json"**
+| OPENCODE_API_KEY | Shared API key fallback for the OpenCode Go and OpenCode Zen providers. Used when the provider-specific key is not set
+| OPENCODE_GO_API_KEY | API key for the OpenCode Go provider
+| OPENCODE_GO_BASE_URL | Base URL for the OpenCode Go provider
+| OPENCODE_ZEN_API_KEY | API key for the OpenCode Zen provider
+| OPENCODE_ZEN_BASE_URL | Base URL for the OpenCode Zen provider
 | OPENID_BASE_URL | Base URL for OpenID Connect services
 | OPENID_CLIENT_ID | Client ID for OpenID Connect authentication
 | OPENID_CLIENT_SECRET | Client secret for OpenID Connect authentication


### PR DESCRIPTION
Documents the OPENCODE_GO_API_KEY, OPENCODE_GO_BASE_URL, OPENCODE_ZEN_API_KEY, OPENCODE_ZEN_BASE_URL and shared OPENCODE_API_KEY fallback environment variables in the proxy environment reference table. These are read by the new opencode_go and opencode_zen first-class providers, and the env-keys documentation test fails until they are listed.