### PR TITLE
docs(proxy): document the Responses session lookup retry env vars

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1360,6 +1360,8 @@ router_settings:
 | REQUEST_TIMEOUT | Timeout in seconds for requests. Default is 6000
 | RESET_BUDGET_JOB_BATCH_SIZE | Maximum rows the budget reset job reads and commits per transaction. Default is 500
 | RESET_BUDGET_JOB_MAX_CHUNKS_PER_RUN | Maximum batches each budget reset phase processes per run; leftovers wait for the next run. Default is 100
+| RESPONSES_SESSION_LOOKUP_MAX_ATTEMPTS | How many times `/v1/responses` looks up the session behind a `previous_response_id` before giving up, so a follow-up sent right after the previous turn does not beat that turn's spend log to the database. Default is 3
+| RESPONSES_SESSION_LOOKUP_RETRY_INTERVAL | Seconds to wait between those session lookup attempts. Default is 0.2
 | ROOT_REDIRECT_URL | URL to redirect root path (/) to when DOCS_URL is set to something other than "/" (DOCS_URL is "/" by default)
 | ROUTER_MAX_FALLBACKS | Maximum number of fallbacks for router. Default is 5
 | RUBRIK_API_KEY | Bearer token for authenticating with the Rubrik webhook service


### PR DESCRIPTION
Adds the two rows the litellm CI documentation check asks for, covering the retry that keeps a `previous_response_id` follow-up from beating its own spend log to the database.

Pairs with BerriAI/litellm#37956, which introduces both variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the proxy config settings table; no runtime or security impact.
> 
> **Overview**
> Documents `RESPONSES_SESSION_LOOKUP_MAX_ATTEMPTS` (default 3) and `RESPONSES_SESSION_LOOKUP_RETRY_INTERVAL` (default 0.2s) in the proxy environment-variable table.
> 
> These control how `/v1/responses` retries session lookup for `previous_response_id` so a follow-up does not race the previous turn’s spend log to the database.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f9b31ec5fcad25002056a38ab65381192a57ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->