### PR TITLE
Clarify Arize AX and Phoenix observability options

### DIFF
--- a/docs/observability/arize_integration.md
+++ b/docs/observability/arize_integration.md
@@ -3,9 +3,11 @@ import TabItem from '@theme/TabItem';
 
 # Arize AX
 
-AI observability and evaluation for LLM applications, at [arize.com](https://arize.com/).
+Use Arize AX when you want the full-featured [Arize AI](https://arize.com/?utm_source=litellm-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=arize-ax-integration) platform for production LLM observability and evaluation, available as managed cloud or enterprise self-hosted deployment.
 
-Arize AX is the hosted platform. If you self-host the open-source tracer, or run it on Phoenix Cloud, see [Arize Phoenix](./phoenix_integration) instead; the two use different credentials and endpoints.
+Arize AX is separate from [Arize Phoenix](https://arize.com/phoenix/), the open-source tracing and evaluation project for local development, experimentation, and self-hosted workflows. LiteLLM supports both backends, but they use different callbacks, credentials, and endpoints. If you are sending traces to Phoenix, use the [Arize Phoenix setup guide](./phoenix_integration) instead.
+
+For production evaluation workflows, see Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of using traces to debug failures, compare model behavior, and improve agent reliability.
 
 :::info
 We want to learn how we can make the callbacks better! Meet the LiteLLM [founders](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version) or

--- a/docs/observability/opentelemetry_v2.md
+++ b/docs/observability/opentelemetry_v2.md
@@ -254,7 +254,7 @@ Every preset turns into one exporter on a single shared tracer. The table lists,
 
 Notes:
 
-- **Arize AX vs Arize Phoenix** are different backends from the same company. AX (`arize`) is the hosted platform; Phoenix (`arize_phoenix`) is the open-source tracer you self-host or run on Phoenix Cloud. They use different credentials and endpoints, so pick the callback for the backend you actually run. You can also enable both at once to send to each.
+- **Arize AX vs Arize Phoenix**: use `arize` for the full-featured AX platform and `arize_phoenix` for Phoenix local or self-hosted workflows. They use different credentials and endpoints, so pick the callback for the backend you actually run. For product-specific setup, see the dedicated [Arize AX](./arize_integration) and [Arize Phoenix](./phoenix_integration) guides.
 - **Langtrace** ingests JSON-only OTLP at a custom path, so litellm v2 (which sends protobuf to `/v1/traces`) cannot export to it directly. Route through an OpenTelemetry Collector that re-encodes to JSON; the `langtrace` preset only adds the Langtrace attribute schema to your spans. See the Langtrace tab above for the collector config.
 - Vocabulary is additive: every preset's spans always carry the canonical OpenTelemetry `gen_ai.*` attributes; the listed vocabulary is layered on top so the destination tool reads its native schema.
 

--- a/docs/observability/phoenix_integration.md
+++ b/docs/observability/phoenix_integration.md
@@ -3,9 +3,11 @@ import TabItem from '@theme/TabItem';
 
 # Arize Phoenix
 
-Open-source LLM tracing and evaluation, at [phoenix.arize.com](https://phoenix.arize.com/). Run it self-hosted or on Phoenix Cloud.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source LLM tracing and evaluation project from [Arize AI](https://arize.com/?utm_source=litellm-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=phoenix-integration). Use it for local development, experimentation, and self-hosted workflows.
 
-Phoenix and [Arize AX](./arize_integration) are different backends from the same company. AX is the hosted platform; Phoenix is the open-source tracer. They take different credentials and endpoints, so pick the callback for the backend you actually run. You can also enable both at once to send to each.
+Phoenix is separate from [Arize AX](https://arize.com/products/ax/), the full-featured platform for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment. LiteLLM supports both backends, but they use different callbacks, credentials, and endpoints. Use `arize_phoenix` for Phoenix, use `arize` for AX, or enable both when you need to send the same traces to each.
+
+For teams building evaluation loops around LiteLLM traces, Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) cover production workflows for tracing failures, evaluating model behavior, and improving agent reliability.
 
 :::info
 We want to learn how we can make the callbacks better! Meet the LiteLLM [founders](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version) or

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -2238,8 +2238,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
     }
 '
 ```
-Expect to see your log on Langfuse
-<Image img={require('../../img/langsmith_new.png')} />
+Expect to see your logs in Arize.
 
 
 ## Langtrace


### PR DESCRIPTION
## Summary
- Clarifies how LiteLLM users should choose between Arize AX and Arize Phoenix
- Keeps the shared OpenTelemetry v2 preset reference focused on callback and endpoint differences
- Updates the Arize-specific pages with concise product context and evaluation workflow guidance

## Why
LiteLLM supports separate `arize` and `arize_phoenix` callbacks. This docs update makes the full-featured AX path clearer for managed cloud or enterprise self-hosted deployments, while keeping Phoenix positioned for open-source local and self-hosted workflows.

## Testing
- Docs-only change; not run.
