### PR TITLE
docs(proxy): warn that budgets are not enforced without a database

### DIFF
--- a/docs/proxy/docker_quick_start.md
+++ b/docs/proxy/docker_quick_start.md
@@ -194,6 +194,16 @@ docker run \
 
 Requests authenticate with the master key. See the [full config reference](./configs.md) for everything the file supports.
 
+:::warning Budgets are not enforced without a database
+
+`litellm_settings.max_budget` is not a spend cap on this path. Loading the proxy's global spend requires a database client, so without one the running total stays unknown and the global budget check never fires; a proxy configured with `max_budget: 100` keeps serving requests past $100 with no per-request error and no budget alert. The proxy does log a one-time warning at startup when a budget is configured with no database connected, and that startup line is the only signal you get
+
+Key and team budgets are not an alternative here either, because virtual keys themselves need a database (requests carrying one fail with `No connected db.`), so the master key is the only credential and it has no budget of its own
+
+If a budget is part of how you bound spend, run LiteLLM with a database as shown at the top of this page. Without one, bound spend upstream instead, at your provider's own spending limits
+
+:::
+
 ## Next steps
 
 Going to production: the [Production Deployment guide](./deploy.md) covers Helm, Terraform, and Kubernetes on AWS, GCP, and Azure, and the [production checklist](./prod.md) covers hardening and tuning. Full container and database options, including Redis and Prometheus, are covered in the repo [docker-compose.yml](https://github.com/BerriAI/litellm/blob/main/docker-compose.yml).

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -19,6 +19,12 @@ Requirements:
 
 - Need to a postgres database (e.g. [Supabase](https://supabase.com/), [Neon](https://neon.tech/), etc) [**See Setup**](./virtual_keys.md#setup)
 
+:::warning Budgets require a database
+
+Every budget on this page is enforced against spend read from the database, so none of them cap anything on a [DB-less deployment](./docker_quick_start.md#running-without-a-database). `litellm_settings.max_budget` fails open there rather than erroring: the proxy's global spend is only loaded when a database client exists, and with no total to compare against, the global budget check is skipped and requests keep being served past the limit. A warning is logged once at startup when a budget is set with no database connected, but nothing blocks at request time. Key, team, and user budgets are unavailable for the same reason, since virtual keys cannot be resolved without a database (`No connected db.`). Run with a database if a budget is part of how you bound spend
+
+:::
+
 
 ## Set Budgets
 


### PR DESCRIPTION
A proxy run without a database silently ignores every budget on it, and neither the DB-less quick start nor the budgets page said so. `litellm_settings.max_budget` reads as a spend cap but fails open: `get_global_proxy_spend` only loads the running total when a prisma client exists, and `_global_proxy_budget_check` requires a non-None total before it can raise, so a proxy configured with `max_budget: 100` serves requests past $100 without erroring. Key and team budgets are not a workaround on that path, because a virtual key cannot be resolved without a database at all; the request fails with `No connected db.`, leaving the master key as the only usable credential and it carries no budget

Both admonitions mention the one-time startup warning added in BerriAI/litellm#36041 so the reader knows the single signal that does exist, and that nothing blocks at request time

## Type

📖 Documentation

## Changes

Adds a warning admonition to the "Running without a database" section of the Docker quick start, and one under the requirements on the budgets page pointing back at it