### PR TITLE
docs(pass_through): correct cost tracking coverage claims

### DIFF
--- a/docs/pass_through/azure_passthrough.md
+++ b/docs/pass_through/azure_passthrough.md
@@ -6,7 +6,7 @@ Pass-through endpoints for `/azure`
 
 | Feature | Supported | Notes |
 |-------|-------|-------|
-| Cost Tracking | ❌ | Not supported |
+| Cost Tracking | ✅ | v1 API paths only: `/v1/chat/completions`, `/v1/embeddings`, `/v1/images/generations`, `/v1/images/edits`, `/v1/responses`. Deployments-style paths (`/openai/deployments/...`) are logged without cost |
 | Logging | ✅ | Works across all integrations |
 | Streaming | ✅ | Fully supported |
 

--- a/docs/pass_through/intro.md
+++ b/docs/pass_through/intro.md
@@ -49,5 +49,5 @@ graph LR
 
 - **Unified Authentication**: One API key for all providers
 - **Centralized Logging**: All requests logged through LiteLLM
-- **Cost Tracking**: Usage tracked across all endpoints
+- **Cost Tracking**: Tracked where the provider page's overview table says so; other passthrough requests are logged without cost
 - **Access Control**: Same permissions apply to passthrough endpoints

--- a/docs/pass_through/openai_passthrough.md
+++ b/docs/pass_through/openai_passthrough.md
@@ -6,7 +6,7 @@ Pass-through endpoints for direct OpenAI API access
 
 | Feature | Supported | Notes | 
 |-------|-------|-------|
-| Cost Tracking | ❌ | Not supported |
+| Cost Tracking | ✅ | Chat completions, embeddings, image generations, image edits, and the Responses API. Other endpoints are logged without cost |
 | Logging | ✅ | Works across all integrations |
 | Streaming | ✅ | Fully supported |
 
@@ -37,12 +37,26 @@ Simply replace `https://api.openai.com` with `LITELLM_PROXY_BASE_URL/openai_pass
 Requirements:
 Set `OPENAI_API_KEY` in your environment variables.
 
+### Embeddings
+
+Spend from passthrough embeddings calls is tracked and attributed to the calling key, just like the native `/embeddings` route
+
+```bash
+curl http://0.0.0.0:4000/openai_passthrough/v1/embeddings \
+  -H "Authorization: Bearer sk-anything" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "text-embedding-3-small",
+    "input": "hello world"
+  }'
+```
+
 ### Assistants API
 
 #### Create OpenAI Client
 
 Make sure you do the following:
-- Point `base_url` to your `LITELLM_PROXY_BASE_URL/openai`
+- Point `base_url` to your `LITELLM_PROXY_BASE_URL/openai_passthrough`
 - Use your `LITELLM_API_KEY` as the `api_key`
 
 ```python


### PR DESCRIPTION
The passthrough docs' cost tracking claims drifted from the code. openai_passthrough.md said cost tracking is not supported, but the proxy tracks chat completions, image generations, image edits, and the Responses API there today, with embeddings landing in BerriAI/litellm#36660. azure_passthrough.md had the same stale flat no while v1 API paths are tracked through the shared OpenAI handler, and intro.md claimed usage is tracked across all endpoints, which overstates it. mistral.md and vllm.md were checked too and stay as they are: no cost handler exists for either, so their tables are still accurate

This updates the three stale files, points base_url at /openai_passthrough consistently in the OpenAI client example, and adds an embeddings curl example. Verified live against a DB-backed proxy running the BerriAI/litellm#36660 branch: a /openai_passthrough/v1/embeddings call for text-embedding-3-small wrote a spend log row and billed the key exactly (6 tokens, $0.00000012), and on today's base branch the same call bills nothing. Best merged after BerriAI/litellm#36660 so the embeddings claim is never ahead of the code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4d5c1cb1d1d72a7ef70c42c47c14b48f9a7bbf58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->