### PR TITLE
docs(proxy): cover config.yaml on the PTU flat cost page

### DIFF
--- a/docs/proxy/ptu_flat_cost.md
+++ b/docs/proxy/ptu_flat_cost.md
@@ -44,6 +44,27 @@ curl -X POST http://localhost:4000/model/new \
   }'
 ```
 
+Or in `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-ptu
+    litellm_params:
+      model: azure/<your-deployment-name>
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE
+    model_info:
+      id: gpt-4o-ptu-team-a
+      team_id: <the owning team id>
+      ptu_count: 100
+      cost_per_ptu_per_hour: 0.02
+      ptu_effective_from: "2026-01-01T00:00:00Z"
+```
+
+Pin `model_info.id` on a deployment declared this way. Left unset, the id is derived from the model name and the resolved `litellm_params`, so rotating the credential mints a new identity and the reservation is charged a second time under it. Any stable string works, and it only has to be unique across your deployments
+
+`team_id` is what the capacity is billed to, so a declaration without one accrues nothing
+
 | Field | Required | Meaning |
 | --- | --- | --- |
 | `team_id` | yes | The team the capacity belongs to. One deployment maps to one team |
@@ -65,6 +86,8 @@ flat cost = ptu_count x cost_per_ptu_per_hour x hours active that day
 ```
 
 Active hours are the overlap between the day and the reservation window, so a reservation starting at noon accrues 12 hours on its first day and 24 thereafter. The rows are written into `LiteLLM_DailyTeamSpend` under the reserved key `__ptu_flat_cost__`, which keeps flat cost separate from the per-request spend recorded against real API keys.
+
+A reservation that starts before the job first sees it is filled in as well: the catch-up pass prices each elapsed day back to `ptu_effective_from`, up to 91 days. A deployment configured today with a backdated start therefore accrues its whole window on the first run
 
 Flat cost does not count against team or key budgets. Reserved capacity is already paid for, so a team cannot exhaust a budget by using the capacity it reserved.
 
@@ -99,4 +122,6 @@ Web search rates are handled the same way. Note that xAI models bill their list 
 
 ## Limitations
 
-Configuration set through `config.yaml`, the Python `Router`, or the legacy `POST /model/update` is not covered. Those paths do not run the rules above, so a PTU deployment defined there keeps billing per token and never accrues flat cost. Use `POST /model/new`, `PATCH /model/{model_id}/update`, or the Admin UI.
+The legacy `POST /model/update` does not run the rules above, so a PTU deployment configured through it keeps billing per token and never accrues flat cost. Use `POST /model/new`, `PATCH /model/{model_id}/update`, the Admin UI, or `config.yaml`
+
+The Python `Router` used on its own zeroes per-token pricing at registration, but nothing schedules the daily job outside the proxy, so flat cost is not accrued there


### PR DESCRIPTION
Corrects the PTU page, which still tells operators that a deployment declared in `config.yaml` is not covered. That shipped in BerriAI/litellm#37556 and BerriAI/litellm#37571, so the statement is now false and points people away from a path that works

Three changes on `docs/proxy/ptu_flat_cost.md`:

The Limitations section no longer lists `config.yaml`. Only the legacy `POST /model/update` is genuinely uncovered. The Python `Router` on its own is called out separately, since it zeroes per-token pricing at registration but has nothing scheduling the daily job

Configure a deployment gains the YAML form alongside the existing `POST /model/new` example, plus the two ways a declaration silently accrues nothing: no `team_id`, and an unpinned `model_info.id`. The id is derived from the model name and the resolved `litellm_params`, so rotating a credential mints a new identity and the reservation is charged again under it. Verified by building the same deployment twice with different keys: derived ids `0ba149287615` and `d5306a5a2275`, and identical when `model_info.id` is set

How the cost is calculated gains a line on the catch-up pass, which prices elapsed days back to `ptu_effective_from` up to 91 days, so a first run after enabling the feature is not a surprise

Verified live on `litellm_internal_staging` at `d7e4b1bdd0` against real Postgres and real provider traffic: a config-only deployment accrued $120 a day for three days, its request logged at $0 per token, and a second run left the total at $360

`npm run build` passes. The one broken anchor it reports is pre-existing on a release-notes page and unrelated

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->