### PR TITLE
docs(proxy): document OpenCode provider environment variables

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1249,6 +1249,11 @@ router_settings:
 | OPENAI_FILE_SEARCH_COST_PER_1K_CALLS | Cost per 1000 calls for OpenAI file search. Default is 0.0025
 | OPENAI_ORGANIZATION | Organization identifier for OpenAI
 | OPENAPI_URL | The path to the OpenAPI JSON endpoint. **By default this is "/openapi.json"**
+| OPENCODE_API_KEY | Shared OpenCode API key, used as a fallback when no per-surface key is set
+| OPENCODE_GO_API_KEY | API key for the `opencode_go` provider. Falls back to `OPENCODE_API_KEY` when unset
+| OPENCODE_GO_BASE_URL | Base URL for the `opencode_go` provider. **Default is `https://opencode.ai/zen/go`**
+| OPENCODE_ZEN_API_KEY | API key for the `opencode_zen` provider. Falls back to `OPENCODE_API_KEY` when unset
+| OPENCODE_ZEN_BASE_URL | Base URL for the `opencode_zen` provider. **Default is `https://opencode.ai/zen`**
 | OPENID_BASE_URL | Base URL for OpenID Connect services
 | OPENID_CLIENT_ID | Client ID for OpenID Connect authentication
 | OPENID_CLIENT_SECRET | Client secret for OpenID Connect authentication


### PR DESCRIPTION
## Why

The LiteLLM proxy now serves OpenCode as a first-class provider through `opencode_go` and `opencode_zen` in BerriAI/litellm#40964. The `documentation_test_env_keys` check on that PR fails because the five OpenCode env vars the provider reads are not documented anywhere

## What changed

Adds rows to the environment variables Reference table in `proxy/config_settings.md` for `OPENCODE_API_KEY`, `OPENCODE_GO_API_BASE`, `OPENCODE_GO_API_KEY`, `OPENCODE_ZEN_API_BASE`, and `OPENCODE_ZEN_API_KEY`. The per-surface keys fall back to the shared `OPENCODE_API_KEY` when unset. The two base URL rows list the gateway defaults and note that a value works with or without a trailing `/v1`

An earlier revision documented `OPENCODE_GO_BASE_URL` and `OPENCODE_ZEN_BASE_URL`, which the provider never reads, so the check would have kept failing after merge

## Proof

With this branch applied on top of current `main` and mounted at `docs/my-website`, running `tests/documentation_tests/test_env_keys.py` from the tip of BerriAI/litellm#40964 prints "Every environment variable read under ./litellm is documented"

