### PR TITLE
docs(batches): note that only proxy admins can set the enqueued-token limit

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -530,6 +530,8 @@ curl -X POST 'http://localhost:4000/key/generate' \
 
 `batch_enqueued_token_limit` also works in team metadata. When both the key and its team set one, the batch must fit both allowances.
 
+Only a proxy admin can set or change `batch_enqueued_token_limit`. Key and team requests from other roles that try to write it are rejected with a `403`.
+
 When a key or team has an enqueued-token limit, batch submission is governed only by that allowance:
 
 1. When the client creates a batch, LiteLLM reserves the file's estimated tokens (the input tokens plus each record's output cap) against the allowance.


### PR DESCRIPTION
## TLDR

Follow-up to #952: BerriAI/litellm#37539 gates writing `batch_enqueued_token_limit` behind the proxy admin role, so the enqueued-token limits section now says so. One sentence added after the team-metadata paragraph

## Why

The section tells readers to set the field in key or team metadata but did not say who is allowed to. Since the gate landed, a non-admin request that writes the field gets a 403, which would surprise anyone following the doc from a non-admin key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9eb20be89e7f8999f4df28c035d1ab2bd8ba5ee6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->