### PR TITLE
docs: state that litellm_settings.callbacks must name an instance

### DIFF
--- a/docs/proxy/agentic_loop_hook.md
+++ b/docs/proxy/agentic_loop_hook.md
@@ -65,12 +65,21 @@ import litellm
 litellm.callbacks = [MyToolCallback()]
 ```
 
-Or in `config.yaml`:
+Or in `config.yaml`, pointing at an instance the module creates:
+
+```python
+# my_module.py, after the class definition above
+my_tool_callback = MyToolCallback()
+```
 
 ```yaml
 litellm_settings:
-  callbacks: ["my_module.MyToolCallback"]
+  callbacks: ["my_module.my_tool_callback"]
 ```
+
+:::warning
+The dotted path must name the instance, not the class. `callbacks: ["my_module.MyToolCallback"]` fails config load, and on versions before that check it started clean and never ran the hook
+:::
 
 ## `AgenticLoopPlan` fields
 

--- a/docs/proxy/call_hooks.md
+++ b/docs/proxy/call_hooks.md
@@ -131,6 +131,8 @@ class MyCustomHandler(CustomLogger): # https://docs.litellm.ai/docs/observabilit
 proxy_handler_instance = MyCustomHandler()
 ```
 
+The last line matters: `callbacks` takes the dotted path of an **instance**, so the file has to create one
+
 2. Add this file to your proxy config
 
 ```yaml
@@ -142,6 +144,10 @@ model_list:
 litellm_settings:
   callbacks: custom_callbacks.proxy_handler_instance # sets litellm.callbacks = [proxy_handler_instance]
 ```
+
+:::warning
+Point `callbacks` at the class (`custom_callbacks.MyCustomHandler`) rather than the instance and the proxy fails config load with an error naming the entry and what it resolved to. The proxy only dispatches `CustomLogger` instances, so on versions before that check it started clean, served traffic and never ran your hooks, with no error and no log line
+:::
 
 3. Start the server + test the request
 

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -1770,6 +1770,10 @@ litellm_settings:
 
 ```
 
+:::warning
+The dotted path has to name the instance created in Step 1 (`proxy_handler_instance = MyCustomHandler()`), not the class. Name the class and the proxy fails config load with an error naming the entry and what it resolved to, since only `CustomLogger` instances are dispatched. On versions before that check, a class-valued entry started clean and never ran, with no error and no log line
+:::
+
 #### Step 2b - Loading Custom Callbacks from S3/GCS (Alternative)
 
 Instead of using local Python files, you can load custom callbacks directly from S3 or GCS buckets. This is useful for centralized callback management or when deploying in containerized environments.


### PR DESCRIPTION
`litellm_settings.callbacks` takes the dotted path of a handler **instance**, and the pages that teach the setting showed `proxy_handler_instance = MyCustomHandler()` in the example without ever saying the line is load bearing. Naming the class instead used to load fine and then never run, so this spells out the rule and the failure mode

The agentic loop hook page is the one real bug here: it shipped `callbacks: ["my_module.MyToolCallback"]`, a class path, right under a python snippet that correctly registers an instance. That config is a silent no-op today, so anyone who followed that page has a hook that has never fired. It now names an instance the module creates

The proxy side is https://github.com/BerriAI/litellm/pull/36858, which makes a class-valued entry fail config load with a message naming the entry and what it resolved to. Merge that one first, since this text describes its behavior

Resolves LIT-5553
