### PR TITLE
docs: add Openlayer to the observability integrations

### DIFF
--- a/docs/observability/openlayer_integration.md
+++ b/docs/observability/openlayer_integration.md
@@ -96,7 +96,9 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 ## What Openlayer renders
 
-Open the Data view of your inference pipeline. Each traced call arrives as a row carrying the provider, the model, prompt and completion token counts, cost, and latency, with the prompt and the response on the row itself. Openlayer reads the canonical `gen_ai.*` schema, so the integration adds no vendor mapper; see [Span attributes](./opentelemetry_v2#span-attributes) for the full list of keys.
+Open the Data view of your inference pipeline. Each traced call arrives as a row carrying the provider, the model, prompt and completion token counts, cost, and latency. Openlayer reads the canonical `gen_ai.*` schema, so the integration adds no vendor mapper; see [Span attributes](./opentelemetry_v2#span-attributes) for the full list of keys.
+
+Where the prompt and the response sit depends on how you run LiteLLM. Openlayer builds a row's input and output from the root span of the trace. From the SDK the model call is the root, so they sit on the row. Through the proxy the model call is nested under the gateway request, so the row summarises the request and the prompt and response sit on that nested step.
 
 Cost is computed by Openlayer from the provider and model on the span rather than from a self-reported figure, so it is filled in for every provider Openlayer prices. Embedding calls report their prompt tokens but are not priced.
 

--- a/docs/observability/openlayer_integration.md
+++ b/docs/observability/openlayer_integration.md
@@ -1,0 +1,129 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Openlayer
+
+AI evaluation and observability, at [openlayer.com](https://www.openlayer.com/).
+
+:::info
+We want to learn how we can make the callbacks better! Meet the LiteLLM [founders](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version) or
+join our [discord](https://discord.gg/wuPM9dRgDw)
+:::
+
+## Pre-Requisites
+
+```shell
+uv add litellm
+```
+
+You need an Openlayer API key and the ID of the inference pipeline that traces should land in. The key is under Workspace settings, API keys; the pipeline ID is on the pipeline you want to publish to.
+
+## Quick Start
+
+<Tabs>
+<TabItem value="python" label="SDK">
+
+```python
+import litellm
+import os
+
+os.environ["OPENLAYER_API_KEY"] = ""
+os.environ["OPENLAYER_INFERENCE_PIPELINE_ID"] = ""
+# LLM API Keys
+os.environ["OPENAI_API_KEY"] = ""
+
+# set openlayer as a callback, litellm will send the data to openlayer
+litellm.callbacks = ["openlayer"]
+
+# openai call
+response = litellm.completion(
+  model="gpt-4o",
+  messages=[
+    {"role": "user", "content": "Hi, i'm openai"}
+  ]
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="LiteLLM Proxy">
+
+1. Setup config.yaml
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  callbacks: ["openlayer"]
+```
+
+2. Set your credentials
+
+```shell
+LITELLM_OTEL_V2=true
+OPENLAYER_API_KEY="your-api-key"
+OPENLAYER_INFERENCE_PIPELINE_ID="your-inference-pipeline-id"
+```
+
+3. Start LiteLLM Proxy
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+4. Test it!
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hey, how are you?"
+    }
+  ]
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## What Openlayer renders
+
+Open the Data view of your inference pipeline. Each traced call arrives as a row carrying the provider, the model, prompt and completion token counts, cost, and latency, with the prompt and the response on the row itself. Openlayer reads the canonical `gen_ai.*` schema, so the integration adds no vendor mapper; see [Span attributes](./opentelemetry_v2#span-attributes) for the full list of keys.
+
+Cost is computed by Openlayer from the provider and model on the span rather than from a self-reported figure, so it is filled in for every provider Openlayer prices. Embedding calls report their prompt tokens but are not priced.
+
+The preset routes spans to `https://api.openlayer.com/v1/otel` with `Authorization: Bearer $OPENLAYER_API_KEY`, plus an `x-bt-parent` header of `pipeline_id:$OPENLAYER_INFERENCE_PIPELINE_ID` that selects the destination pipeline.
+
+## Configuration
+
+| Variable | Required | Notes |
+|---|---|---|
+| `OPENLAYER_API_KEY` | Yes | Workspace API key, sent as `Authorization: Bearer` |
+| `OPENLAYER_INFERENCE_PIPELINE_ID` | Yes | Pipeline traces are published to, sent as `x-bt-parent: pipeline_id:<id>` |
+| `OPENLAYER_OTEL_ENDPOINT` | No | Self-hosted collector. Defaults to `https://api.openlayer.com/v1/otel` |
+
+Both required variables are validated at startup; the integration raises if either is missing, naming the one that is absent. To label spans with an environment, set `OTEL_ENVIRONMENT_NAME`, which stamps `deployment.environment` on every span.
+
+The endpoint is a base URL rather than the signal path. LiteLLM appends `/v1/traces` for you and appends it only once, so the already suffixed spelling resolves to the same URL instead of doubling it.
+
+## Which OpenTelemetry path is used
+
+Setting `LITELLM_OTEL_V2=true` routes spans through the v2 preset, which is the path the proxy uses. Without it the callback falls back to the v1 OpenTelemetry logger, which is why the SDK example above needs no flag. Endpoint and credentials are read from the same place either way, so the two paths cannot drift apart.
+
+## Full OpenTelemetry reference
+
+This page covers the Openlayer specific setup. For span attributes, prompt and response capture, metrics, distributed tracing, and which routes are traced, see the [OpenTelemetry v2 guide](./opentelemetry_v2).
+
+## Support & Talk to Founders
+
+- [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
+- [Community Discord 💭](https://discord.gg/wuPM9dRgDw)
+- Our emails ✉️ ishaan@berri.ai / krrish@berri.ai

--- a/docs/observability/opentelemetry_v2.md
+++ b/docs/observability/opentelemetry_v2.md
@@ -223,6 +223,21 @@ AGENTOPS_API_KEY="your-api-key"
 
 </TabItem>
 
+<TabItem value="openlayer" label="Openlayer">
+
+```yaml title="config.yaml"
+litellm_settings:
+  callbacks: ["openlayer"]
+```
+
+```shell
+LITELLM_OTEL_V2=true
+OPENLAYER_API_KEY="your-api-key"
+OPENLAYER_INFERENCE_PIPELINE_ID="your-inference-pipeline-id"
+```
+
+</TabItem>
+
 </Tabs>
 
 :::tip Send to several backends at once
@@ -251,6 +266,7 @@ Every preset turns into one exporter on a single shared tracer. The table lists,
 | Langtrace | `langtrace` | none of its own | — | Langtrace, via an OpenTelemetry Collector (Langtrace ingests JSON-only OTLP) | Langtrace | No |
 | Levo | `levo` | `LEVOAI_API_KEY`, `LEVOAI_ORG_ID`, `LEVOAI_WORKSPACE_ID`, `LEVOAI_COLLECTOR_URL` | — | Levo collector | canonical `gen_ai.*` only | No |
 | AgentOps | `agentops` | `AGENTOPS_API_KEY` | `AGENTOPS_SERVICE_NAME` (default `agentops`), `AGENTOPS_ENVIRONMENT` (no default) | AgentOps (`https://otlp.agentops.ai/v1/traces`) | canonical `gen_ai.*` only | No |
+| Openlayer | `openlayer` | `OPENLAYER_API_KEY`, `OPENLAYER_INFERENCE_PIPELINE_ID` | `OPENLAYER_OTEL_ENDPOINT` (self-hosted collector; default `https://api.openlayer.com/v1/otel`) | Openlayer | canonical `gen_ai.*` only | No |
 
 Notes:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -63,6 +63,7 @@ const sidebars = {
             "observability/logfire_integration",
             "observability/lunary_integration",
             "observability/mlflow",
+            "observability/openlayer_integration",
             "observability/promptlayer_integration",
             "observability/qualifire_integration",
             "observability/wandb_integration",


### PR DESCRIPTION
## Summary

Documents the `openlayer` callback that [BerriAI/litellm#37719](https://github.com/BerriAI/litellm/pull/37719) adds. Openlayer is an AI evaluation and observability platform that ingests OTLP/HTTP protobuf, so the integration is a base URL plus two credentials.

Three changes: a dedicated page at `docs/observability/openlayer_integration.md` modelled on the Levo page, since Levo is the closest existing analogue (OTLP with bearer auth plus a routing header); an entry in both the vendor preset tabs and the preset table in the OpenTelemetry v2 guide; and a sidebar link.

## Two things the page calls out

The endpoint is a base URL rather than the signal path. LiteLLM appends `/v1/traces` itself, on both the v1 and v2 paths, and appends it only once, so the already suffixed spelling resolves to the same URL instead of doubling into `/v1/otel/v1/traces/v1/traces`. That is the mistake someone hand-writing `OTEL_ENDPOINT` makes, so it seemed worth stating rather than leaving to be discovered.

The SDK example deliberately sets no `LITELLM_OTEL_V2` flag. Without it the callback exports through the v1 OpenTelemetry logger, which covers synchronous calls; the proxy tab keeps the flag, matching how the other presets are documented. Both paths read the same credentials, so they cannot drift.

## Verification

`node scripts/check-writing-style.js docs blog release_notes` reports no prose em dashes and no vocabulary warnings in the new or edited files. `npm run build` succeeds; the page renders at `build/docs/observability/openlayer_integration` and the `#span-attributes` anchor it links resolves. The broken anchors the build reports are pre-existing in release notes and unrelated.

The setup the page describes was run end to end against a live Openlayer pipeline on both the v1 and v2 paths, so the env vars, the endpoint and the header shape are what the code actually sends.

## Note

No screenshot tab was added to the "What each backend renders" section of the v2 guide, since each of those embeds an image and there is no Openlayer image in `static/img/observability` yet. Levo is documented the same way. Happy to add one if you would like it.
