### PR TITLE
docs: document the background interaction cost polling env vars

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -605,6 +605,10 @@ router_settings:
 | AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY | Cost per GB per day for Azure Vector Store service
 | BACKGROUND_HEALTH_CHECK_MAX_TOKENS | Optional global default for `max_tokens` on proxy background health checks when a model has no `health_check_max_tokens`. If unset, non-wildcard models default to 5. Applies to wildcard routes when set. Default is unset
 | BACKGROUND_HEALTH_CHECK_MAX_TOKENS_REASONING | For **non-wildcard** reasoning models (`supports_reasoning(model)=true`), this takes precedence over `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` when set. If unset, reasoning models fall back to `BACKGROUND_HEALTH_CHECK_MAX_TOKENS` (if set) or default behavior. Wildcard routes ignore this. Default is unset
+| BACKGROUND_INTERACTION_COST_POLLING_ENABLED | Set to `false` to stop the proxy polling `background=true` Interactions API requests for their final usage. Cost for those requests then goes untracked. Default is `true`
+| BACKGROUND_INTERACTION_COST_POLL_INITIAL_INTERVAL_SECONDS | Delay in seconds before the first poll of a background interaction. The interval doubles on each retry. Default is 5
+| BACKGROUND_INTERACTION_COST_POLL_MAX_INTERVAL_SECONDS | Ceiling in seconds that the background interaction poll interval backs off to. Default is 60
+| BACKGROUND_INTERACTION_COST_POLL_TIMEOUT_SECONDS | How long in seconds to keep polling a background interaction before giving up and releasing its budget reservation. Default is 3600 (1 hour)
 | BASETEN_API_BASE | Base URL for Baseten. Default is https://inference.baseten.co/v1
 | BATCH_STATUS_POLL_INTERVAL_SECONDS | Interval in seconds for polling batch status. Default is 3600 (1 hour)
 | BATCH_STATUS_POLL_MAX_ATTEMPTS | Maximum number of attempts for polling batch status. Default is 24 (for 24 hours)


### PR DESCRIPTION
## TLDR

Adds the four `BACKGROUND_INTERACTION_COST_POLL*` settings to the environment variables reference table in `docs/proxy/config_settings.md`.

These are read by the proxy's background cost tracking for Google Interactions API requests (BerriAI/litellm#33310). litellm's `tests/documentation_tests/test_env_keys.py` checks this repo's table for every env var the proxy reads, so the rows have to land here before that PR's documentation check can pass.

| Variable | Default |
| --- | --- |
| `BACKGROUND_INTERACTION_COST_POLLING_ENABLED` | `true` |
| `BACKGROUND_INTERACTION_COST_POLL_INITIAL_INTERVAL_SECONDS` | 5 |
| `BACKGROUND_INTERACTION_COST_POLL_MAX_INTERVAL_SECONDS` | 60 |
| `BACKGROUND_INTERACTION_COST_POLL_TIMEOUT_SECONDS` | 3600 |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table rows; no runtime, auth, or cost-tracking code changes.
> 
> **Overview**
> Documents four proxy env vars that control cost polling for `background=true` Interactions API requests: enable/disable, initial interval, max backoff, and timeout.
> 
> These rows land in the environment-variables table in `docs/proxy/config_settings.md` so LiteLLM’s env-key documentation check can pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ccd6b5619cdca2dcb43f8160c54837fe3226cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->