### PR TITLE
docs(proxy): require model_info.id and drop the status code from the PTU page

### DIFF
--- a/docs/proxy/ptu_flat_cost.md
+++ b/docs/proxy/ptu_flat_cost.md
@@ -109,7 +109,7 @@ The Usage page in the Admin UI shows the same figures under Team Usage, charting
 
 ## Rates you must not set
 
-LiteLLM refuses a per-token, per-second, or cache rate on a PTU deployment, and answers `400` naming the field. Sending `0`, an all-zero table, or no value at all is accepted:
+LiteLLM refuses a per-token, per-second, or cache rate on a PTU deployment, and names the field it rejected. Sending `0`, an all-zero table, or no value at all is accepted:
 
 ```
 A PTU deployment bills by reserved capacity, so input_cost_per_token cannot be charged on top

--- a/docs/proxy/ptu_flat_cost.md
+++ b/docs/proxy/ptu_flat_cost.md
@@ -61,12 +61,15 @@ model_list:
       ptu_effective_from: "2026-01-01T00:00:00Z"
 ```
 
-Pin `model_info.id` on a deployment declared this way. Left unset, the id is derived from the model name and the resolved `litellm_params`, so rotating the credential mints a new identity and the reservation is charged a second time under it. Any stable string works, and it only has to be unique across your deployments
+`model_info.id` is required on a deployment declared this way, and the proxy refuses to load one without it, naming the deployment in the startup log. Left to itself the id is derived from the model name and the resolved `litellm_params`, so rotating the credential mints a new identity and the reservation is charged a second time under it, which nothing later retracts. Any stable string works, and it has to be unique across your deployments
+
+Upgrading an existing reservation that has already accrued cost, set `id` to the id it uses today rather than a fresh name, or the charges already written stay under the old identity and the new one starts beside them. The startup refusal quotes that current id so you can copy it
 
 `team_id` is what the capacity is billed to, so a declaration without one accrues nothing
 
 | Field | Required | Meaning |
 | --- | --- | --- |
+| `id` | in `config.yaml` | The deployment's stable identity. Not needed through the API or the UI, where one is stored for you |
 | `team_id` | yes | The team the capacity belongs to. One deployment maps to one team |
 | `ptu_count` | yes | Provisioned throughput units reserved |
 | `cost_per_ptu_per_hour` | yes | Your contracted hourly rate per unit |


### PR DESCRIPTION
The PTU page says a rejected rate answers `400`. Some invalid PTU configurations answer `422` instead, so naming one code sends readers looking for a response they may not get

Removes the code and keeps the part that is reliably true, that the rejection names the field it refused. No behaviour change is implied here; this is a docs correction only, and whether the endpoints should be normalised onto a single code is a separate question
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->