### PR TITLE
docs(caching): document the semantic cache embedding deadline

### DIFF
--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -998,6 +998,24 @@ Caching only runs on the call types listed in `supported_call_types` (OpenAI-com
 
 :::
 
+## Semantic Caching and a Slow Embedding Endpoint
+
+A semantic cache embeds the prompt before every request, and that embedding call runs inline, so the request cannot reach the LLM until it finishes. LiteLLM caps it at 5 seconds. Past the deadline the lookup is abandoned, the response carries `x-litellm-semantic-similarity: 0.0`, and the request proceeds to the model as a cache miss. An embedding endpoint that is unreachable or hanging therefore costs a few seconds instead of stalling the request.
+
+Raise the deadline if your embedding endpoint is legitimately slower than that, either per cache with `semantic_cache_embedding_timeout` under `cache_params` or globally with the `SEMANTIC_CACHE_EMBEDDING_TIMEOUT_SECONDS` environment variable.
+
+```yaml
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis-semantic
+    similarity_threshold: 0.8
+    redis_semantic_cache_embedding_model: my-embedding-model
+    semantic_cache_embedding_timeout: 10.0
+```
+
+Bear in mind that a higher deadline is how long every request waits when the embedding endpoint stops answering, so keep it close to the endpoint's real latency.
+
 ## Set cache for proxy, but not on the actual llm api call
 
 Use this if you just want to enable features like rate limiting, and loadbalancing across multiple
@@ -1277,6 +1295,10 @@ cache_params:
   gcs_bucket_name: your_gcs_bucket_name # Name of the GCS bucket
   gcs_path_service_account: /path/to/service-account.json # Path to GCS service account JSON file
   gcs_path: cache/ # [OPTIONAL] GCS path prefix for cache objects
+
+  # Semantic cache parameters (redis-semantic, valkey-semantic, qdrant-semantic)
+  similarity_threshold: 0.8 # Minimum cosine similarity for a cached response to be served
+  semantic_cache_embedding_timeout: 5.0 # Seconds the prompt embedding may take before the lookup gives up
 ```
 
 ## Provider-Specific Optional Parameters Caching

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1363,6 +1363,7 @@ router_settings:
 | S3_VECTORS_DEFAULT_DIMENSION | Default vector dimension for S3 Vectors RAG ingestion. Default is 1024
 | S3_VECTORS_DEFAULT_DISTANCE_METRIC | Default distance metric for S3 Vectors RAG ingestion. Options: "cosine", "euclidean". Default is "cosine"
 | SECRET_MANAGER_REFRESH_INTERVAL | Refresh interval in seconds for secret manager. Default is 86400 (24 hours)
+| SEMANTIC_CACHE_EMBEDDING_TIMEOUT_SECONDS | Deadline in seconds for the embedding call a semantic cache makes before each request. Exceeding it skips the cache instead of holding the request. Default is 5.0
 | SERVER_ROOT_PATH | Root path for the server application
 | SEND_USER_API_KEY_ALIAS | Flag to send user API key alias to Zscaler AI Guard. Default is False
 | SEND_USER_API_KEY_TEAM_ID | Flag to send user API key team ID to Zscaler AI Guard. Default is False


### PR DESCRIPTION
## TLDR

Documents the deadline that BerriAI/litellm#37742 puts on the semantic cache's prompt embedding call.

That embedding runs inline before every request, so an embedding endpoint that is unreachable or hanging used to park the whole request for minutes. It is now capped at 5 seconds, tunable per cache with `semantic_cache_embedding_timeout` or globally with `SEMANTIC_CACHE_EMBEDDING_TIMEOUT_SECONDS`

## Changes

A short section in `docs/proxy/caching.md` explaining what happens when the deadline fires (cache miss, `x-litellm-semantic-similarity: 0.0`, request continues to the model) and how to raise it, plus the two semantic `cache_params` in the supported-params block and a row in the environment variable reference table

## Note on ordering

litellm's `code-quality` and `documentation` jobs check out this repo's default branch, so BerriAI/litellm#37742 stays red on `SEMANTIC_CACHE_EMBEDDING_TIMEOUT_SECONDS` until this merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or security behavior changes.
> 
> **Overview**
> Documents the **5-second deadline** on the inline prompt-embedding call used by semantic caches. If the embedding endpoint hangs, the lookup is dropped as a miss (`x-litellm-semantic-similarity: 0.0`) and the request continues to the model.
> 
> Shows how to raise the deadline with `semantic_cache_embedding_timeout` under `cache_params` or `SEMANTIC_CACHE_EMBEDDING_TIMEOUT_SECONDS`, lists those params in the supported `cache_params` block, and adds the env var to the config settings table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c67a2f05c9ad2a88a61a70729a722241567c0f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->