### PR TITLE
docs(release_notes): promote v1.97.0 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.96.0 — MCP Entitlements, Redis Config Sync & Auto-Router Context](/release_notes/v1.96.0/v1-96-0)
+### [v1.97.0 — Tool-Result Guardrails, Deployment Affinity & Viewer Parity](/release_notes/v1.97.0/v1-97-0)
 
-_August 9, 2026_
+_August 15, 2026_
 
-An internal user's `object_permission` becomes a real MCP entitlement level that intersects the key, team, agent, and org scopes and is enforced at both `tools/list` and `tools/call`; a new `post_mcp_call` guardrail mode that finally lets a guardrail mask or reject the contents of an MCP tool result; config changes propagating to every pod through a coordination-Redis invalidation event instead of the 30s poll; OpenAI's GPT-5.6 price cut of 20% on terra and 80% on luna, mirrored onto Bedrock Mantle with new flex long-context rates; a complexity classifier that now sees prior and assistant turns and records its tier decision in spend logs; a generic `/management/v1` list contract with `GET /management/v1/budgets` on top of it; and operational hardening for large deployments covering DB statement and lock timeouts, `REPLICA IDENTITY FULL`, and an unreachable Redis that no longer blocks every request. Note that mock testing request params are now gated behind a config flag that is off by default.
+A per-guardrail `scan_only_tool_results` flag that scans and masks tool output while system, user, and assistant content passes through untouched, so an agent platform can keep injection detection on untrusted tool results without its own harness prompts tripping the filter; auto-router `deployment_affinity` on by default, pinning a session to the deployment it used before so the provider prompt cache stays warm while every turn is still classified on its own merits; a new `LiteLLM_DailyGatewayRequests` table written by the ASGI request-metrics middleware, so successful and failed request counts survive spend logging being off and come with a by-endpoint breakdown; read parity for `proxy_admin_viewer` across roughly fifteen endpoints that previously compared against `PROXY_ADMIN` exactly; four caller-scoped `spend/report` endpoints for keys, users, teams, and organizations; a correctness sweep over managed files and batches covering deterministic unified output file ids and unparseable rows; and an admin-published, dismissible markdown banner rendered on every dashboard page. Note that request-parameter checks now apply to path and form inputs as well as the body.
 
 ---
 
@@ -22,6 +22,7 @@ An internal user's `object_permission` becomes a real MCP entitlement level that
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.97.0](/release_notes/v1.97.0/v1-97-0)   | Aug 15, 2026 | Tool-result guardrails, auto-router deployment affinity, admin viewer parity |
 | [v1.96.0](/release_notes/v1.96.0/v1-96-0)   | Aug 9, 2026  | MCP entitlements, Redis config sync, auto-router context, GPT-5.6 price cut |
 | [v1.95.0](/release_notes/v1.95.0/v1-95-0)   | Aug 1, 2026  | Claude Opus 5, MCP gateway DCR, Rust `/v1/messages`, SAML 2.0 SSO |
 | [v1.94.0](/release_notes/v1.94.0/v1-94-0)   | Jul 28, 2026 | Router plugins & Auto-Router v2, MCP client-held credentials, shared DataTable UI |

--- a/release_notes/v1.97.0/index.md
+++ b/release_notes/v1.97.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.97.0rc1 - Tool-Result Guardrails, Deployment Affinity & Viewer Parity"
-slug: "v1-97-0-rc-1"
-date: 2026-08-08T14:24:04
+title: "v1.97.0 - Tool-Result Guardrails, Deployment Affinity & Viewer Parity"
+slug: "v1-97-0"
+date: 2026-08-15T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,14 +30,14 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.97.0-rc.1
+docker.litellm.ai/berriai/litellm:1.97.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.97.0rc1
+pip install litellm==1.97.0
 ```
 
 </TabItem>
@@ -52,8 +52,6 @@ pip install litellm==1.97.0rc1
 :::
 
 ## Key Highlights
-
-`v1.97.0rc1` is the current release candidate for 1.97.0.
 
 - **Guardrails can be pointed at tool results alone** - a new per-guardrail `scan_only_tool_results` flag scans and masks tool output while system, user, and assistant content pass through untouched, so an agent platform can keep injection detection on untrusted tool results without its own harness prompts tripping the filter. Works on both `/v1/messages` and `/v1/chat/completions`
 - **The auto-router now sticks to a deployment, not just a model group** - `deployment_affinity` is on by default, so a conversation returning to a model group lands on the deployment it used there before and the provider prompt cache stays warm, while every turn is still classified on its own merits. `session_affinity` implies it, and session pins are now scoped by the caller's hashed API key
@@ -136,6 +134,7 @@ Beyond the new entries, this release carries OpenAI's GPT-5.6 price cut onto the
     - Return unified ids from unscoped file listing and unified output file ids from `GET /batches` - [PR #36031](https://github.com/BerriAI/litellm/pull/36031), [PR #36049](https://github.com/BerriAI/litellm/pull/36049)
 - **[Passthrough](../../docs/pass_through/vertex_ai)**
     - Resolve pass-through credentials live from router deployments - [PR #35916](https://github.com/BerriAI/litellm/pull/35916)
+    - Stop forwarding the client's `Accept-Encoding` upstream - [PR #37058](https://github.com/BerriAI/litellm/pull/37058)
 - **Web search**
     - Restore snippet text in native `web_search_tool_result` blocks - [PR #36228](https://github.com/BerriAI/litellm/pull/36228)
 - **General**
@@ -313,13 +312,13 @@ Beyond the new entries, this release carries OpenAI's GPT-5.6 price cut onto the
 
 ### PR roll-up by ownership area
 
-PRs by ownership area (total: 252)
+PRs by ownership area (total: 253)
 
 - Other (CI / chore / tests / build / version bumps): 86
 - Performance: 30
 - UI: 28
+- LLM API Endpoints: 21
 - Auth & Management: 20
-- LLM API Endpoints: 20
 - Spend / Budgets / Rate Limits: 20
 - Models & Providers: 17
 - Logging: 15
@@ -343,4 +342,4 @@ This window added 18 test-only PRs, 11 of them touching the live e2e suite. New 
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.96.0-rc.1...v1.97.0-rc.1
+https://github.com/BerriAI/litellm/compare/v1.96.0...v1.97.0


### PR DESCRIPTION
Renames the `v1.97.0rc1` folder to `v1.97.0` and moves the title, slug, date, Docker tag, pip install, and Full Changelog range onto the stable form. The changelog landing page now leads with v1.97.0 and gains its row in Recent Releases.

One user-facing change landed on `rc/1.97.0` after the `v1.97.0-rc.1` tag and is folded into the passthrough bug list: [PR #37058](https://github.com/BerriAI/litellm/pull/37058), which stops forwarding the client's `Accept-Encoding` upstream. The `v1.97.0` tag contains that commit, so it does ship here. The ownership roll-up goes from 252 to 253 with LLM API Endpoints taking the extra PR; that total comes from the release-notes tooling rather than a plain git count, so treat it as an estimate rather than a canonical recount.

The Full Changelog now points at `v1.96.0...v1.97.0` and resolves, since both stable tags exist.