### PR TITLE
docs(passthrough): document upstream-reported cost and usage headers

### DIFF
--- a/docs/pass_through/intro.md
+++ b/docs/pass_through/intro.md
@@ -49,5 +49,5 @@ graph LR
 
 - **Unified Authentication**: One API key for all providers
 - **Centralized Logging**: All requests logged through LiteLLM
-- **Cost Tracking**: Tracked where the provider page's overview table says so; other passthrough requests are logged without cost
+- **Cost Tracking**: Tracked where the provider page's overview table says so. A custom pass-through target that LiteLLM cannot price can report its own totals, see [Pass-Through Cost & Usage Tracking](../proxy/pass_through_cost_tracking.md). Anything else is logged without cost
 - **Access Control**: Same permissions apply to passthrough endpoints

--- a/docs/proxy/pass_through.md
+++ b/docs/proxy/pass_through.md
@@ -8,7 +8,7 @@ Route requests from your LiteLLM proxy to any external API. Perfect for custom m
 
 **Key Benefits:**
 - Onboard third-party endpoints like Bria API and Mistral OCR
-- Set custom pricing per request
+- Set custom pricing per request, or let a target that fans out to several models [report its own cost and usage](./pass_through_cost_tracking.md)
 - Proxy Admins don't need to give developers api keys to upstream llm providers like Bria, Mistral OCR, etc.
 - Maintain centralized authentication, spend tracking, budgeting
 
@@ -72,6 +72,7 @@ Configure the required authentication and pricing:
 **Pricing Configuration:**
 - Set a cost per request (e.g., $12.00 in this example)
 - This enables cost tracking and billing for your users
+- A flat cost per request suits a target whose price does not vary. If the target invokes several models internally and knows its own totals, have it report them instead, see [Pass-Through Cost & Usage Tracking](./pass_through_cost_tracking.md)
 
 <Image 
   img={require('../../img/pt_2.png')}

--- a/docs/proxy/pass_through_cost_tracking.md
+++ b/docs/proxy/pass_through_cost_tracking.md
@@ -1,0 +1,91 @@
+# Pass-Through Cost & Usage Tracking
+
+Some pass-through targets fan a single HTTP request out to several models internally. LiteLLM cannot price those requests from the response body, so before this contract existed they landed in the spend logs with zero cost and zero tokens
+
+The target can instead report the totals for the whole request in two response headers. LiteLLM records what it reports, without recomputing it
+
+## The headers
+
+| Header | Format | Meaning |
+| --- | --- | --- |
+| `x-litellm-response-cost` | decimal string, USD | Total cost of this request across every internal model call, e.g. `0.000415` |
+| `x-litellm-total-tokens` | integer string | Total tokens across every internal model call, e.g. `1874` |
+
+Send one total per HTTP request. There is no per-model breakdown, and the reported values are authoritative
+
+## Quick start
+
+Define the pass-through endpoint as usual. Nothing in the config opts into this contract; LiteLLM reads the headers whenever the target sends them
+
+```yaml
+general_settings:
+  pass_through_endpoints:
+    - path: "/internal-api"
+      target: "https://internal-api.example.com/v1/answer"
+      include_subpath: true
+      headers:
+        Authorization: "Bearer os.environ/INTERNAL_API_TOKEN"
+```
+
+Call it through the proxy with your LiteLLM key:
+
+```shell
+curl -i -X POST 'http://localhost:4000/internal-api/summarize' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{"document_id": "doc-9931"}'
+```
+
+Have the target answer with the totals it computed:
+
+```
+HTTP/1.1 200 OK
+content-type: application/json
+x-litellm-response-cost: 0.000415
+x-litellm-total-tokens: 1874
+```
+
+LiteLLM books `0.000415` and `1874` against the calling key, team, and user, and the values show up in the spend logs and on the usage dashboards alongside the rest of that key's traffic
+
+## What LiteLLM records
+
+The reported values are written as sent. LiteLLM parses them, checks them for sanity, and never recomputes a cost of its own on top
+
+Only the values the target actually reported are written. A target that sends a cost but no token count keeps the token count LiteLLM derived on its own, rather than having it zeroed. A target that sends neither header is left alone entirely, which is the normal case for provider pass-through routes like Anthropic or Vertex AI, where LiteLLM derives the cost from the response body
+
+## Validation
+
+A value that fails any of these checks is treated as not reported, and a warning is written to the proxy logs naming the header and the offending value
+
+| Header | Accepted | Rejected |
+| --- | --- | --- |
+| `x-litellm-response-cost` | Any finite, non-negative decimal, including `0` | Unparseable text, negative values, `inf`, `nan` |
+| `x-litellm-total-tokens` | Any non-negative integer, including `0` | Unparseable text, negative values |
+
+An explicit `0` is a real value, not a missing one, so send both headers even when the totals are zero
+
+## Error responses
+
+The headers are read on every upstream response, whatever the status code. A request that burned tokens before failing books its spend on the failure row instead of being dropped for having a 4xx or 5xx status. Send the headers on error responses too whenever cost was still incurred
+
+On a failure row, a value that was missing or unusable is recorded as `0`
+
+## Precedence over `cost_per_request`
+
+A target that prices its own requests always wins over the flat [`cost_per_request`](./pass_through.md) estimate configured on the endpoint. `cost_per_request` defaults to `0.0` on every config-defined endpoint, so honoring it would zero out the real cost the target just reported
+
+That holds even when the reported value could not be parsed. The request records `0` rather than billing an estimate the target has contradicted
+
+## Rate limits and budgets
+
+Reported tokens charge the same TPM window as the rest of the caller's traffic, so a key or team cannot exceed its shared token limit through pass-through traffic alone. Before this contract, pass-through usage never reached the token window at all, because the rate limiter only read usage off response shapes it models
+
+Recorded cost counts toward budgets the same way any other request's cost does
+
+## Streaming
+
+Streaming targets work, because response headers arrive before the body. A target that only knows its final cost after it has finished streaming cannot report it through this contract, since by then the headers are already on the wire
+
+## Reading the values back
+
+Upstream response headers relay through to the calling client, so callers see the same `x-litellm-response-cost` shape they get from the general API. LiteLLM adds `x-litellm-call-id` on the way out, which is the value to match against the spend logs when reconciling any individual request

