### PR TITLE
docs(proxy): document the dark mode UI logo

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1404,6 +1404,7 @@ router_settings:
 | TOOL_CHOICE_OBJECT_TOKEN_COUNT | Token count for tool choice objects. Default is 4
 | TOOL_POLICY_CACHE_TTL_SECONDS | TTL in seconds for caching tool policy guardrail results. Default is 60
 | UI_LOGO_PATH | Path to the logo image used in the UI
+| UI_LOGO_PATH_DARK | Path to the logo image used in the UI in dark mode. Falls back to UI_LOGO_PATH when unset
 | UI_PASSWORD | Password for accessing the UI
 | UI_USERNAME | Username for accessing the UI
 | UPSTREAM_LANGFUSE_DEBUG | Flag to enable debugging for upstream Langfuse

--- a/docs/proxy/ui/ui_edit_logo.md
+++ b/docs/proxy/ui/ui_edit_logo.md
@@ -62,6 +62,14 @@ Click **Save Changes** to apply your new logo.
 
 Your custom logo will now appear in the LiteLLM dashboard sidebar and login page.
 
+## Dark Mode Logo
+
+A logo drawn for a light background rarely reads well on a dark one, so you can set a second logo that LiteLLM uses whenever the dashboard is in dark mode. Fill in **Custom Logo URL (dark mode)** on the same UI Theme page, or set `UI_LOGO_PATH_DARK`
+
+Leaving it empty is a valid choice. Dark mode then reuses whatever you set for the light logo, so your branding still shows rather than reverting to LiteLLM's. The same thing happens if the dark logo is set but cannot be loaded, which means a broken or deleted image never costs you your branding
+
+Setting only the dark logo leaves light mode on the default LiteLLM logo, so set both if you want your own artwork in each theme
+
 ## Via the API
 
 ### Set a Custom Logo
@@ -71,9 +79,12 @@ curl -X PATCH 'http://localhost:4000/settings/update/ui_theme_settings' \
   -H 'Authorization: Bearer <your-admin-key>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "logo_url": "https://example.com/your-company-logo.png"
+    "logo_url": "https://example.com/your-company-logo.png",
+    "logo_url_dark": "https://example.com/your-company-logo-dark.png"
   }'
 ```
+
+`logo_url_dark` is optional. Omit it and dark mode reuses `logo_url`
 
 ### Set a Custom Favicon
 
@@ -116,14 +127,16 @@ You can also set the logo URL in your proxy configuration file:
 litellm_settings:
   ui_theme_config:
     logo_url: "https://example.com/your-company-logo.png"
+    logo_url_dark: "https://example.com/your-company-logo-dark.png"  # optional
     favicon_url: "https://example.com/your-favicon.ico"  # optional
 ```
 
-Or set it as an environment variable:
+Or set them as environment variables:
 
 ```yaml
 environment_variables:
   UI_LOGO_PATH: "https://example.com/your-company-logo.png"
+  UI_LOGO_PATH_DARK: "https://example.com/your-company-logo-dark.png"
 ```
 
 ## Supported Logo Formats


### PR DESCRIPTION
Documents the dark mode UI logo that [BerriAI/litellm#37662](https://github.com/BerriAI/litellm/pull/37662) adds: the `UI_LOGO_PATH_DARK` env var and the matching `logo_url_dark` theme setting.

`docs/proxy/ui/ui_edit_logo.md` gets a "Dark Mode Logo" section plus the field in the existing API and `proxy_config.yaml` examples. `docs/proxy/config_settings.md` gets the env var reference row.

The section leads on the fallback, since that is the part an admin is most likely to get wrong: leaving the dark logo unset, or setting one that cannot be loaded, reuses the light logo rather than reverting to LiteLLM's branding. Setting only the dark logo leaves light mode on the default, which is called out too.

Worth merging before the litellm PR, which cannot go green until this lands. `test-unit-documentation.yml` checks out this repo's `main` into `docs/my-website` and runs `tests/documentation_tests/test_env_keys.py`, so `code-quality` and `documentation` both fail there today with `Environment variables read under ./litellm but mentioned nowhere in the docs: ['UI_LOGO_PATH_DARK']`. Verified locally by symlinking this branch into that path and running the test, which fails on `main` and passes here