### PR TITLE
docs(observability): document Phoenix project routing per team and key

### DIFF
--- a/docs/observability/opentelemetry_v2.md
+++ b/docs/observability/opentelemetry_v2.md
@@ -299,6 +299,8 @@ See the full [OpenInference spec](https://github.com/Arize-ai/openinference/blob
 
 Open Phoenix; the project comes from `PHOENIX_PROJECT_NAME` (default `default`), stamped as the `openinference.project.name` resource attribute. Phoenix uses the same OpenInference vocabulary as Arize AX.
 
+On the proxy you can send a team's or key's LLM spans to a different Phoenix project on the same collector. Set `phoenix_project_name` on the team or key; see [Route traces to a Phoenix project per team or key](./phoenix_integration#route-traces-to-a-phoenix-project-per-team-or-key).
+
 #### Attributes added by the `openinference` mapper
 
 Same as the Arize tab above.
@@ -665,6 +667,8 @@ OTEL_PYTHON_FASTAPI_EXCLUDED_URLS="/health,/internal"
 ## Per-key / per-team destinations (multi-tenant)
 
 One proxy can serve many tenants and send each tenant's traces only to that tenant's own backend, so a team never sees another team's traces. The proxy admin owns the routing; a team or key just points at a destination by name and never handles another tenant's secrets.
+
+To keep one Phoenix collector and only split *projects* by team or key, use [`phoenix_project_name` on the team or key](./phoenix_integration#route-traces-to-a-phoenix-project-per-team-or-key) instead of a destination. Destinations are for a different Langfuse, Arize, Weave, or OTLP backend per tenant.
 
 ```
 Proxy admin                          Team admin

--- a/docs/observability/phoenix_integration.md
+++ b/docs/observability/phoenix_integration.md
@@ -99,7 +99,7 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 ## What Phoenix renders
 
-Open Phoenix; the project comes from `PHOENIX_PROJECT_NAME` (default `default`), stamped as the `openinference.project.name` resource attribute. Each request shows up as a `chat <model>` span under the request root.
+Open Phoenix; the project comes from `PHOENIX_PROJECT_NAME` (default `default`), stamped as the `openinference.project.name` resource attribute. Each request shows up as a `chat <model>` span under the request root. On the proxy you can send a team's or key's LLM spans to a different Phoenix project; see [Route traces to a Phoenix project per team or key](#route-traces-to-a-phoenix-project-per-team-or-key).
 
 Phoenix uses the same OpenInference vocabulary as Arize AX, so the LLM-call span carries `llm.model_name`, `llm.provider`, the `llm.token_count.*` usage split, `llm.invocation_parameters`, the message arrays when content capture is on, and `llm.tools.*`, alongside the canonical `gen_ai.*` keys. See the [full attribute table](./opentelemetry_v2#seeing-your-traces).
 
@@ -112,7 +112,7 @@ Phoenix uses the same OpenInference vocabulary as Arize AX, so the LLM-call span
 | `PHOENIX_API_KEY` | Phoenix Cloud only | Required when the endpoint is on `app.phoenix.arize.com`; litellm raises without it. Self-hosted Phoenix does not need one |
 | `PHOENIX_COLLECTOR_HTTP_ENDPOINT` | No | Collector endpoint; takes precedence over `PHOENIX_COLLECTOR_ENDPOINT` when both are set |
 | `PHOENIX_COLLECTOR_ENDPOINT` | No | Collector endpoint, used when the HTTP variable is unset |
-| `PHOENIX_PROJECT_NAME` | No | Defaults to `default`; also readable as `PHOENIX_COLLECTOR_PROJECT_NAME` |
+| `PHOENIX_PROJECT_NAME` | No | Defaults to `default`; also readable as `PHOENIX_COLLECTOR_PROJECT_NAME`. This is the fallback project when a key or team does not set `phoenix_project_name` |
 
 If neither endpoint variable is set, litellm falls back to `http://localhost:6006/v1/traces`.
 
@@ -130,6 +130,92 @@ Phoenix has more than one collector endpoint shape, and picking the wrong one is
 | Phoenix Cloud (legacy) | `https://app.phoenix.arize.com/legacy/v1/traces` |
 | Phoenix Cloud (old) | `https://app.phoenix.arize.com/v1/traces` |
 | Self-hosted | `http://localhost:6006/v1/traces` |
+
+## Route traces to a Phoenix project per team or key
+
+One Phoenix collector can hold many projects. On the LiteLLM proxy, set `phoenix_project_name` on a team or a virtual key so that team's (or that key's) LLM spans land in their own Phoenix project. Keys with no project name keep using `PHOENIX_PROJECT_NAME`.
+
+This is how you split traces by team without standing up a Phoenix instance per tenant. The project comes only from the team or key the proxy resolved at auth. A caller who puts `phoenix_project_name` in the request body is ignored; the call still returns 200 and no attacker-chosen project is created.
+
+Requires OTel v2 (`LITELLM_OTEL_V2=true`) and `callbacks: ["arize_phoenix"]`. Phoenix 15.5.0+ honors the `x-project-name` header this uses; older collectors ignore it and stay on the env project.
+
+<Tabs>
+<TabItem value="team" label="Per team">
+
+Every key on the team sends its LLM spans to the named project.
+
+```bash
+curl -X POST 'http://localhost:4000/team/new' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"team_alias": "payments", "metadata": {"phoenix_project_name": "payments-prod"}}'
+```
+
+Update an existing team the same way:
+
+```bash
+curl -X POST 'http://localhost:4000/team/update' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"team_id": "<team-id>", "metadata": {"phoenix_project_name": "payments-prod"}}'
+```
+
+Then generate a key for that team and call the proxy as usual:
+
+```bash
+curl -X POST 'http://localhost:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"team_id": "<team-id>"}'
+```
+
+```bash
+curl -X POST 'http://localhost:4000/v1/chat/completions' \
+  -H 'Authorization: Bearer $TEAM_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "hello"}]}'
+```
+
+</TabItem>
+<TabItem value="key" label="Per key">
+
+A single key can name its own project, including keys that do not belong to a team.
+
+```bash
+curl -X POST 'http://localhost:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"metadata": {"phoenix_project_name": "payments-canary"}}'
+```
+
+Existing keys take the same field on `/key/update`.
+
+</TabItem>
+</Tabs>
+
+You can set the same `metadata.phoenix_project_name` field on the team or key in the Admin UI.
+
+After the chat (or `/v1/messages`, `/v1/responses`) call, Phoenix shows a project named `payments-prod` containing that request's `chat <model>` span. A second team with `phoenix_project_name: "search-prod"` lands in a different project on the same collector.
+
+### Which project wins
+
+Highest priority first:
+
+1. `phoenix_project_name_override` on the key or team
+2. `phoenix_project_name` on the key or team
+3. `PHOENIX_PROJECT_NAME` (or `PHOENIX_COLLECTOR_PROJECT_NAME`), else `default`
+
+If the same field is set on both the key and the team, the team's value is used. `phoenix_project_name_override` is the escape hatch when a key should leave its team's project.
+
+### What is and is not routed
+
+The LLM-call span (`chat <model>`) is the span Phoenix uses to create and fill the named project. The request's HTTP root, auth, and database spans stay in the env-configured default project.
+
+Phoenix assigns a whole trace to one project by whichever of its spans arrives first. The routed LLM span therefore starts its own trace, with a link back to the request trace so you can still jump between them.
+
+A gRPC-only Phoenix exporter cannot route: `x-project-name` is honored on OTLP/HTTP only. Point `PHOENIX_COLLECTOR_HTTP_ENDPOINT` at an HTTP `/v1/traces` URL (see [Picking the right collector endpoint](#picking-the-right-collector-endpoint)). Guardrail spans are not project-routed.
+
+This is different from [per-team destinations](./opentelemetry_v2#per-key--per-team-destinations-multi-tenant), which send traces to a different backend. Project routing stays on the one Phoenix collector and only changes the project name.
 
 ## Advanced
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- OTel v2 can send a team's LLM spans to their own Phoenix project
- that path was implemented in BerriAI/litellm#36706 and never documented
- admins only had the single env-wide `PHOENIX_PROJECT_NAME`

How it solves it:

- documents `phoenix_project_name` on team and key metadata
- shows `/team/new`, `/team/update`, and `/key/generate` examples
- states precedence, what stays in the default project, and the HTTP-only limit

## User Flow

Before: an admin who wants payments traces in their own Phoenix project has no documented way to set it

1. They open https://docs.litellm.ai/docs/observability/phoenix_integration
2. The page only shows `PHOENIX_PROJECT_NAME` as a global env var
3. They set that env var and every team's spans land in one project

After: the same page walks them through per-team routing

1. They open https://docs.litellm.ai/docs/observability/phoenix_integration#route-traces-to-a-phoenix-project-per-team-or-key
2. They create a team with `{"metadata": {"phoenix_project_name": "payments-prod"}}` via POST http://localhost:4000/team/new
3. A developer calls POST http://localhost:4000/v1/chat/completions with a key on that team
4. Phoenix shows a `payments-prod` project containing that request's chat span
5. A caller who puts `phoenix_project_name` in the request body still gets 200 and no extra project appears

## Relevant issues

Documents BerriAI/litellm#36706

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Docs-only. After merge, open:

1. https://docs.litellm.ai/docs/observability/phoenix_integration#route-traces-to-a-phoenix-project-per-team-or-key
2. https://docs.litellm.ai/docs/observability/opentelemetry_v2 (Phoenix tab, and the per-team destinations section)

## Type

Documentation

## Caveats (if any)

- the code lives in BerriAI/litellm#36706, which is still open
- a local Docusaurus build was not finished in this session