### PR TITLE
docs(anthropic_unified): document metadata.user_id to prompt_cache_key mapping

### DIFF
--- a/docs/anthropic_unified/messages_to_responses_mapping.md
+++ b/docs/anthropic_unified/messages_to_responses_mapping.md
@@ -29,7 +29,7 @@ The transformation lives in `litellm/llms/anthropic/experimental_pass_through/re
 | `top_k` | ❌ Not mapped | Dropped silently |
 | `speed` | ❌ Not mapped | Only used to set Anthropic beta headers on the native path |
 
-The chat-completions path (`litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, and every non-OpenAI provider) derives the same two parameters from `metadata.user_id`, with two differences: `user` is passed through untruncated, and `prompt_cache_key` is only set when the target provider's supported params include it. OpenAI, Azure OpenAI and other OpenAI-compatible providers do; Gemini, Vertex AI, Bedrock and Anthropic do not.
+The chat-completions path (`litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, and every non-OpenAI provider) derives the same two parameters from `metadata.user_id`, with two differences: `user` is passed through untruncated, and `prompt_cache_key` is only set when the target provider's supported params include it. OpenAI, Azure OpenAI and other OpenAI-compatible providers do; Gemini, Vertex AI, Bedrock and Anthropic do not. `litellm_proxy/` deployments (one LiteLLM proxy in front of another) never get the derived key, because the downstream proxy's real provider is unknown and would reject it unless `drop_params` is set there.
 
 
 ### How messages get converted

--- a/docs/anthropic_unified/messages_to_responses_mapping.md
+++ b/docs/anthropic_unified/messages_to_responses_mapping.md
@@ -24,9 +24,12 @@ The transformation lives in `litellm/llms/anthropic/experimental_pass_through/re
 | `output_format` or `output_config.format` | `text` | Wrapped as `{"format": {"type": "json_schema", "name": "structured_output", "schema": ..., "strict": true}}` |
 | `context_management` | `context_management` | Converted from Anthropic dict to OpenAI array format — see the context_management section below |
 | `metadata.user_id` | `user` | Extracted from the metadata object and truncated to 64 characters |
+| `metadata.user_id` | `prompt_cache_key` | Same value, truncated to 64 characters (OpenAI's key limit), so one user's requests keep hitting the same prompt cache. Not set when `user_id` is empty or null. A `prompt_cache_key` sent in the request body wins over the derived one |
 | `stop_sequences` | ❌ Not mapped | Dropped silently |
 | `top_k` | ❌ Not mapped | Dropped silently |
 | `speed` | ❌ Not mapped | Only used to set Anthropic beta headers on the native path |
+
+The chat-completions path (`litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, and every non-OpenAI provider) derives the same two parameters from `metadata.user_id`, with two differences: `user` is passed through untruncated, and `prompt_cache_key` is only set when the target provider's supported params include it. OpenAI, Azure OpenAI and other OpenAI-compatible providers do; Gemini, Vertex AI, Bedrock and Anthropic do not.
 
 
 ### How messages get converted


### PR DESCRIPTION
## Summary

`metadata.user_id` on the `/v1/messages` bridge now maps to OpenAI's `prompt_cache_key` as well as `user`, capped at 64 characters, so the Responses mapping table gets a second row for it. A short note under the table covers the chat-completions path, where the key is only set for providers that support it, and that a `prompt_cache_key` sent by the client wins over the derived one

Pairs with BerriAI/litellm#37623, which ships the behavior

Related: LIT-5875

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact; behavior is described as shipped in a paired implementation PR.
> 
> **Overview**
> Documents that **`metadata.user_id`** on the `/v1/messages` → Responses bridge now maps to **`prompt_cache_key`** in addition to **`user`**, using the same value truncated to 64 characters so per-user traffic can reuse OpenAI prompt cache entries. The table notes when the derived key is omitted (empty/null `user_id`) and that an explicit request **`prompt_cache_key`** overrides the derived value.
> 
> Adds a short note for the **chat-completions** path: the same two fields are derived from `metadata.user_id`, but **`user`** is not truncated and **`prompt_cache_key`** is only forwarded when the target provider supports it (OpenAI/Azure-compatible yes; Gemini, Vertex, Bedrock, Anthropic no).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c73157e0202be80f6d769aa26f5717cb4ea3ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->