### PR TITLE
docs(cursor): explain built-in model name collisions and the v1.97.0 model list floor

### DIFF
--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -66,6 +66,17 @@ Paste the name in Cursor and enable the toggle.
 
 ![](https://ajeuwbhvhr.cloudimg.io/https://colony-recorder.s3.amazonaws.com/files/2025-12-13/5ab35f93-d417-423f-a359-9811ce18e2c3/ascreenshot.jpeg?tl_px=352,26&br_px=1728,795&force_format=jpeg&q=100&width=1120.0&wat=1&wat_opacity=0.7&wat_gravity=northwest&wat_url=https://colony-recorder.s3.us-west-1.amazonaws.com/images/watermarks/FB923C_standard.png&wat_pad=786,277)
 
+:::warning Built-in model names
+Cursor rejects a custom model whose name matches one of its built-in models with `The model "X" is already available as "Y"`. Cursor runs this check locally, before any request reaches LiteLLM. Add a `model_list` entry with a distinct public model name for the same deployment and use that name in Cursor:
+
+```yaml
+model_list:
+  - model_name: litellm-claude-haiku-4-5
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+```
+:::
+
 :::tip Model variants
 Cursor's model picker can emit thinking and fast variants of a model name, e.g. `claude-opus-5-thinking`. LiteLLM v1.97.0+ resolves these suffixes to the underlying model automatically, so key scopes and per-model budgets apply to the resolved model and you don't need separate `model_list` entries for the variants.
 :::
@@ -121,3 +132,5 @@ LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api
 | Model not responding | Check base URL ends with `/cursor` and key has model access |
 | Auth errors | Regenerate key; ensure it starts with `sk-` |
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |
+| Cursor does not list your LiteLLM models | Upgrade to LiteLLM v1.97.0+, which serves `GET /cursor/models`. Earlier versions do not serve that route and answer 401 or 404. Verify with `curl <LITELLM_PROXY_BASE_URL>/cursor/models -H "Authorization: Bearer <LITELLM_VIRTUAL_KEY>"` |
+| `The model "X" is already available as "Y"` | Cursor blocks names that match its built-in models. Add the model under a distinct public model name (see the warning in step 3) |


### PR DESCRIPTION
## TLDR

Adds a warning and two troubleshooting rows to `docs/tutorials/cursor_integration.md`: Cursor rejects custom model names that match its built-in models, and model listing at `GET /cursor/models` needs LiteLLM v1.97.0+

## Context

A customer on LiteLLM v1.94.0 could not get Cursor to list their LiteLLM models, and adding one by hand failed with `The model "claude-haiku-4-5" is already available as "Haiku 4.5"`. The first symptom is a version floor: BerriAI/litellm commit 96916f29a6, first shipped in v1.97.0, serves the OpenAI model list at `/cursor/models` for the BYOK base URL, and earlier versions answer that request with 401 or 404. The second is a Cursor-side check that runs before any request reaches LiteLLM, and the only workaround is a distinct public model name for the same deployment. Neither was on the docs page

## Changes

A `:::warning Built-in model names` admonition in step 3 (Add Custom Model) with the exact Cursor error, a note that the check runs inside Cursor, and a `model_list` snippet showing an aliased public model name. Two new Troubleshooting rows: one for Cursor not listing models (upgrade to v1.97.0+, curl to verify) and one for the built-in name error pointing back at the warning

## Linear ticket

Resolves LIT-4515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8efe9fd179a642e7c94dd9fd525d107c495922de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->