### PR TITLE
docs(pass_through): correct the Enterprise label on the auth field

### DIFF
--- a/docs/proxy/pass_through.md
+++ b/docs/proxy/pass_through.md
@@ -178,7 +178,7 @@ general_settings:
   pass_through_endpoints:
     - path: string                    # Route on LiteLLM Proxy Server
       target: string                  # Target URL for forwarding
-      auth: boolean                   # Enable LiteLLM authentication (Enterprise)
+      auth: boolean                   # Enable LiteLLM authentication (OSS since v1.84.0)
       forward_headers: boolean        # Forward all incoming headers
       include_subpath: boolean        # If true, forwards requests to sub-paths (default: false)
       timeout: float                  # Optional: per-endpoint upstream timeout (seconds). Overrides pass_through_request_timeout


### PR DESCRIPTION
## TLDR

Problem this solves:

- Docs mark pass-through `auth` as Enterprise-only
- The gate was removed in v1.84.0
- OSS operators conclude they cannot enable it

How it solves it:

- Replaces the stale `(Enterprise)` label with the real tier

## User Flow

Before: an operator running OSS wants authenticated pass-through and concludes it needs a paid license

1. They open https://docs.litellm.ai/docs/proxy/pass_through and scroll to Configuration Reference
2. The `auth` line reads `# Enable LiteLLM authentication (Enterprise)`
3. They read that as a paid feature and do not enable it

After: the same operator sees no license claim and turns it on

1. They open the same page and scroll to the same block
2. The `auth` line reads `# Enable LiteLLM authentication (OSS since v1.84.0)`
3. They set `auth: true` on their pass-through entry and the route starts requiring a LiteLLM API key

## Relevant issues

None

## Linear ticket

<!-- left blank: external contributor, no ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

No runtime behavior changes, so there is no e2e run to capture. The gate was removed upstream in BerriAI/litellm#26827 and shipped in v1.84.0. The diff at 9c5e011:

```diff
-      auth: boolean                   # Enable LiteLLM authentication (Enterprise)
+      auth: boolean                   # Enable LiteLLM authentication (OSS since v1.84.0)
```

`npm run build` passes locally, and the Vercel preview on this PR renders the corrected line

## Type

📖 Documentation

## Caveats

None

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
