### PR TITLE
docs(rate limits): document budget reservation and batch rate limiting

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -435,35 +435,47 @@ All batch and file endpoints support model-based routing:
 
 ## How Rate Limiting for Batches API Works
 
-`POST /v1/batches` does not go through the same TPM/RPM path as `/chat/completions`. A chat request is rate limited from an estimate of the prompt it carries; a batch request carries only an `input_file_id`, so LiteLLM downloads the input JSONL before dispatching, counts the tokens in every line, and charges the whole file against the caller's TPM limit and its line count against the RPM limit in one atomic check. A batch that would push either counter past its limit is rejected with a `429` at submission, so a single large file cannot slip through a per-minute limit the way it would if the submission counted as one request.
+Batch rate limiting is enabled by default for `POST /v1/batches`. Because a batch submission references an input file instead of including prompts directly, LiteLLM evaluates the JSONL file before sending the request to the provider:
 
-This is on by default and needs no configuration. Three things about it are worth knowing before you rely on it:
+1. Counts the tokens across all JSONL records and applies the total to the caller's TPM limit.
+2. Counts the JSONL records and applies the total to the caller's RPM limit.
+3. Returns a `429` response if the batch would exceed either limit.
 
-The reservation is never reconciled. Unlike the chat path, which replaces its pre-call estimate with real usage once the response lands, the batch counters keep the count taken from the input file. Tokens estimated from the JSONL are the final charge against TPM, whatever the batch actually consumes.
+The check is atomic, so LiteLLM evaluates the full batch against the limits available at submission time.
 
-Rate limiting fails open. If the input file cannot be read or counted, the error is logged and the batch is admitted uncounted rather than rejected. A batch submitted with no `input_file_id`, or by a key with no applicable TPM/RPM limit, is likewise not counted.
+### What to expect
 
