### PR TITLE
docs(deploy): point the monolithic image guidance at ghcr.io/berriai/litellm

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -44,7 +44,7 @@ STORE_MODEL_IN_DB="True"      # manage models from the Admin UI instead of confi
 
 `LITELLM_SALT_KEY` cannot be rotated after you add models: it encrypts the provider credentials stored in your database, and changing it makes them unreadable. Generate a strong random value and store both keys in your cloud's secret manager.
 
-Official images are published to `ghcr.io/berriai` and mirrored at `docker.litellm.ai/berriai`. Use `ghcr.io/berriai/litellm-database` for monolithic deployments with Postgres (it bundles the Prisma toolchain), and pin a version tag rather than `latest` or a moving tag, so rollbacks are deterministic. All images are signed; see the [Docker Image Security Guide](./docker_image_security.md) for verification and the non-root variant.
+Official images are published to `ghcr.io/berriai` and mirrored at `docker.litellm.ai/berriai`. Use `ghcr.io/berriai/litellm` for monolithic deployments, including those with Postgres, since it bundles the Prisma toolchain, and pin a version tag rather than `latest` or a moving tag, so rollbacks are deterministic. All images are signed; see the [Docker Image Security Guide](./docker_image_security.md) for verification and the non-root variant.
 
 ## Provision the data stores
 
@@ -109,7 +109,7 @@ Then pick a deployment mode:
 replicaCount: 3
 
 image:
-  repository: ghcr.io/berriai/litellm-database
+  repository: ghcr.io/berriai/litellm
   tag: "v1.90.2"          # pin your version
 
 masterkeySecretName: litellm-masterkey
@@ -322,7 +322,7 @@ spec:
 
 </details>
 
-To connect the database, switch the image to `docker.litellm.ai/berriai/litellm-database` and add `DATABASE_URL` and `LITELLM_MASTER_KEY` to the Secret; nothing else in the manifest changes.
+To connect the database, add `DATABASE_URL` and `LITELLM_MASTER_KEY` to the Secret; nothing else in the manifest changes, because the image already carries the Prisma toolchain.
 
 ## Deploy with Terraform (AWS and GCP)
 


### PR DESCRIPTION
Companion to BerriAI/litellm#37491, which changes the `litellm-helm` chart default from `ghcr.io/berriai/litellm-database` to `ghcr.io/berriai/litellm`. Merge this after that one

Without this, the monolithic `values.yaml` sample on this page pins `image.repository` back to the legacy repository, so a reader following the docs would override the chart's new default for no reason

The two images have converged. `Dockerfile` and `docker/Dockerfile.database` in the code repo differ only in comment text and one builder-stage `apk` package, and reading both published manifests off GHCR at `v1.97.0` shows identical entrypoint, working dir and prisma configuration, 21 layers each, with the first 11 layer digests byte-identical. Running the migration the chart's Job runs, `python litellm/proxy/prisma_migration.py` in `/app`, from each image against its own empty Postgres produced the same 65-table schema, so "it bundles the Prisma toolchain" is now true of the plain image too

Three sites on this page change, kept together so the page stays self-consistent:

- the image guidance sentence, which was the thing telling readers to pick `litellm-database` for Postgres
- the `litellm-helm` `values.yaml` sample, which is the one that directly contradicted the new chart default
- the Kubernetes "connect the database" line, which told readers to switch images for something the image already does

Scope note: 15 further `litellm-database` references remain across `docker_image_security.md`, `configs.md`, `server_tuning.md`, `enterprise_quickstart.md` and `load_test_advanced.md`. Those are about `docker run` and signature verification rather than the chart, so they do not contradict anything this PR or #37491 changes, and retiring them is a broader editorial call that deserves its own review. Tracked separately

## Verification

`npm run build` succeeds. The build reports 176 broken-anchor warnings, all pre-existing on old release-notes pages, and `grep -c "proxy/deploy"` over the build log returns 0, so this page contributes none of them
