### PR TITLE
docs: fix nonexistent turn_on_message_logging reference in logging docs

### DIFF
--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -167,7 +167,7 @@ litellm_settings:
 
 ### Disable Message Redaction
 
-If you have `litellm.turn_on_message_logging` turned on, you can override it for specific requests by
+If you have `litellm.turn_off_message_logging` enabled, you can override it for specific requests by
 setting a request header `LiteLLM-Disable-Message-Redaction: true`.
 
 


### PR DESCRIPTION
Fixes BerriAI/litellm#37143

## Summary
The logging docs referenced `litellm.turn_on_message_logging`, which doesn't exist. The actual setting is `litellm.turn_off_message_logging` (see the "Disable Message Logging" section above this one). Users following this section would hit an `AttributeError`.

Changed the reference to the real setting name.
