### PR TITLE
docs: fix references to non-existent litellm config and error classes

### DIFF
--- a/docs/completion/provider_specific_params.md
+++ b/docs/completion/provider_specific_params.md
@@ -382,7 +382,7 @@ response_1 = litellm.completion(
 response_1_text = response_1.choices[0].message.content
 
 ## SET MAX TOKENS - via config
-litellm.CohereConfig(max_tokens=200)
+litellm.CohereChatConfig(max_tokens=200)
 response_2 = litellm.completion(
             model="command-nightly",
             messages=[{ "content": "Hello, how are you?","role": "user"}],

--- a/docs/proxy/reliability.md
+++ b/docs/proxy/reliability.md
@@ -151,7 +151,7 @@ You can also set [`default_fallbacks`](#default-fallbacks), in case a specific m
 
 There are 3 types of fallbacks: 
 - `content_policy_fallbacks`: For litellm.ContentPolicyViolationError - LiteLLM maps content policy violation errors across providers [**See Code**](https://github.com/BerriAI/litellm/blob/89a43c872a1e3084519fb9de159bf52f5447c6c4/litellm/utils.py#L8495C27-L8495C54)
-- `context_window_fallbacks`: For litellm.ContextWindowExceededErrors - LiteLLM maps context window error messages across providers [**See Code**](https://github.com/BerriAI/litellm/blob/89a43c872a1e3084519fb9de159bf52f5447c6c4/litellm/utils.py#L8469)
+- `context_window_fallbacks`: For litellm.ContextWindowExceededError - LiteLLM maps context window error messages across providers [**See Code**](https://github.com/BerriAI/litellm/blob/89a43c872a1e3084519fb9de159bf52f5447c6c4/litellm/utils.py#L8469)
 - `fallbacks`: For all remaining errors - e.g. litellm.RateLimitError
 
 


### PR DESCRIPTION
Several docs pages reference litellm classes that do not exist in the litellm package:

- `litellm.HuggingfaceConfig` -> `litellm.HuggingFaceChatConfig`, the chat config class exposed in litellm/__init__.py. The example also passed `max_new_tokens`, which is not a field of that config, so it now uses the supported `max_tokens` parameter
- `litellm.OllamConfig` -> `litellm.OllamaConfig`
- `litellm.CohereConfig` -> `litellm.CohereChatConfig`
- `litellm.ContextWindowExceededErrors` -> `litellm.ContextWindowExceededError`, the exception class is singular

None of the old names appear anywhere in the litellm codebase; the corrected names are the ones registered in litellm/__init__.py and litellm/_lazy_imports_registry.py