### PR TITLE
docs(scim): correct which identity providers can provision to LiteLLM

### DIFF
--- a/docs/proxy/identity_provisioning.md
+++ b/docs/proxy/identity_provisioning.md
@@ -43,7 +43,7 @@ sequenceDiagram
 
 ## Prerequisites
 
-You need a LiteLLM proxy backed by a database (both SCIM and `auto_register` write to it), an enterprise license (SCIM and JWT auth are both enterprise features), your proxy `master_key`, and an identity provider that supports OIDC for the JWTs and SCIM 2.0 for provisioning (Okta, Entra ID, OneLogin, Keycloak, Auth0, Google Workspace).
+You need a LiteLLM proxy backed by a database (both SCIM and `auto_register` write to it), an enterprise license (SCIM and JWT auth are both enterprise features), your proxy `master_key`, and an identity provider that supports OIDC for the JWTs and can provision to a custom SCIM 2.0 endpoint (Okta, Entra ID, OneLogin). Google Workspace, Auth0, and Keycloak cannot push SCIM to LiteLLM; see [supported SCIM providers](../tutorials/scim_litellm.md#supported-sso-providers-for-scim) for why, and for the alternatives if Google Workspace is your source of truth.
 
 ---
 

--- a/docs/tutorials/scim_litellm.md
+++ b/docs/tutorials/scim_litellm.md
@@ -12,13 +12,18 @@ Enables identity providers (Okta, Azure AD, OneLogin, etc.) to automate user and
 This tutorial will walk you through the steps to connect your IDP to LiteLLM SCIM Endpoints.
 
 ### Supported SSO Providers for SCIM
-Below is a list of supported SSO providers for connecting to LiteLLM SCIM Endpoints.
+
+LiteLLM exposes standard SCIM 2.0 endpoints under `/scim/v2`, authenticated with a bearer token. Any identity provider that can provision to a generic or custom SCIM 2.0 application can connect to them:
+
 - Microsoft Entra ID (Azure AD)
 - Okta
-- Google Workspace
 - OneLogin
-- Keycloak
-- Auth0
+
+#### Providers that cannot push SCIM to LiteLLM
+
+Google Workspace only supports automated user provisioning for applications in [Google's pre-integrated connector catalog](https://knowledge.workspace.google.com/admin/users/advanced/about-automated-user-provisioning), and LiteLLM is not in that catalog. Custom SAML apps do not get auto-provisioning, and there is no way to point Google Workspace at a custom SCIM endpoint. See [Google Workspace](#google-workspace) below for the alternatives.
+
+Auth0 supports [inbound SCIM](https://auth0.com/docs/authenticate/protocols/scim/configure-inbound-scim) only; it can be provisioned into by an upstream identity provider, but it cannot provision outward to LiteLLM. Keycloak does not ship a stable outbound SCIM client, so provisioning to LiteLLM requires a third-party extension.
 
 
 ## 1. Get your SCIM Tenant URL and Bearer Token
@@ -73,6 +78,15 @@ On the LiteLLM UI, Navigate to `Teams`, You should see the new team `Production 
 <Image img={require('../../img/msft_auto_team.png')}  style={{ width: '900px', height: 'auto' }} />
 
 > **Note:** When a user is removed from your organization via SCIM, all API keys and access tokens associated with that user will be automatically deleted from LiteLLM. This ensures that removed users lose all access immediately and securely.
+
+
+## Google Workspace
+
+Google Workspace cannot provision into LiteLLM over SCIM. Google's automated user provisioning only works for applications in Google's own connector catalog, and LiteLLM is not in that catalog. Custom SAML apps do not get auto-provisioning, and the Workspace admin console has no field for a custom SCIM endpoint.
+
+Google Workspace SSO into LiteLLM is supported; see [SSO for Admin UI](../proxy/admin_ui_sso.md). Note that this creates users on first login only. It does not populate teams from Google groups, and it does not deprovision users when they are removed from Workspace.
+
+If you need group sync or deprovisioning with Google Workspace as your source of truth, there are two options. You can drive the SCIM endpoints yourself: `/scim/v2` is standard SCIM 2.0 with bearer-token auth, so any SCIM client can call it, including a sync job you run against the [Google Admin SDK Directory API](https://developers.google.com/workspace/admin/directory/reference/rest). Alternatively, you can federate Google Workspace behind an identity provider that supports outbound SCIM to custom endpoints, such as Microsoft Entra ID, Okta, or OneLogin, and provision to LiteLLM from there.
 
 
 


### PR DESCRIPTION
The SCIM tutorial listed Google Workspace, Keycloak, and Auth0 as supported providers for connecting an IdP to LiteLLM's SCIM endpoints, and the prerequisites line on the identity provisioning page repeated the same list. None of those three can push SCIM to a custom endpoint like LiteLLM's, so both pages were pointing people at a setup that cannot be configured.

Google Workspace only auto-provisions into applications in [Google's pre-integrated connector catalog](https://knowledge.workspace.google.com/admin/users/advanced/about-automated-user-provisioning), and LiteLLM is not in it; custom SAML apps get no auto-provisioning, and the Workspace admin console has no field for a custom SCIM endpoint. Auth0 implements [inbound SCIM](https://auth0.com/docs/authenticate/protocols/scim/configure-inbound-scim) only, so it can be provisioned into by an upstream IdP but cannot provision outward. Keycloak ships no stable outbound SCIM client and needs a third-party extension.

This narrows the list to Microsoft Entra ID, Okta, and OneLogin, and states the general rule rather than an enumeration: `/scim/v2` is standard SCIM 2.0 with bearer auth, so any IdP that can provision to a generic or custom SCIM 2.0 application works. It also adds a Google Workspace section covering what does work there, since that combination comes up regularly. SSO into LiteLLM is supported, with the caveat that it creates users on first login only and populates no teams and no deprovisioning. For real group sync the options are a self-run job against the Admin SDK Directory API driving `/scim/v2`, or federating Workspace behind an IdP that does support outbound SCIM.

The provider list has been unchanged since the page was first added and does not appear to have been validated per provider; every step in the walkthrough is Entra ID.

`npm run build` passes. The remaining broken-link and broken-anchor warnings are pre-existing and in unrelated pages.