-Costs are still tracked separately, through the events described below, and land when the batch completes. Budget enforcement at submission time is read-time only; see [budget reservation](./proxy/users#budget-reservation).
+| Behavior | Operational impact |
+| --- | --- |
+| File-based accounting | TPM and RPM usage is based on the submitted JSONL file. The counters are not adjusted after the provider completes the batch. |
+| File cannot be read or counted | LiteLLM logs the error and submits the batch without charging it to TPM or RPM. Monitor these errors if your deployment requires strict rate-limit enforcement. |
+| No applicable TPM or RPM limit | LiteLLM submits the batch without counting the input file. |
+| Cost and budget tracking | LiteLLM records the final cost separately when the batch completes. Budget reservation at submission does not provide a hard spending limit for the full batch. See [Budget reservation](./proxy/users#budget-reservation). |
 
 ### Skipping the input-file pre-read
 
-Downloading and counting a large JSONL adds latency to every submission. Two `general_settings` keys opt out of it:
+Reading a large JSONL file can add latency to batch submission. If you do not need the batch to be charged against TPM or RPM at submission, configure one of these options:
 
 ```yaml
 general_settings:
-  # skip for every batch
+  # Apply to all batch submissions
   disable_batch_input_file_rate_limiting: true
 
-  # or skip only for batches routed to these providers
+  # Or apply only to batches routed to selected providers
   skip_batch_input_file_rate_limiting_for_providers:
     - hosted_vllm
 ```
 
-The provider is resolved from the routing deployment's configured credentials rather than from the caller's `custom_llm_provider`, so a caller cannot name a skip-listed provider to get out of being counted.
+The provider-specific option uses the provider configured on the selected route. It does not use a `custom_llm_provider` value supplied by the client.
 
-Neither skip is honored for a key that has a model allowlist. Those keys always have their JSONL read, because every `body.model` entry in the file has to be validated against the allowlist; the skip only avoids the counter update, not the download.
+For API keys with a model allowlist, LiteLLM must still read the file to validate each `body.model` value. In this case, the settings above skip the TPM and RPM counter update, but not the file download or model validation.
 
-There is no per-model skip and no per-request escape hatch. `skip_batch_input_file_rate_limiting_for_models` is accepted for backwards compatibility but has no effect and logs a warning, and a `skip_batch_input_file_rate_limiting` flag in request metadata is ignored. Both are refused for the same reason: the model a batch runs on is caller-influenced, since the top-level `model` and the model embedded in a `file-...` id can both name a skip-listed deployment while the JSONL routes rate-limited models.
+The following options are not supported:
+
+- `skip_batch_input_file_rate_limiting_for_models` is retained for compatibility but has no effect. LiteLLM logs a warning at startup when it is configured.
+- A `skip_batch_input_file_rate_limiting` flag in request metadata is ignored.
+
+Use the global or provider-specific settings above to manage this behavior at the server level.
 
 ## How Cost Tracking for Batches API Works
 

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -425,32 +425,56 @@ All batch and file endpoints support model-based routing:
 | `/v1/batches/{batch_id}` | GET | ✅ Auto from encoded ID |
 | `/v1/batches/{batch_id}/cancel` | POST | ✅ Auto from encoded ID |
 
-## **Supported Providers**:
-### [Azure OpenAI](./providers/azure#azure-batches-api)
-### [OpenAI](#quick-start)
-### [Vertex AI](./providers/vertex#batch-apis)
-### [Bedrock](./providers/bedrock_batches)
-### [vLLM](./providers/vllm_batches)
+## Supported providers
 
+LiteLLM supports the following provider-native batch APIs:
+
+| Provider | Documentation |
+| --- | --- |
+| Azure OpenAI | [Azure OpenAI batches](./providers/azure#azure-batches-api) |
+| OpenAI | [Quick start](#quick-start) |
+| Google Vertex AI | [Vertex AI batch APIs](./providers/vertex#batch-apis) |
+| Amazon Bedrock | [Amazon Bedrock batch inference](./providers/bedrock_batches) |
+| vLLM | [vLLM batches](./providers/vllm_batches) |
+
+Amazon Bedrock is the supported AWS integration for batch inference.
 
 ## How Rate Limiting for Batches API Works
 
-Batch rate limiting is enabled by default for `POST /v1/batches`. Because a batch submission references an input file instead of including prompts directly, LiteLLM evaluates the JSONL file before sending the request to the provider:
+Batch rate limits are enforced when the client calls `POST /v1/batches`, not when the input file is uploaded.
 
-1. Counts the tokens across all JSONL records and applies the total to the caller's TPM limit.
-2. Counts the JSONL records and applies the total to the caller's RPM limit.
-3. Returns a `429` response if the batch would exceed either limit.
+1. The client uploads the JSONL input file with `POST /v1/files`. This upload does not consume the batch TPM or RPM allowance.
+2. When the client creates the batch, LiteLLM downloads and evaluates the referenced input file.
+3. LiteLLM atomically checks the complete file against every applicable limit.
+4. If any limit would be exceeded, LiteLLM returns `429` and does not submit the batch to the provider. Otherwise, it records the usage and creates the provider batch.
 
-The check is atomic, so LiteLLM evaluates the full batch against the limits available at submission time.
+This allows LiteLLM to accept or reject the batch before the provider processes it.
 
-### What to expect
+### What LiteLLM counts
+
+| Limit | Batch charge |
+| --- | --- |
+| RPM | One request for each JSONL record. |
+| TPM | Input tokens found in each record's `body.messages`, `body.prompt`, or `body.input`. |
+| Project ITPM | The same input-token count, grouped by each record's `body.model`. |
+| Project OTPM | An output-token reservation for each record, grouped by `body.model`. LiteLLM uses `max_tokens`, `max_completion_tokens`, or `max_output_tokens` when present and accounts for `n` or `best_of`. Embedding records reserve no output tokens. If no output cap is present, LiteLLM uses the v3 limiter's built-in estimate, bounded by the smallest applicable OTPM limit. |
+
+If LiteLLM cannot tokenize an individual record, it uses a conservative estimate based on the serialized record size. A malformed JSONL line still counts as one request.
+
+:::important
+
+`LITELLM_TPM_TOKEN_RESERVATION_ENABLED` does not control batch rate limiting. That variable controls pre-request reservation for real-time requests such as chat completions. `POST /v1/batches` always uses the batch input-file limiter described here unless one of the batch-specific skip settings below is enabled.
+
+:::
+
+### Operational behavior
 
 | Behavior | Operational impact |
 | --- | --- |
-| File-based accounting | TPM and RPM usage is based on the submitted JSONL file. The counters are not adjusted after the provider completes the batch. |
-| File cannot be read or counted | LiteLLM logs the error and submits the batch without charging it to TPM or RPM. Monitor these errors if your deployment requires strict rate-limit enforcement. |
-| No applicable TPM or RPM limit | LiteLLM submits the batch without counting the input file. |
-| Cost and budget tracking | LiteLLM records the final cost separately when the batch completes. Budget reservation at submission does not provide a hard spending limit for the full batch. See [Budget reservation](./proxy/users#budget-reservation). |
+| Accounting is based on the submitted file | Batch TPM and RPM counters are not reconciled against the provider's final usage. Final cost tracking is separate. |
+| The complete file cannot be downloaded or evaluated | LiteLLM logs the error and submits the batch without charging it to TPM or RPM. Monitor these errors if your deployment requires strict rate-limit enforcement. |
+| No applicable rate limit is configured | LiteLLM submits the batch without downloading it for rate-limit accounting. |
+| The API key has a model allowlist | LiteLLM reads the file and validates every `body.model` before submission. |
 
 ### Skipping the input-file pre-read
 
@@ -479,21 +503,23 @@ Use the global or provider-specific settings above to manage this behavior at th
 
 ## How Cost Tracking for Batches API Works
 
-LiteLLM tracks batch processing costs by logging two key events:
+✨ **Enterprise:** Automated batch cost tracking requires a LiteLLM Enterprise license.
 
-| Event Type | Description | When it's Logged |
-|------------|-------------|------------------|
-| `acreate_batch` | Initial batch creation | When batch request is submitted |
-| `batch_success` | Final usage and cost | When batch processing completes |
+For managed batches, LiteLLM monitors the provider job in the background. When the job reaches a terminal state, LiteLLM:
 
-Cost calculation:
+1. Downloads the provider's output file.
+2. Reads each successful output record.
+3. Aggregates prompt, completion, and total token usage across those records.
+4. Calculates each record's cost using the deployment's configured batch pricing.
+5. Records the combined usage and cost against the user, key, team, and request tags that created the batch.
 
-- LiteLLM polls the batch status until completion
-- Upon completion, it aggregates usage and costs from all responses in the output file
-- Total `token` and `response_cost` reflect the combined metrics across all batch responses
+Failed output records are excluded from the aggregate. If the batch has no output file because every record failed, LiteLLM records zero usage and zero cost.
 
+| Event | Purpose |
+| --- | --- |
+| `acreate_batch` | Records the initial batch submission. |
+| `batch_success` | Records the aggregate usage and cost when processing completes. |
 
-
-
+Batch cost tracking does not change the TPM or RPM counters reserved at submission. Those counters remain based on the input-file calculation described above.
 
 ## [Swagger API Reference](https://litellm-api.up.railway.app/#/batch)

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -515,10 +515,7 @@ For managed batches, LiteLLM monitors the provider job in the background. When t
 
 Failed output records are excluded from the aggregate. If the batch has no output file because every record failed, LiteLLM records zero usage and zero cost.
 
-| Event | Purpose |
-| --- | --- |
-| `acreate_batch` | Records the initial batch submission. |
-| `batch_success` | Records the aggregate usage and cost when processing completes. |
+The initial submission and the completed aggregate are recorded separately. The completed aggregate is emitted through standard spend tracking as an `aretrieve_batch` record, so it is available to the Admin UI and configured logging callbacks.
 
 Batch cost tracking does not change the TPM or RPM counters reserved at submission. Those counters remain based on the input-file calculation described above.
 

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -433,6 +433,38 @@ All batch and file endpoints support model-based routing:
 ### [vLLM](./providers/vllm_batches)
 
 
+## How Rate Limiting for Batches API Works
+
+`POST /v1/batches` does not go through the same TPM/RPM path as `/chat/completions`. A chat request is rate limited from an estimate of the prompt it carries; a batch request carries only an `input_file_id`, so LiteLLM downloads the input JSONL before dispatching, counts the tokens in every line, and charges the whole file against the caller's TPM limit and its line count against the RPM limit in one atomic check. A batch that would push either counter past its limit is rejected with a `429` at submission, so a single large file cannot slip through a per-minute limit the way it would if the submission counted as one request.
+
+This is on by default and needs no configuration. Three things about it are worth knowing before you rely on it:
+
+The reservation is never reconciled. Unlike the chat path, which replaces its pre-call estimate with real usage once the response lands, the batch counters keep the count taken from the input file. Tokens estimated from the JSONL are the final charge against TPM, whatever the batch actually consumes.
+
+Rate limiting fails open. If the input file cannot be read or counted, the error is logged and the batch is admitted uncounted rather than rejected. A batch submitted with no `input_file_id`, or by a key with no applicable TPM/RPM limit, is likewise not counted.
+
+Costs are still tracked separately, through the events described below, and land when the batch completes. Budget enforcement at submission time is read-time only; see [budget reservation](./proxy/users#budget-reservation).
+
+### Skipping the input-file pre-read
+
+Downloading and counting a large JSONL adds latency to every submission. Two `general_settings` keys opt out of it:
+
+```yaml
+general_settings:
+  # skip for every batch
+  disable_batch_input_file_rate_limiting: true
+
+  # or skip only for batches routed to these providers
+  skip_batch_input_file_rate_limiting_for_providers:
+    - hosted_vllm
+```
+
+The provider is resolved from the routing deployment's configured credentials rather than from the caller's `custom_llm_provider`, so a caller cannot name a skip-listed provider to get out of being counted.
+
+Neither skip is honored for a key that has a model allowlist. Those keys always have their JSONL read, because every `body.model` entry in the file has to be validated against the allowlist; the skip only avoids the counter update, not the download.
+
+There is no per-model skip and no per-request escape hatch. `skip_batch_input_file_rate_limiting_for_models` is accepted for backwards compatibility but has no effect and logs a warning, and a `skip_batch_input_file_rate_limiting` flag in request metadata is ignored. Both are refused for the same reason: the model a batch runs on is caller-influenced, since the top-level `model` and the model embedded in a `file-...` id can both name a skip-listed deployment while the JSONL routes rate-limited models.
+
 ## How Cost Tracking for Batches API Works
 
 LiteLLM tracks batch processing costs by logging two key events:

--- a/docs/proxy/access_control.md
+++ b/docs/proxy/access_control.md
@@ -57,6 +57,19 @@ LiteLLM has two types of roles:
 | `org_admin` | Admin over a specific organization. Can create teams and users within their organization ✨ **Premium Feature** |
 | `team_admin` | Admin over a specific team. Can manage team members, update team member permissions, and create keys for their team. ✨ **Premium Feature** |
 
+## Usage dashboard visibility
+
+The Usage page shows different data depending on the selected view and the signed-in user's role:
+
+| View | What it shows |
+| --- | --- |
+| Personal usage | The signed-in user's aggregate usage. If the user belongs to multiple teams, this view does not split their personal usage by team. |
+| Team usage | The complete usage for the selected team, not only the signed-in user's contribution to that team. |
+| Organization usage | Aggregate usage for an organization, when the user's organization role permits access. |
+| Global usage | Platform-wide usage for proxy admins and proxy admin viewers. |
+
+The LiteLLM Admin UI does not host custom dashboards. For a custom view such as per-user usage within each team, query the spend data through the management API or export telemetry to an external system. See [Prometheus metrics](./prometheus.md) and [OpenTelemetry](../observability/opentelemetry_v2.md) for Grafana-compatible exports.
+
 ## What Can Each Role Do?
 
 Here's what each role can actually do. Think of it like levels of access.

--- a/docs/proxy/cli.md
+++ b/docs/proxy/cli.md
@@ -326,7 +326,8 @@ This page documents all command-line interface (CLI) arguments available for the
    - **Default:** `False`
    - **Type:** `bool` (Flag)
    - Connects to an RDS database using IAM token authentication instead of a password. This is useful for AWS RDS instances that are configured to use IAM database authentication.
-   - When enabled, LiteLLM will generate an IAM authentication token to connect to the database.
+   - When enabled, LiteLLM will generate an IAM authentication token to connect to the database, and refresh it in the background before it expires.
+   - AWS RDS and Aurora only. The token is minted through boto3, so this flag does not work against GCP Cloud SQL. To use Cloud SQL IAM database authentication, run the Cloud SQL Auth Proxy with `--auto-iam-authn` alongside the proxy and point `DATABASE_URL` at it; LiteLLM then connects as if to a local Postgres and needs neither this flag nor the variables below.
    - **Required Environment Variables:**
      - `DATABASE_HOST` - The RDS database host
      - `DATABASE_PORT` - The database port

--- a/docs/proxy/cli.md
+++ b/docs/proxy/cli.md
@@ -325,9 +325,9 @@ This page documents all command-line interface (CLI) arguments available for the
 ### --iam_token_db_auth
    - **Default:** `False`
    - **Type:** `bool` (Flag)
-   - Connects to an RDS database using IAM token authentication instead of a password. This is useful for AWS RDS instances that are configured to use IAM database authentication.
-   - When enabled, LiteLLM will generate an IAM authentication token to connect to the database, and refresh it in the background before it expires.
-   - AWS RDS and Aurora only. The token is minted through boto3, so this flag does not work against GCP Cloud SQL. To use Cloud SQL IAM database authentication, run the Cloud SQL Auth Proxy with `--auto-iam-authn` alongside the proxy and point `DATABASE_URL` at it; LiteLLM then connects as if to a local Postgres and needs neither this flag nor the variables below.
+   - Authenticates to PostgreSQL on Amazon RDS or Amazon Aurora with a short-lived IAM token instead of a stored password.
+   - LiteLLM generates the token with boto3 and refreshes it before it expires.
+   - This option supports AWS only. For Google Cloud SQL, run the Cloud SQL Auth Proxy with `--auto-iam-authn`, then configure `DATABASE_URL` to use the local proxy connection. Do not enable this flag for Cloud SQL.
    - **Required Environment Variables:**
      - `DATABASE_HOST` - The RDS database host
      - `DATABASE_PORT` - The database port

--- a/docs/proxy/cli.md
+++ b/docs/proxy/cli.md
@@ -348,6 +348,19 @@ This page documents all command-line interface (CLI) arguments available for the
      litellm
      ```
 
+#### Amazon ECS setup
+
+For LiteLLM running on Amazon ECS:
+
+1. Enable IAM database authentication on the Amazon RDS or Aurora PostgreSQL instance.
+2. Configure the PostgreSQL user for IAM authentication.
+3. Grant the ECS task role permission to connect to the database as that user.
+4. Set `IAM_TOKEN_DB_AUTH=True` and the required `DATABASE_*` variables in the ECS task definition.
+
+LiteLLM uses the task role's AWS credentials to generate and refresh the database token. A static database password is not required.
+
+These settings are read from the task environment when LiteLLM starts. To change the flag or connection parameters, deploy a new task definition or restart the proxy tasks. Token refreshes do not require a restart.
+
 ### --use_prisma_db_push
    - **Default:** `False`
    - **Type:** `bool` (Flag)

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -131,7 +131,7 @@ general_settings:
   reject_clientside_metadata_tags: boolean  # if true, rejects requests with client-side 'metadata.tags' to prevent users from influencing budgets
   disable_batch_input_file_rate_limiting: boolean  # if true, skip pre-reading batch input files for rate-limit/model checks
   skip_batch_input_file_rate_limiting_for_providers: ["hosted_vllm"]  # provider allowlist for skipping batch input-file pre-read
-  skip_batch_input_file_rate_limiting_for_models: ["my-batch-model-prefix"]  # model/prefix allowlist for skipping batch input-file pre-read
+  disable_budget_reservation: boolean  # if true, turn off the optimistic per-request budget reservation (weakens hard budget enforcement)
   allowed_routes: ["route1", "route2"]  # list of allowed proxy API routes - a user can access. (currently JWT-Auth only)
   key_management_system: google_kms  # either google_kms or azure_kms
   master_key: string
@@ -263,9 +263,10 @@ router_settings:
 | enable_jwt_auth | boolean | allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims. [Doc on JWT Tokens](token_auth) |
 | enforce_user_param | boolean | If true, requires all OpenAI endpoint requests to have a 'user' param. [Doc on call hooks](call_hooks)|
 | reject_clientside_metadata_tags | boolean | If true, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata. |
-| disable_batch_input_file_rate_limiting | boolean | If true, skips pre-reading batch input files during `POST /batches` pre-checks. |
-| skip_batch_input_file_rate_limiting_for_providers | array of strings | Skip batch input-file pre-read for specific providers (for example `["hosted_vllm"]`). |
-| skip_batch_input_file_rate_limiting_for_models | array of strings | Skip batch input-file pre-read for specific model names or prefixes. |
+| disable_batch_input_file_rate_limiting | boolean | If true, skips pre-reading batch input files during `POST /batches` pre-checks, so a batch is admitted without its tokens or its request count being charged against TPM/RPM. The skip is ignored for keys that have a model allowlist, because the JSONL must still be read to validate every `body.model` entry against that allowlist. See [batch rate limiting](../batches#how-rate-limiting-for-batches-api-works). |
+| skip_batch_input_file_rate_limiting_for_providers | array of strings | Skip the batch input-file pre-read only for batches routed to these providers (for example `["hosted_vllm"]`). The provider is resolved from the routing deployment's configured credentials, not from the caller's `custom_llm_provider`, so it cannot be spoofed. As with `disable_batch_input_file_rate_limiting`, the skip is ignored for keys that have a model allowlist. |
+| skip_batch_input_file_rate_limiting_for_models | array of strings | Accepted but has no effect, and the proxy logs a warning once at startup when it is set. A per-model skip is deliberately unsupported because the model a batch runs on is caller-influenced: both the top-level `model` and the model embedded in a `file-...` id can name a skip-listed deployment while the JSONL routes rate-limited models. Use `skip_batch_input_file_rate_limiting_for_providers` or `disable_batch_input_file_rate_limiting` instead. |
+| disable_budget_reservation | boolean | Default `false`. When `true`, turns off the optimistic per-request budget reservation, so budgets are enforced only from spend already recorded at read time. This weakens hard budget enforcement: a burst of concurrent requests on one key can each pass the spend check before any of them is charged, letting a configured budget be exceeded. An already-exhausted budget is still rejected. A warning is logged on every request while this is on. See [budget reservation](./users#budget-reservation). |
 | allowed_routes | array of strings | List of allowed proxy API routes a user can access [Doc on controlling allowed routes](enterprise#control-available-public-private-routes)|
 | key_management_system | string | Specifies the key management system. [Doc Secret Managers](../secret) |
 | master_key | string | The master key for the proxy [Set up Virtual Keys](virtual_keys) |
@@ -1044,7 +1045,7 @@ router_settings:
 | HUGGINGFACE_API_BASE | Base URL for Hugging Face API
 | HUGGINGFACE_API_KEY | API key for Hugging Face API
 | HUMANLOOP_PROMPT_CACHE_TTL_SECONDS | Time-to-live in seconds for cached prompts in Humanloop. Default is 60
-| IAM_TOKEN_DB_AUTH | IAM token for database authentication
+| IAM_TOKEN_DB_AUTH | When `True`, authenticate to Postgres with a short-lived **AWS RDS** IAM token minted through boto3 instead of a password, refreshed automatically before it expires. AWS RDS and Aurora only; GCP Cloud SQL IAM auth is not supported, run the Cloud SQL Auth Proxy with `--auto-iam-authn` and point `DATABASE_URL` at it instead. Requires `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER` and `DATABASE_NAME`
 | IBM_GUARDRAILS_API_BASE | Base URL for IBM Guardrails API
 | IBM_GUARDRAILS_AUTH_TOKEN | Authorization bearer token for IBM Guardrails API
 | INITIAL_RETRY_DELAY | Initial delay in seconds for retrying requests. Default is 0.5
@@ -1172,7 +1173,7 @@ router_settings:
 | LITELLM_SSL_CIPHERS | SSL/TLS cipher configuration for faster handshakes. Controls cipher suite preferences for OpenSSL connections.
 | LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE | AWS KMS encrypted license for LiteLLM
 | LITELLM_TOKEN | Access token for LiteLLM integration
-| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | When false, the v3 rate limiter skips the upfront TPM token reservation and enforces TPM post-call from actual usage. Default is true
+| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | When false, the v3 rate limiter skips the upfront TPM token reservation and enforces TPM post-call from actual usage (pre-v1.82 behavior). This sheds a Redis round-trip per request at the cost of letting concurrent requests all pass the TPM check before any of their usage lands. Default is true. Does not apply to `POST /batches`, which uses its own limiter. See [estimated output tokens](./users#estimated-output-tokens-requests-without-max_tokens)
 | LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES | When set to "true", routes OpenAI /v1/messages requests through chat/completions instead of the Responses API for Anthropic models. Can also be set via `litellm_settings.use_chat_completions_url_for_anthropic_messages`
 | LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES | When set to "true", routes all OpenAI /chat/completions requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via `litellm_settings.route_all_chat_openai_to_responses`
 | LITELLM_GEMINI_LIVE_DEFER_SETUP | When set to "true", defers Gemini/Vertex Live setup until the client sends `session.update` (required for runtime tool injection). Default is "false" for backwards compatibility, which auto-sends setup on connect. Can also be set via `litellm.gemini_live_defer_setup`

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -129,9 +129,9 @@ general_settings:
   enable_jwt_auth: boolean  # allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims
   enforce_user_param: boolean  # requires all openai endpoint requests to have a 'user' param
   reject_clientside_metadata_tags: boolean  # if true, rejects requests with client-side 'metadata.tags' to prevent users from influencing budgets
-  disable_batch_input_file_rate_limiting: boolean  # if true, skip pre-reading batch input files for rate-limit/model checks
-  skip_batch_input_file_rate_limiting_for_providers: ["hosted_vllm"]  # provider allowlist for skipping batch input-file pre-read
-  disable_budget_reservation: boolean  # if true, turn off the optimistic per-request budget reservation (weakens hard budget enforcement)
+  disable_batch_input_file_rate_limiting: boolean  # skip TPM/RPM accounting for batch input files
+  skip_batch_input_file_rate_limiting_for_providers: ["hosted_vllm"]  # apply the batch accounting skip only to these providers
+  disable_budget_reservation: boolean  # disable pre-request budget reservation; may allow overspend under concurrency
   allowed_routes: ["route1", "route2"]  # list of allowed proxy API routes - a user can access. (currently JWT-Auth only)
   key_management_system: google_kms  # either google_kms or azure_kms
   master_key: string
@@ -263,10 +263,10 @@ router_settings:
 | enable_jwt_auth | boolean | allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims. [Doc on JWT Tokens](token_auth) |
 | enforce_user_param | boolean | If true, requires all OpenAI endpoint requests to have a 'user' param. [Doc on call hooks](call_hooks)|
 | reject_clientside_metadata_tags | boolean | If true, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata. |
-| disable_batch_input_file_rate_limiting | boolean | If true, skips pre-reading batch input files during `POST /batches` pre-checks, so a batch is admitted without its tokens or its request count being charged against TPM/RPM. The skip is ignored for keys that have a model allowlist, because the JSONL must still be read to validate every `body.model` entry against that allowlist. See [batch rate limiting](../batches#how-rate-limiting-for-batches-api-works). |
-| skip_batch_input_file_rate_limiting_for_providers | array of strings | Skip the batch input-file pre-read only for batches routed to these providers (for example `["hosted_vllm"]`). The provider is resolved from the routing deployment's configured credentials, not from the caller's `custom_llm_provider`, so it cannot be spoofed. As with `disable_batch_input_file_rate_limiting`, the skip is ignored for keys that have a model allowlist. |
-| skip_batch_input_file_rate_limiting_for_models | array of strings | Accepted but has no effect, and the proxy logs a warning once at startup when it is set. A per-model skip is deliberately unsupported because the model a batch runs on is caller-influenced: both the top-level `model` and the model embedded in a `file-...` id can name a skip-listed deployment while the JSONL routes rate-limited models. Use `skip_batch_input_file_rate_limiting_for_providers` or `disable_batch_input_file_rate_limiting` instead. |
-| disable_budget_reservation | boolean | Default `false`. When `true`, turns off the optimistic per-request budget reservation, so budgets are enforced only from spend already recorded at read time. This weakens hard budget enforcement: a burst of concurrent requests on one key can each pass the spend check before any of them is charged, letting a configured budget be exceeded. An already-exhausted budget is still rejected. A warning is logged on every request while this is on. See [budget reservation](./users#budget-reservation). |
+| disable_batch_input_file_rate_limiting | boolean | Default `false`. Set to `true` to skip TPM and RPM accounting for batch input files at submission. Files are still read when an API key has a model allowlist. See [Batch rate limiting](../batches#how-rate-limiting-for-batches-api-works). |
+| skip_batch_input_file_rate_limiting_for_providers | array of strings | Skips batch input-file TPM and RPM accounting for the listed providers, for example `["hosted_vllm"]`. LiteLLM determines the provider from the selected route. Files are still read when an API key has a model allowlist. |
+| skip_batch_input_file_rate_limiting_for_models | array of strings | Deprecated. This setting has no effect and produces a startup warning. Use `skip_batch_input_file_rate_limiting_for_providers` or `disable_batch_input_file_rate_limiting` instead. |
+| disable_budget_reservation | boolean | Default `false`. Set to `true` to disable pre-request cost reservation. This can allow concurrent requests to exceed a configured budget; requests are still rejected when the budget is already exhausted. LiteLLM logs a warning while this option is enabled. See [Budget reservation](./users#budget-reservation). |
 | allowed_routes | array of strings | List of allowed proxy API routes a user can access [Doc on controlling allowed routes](enterprise#control-available-public-private-routes)|
 | key_management_system | string | Specifies the key management system. [Doc Secret Managers](../secret) |
 | master_key | string | The master key for the proxy [Set up Virtual Keys](virtual_keys) |
@@ -1045,7 +1045,7 @@ router_settings:
 | HUGGINGFACE_API_BASE | Base URL for Hugging Face API
 | HUGGINGFACE_API_KEY | API key for Hugging Face API
 | HUMANLOOP_PROMPT_CACHE_TTL_SECONDS | Time-to-live in seconds for cached prompts in Humanloop. Default is 60
-| IAM_TOKEN_DB_AUTH | When `True`, authenticate to Postgres with a short-lived **AWS RDS** IAM token minted through boto3 instead of a password, refreshed automatically before it expires. AWS RDS and Aurora only; GCP Cloud SQL IAM auth is not supported, run the Cloud SQL Auth Proxy with `--auto-iam-authn` and point `DATABASE_URL` at it instead. Requires `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER` and `DATABASE_NAME`
+| IAM_TOKEN_DB_AUTH | Set to `True` to authenticate PostgreSQL on Amazon RDS or Amazon Aurora with a short-lived IAM token. LiteLLM generates and refreshes the token with boto3. This option does not support Google Cloud SQL; use the Cloud SQL Auth Proxy with `--auto-iam-authn` instead. Requires `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, and `DATABASE_NAME`. |
 | IBM_GUARDRAILS_API_BASE | Base URL for IBM Guardrails API
 | IBM_GUARDRAILS_AUTH_TOKEN | Authorization bearer token for IBM Guardrails API
 | INITIAL_RETRY_DELAY | Initial delay in seconds for retrying requests. Default is 0.5
@@ -1173,7 +1173,7 @@ router_settings:
 | LITELLM_SSL_CIPHERS | SSL/TLS cipher configuration for faster handshakes. Controls cipher suite preferences for OpenSSL connections.
 | LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE | AWS KMS encrypted license for LiteLLM
 | LITELLM_TOKEN | Access token for LiteLLM integration
-| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | When false, the v3 rate limiter skips the upfront TPM token reservation and enforces TPM post-call from actual usage (pre-v1.82 behavior). This sheds a Redis round-trip per request at the cost of letting concurrent requests all pass the TPM check before any of their usage lands. Default is true. Does not apply to `POST /batches`, which uses its own limiter. See [estimated output tokens](./users#estimated-output-tokens-requests-without-max_tokens)
+| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | Default `true`. Set to `false` to disable pre-request TPM reservation in the v3 rate limiter and apply actual usage after each request completes. This removes one Redis operation per request, but concurrent requests may temporarily exceed the TPM limit. This setting does not apply to `POST /batches`. See [Estimated output tokens](./users#estimated-output-tokens-requests-without-max_tokens). |
 | LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES | When set to "true", routes OpenAI /v1/messages requests through chat/completions instead of the Responses API for Anthropic models. Can also be set via `litellm_settings.use_chat_completions_url_for_anthropic_messages`
 | LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES | When set to "true", routes all OpenAI /chat/completions requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via `litellm_settings.route_all_chat_openai_to_responses`
 | LITELLM_GEMINI_LIVE_DEFER_SETUP | When set to "true", defers Gemini/Vertex Live setup until the client sends `session.update` (required for runtime tool injection). Default is "false" for backwards compatibility, which auto-sends setup on connect. Can also be set via `litellm.gemini_live_defer_setup`

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1045,7 +1045,7 @@ router_settings:
 | HUGGINGFACE_API_BASE | Base URL for Hugging Face API
 | HUGGINGFACE_API_KEY | API key for Hugging Face API
 | HUMANLOOP_PROMPT_CACHE_TTL_SECONDS | Time-to-live in seconds for cached prompts in Humanloop. Default is 60
-| IAM_TOKEN_DB_AUTH | Set to `True` to authenticate PostgreSQL on Amazon RDS or Amazon Aurora with a short-lived IAM token. LiteLLM generates and refreshes the token with boto3. This option does not support Google Cloud SQL; use the Cloud SQL Auth Proxy with `--auto-iam-authn` instead. Requires `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, and `DATABASE_NAME`. |
+| IAM_TOKEN_DB_AUTH | Set to `True` to authenticate PostgreSQL on Amazon RDS or Amazon Aurora with a short-lived IAM token. LiteLLM generates and refreshes the token with boto3. This option does not support Google Cloud SQL; use the Cloud SQL Auth Proxy with `--auto-iam-authn` instead. Requires `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, and `DATABASE_NAME`. For ECS task-role setup and restart behavior, see [`--iam_token_db_auth`](./cli#--iam_token_db_auth). |
 | IBM_GUARDRAILS_API_BASE | Base URL for IBM Guardrails API
 | IBM_GUARDRAILS_AUTH_TOKEN | Authorization bearer token for IBM Guardrails API
 | INITIAL_RETRY_DELAY | Initial delay in seconds for retrying requests. Default is 0.5
@@ -1173,7 +1173,7 @@ router_settings:
 | LITELLM_SSL_CIPHERS | SSL/TLS cipher configuration for faster handshakes. Controls cipher suite preferences for OpenSSL connections.
 | LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE | AWS KMS encrypted license for LiteLLM
 | LITELLM_TOKEN | Access token for LiteLLM integration
-| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | Default `true`. Set to `false` to disable pre-request TPM reservation in the v3 rate limiter and apply actual usage after each request completes. This removes one Redis operation per request, but concurrent requests may temporarily exceed the TPM limit. This setting does not apply to `POST /batches`. See [Estimated output tokens](./users#estimated-output-tokens-requests-without-max_tokens). |
+| LITELLM_TPM_TOKEN_RESERVATION_ENABLED | Default `true`. Set to `false` to disable pre-request TPM reservation in the v3 rate limiter and apply actual usage after each real-time request completes. This removes one Redis operation per request, but concurrent requests may temporarily exceed the TPM limit. This setting does not apply to `POST /v1/batches`, which uses a [separate input-file limiter](../batches#how-rate-limiting-for-batches-api-works). See [Estimated output tokens](./users#estimated-output-tokens-requests-without-max_tokens). |
 | LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES | When set to "true", routes OpenAI /v1/messages requests through chat/completions instead of the Responses API for Anthropic models. Can also be set via `litellm_settings.use_chat_completions_url_for_anthropic_messages`
 | LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES | When set to "true", routes all OpenAI /chat/completions requests through the Responses API bridge. Recommended for OpenAI models. Can also be set via `litellm_settings.route_all_chat_openai_to_responses`
 | LITELLM_GEMINI_LIVE_DEFER_SETUP | When set to "true", defers Gemini/Vertex Live setup until the client sends `session.update` (required for runtime tool injection). Default is "false" for backwards compatibility, which auto-sends setup on connect. Can also be set via `litellm.gemini_live_defer_setup`

--- a/docs/proxy/managed_batches.md
+++ b/docs/proxy/managed_batches.md
@@ -58,15 +58,13 @@ general_settings:
   skip_batch_input_file_rate_limiting_for_providers:
     - hosted_vllm
 
-  # Optional: skip only for selected model names / prefixes
-  # skip_batch_input_file_rate_limiting_for_models:
-  #   - my-vllm-batch-model
-
 litellm_settings:
   # Optional: require target_model_names on POST /v1/files (blocks classic file uploads)
   # require_managed_files: true
 
 ```
+
+LiteLLM reads the batch input file before dispatching and charges its tokens and line count against the caller's TPM/RPM limits. The two `skip_` settings above opt out of that pre-read; see [how rate limiting for the batches API works](../batches#how-rate-limiting-for-batches-api-works) for what the skips do and do not cover.
 
 ### 2. Create Virtual Key
 
@@ -146,17 +144,6 @@ batch_response = client.batches.retrieve(
     batch_id
 )
 status = batch_response.status
-```
-
-You can also skip input-file pre-read per request:
-
-```python showLineNumbers title="create_batch.py"
-batch = client.batches.create(
-    input_file_id=batch_input_file.id,
-    endpoint="/v1/chat/completions",
-    completion_window="24h",
-    metadata={"skip_batch_input_file_rate_limiting": True},
-)
 ```
 
 ### 4. Retrieve Batch Content 

--- a/docs/proxy/managed_batches.md
+++ b/docs/proxy/managed_batches.md
@@ -51,10 +51,10 @@ model_list:
       mode: batch # 👈 SPECIFY MODE AS BATCH, to tell user this is a batch model
 
 general_settings:
-  # Optional: disable batch input-file pre-read globally
+  # Optional: do not charge batch input files against TPM/RPM
   # disable_batch_input_file_rate_limiting: true
 
-  # Optional: skip only for selected providers (example: custom vLLM)
+  # Optional: apply this behavior only to selected providers
   skip_batch_input_file_rate_limiting_for_providers:
     - hosted_vllm
 
@@ -64,7 +64,7 @@ litellm_settings:
 
 ```
 
-LiteLLM reads the batch input file before dispatching and charges its tokens and line count against the caller's TPM/RPM limits. The two `skip_` settings above opt out of that pre-read; see [how rate limiting for the batches API works](../batches#how-rate-limiting-for-batches-api-works) for what the skips do and do not cover.
+By default, LiteLLM reads each batch input file before submission and charges its tokens and record count against the caller's TPM and RPM limits. This can add latency for large files. Use the settings above only when batch submissions do not need to be included in TPM or RPM accounting. For details and limitations, see [How rate limiting works for the Batches API](../batches#how-rate-limiting-for-batches-api-works).
 
 ### 2. Create Virtual Key
 

--- a/docs/proxy/model_management.md
+++ b/docs/proxy/model_management.md
@@ -44,6 +44,19 @@ Database storage does not replace your `config.yaml`. Any models defined there k
 
 Settings behave differently from models here. Anything the UI writes into `general_settings`, `router_settings`, `litellm_settings`, or `environment_variables` is stored in `LiteLLM_Config` and overlaid on top of your `config.yaml` at startup, so the database value wins and editing the same key in the YAML then restarting will not take effect. See [config.yaml vs database settings](./configs.md#configyaml-vs-database-settings).
 
+### Choose one source of truth for models
+
+For production deployments, use one primary source of truth for model definitions:
+
+| Approach | Storage | Restart required for model changes? | Best for |
+| --- | --- | --- | --- |
+| `config.yaml` | Configuration file | Yes. Reload or restart the proxy tasks after changing the file. | GitOps workflows where every model change is deployed with the application. |
+| Admin UI, management API, or Terraform | LiteLLM database | No. Changes apply to new requests after the write succeeds. | Day-2 operations, frequent model changes, and centralized automation. |
+
+LiteLLM can load file-based and database-backed models at the same time, but using both as model-management systems creates two sources of truth. A model loaded from `config.yaml` remains owned by that file and cannot be edited or deleted through the UI. Keep model definitions in one system, and continue using `config.yaml` or environment variables for infrastructure settings that are not exposed through the management API.
+
+The [LiteLLM Terraform provider](https://github.com/BerriAI/terraform-provider-litellm) calls the same management API used by the Admin UI. It persists resources in the LiteLLM database, so you do not need to build a separate REST client or restart the proxy for model changes.
+
 ## Automation (API)
 
 The same operations are available over HTTP, which is what you want for CI/CD or scripting bulk changes. These endpoints require `store_model_in_db` to be enabled; with it off, `POST /model/new` fails because there is nowhere to persist the model.

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -732,6 +732,28 @@ model_list:
 ```
 
 **Note:** The cost fields must be explicitly set to `0`. If they are unset (`null`/missing), the model is not treated as free and budget checks still apply.
+
+## Budget reservation
+
+Budgets are checked against spend that has already been recorded. On its own that check is racy: a burst of concurrent requests on one key can all read the same under-budget spend figure and all be admitted, and the budget is only found to be blown once their costs land. To close that window LiteLLM reserves an estimated maximum cost against the spend counter before dispatching the request, then reconciles the reservation down to the real cost once the response is priced. A request that would push the counter past the budget is rejected up front rather than after the fact.
+
+This is on by default and there is nothing to enable. The reservation is estimated from the request body, using the requested `max_tokens` / `max_completion_tokens` where present and the model's limits where not, priced with the model's cost entry. When the model has no token pricing (image and audio routes, for example) no reservation is taken and enforcement falls back to read time.
+
+Turn it off only to work around leaked reservations showing up as phantom `BudgetExceededError` responses:
+
+```yaml
+general_settings:
+  disable_budget_reservation: true
+```
+
+With it off, budgets are enforced from recorded spend alone, so a configured budget can be exceeded under concurrency. An already-exhausted budget is still rejected, and the proxy logs a warning on every request as a reminder that hard enforcement is relaxed. Pair the default (reservation on) with [`fail_closed_budget_enforcement`](#hard-budget-enforcement-fail-closed) when a budget has to hold even while Redis is degraded.
+
+:::info
+
+Budget reservation does not meaningfully bound batch jobs. A `POST /batches` body carries an `input_file_id` rather than the prompts themselves, so there is nothing in it to price, and the reservation falls back to the model's context window regardless of how many rows the JSONL holds. The submission response costs nothing, so the reservation is released immediately and the real cost is recorded later when the batch completes. Batches are still rate limited from the input file; see [how batch rate limiting works](../batches#how-rate-limiting-for-batches-api-works).
+
+:::
+
 ## Hard budget enforcement (fail closed)
 
 Budget checks read current spend from a cross-pod counter in Redis, which keeps enforcement fast and consistent across workers and replicas. The counter is the source of truth on the hot path, and the database is reconciled in the background. If Redis restarts and reloads an older snapshot, the counter can come back lower than the spend already recorded in the database; on the hot path that stale value is trusted, which can let a key keep spending past its `max_budget` until the counter is corrected.

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -735,24 +735,41 @@ model_list:
 
 ## Budget reservation
 
-Budgets are checked against spend that has already been recorded. On its own that check is racy: a burst of concurrent requests on one key can all read the same under-budget spend figure and all be admitted, and the budget is only found to be blown once their costs land. To close that window LiteLLM reserves an estimated maximum cost against the spend counter before dispatching the request, then reconciles the reservation down to the real cost once the response is priced. A request that would push the counter past the budget is rejected up front rather than after the fact.
+Budget reservation is enabled by default. It helps enforce budgets during concurrent traffic by accounting for a request before the provider processes it.
 
-This is on by default and there is nothing to enable. The reservation is estimated from the request body, using the requested `max_tokens` / `max_completion_tokens` where present and the model's limits where not, priced with the model's cost entry. When the model has no token pricing (image and audio routes, for example) no reservation is taken and enforcement falls back to read time.
+### How it works
 
-Turn it off only to work around leaked reservations showing up as phantom `BudgetExceededError` responses:
+1. LiteLLM estimates the request's maximum cost from the request body and the model's pricing.
+2. It temporarily reserves that amount against the applicable budget.
+3. If the reservation would exceed the budget, LiteLLM rejects the request before sending it to the provider.
+4. After the response is priced, LiteLLM replaces the reservation with the actual cost.
+
+When `max_tokens` or `max_completion_tokens` is present, LiteLLM uses that value in the estimate. Otherwise, it uses the model's configured limits. For routes without token pricing, such as some image and audio routes, LiteLLM cannot reserve a cost and instead enforces the budget using recorded spend.
+
+### Disable budget reservation
+
+Disable reservation only as a temporary mitigation if unreconciled reservations cause unexpected `BudgetExceededError` responses after the affected requests have completed:
 
 ```yaml
 general_settings:
   disable_budget_reservation: true
 ```
 
-With it off, budgets are enforced from recorded spend alone, so a configured budget can be exceeded under concurrency. An already-exhausted budget is still rejected, and the proxy logs a warning on every request as a reminder that hard enforcement is relaxed. Pair the default (reservation on) with [`fail_closed_budget_enforcement`](#hard-budget-enforcement-fail-closed) when a budget has to hold even while Redis is degraded.
+:::warning
 
-:::info
-
-Budget reservation does not meaningfully bound batch jobs. A `POST /batches` body carries an `input_file_id` rather than the prompts themselves, so there is nothing in it to price, and the reservation falls back to the model's context window regardless of how many rows the JSONL holds. The submission response costs nothing, so the reservation is released immediately and the real cost is recorded later when the batch completes. Batches are still rate limited from the input file; see [how batch rate limiting works](../batches#how-rate-limiting-for-batches-api-works).
+Disabling reservation can allow concurrent requests to exceed a configured budget because each request is evaluated only against spend already recorded.
 
 :::
+
+Requests are still rejected when the budget is already exhausted. LiteLLM also logs a warning for each request while reservation is disabled.
+
+If a budget must remain a hard ceiling when Redis is unavailable or contains stale data, keep reservation enabled and also configure [`fail_closed_budget_enforcement`](#hard-budget-enforcement-fail-closed).
+
+### Batch requests
+
+Budget reservation cannot estimate the full cost of a batch job. A `POST /batches` request contains an `input_file_id` rather than the prompts in the file, so LiteLLM cannot price the complete workload at submission. The submission reservation is released after the submission response, and LiteLLM records the final cost when the batch completes.
+
+Use [batch rate limiting](../batches#how-rate-limiting-for-batches-api-works) to control batch throughput, and monitor completed batch costs for budget reporting.
 
 ## Hard budget enforcement (fail closed)
 


### PR DESCRIPTION
Someone asked how to enable TPM and budget reservation and where the docs are, and the honest answer was that most of it isn't written down. Auditing that area turned up two settings documented as working that the proxy deliberately ignores, so this fixes those as well as filling the gaps

## Budget reservation was undocumented

Budget reservation has shipped on by default since v1.84.0. It reserves an estimated max cost against the spend counter before dispatch and reconciles it to the real cost afterwards, which is what stops a burst of concurrent requests on one key from all passing the same under-budget spend check. None of that appears in the docs, and `disable_budget_reservation` (added in v1.88.2) has no entry anywhere except that release note, so an operator hitting phantom `BudgetExceededError` responses has no documented way out

Adds a "Budget reservation" section to `docs/proxy/users.md` next to the existing fail-closed section, and the `general_settings` row plus config example entry

## Two documented batch bypasses don't work

`skip_batch_input_file_rate_limiting_for_models` is documented in three places as a model allowlist for skipping the batch input-file pre-read. `_PROXY_BatchRateLimiter._warn_if_unsupported_model_skip_configured` ignores it and logs a warning, on purpose: the model a batch runs on is caller-influenced, so both the top-level `model` and the model embedded in a `file-...` id can name a skip-listed deployment while the JSONL routes rate-limited models

`docs/proxy/managed_batches.md` also showed `metadata={"skip_batch_input_file_rate_limiting": True}` as a per-request skip. That flag is read from `litellm_metadata`, not `metadata`, and is ignored either way; there's a test asserting it stays ignored, since honoring it would let any caller opt out of its own rate limits

Both are the kind of thing an operator sets, sees no error, and assumes took effect. The per-model row is kept but rewritten to say it has no effect, since people already have it in their configs. The per-request snippet is removed

## Batch rate limiting had no conceptual doc

`POST /v1/batches` doesn't use the normal TPM path at all. The pre-call hook hands it to a separate limiter that downloads the input JSONL, counts every line, and charges the whole file against TPM and the line count against RPM in one atomic check. Nothing described this, so the reasonable assumption is that a batch counts as one request

Adds "How Rate Limiting for Batches API Works" to `docs/batches.md`, covering the counting model, the skip settings and what they do not cover (keys with a model allowlist always get the JSONL read, because every `body.model` still has to be validated), and two behaviors worth knowing: the counters are never reconciled against what the batch actually consumed, and a file that can't be read or counted is admitted uncounted rather than rejected

The new `users.md` section also notes that budget reservation doesn't meaningfully bound a batch. A `POST /batches` body carries an `input_file_id` and no prompts, so there's nothing to price and the estimate falls back to the model's context window no matter how large the file is

## IAM DB auth is AWS only

`IAM_TOKEN_DB_AUTH` was described as "IAM token for database authentication", which reads as cloud-agnostic. The token is minted through boto3's `generate_db_auth_token`, so it's RDS and Aurora only. `docs/proxy/cli.md` and the env var table now say so and point Cloud SQL users at the Cloud SQL Auth Proxy with `--auto-iam-authn` instead

## Verification

`npm run build` with `node_modules/.cache` cleared. New anchors resolve (`/docs/batches#how-rate-limiting-for-batches-api-works` and `/docs/proxy/users#budget-reservation` both appear as real ids in the built HTML and both inbound links render), and the broken-link list is unchanged from `main`
