### PR TITLE
docs(cli): move the `lite login` credential to the OS keychain

### DIFF
--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -115,7 +115,7 @@ Example poll response (after SSO completes):
    uv tool install 'litellm[cli]'
    ```
 
-   Any of these gives you the `lite` command; if you already run a proxy server from `litellm[proxy]`, it ships there too. Start by typing it in your terminal:
+   Any of these gives you the `lite` command. A proxy server installed from `litellm[proxy]` ships it too, but that extra leaves out `keyring`, so its credential stays in a file instead of your OS keychain. Start by typing it in your terminal:
 
    ```shell
    lite

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -139,6 +139,8 @@ Example poll response (after SSO completes):
 
    This will open a browser window to authenticate. If you have connected LiteLLM Proxy to your SSO provider, you should be able to login with your SSO credentials. Once logged in, you can use the CLI to make requests to the LiteLLM Gateway.
 
+   The credential goes into your OS keychain, and `lite login` prints where it landed. On a machine with no keychain it falls back to `~/.litellm/token.json` with owner-only permissions. See [the `lite login` credential](./management_cli.md#the-lite-login-credential) for the details and for how to turn keychain storage off
+
 4. **Make a test request to view models**
 
    ```shell

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1100,6 +1100,7 @@ router_settings:
 | LITELLM_BILLING_METRICS_CA_CERT | CA bundle for verifying the metering collector. Only for private or test collectors; unset uses the system trust store
 | LITELLM_BILLING_METRICS_EXPORT_INTERVAL_MS | Push cadence for billable-request metering in milliseconds. Default is 60000
 | LITELLM_BLOG_POSTS_URL | Custom URL for fetching LiteLLM blog posts JSON. Default is the GitHub main branch URL
+| LITELLM_CLI_DISABLE_KEYRING | Set on the machine running the `lite` CLI to `1`, `true`, `yes`, or `on` to keep the CLI away from the OS keychain, so the credential from `lite login` stays in `~/.litellm/token.json` (`0600`) instead. Unset by default, which stores the credential in the keychain whenever one is reachable
 | LITELLM_CLI_JWT_EXPIRATION_HOURS | Expiration time in hours for CLI-generated JWT tokens. Default is 24 hours
 | LITELLM_CLI_SSO_CLAIM_MAP | Alias for `CLI_SSO_CLAIM_MAP` — allowlisted OIDC claims for CLI SSO attribution metadata
 | LITELLM_CORS_ALLOW_CREDENTIALS | Set to `true` to explicitly allow credentials in CORS responses. When not set, credentials are disabled automatically if `LITELLM_CORS_ORIGINS` is `*` (wildcard) to prevent the browser security misconfiguration of reflecting any origin with credentials

--- a/docs/proxy/identity_provisioning.md
+++ b/docs/proxy/identity_provisioning.md
@@ -119,7 +119,7 @@ export LITELLM_PROXY_URL=https://your-litellm-proxy:4000
 lite claude          # or: lite codex / lite opencode
 ```
 
-On first run this triggers `lite login` (browser SSO), stores a short-lived session token at `~/.litellm/token.json` (`0600`), then starts the agent. The wrapper sets the right variables per agent: Claude Code gets `ANTHROPIC_BASE_URL` (the proxy root) and `ANTHROPIC_AUTH_TOKEN`, and it clears any stray `ANTHROPIC_API_KEY` so the proxy token wins; Codex and OpenCode get `OPENAI_BASE_URL` (proxy plus `/v1`) and `OPENAI_API_KEY`, with Codex additionally pointed at a custom provider since it ignores `OPENAI_BASE_URL`. Forward the agent's own flags through the wrapper, for example `lite claude --model my-proxy-model`, and whatever model it requests must exist on the proxy. This path uses the session token from `lite login`, tied to the SSO'd (and SCIM-provisioned) user, so it does not go through the Step 3 `auto_register` path; the login flow issues the credential and spend still tracks against that user. To use a long-lived virtual key instead of the SSO session token, pass `--api-key` or set `LITELLM_PROXY_API_KEY`. See [CLI authentication](./cli_sso.md) for deployment prerequisites.
+On first run this triggers `lite login` (browser SSO), stores a short-lived session token in the developer's OS keychain, then starts the agent. The wrapper sets the right variables per agent: Claude Code gets `ANTHROPIC_BASE_URL` (the proxy root) and `ANTHROPIC_AUTH_TOKEN`, and it clears any stray `ANTHROPIC_API_KEY` so the proxy token wins; Codex and OpenCode get `OPENAI_BASE_URL` (proxy plus `/v1`) and `OPENAI_API_KEY`, with Codex additionally pointed at a custom provider since it ignores `OPENAI_BASE_URL`. Forward the agent's own flags through the wrapper, for example `lite claude --model my-proxy-model`, and whatever model it requests must exist on the proxy. This path uses the session token from `lite login`, tied to the SSO'd (and SCIM-provisioned) user, so it does not go through the Step 3 `auto_register` path; the login flow issues the credential and spend still tracks against that user. To use a long-lived virtual key instead of the SSO session token, pass `--api-key` or set `LITELLM_PROXY_API_KEY`. See [CLI authentication](./cli_sso.md) for deployment prerequisites.
 
 **Clients that already carry an IdP JWT.** Services, or agents already wired to your IdP, send the IdP-minted JWT straight to the proxy as the bearer token; LiteLLM never stores it. This is the path that triggers Step 3's `auto_register`, minting a per-user virtual key on the first request. For an Anthropic-style client, point it at the proxy root and pass the JWT as the auth token:
 
@@ -128,7 +128,7 @@ export ANTHROPIC_BASE_URL="https://your-litellm-proxy:4000"
 export ANTHROPIC_AUTH_TOKEN="<user-sso-jwt-token>"
 ```
 
-Two clarifications that trip people up. LiteLLM has no OS keychain or credential-helper integration; the on-device store for the CLI flow is that `0600` JSON file, not the macOS Keychain, Windows Credential Manager, or a git-style credential helper, so if you want it in an OS keychain you wrap `lite login` with your own tooling. And the session token the CLI stores is a LiteLLM-issued token scoped to the gateway, not the raw IdP JWT and not a persisted virtual key that appears in the Keys UI.
+Two clarifications that trip people up. The credential from `lite login` lives in the OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service) under the service `litellm-cli`, and `~/.litellm/token.json` keeps only non-secret metadata: the gateway URL, the user's id, email, and role, the auth header name, and the sign-in timestamp. Reaching the keychain needs the `keyring` package, which comes with the `cli` extra, so install the CLI as `litellm[cli]`. Where no keychain is available, on a headless Linux box for instance, or where you set `LITELLM_CLI_DISABLE_KEYRING` to turn keychain storage off, the credential falls back into that same `0600` file and `lite login` says which of the two it used. There is still no git-style credential-helper integration. And the session token the CLI stores is a LiteLLM-issued token scoped to the gateway, not the raw IdP JWT and not a persisted virtual key that appears in the Keys UI
 
 ---
 
@@ -175,9 +175,9 @@ Configure `user_id_jwt_field` to reference the JWT claim that contains the same 
 | JWT auth authenticates requests with IdP tokens | Yes |
 | JWT auth auto-registers a per-client virtual key | Yes, with `virtual_key_claim_field` + `auto_register` |
 | SCIM provisioning event directly triggers key creation | No (the first request does, lazily) |
-| `lite login` stores a gateway credential on the device | Yes (`~/.litellm/token.json`, `0600`) |
+| `lite login` stores a gateway credential on the device | Yes (OS keychain, or `~/.litellm/token.json` at `0600` when there is none) |
 | `lite claude` / `lite codex` / `lite opencode` set the agent's env vars for you | Yes (base URL and bearer token wired per agent) |
-| Credential stored in an OS keychain / credential helper | No (plain file with owner-only permissions) |
+| Credential stored in an OS keychain | Yes (service `litellm-cli`; no git-style credential-helper integration) |
 | Device-stored credential is the raw IdP JWT | No (it is a LiteLLM-issued session token) |
 
 ---

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -151,12 +151,18 @@ The token minted by `lite login` is a short-lived, per-session agent credential,
 
 The credential is short-lived by design (default 24h, configurable via `LITELLM_CLI_JWT_EXPIRATION_HOURS`); run `lite login` again to refresh it, which also re-reads your latest team and user settings. It does not appear in the Keys UI and cannot be rotated or revoked mid-session, and `lite claude`, `lite codex`, and `lite opencode` work with it on a default deployment. If you need a long-lived, rotatable key that shows up in the Keys UI, create a dedicated virtual key in the dashboard and pass it via `--api-key` or `LITELLM_PROXY_API_KEY` instead.
 
+`lite login` keeps the credential in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service) under the service `litellm-cli` and the account `credential`. Only the non-secret half lands in `~/.litellm/token.json`: the gateway URL, your user id, email, and role, the auth header name, and the sign-in timestamp. That file is created `0600` inside a `0700` directory. Reaching the keychain needs the `keyring` package, which ships with the `cli` extra, so install with `pip install 'litellm[cli]'` rather than a bare `pip install litellm` if you want keychain storage
+
+A machine with no keychain, a headless Linux box for example, keeps the credential in that same owner-only file instead, and so do installs missing `keyring` and shells that set `LITELLM_CLI_DISABLE_KEYRING` to `1`, `true`, `yes`, or `on`, which turns keychain storage off entirely. `lite login` prints where the credential ended up either way. A credential written into `token.json` in plaintext by an older `lite` still authenticates: the next command that reads it moves it into the keychain and takes it out of the file
+
 When you authenticate to a team during login, or want to move your stored key onto a different team afterward, use `lite teams assign-key` (see [Teams Management](#teams-management)). Inspect or clear the stored credential with:
 
 ```bash
 lite whoami   # show the authenticated user and the token age
-lite logout   # clear the stored token
+lite logout   # clear the keychain entry and the token file
 ```
+
+`lite logout` clears both stores. When the keychain refuses to release the entry, or cannot be reached to check, it warns you and tells you what to do rather than reporting a clean logout
 
 ## Main Commands
 

--- a/docs/proxy/management_cli.md
+++ b/docs/proxy/management_cli.md
@@ -34,7 +34,7 @@ Codex, OpenCode) with their LLM traffic routed through the proxy.
    uv tool install 'litellm[cli]'
    ```
 
-   Any of these gives you the `lite` command; if you already run a proxy server from `litellm[proxy]`, it ships there too. Start by typing it in your terminal:
+   Any of these gives you the `lite` command. A proxy server installed from `litellm[proxy]` ships it too, but that extra leaves out `keyring`, so its credential stays in a file instead of your OS keychain. Start by typing it in your terminal:
 
    ```shell
    lite
@@ -151,7 +151,7 @@ The token minted by `lite login` is a short-lived, per-session agent credential,
 
 The credential is short-lived by design (default 24h, configurable via `LITELLM_CLI_JWT_EXPIRATION_HOURS`); run `lite login` again to refresh it, which also re-reads your latest team and user settings. It does not appear in the Keys UI and cannot be rotated or revoked mid-session, and `lite claude`, `lite codex`, and `lite opencode` work with it on a default deployment. If you need a long-lived, rotatable key that shows up in the Keys UI, create a dedicated virtual key in the dashboard and pass it via `--api-key` or `LITELLM_PROXY_API_KEY` instead.
 
-`lite login` keeps the credential in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service) under the service `litellm-cli` and the account `credential`. Only the non-secret half lands in `~/.litellm/token.json`: the gateway URL, your user id, email, and role, the auth header name, and the sign-in timestamp. That file is created `0600` inside a `0700` directory. Reaching the keychain needs the `keyring` package, which ships with the `cli` extra, so install with `pip install 'litellm[cli]'` rather than a bare `pip install litellm` if you want keychain storage
+`lite login` keeps the credential in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service) under the service `litellm-cli` and the account `credential`. Only the non-secret half lands in `~/.litellm/token.json`: the gateway URL, your user id, email, and role, the auth header name, and the sign-in timestamp. That file is created `0600` inside a `0700` directory. Reaching the keychain needs the `keyring` package, which ships with the `cli` extra, so install with `pip install 'litellm[cli]'` rather than a bare `pip install litellm` or `pip install 'litellm[proxy]'` if you want keychain storage. Code that reads the credential back through `litellm.get_litellm_gateway_api_key()` needs `keyring` for the same reason: without it the call cannot see a keychain entry and returns `None`, even though `lite login` stored one
 
 A machine with no keychain, a headless Linux box for example, keeps the credential in that same owner-only file instead, and so do installs missing `keyring` and shells that set `LITELLM_CLI_DISABLE_KEYRING` to `1`, `true`, `yes`, or `on`, which turns keychain storage off entirely. `lite login` prints where the credential ended up either way. A credential written into `token.json` in plaintext by an older `lite` still authenticates: the next command that reads it moves it into the keychain and takes it out of the file
 


### PR DESCRIPTION
## TLDR

`lite login` now puts the credential in the OS keychain instead of writing it into `~/.litellm/token.json`, so the pages that told readers their credential sits in a plaintext file were wrong. See [BerriAI/litellm#37566](https://github.com/BerriAI/litellm/pull/37566)

## What changed in the code

The credential goes into the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) under the service `litellm-cli` and the account `credential`. `~/.litellm/token.json` keeps only non-secret metadata: base URL, user id, email, role, auth header name, and the sign-in timestamp, in a `0600` file inside a `0700` directory. With no keychain reachable, which covers a headless Linux box, an install without the optional `keyring` package (it ships with the `cli` extra), and `LITELLM_CLI_DISABLE_KEYRING` set to `1`/`true`/`yes`/`on`, the credential falls back into that same owner-only file, and `lite login` prints which store it used. `lite logout` clears both and warns when the keychain will not release the entry. A plaintext credential left by an older `lite` still authenticates, then moves itself into the keychain

## Pages changed

`docs/proxy/identity_provisioning.md`: Step 4 said `lite login` stores the token at `~/.litellm/token.json`, and the paragraph after it said LiteLLM has no OS keychain integration at all. Both now describe keychain storage, the metadata-only token file, the `keyring` requirement, and the fallback. The support matrix rows for on-device storage and keychain storage were flipped to match

`docs/proxy/management_cli.md`: the `lite login` credential section only said the token was "stored". It now says where each half lives, what the fallback cases are, what `LITELLM_CLI_DISABLE_KEYRING` does, and what `lite logout` clears. The quick start offered `litellm[proxy]` as another way to get the `lite` command without saying that extra leaves out `keyring`, so that line now names the consequence, and the credential section says the SDK getter `litellm.get_litellm_gateway_api_key()` needs `keyring` for the same reason

`docs/proxy/cli_sso.md`: the login step now points at where the credential lands and links to the section above, and its install step carries the same `litellm[proxy]` correction

`docs/proxy/config_settings.md`: added `LITELLM_CLI_DISABLE_KEYRING` to the environment variable table

## Checks

`npm run build` passes. The broken-anchor warnings it prints are all pre-existing links from release notes into `docs/proxy/logging` and friends; none of them touch these pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CLI credential storage. No runtime, auth, or proxy behavior changes in this PR.
> 
> **Overview**
> Aligns CLI docs with keychain storage for `lite login`: the session key lives in the OS keychain (service `litellm-cli`), and `~/.litellm/token.json` keeps non-secret metadata. Fallback remains the owner-only file when there is no keychain, `keyring` is missing (`litellm[proxy]` does not include it), or `LITELLM_CLI_DISABLE_KEYRING` is set.
> 
> **PKCE** still puts the refresh token in `token.json` (treat that file as sensitive). `lite logout` clears both stores and warns if the keychain entry cannot be removed. Older plaintext tokens migrate into the keychain on next read.
> 
> Also documents `LITELLM_CLI_DISABLE_KEYRING` in the env-var table and flips the identity-provisioning support matrix from “no keychain” to “yes”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a02047a67349335861a085f41e0a0e4c019acc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

