### PR TITLE
docs(team-logging): document removing a single team callback

### DIFF
--- a/docs/proxy/team_logging.md
+++ b/docs/proxy/team_logging.md
@@ -210,25 +210,6 @@ To deregister one integration while the team's other callbacks keep running, use
 
 Every entry registered under that `callback_name` is removed, across callback types, so an integration registered for both `success` and `failure` is deregistered by one call. The response lists the callbacks that survive, and a `callback_name` the team has not registered returns `404` without changing anything
 
-```shell
-curl -X DELETE 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback/langsmith' \
-        -H 'Authorization: Bearer sk-1234'
-```
-
-Expected response
-
-```json
-{
-    "status": "success",
-    "message": "Callback langsmith removed for team dbe2f686-a686-4896-864a-4c3924458709",
-    "data": {
-        "team_id": "dbe2f686-a686-4896-864a-4c3924458709",
-        "success_callbacks": ["langfuse"],
-        "failure_callbacks": []
-    }
-}
-```
-
 ### Team Logging Endpoints
 
 - [`POST /team/{team_id}/callback` Add a success/failure callback to a team](https://litellm-api.up.railway.app/#/team%20management/add_team_callbacks_team__team_id__callback_post)

--- a/docs/proxy/team_logging.md
+++ b/docs/proxy/team_logging.md
@@ -151,7 +151,7 @@ To disable logging for a specific team, you can use the following endpoint:
 
 `POST /team/{team_id}/disable_logging`
 
-This endpoint removes all success and failure callbacks for the specified team, effectively disabling logging.
+This endpoint removes all success and failure callbacks for the specified team, effectively disabling logging. To remove a single integration and leave the team's other callbacks running, use `DELETE /team/{team_id}/callback/{callback_name}` instead, documented below
 
 #### Step 1. Disable logging for team
 
@@ -202,10 +202,39 @@ curl -X GET 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/cal
         -H 'Authorization: Bearer sk-1234'
 ```
 
+### Remove a Single Callback from a Team
+
+To deregister one integration while the team's other callbacks keep running, use:
+
+`DELETE /team/{team_id}/callback/{callback_name}`
+
+Every entry registered under that `callback_name` is removed, across callback types, so an integration registered for both `success` and `failure` is deregistered by one call. The response lists the callbacks that survive, and a `callback_name` the team has not registered returns `404` without changing anything
+
+```shell
+curl -X DELETE 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback/langsmith' \
+        -H 'Authorization: Bearer sk-1234'
+```
+
+Expected response
+
+```json
+{
+    "status": "success",
+    "message": "Callback langsmith removed for team dbe2f686-a686-4896-864a-4c3924458709",
+    "data": {
+        "team_id": "dbe2f686-a686-4896-864a-4c3924458709",
+        "success_callbacks": ["langfuse"],
+        "failure_callbacks": []
+    }
+}
+```
+
 ### Team Logging Endpoints
 
 - [`POST /team/{team_id}/callback` Add a success/failure callback to a team](https://litellm-api.up.railway.app/#/team%20management/add_team_callbacks_team__team_id__callback_post)
 - [`GET /team/{team_id}/callback` - Get the success/failure callbacks and variables for a team](https://litellm-api.up.railway.app/#/team%20management/get_team_callbacks_team__team_id__callback_get)
+- [`DELETE /team/{team_id}/callback/{callback_name}` - Remove a single callback from a team](https://litellm-api.up.railway.app/#/team%20management/delete_team_callback_team__team_id__callback__callback_name__delete)
+- [`POST /team/{team_id}/disable_logging` - Remove every callback from a team](https://litellm-api.up.railway.app/#/team%20management/disable_team_logging_team__team_id__disable_logging_post)
 
 
 


### PR DESCRIPTION
Adds `DELETE /team/{team_id}/callback/{callback_name}` to the team logging page

The page currently presents `POST /team/{team_id}/disable_logging` as the way to stop a team's logging, and that endpoint clears every callback the team has at once. A tenant sharing a team with others had no documented way to remove just its own integration, which is the gap the new route fills

Changes on `docs/proxy/team_logging.md`

- The `disable_logging` description now points at the per-callback route for the single-integration case
- New "Remove a Single Callback from a Team" section covering that every callback_type registered under the name is removed and that an unregistered name returns 404 without changing anything
- The "Team Logging Endpoints" link list gains both removal endpoints; it was missing `disable_logging` as well

Code PR: BerriAI/litellm#37331. The deep link's operationId matches the generated OpenAPI spec, and `npm run build` passes with no new warnings on this page

Refs LIT-5161