### PR TITLE
docs: document LITELLM_MCP_OAUTH_DISCOVERY_ON_STARTUP in the env var reference

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -849,6 +849,7 @@ router_settings:
 | LITELLM_MCP_CLIENT_TIMEOUT | MCP client connection timeout in seconds (stdio and HTTP/SSE transports). Default is 60
 | LITELLM_MCP_TOOL_LISTING_TIMEOUT | Timeout in seconds for listing tools from an MCP server. Default is 30
 | LITELLM_MCP_METADATA_TIMEOUT | HTTP client timeout in seconds for OAuth metadata fetching. Default is 10
+| LITELLM_MCP_OAUTH_DISCOVERY_ON_STARTUP | Set to `1`, `true`, `yes`, or `on` to fetch remote MCP OAuth metadata eagerly while servers are registered at startup, which lets an unreachable OAuth server delay proxy readiness. Default is unset: metadata is fetched in a background task that the first request needing it joins, and a failed fetch is retried after a cooldown
 | LITELLM_MCP_HEALTH_CHECK_TIMEOUT | Health check timeout in seconds for MCP servers. Default is 10
 | LITELLM_MCP_STDIO_EXTRA_COMMANDS | Comma-separated extra command basenames allowed for MCP stdio transport beyond the built-in allowlist. Example: `my-mcp-bin`. Empty by default
 | MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL | Default TTL in seconds for MCP OAuth2 token cache. Default is 3600


### PR DESCRIPTION
## TLDR

Adds `LITELLM_MCP_OAUTH_DISCOVERY_ON_STARTUP` to the environment variable reference in `docs/proxy/config_settings.md`, next to the other `LITELLM_MCP_*` timeouts

## Context

BerriAI/litellm PR #36599 made remote MCP OAuth metadata discovery non-blocking by default. Metadata is now fetched in a background task at server registration, the first request that needs it joins that task, and a failed fetch is retried after a cooldown. Operators who still want the previous eager behavior, where discovery runs during startup and an unreachable OAuth server can delay proxy readiness, opt back in by setting the variable to `1`, `true`, `yes`, or `on`. That PR noted the variable was not yet on the docs site

## Changes

One new row in the environment variables table, matching the format of its neighbors: what the variable does when set, the accepted values, and the default (unset)

## Linear ticket

Resolves LIT-5719

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1f68f2adb6798ca8eb44620229fcbd5044ee95b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->