--- a/sidebars.js
+++ b/sidebars.js
@@ -939,6 +939,7 @@ const sidebars = {
             },
             "pass_through/vllm",
             "proxy/pass_through",
+            "proxy/pass_through_cost_tracking",
             "proxy/pass_through_guardrails"
           ]
         },


### PR DESCRIPTION
## What

Adds `docs/proxy/pass_through_cost_tracking.md`, covering the `x-litellm-response-cost` and `x-litellm-total-tokens` response headers a custom pass-through target can send so LiteLLM books its spend

Also corrects the pass-through intro, which claimed that anything outside the provider overview tables is logged without cost, and links the new page from the two cost-per-request spots in the Create Pass Through Endpoints page

## Why

The feature shipped in v1.95.0 (#34590) with no documentation at all. The introducing PR touched seven files, every one of them code or tests, and `x-litellm-total-tokens` appeared nowhere in this repo. A target that fans one HTTP request out to several models internally cannot be priced from its response body, so without this contract those requests land in the spend logs at zero cost, and there was no way for a reader to discover the way out

The page is written from the merged code rather than from the original design, so a few things differ from what a reader might expect. Only the values a target actually reports get written, so a good cost header with a broken token header keeps the token count LiteLLM derived itself instead of zeroing it. Unusable values record as 0 on failure rows specifically. An upstream that prices its own request takes precedence over the flat `cost_per_request` estimate, which matters because that setting defaults to 0.0 on every config-defined endpoint and would otherwise zero out real spend

Scope is cost and usage only. Team identification and the shared budget enforcement path are separate and predate this

## How to verify

1. `npm i && npm run build` in the repo root, which exits 0 with no broken-link warning naming `pass_through_cost_tracking`
2. `npm run serve`, then open http://localhost:3000/docs/proxy/pass_through_cost_tracking and confirm the page renders with both header tables
3. Open http://localhost:3000/docs/pass_through/intro and confirm the Cost Tracking bullet now links to the new page
4. Open http://localhost:3000/docs/proxy/pass_through and confirm the Key Benefits bullet and the Pricing Configuration step both link to it

## Linear ticket