### PR TITLE
fix(providers): repair dangling #sample-usage anchor on scx_ai page

### DIFF
--- a/docs/providers/scx_ai.md
+++ b/docs/providers/scx_ai.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 | Provider Route on LiteLLM | `scx-ai/` |
 | Link to Provider Doc | [SCX.ai Documentation ↗](https://scx.ai) |
 | Base URL | `https://api.scx.ai/v1` |
-| Supported Operations | [`/chat/completions`](#sample-usage) |
+| Supported Operations | [`/chat/completions`](#usage---litellm-python-sdk) |
 
 <br />
 <br />


### PR DESCRIPTION
`docs/providers/scx_ai.md`'s "Supported Operations" row links `/chat/completions` to `#sample-usage`, but the page has no heading that produces that anchor slug; the actual section is `## Usage - LiteLLM Python SDK`. Slipped in with #808.

`onBrokenAnchors` was set to `throw` in #974, so this now fails the production build for every PR based on current `main`, unrelated to whatever that PR actually changes. Confirmed on #981 and #982 both failing on this same anchor.

Points the link at the real section (`#usage---litellm-python-sdk`). Ran a full `npm run build` before and after: it was the only broken anchor site-wide, and the build is clean after this change.

No other pages reference `scx_ai#sample-usage`.