### PR TITLE
docs(parallel_ai): document PARALLEL_API_KEY and PARALLEL_AI_API_BASE

### DIFF
--- a/docs/search/parallel_ai.md
+++ b/docs/search/parallel_ai.md
@@ -2,6 +2,13 @@
 
 **Get API Key:** [https://www.parallel.ai](https://www.parallel.ai)
 
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `PARALLEL_AI_API_KEY` | API key. `PARALLEL_API_KEY` is accepted as a fallback when it is unset. |
+| `PARALLEL_AI_API_BASE` | Overrides the API base. Defaults to `https://api.parallel.ai`. |
+
 ## LiteLLM Python SDK
 
 ```python showLineNumbers title="Parallel AI Search"


### PR DESCRIPTION
## Problem

`litellm`'s `documentation_test_env_keys` check fails any env var that is read
under `./litellm` but mentioned nowhere in these docs. `PARALLEL_API_KEY` — the
fallback the Parallel AI provider accepts when `PARALLEL_AI_API_KEY` is unset —
appears nowhere here, so the check fails on the litellm side.

This blocks BerriAI/litellm#37885 and BerriAI/litellm#37886, where both the
`code-quality` and `documentation` jobs fail on:

```
Environment variables read under ./litellm but mentioned nowhere in the docs: ['PARALLEL_API_KEY']
```

## Solution

Add a short environment-variable table to the Parallel AI Search page covering
`PARALLEL_AI_API_KEY`, its `PARALLEL_API_KEY` fallback, and the
`PARALLEL_AI_API_BASE` override. All three are already honored by the provider;
only the first was documented.

## Testing

Ran the litellm-side checker against this branch mounted at `docs/my-website`:

```
$ python ./tests/documentation_tests/test_env_keys.py
Every environment variable read under ./litellm is documented
```

Without this change the same command fails on `['PARALLEL_API_KEY']`, so the fix
is what clears it.