### PR TITLE
docs(search): add Nimble search provider page

### DIFF
--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -2,7 +2,7 @@
 
 | Feature | Supported | 
 |---------|-----------|
-| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent`, `agentcore` |
+| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent`, `agentcore`, `nimble` |
 | Cost Tracking | ✅ |
 | Logging | ✅ |
 | Load Balancing | ❌ |
@@ -282,6 +282,7 @@ The response follows Perplexity's search format with the following structure:
 | You.com | `YOUCOM_API_KEY` *(optional — omit for keyless free tier)* | `you_com` |
 | APISerpent | `APISERPENT_API_KEY` | `apiserpent` |
 | Bedrock AgentCore | `AGENTCORE_GATEWAY_URL` (required), AWS credentials or `AGENTCORE_GATEWAY_TOKEN` | `agentcore` |
+| Nimble | `NIMBLE_API_KEY` | `nimble` |
 
 See the individual provider documentation for detailed setup instructions and provider-specific parameters.
 

--- a/docs/search/nimble.md
+++ b/docs/search/nimble.md
@@ -1,0 +1,86 @@
+# Nimble Search
+
+**Get API Key:** [https://online.nimbleway.com/settings/api-keys](https://online.nimbleway.com/settings/api-keys)
+
+:::info
+
+Supported from LiteLLM v1.98.0+
+:::
+
+## LiteLLM Python SDK
+
+```python showLineNumbers title="Nimble Search"
+import os
+from litellm import search
+
+os.environ["NIMBLE_API_KEY"] = "..."
+
+response = search(
+    query="latest AI developments",
+    search_provider="nimble",
+    max_results=5
+)
+```
+
+## LiteLLM AI Gateway
+
+### 1. Setup config.yaml
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-5.6
+    litellm_params:
+      model: gpt-5.6
+      api_key: os.environ/OPENAI_API_KEY
+
+search_tools:
+  - search_tool_name: nimble-search
+    litellm_params:
+      search_provider: nimble
+      api_key: os.environ/NIMBLE_API_KEY
+```
+
+### 2. Start the proxy
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+### 3. Test the search endpoint
+
+```bash showLineNumbers title="Test Request"
+curl http://0.0.0.0:4000/v1/search/nimble-search \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "latest AI developments",
+    "max_results": 5
+  }'
+```
+
+## Provider-specific Parameters
+
+```python showLineNumbers title="Nimble Search with Provider-specific Parameters"
+import os
+from litellm import search
+
+os.environ["NIMBLE_API_KEY"] = "..."
+
+response = search(
+    query="latest tech news",
+    search_provider="nimble",
+    max_results=5,
+    # Nimble-specific parameters
+    focus="news",                    # 'serp', 'general', 'news', 'location', 'coding',
+                                     # 'academic', 'geo', 'shopping', 'social'
+    search_depth="deep",             # 'lite', 'fast', 'deep' ('fast' needs focus='general')
+    time_range="week",               # 'hour', 'day', 'week', 'month', 'year'
+    output_format="markdown"         # 'plain_text', 'markdown', 'simplified_html'
+)
+```
+
+Domains can be restricted either through the unified `search_domain_filter`, where a `-` prefix excludes a host, or through Nimble's own `include_domains` and `exclude_domains`, which win when both are given. See the [Nimble Search API reference](https://docs.nimbleway.com/api-reference/search/search) for the full parameter set, including `content_type`, `start_date` and `end_date`.
+
+Set `NIMBLE_API_BASE` to override the default `https://sdk.nimbleway.com/v2` endpoint.

--- a/sidebars.js
+++ b/sidebars.js
@@ -967,6 +967,7 @@ const sidebars = {
             "search/you_com",
             "search/apiserpent",
             "search/agentcore",
+            "search/nimble",
           ]
         },
         "skills",


### PR DESCRIPTION
Adds a Nimble page under `/search`, mirroring the structure of the existing Tavily and Exa pages, and registers it in the `/search` sidebar category plus the two supported-provider tables in `docs/search/index.md`

This is the docs half of BerriAI/litellm#36347, which added Nimble as a native search provider and is merged. The provider ships in v1.98, so the page carries a "Supported from LiteLLM v1.98.0+" note and is ready whenever that cut lands

Every snippet was run before opening this. The two SDK examples return results against the live API, and the gateway example was verified by starting a proxy on the exact `config.yaml` from the page and running the exact curl, which returns 200 with five results. The values in the provider-specific section came from Nimble's API rather than from the provider code, since that code forwards unrecognized parameters without validating them, so the implementation is not a reliable source for allowed values. The `search_depth` and `focus` interaction is noted inline because Nimble rejects `fast` outside `focus="general"`

The `model_list` block uses `gpt-5.6` rather than the `gpt-4` that older search pages copy around, following the convention that docs reference the latest model in the family

Disclosure: I work at Nimble
