### PR TITLE
docs: clarify provider key attribute pattern in set_keys page

### DIFF
--- a/docs/set_keys.md
+++ b/docs/set_keys.md
@@ -81,7 +81,7 @@ litellm.api_key = "sk-AnthropicKey"
 response = litellm.completion(messages=messages, model="claude-2")
 ```
 
-### litellm.<provider>_key (example litellm.openai_key)
+### `litellm.<provider>_key` (example `litellm.openai_key`)
 
 ```python
 litellm.openai_key = "sk-OpenAIKey"

--- a/docs/set_keys.md
+++ b/docs/set_keys.md
@@ -81,7 +81,7 @@ litellm.api_key = "sk-AnthropicKey"
 response = litellm.completion(messages=messages, model="claude-2")
 ```
 
-### litellm.provider_key (example litellm.openai_key)
+### litellm.<provider>_key (example litellm.openai_key)
 
 ```python
 litellm.openai_key = "sk-OpenAIKey"


### PR DESCRIPTION
The heading "litellm.provider_key" in docs/set_keys.md suggests a single attribute called provider_key, but the code examples below it set provider-specific keys such as litellm.openai_key and litellm.anthropic_key. litellm.provider_key does not exist in the litellm package. Changed the heading to the placeholder form litellm.<provider>_key, which matches the pattern the examples demonstrate.