### PR TITLE
docs(claude-code): keep MCP tools deferred behind the proxy with ENABLE_TOOL_SEARCH

### DIFF
--- a/docs/tutorials/claude_mcp.md
+++ b/docs/tutorials/claude_mcp.md
@@ -133,3 +133,28 @@ d. Start the OAuth flow
 e. Once completed, you should see this success message:
 
 <img src={require('../../img/oauth_2_success.png').default} alt="OAuth 2.0 Success" style={{ width: '500px', height: 'auto' }} />
+
+## Keep MCP tools out of the context window (tool search)
+
+Claude Code normally keeps MCP tool schemas out of the context window and loads them on demand through its built-in tool search. That flow needs the `advanced-tool-use-2025-11-20` beta header on every request and `tool_reference` blocks to round-trip through the API, so since Claude Code 2.1.70 the client turns tool search off on its own whenever `ANTHROPIC_BASE_URL` points at anything other than a first-party Anthropic host. The decision happens on the client before any request is sent, which is why `/context` shows every MCP tool schema inlined (tens of thousands of tokens with a few hundred tools) as soon as Claude Code is routed through LiteLLM, and why no proxy-side setting can turn it back on.
+
+LiteLLM passes the beta header, `defer_loading`, and `tool_reference` blocks through unchanged on `/v1/messages` (and translates the beta to the Bedrock and Vertex AI names), so the fix lives on the Claude Code side. Tell it to keep tool search on (Claude Code 2.1.72 or newer):
+
+```bash
+export ANTHROPIC_BASE_URL=http://0.0.0.0:4000
+export ANTHROPIC_AUTH_TOKEN=sk-1234
+export ENABLE_TOOL_SEARCH=true
+claude
+```
+
+Or persist it in `~/.claude/settings.json` (or a managed settings file, to cover the whole team):
+
+```json
+{
+  "env": {
+    "ENABLE_TOOL_SEARCH": "true"
+  }
+}
+```
+
+`/context` then lists the MCP tools as `loaded on-demand` at 0 tokens, and Claude loads a tool's schema through `ToolSearch` the first time it needs it. `ENABLE_TOOL_SEARCH=auto` (or `auto:N`) only defers once tool schemas pass N% of the context window. See the [Claude Code docs](https://code.claude.com/docs/en/mcp#configure-tool-search) for the full option list.

--- a/docs/tutorials/claude_responses_api.md
+++ b/docs/tutorials/claude_responses_api.md
@@ -229,6 +229,10 @@ Common issues and solutions:
 - Use `--model` flag or environment variables to specify the model
 - Check LiteLLM logs for detailed error messages
 
+**MCP tools filling the context window:**
+- Claude Code turns its tool search off when `ANTHROPIC_BASE_URL` is not a first-party Anthropic host, so `/context` shows every MCP tool schema inlined instead of `loaded on-demand`
+- Set `ENABLE_TOOL_SEARCH=true` in Claude Code's environment; see [Keep MCP tools out of the context window](./claude_mcp.md#keep-mcp-tools-out-of-the-context-window-tool-search)
+
 ## Using Bedrock/Vertex AI/Azure Foundry Models
 
 Expand your configuration to support multiple providers and models:


### PR DESCRIPTION
## TLDR

Documents why Claude Code inlines every MCP tool schema the moment it is routed through LiteLLM, and the one-line fix (`ENABLE_TOOL_SEARCH=true`). Since Claude Code 2.1.70 the client switches its tool search off whenever `ANTHROPIC_BASE_URL` is not a first-party Anthropic host, before any request is sent. LiteLLM already forwards the `advanced-tool-use-2025-11-20` beta, `defer_loading`, and `tool_reference` blocks on `/v1/messages`, so nothing proxy-side can turn it back on; the override has to come from Claude Code's environment

## Changes

Adds a "Keep MCP tools out of the context window (tool search)" section to the Claude Code MCP tutorial (env var and `settings.json` forms, the `auto:N` mode, and a link to the Claude Code docs) plus a matching Troubleshooting entry in the Claude Code quickstart that points at it

## Proof

Claude Code 2.1.240 against a local LiteLLM proxy on a default config (`anthropic/claude-haiku-4-5`, no `forward_client_headers_to_llm_api`). With the default environment, `/context` reports:

```
MCP tools · /mcp
└ 107 tools · 30.6k tokens
```

Same proxy and model with `ENABLE_TOOL_SEARCH=true` in the environment:

```
MCP tools · /mcp (loaded on-demand)
└ 107 tools · 0 tokens
```

In the proxy log for the second run every request carried `anthropic-beta: ...,advanced-tool-use-2025-11-20` and `defer_loading: true`, later turns carried `tool_reference` blocks, all nine upstream calls to api.anthropic.com returned 200, and a `ToolSearch`-loaded MCP tool call (`mcp__buildkite__current_user`) completed end to end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents why Claude Code inlines every MCP tool schema when routed through LiteLLM, and how to keep tool search on with `ENABLE_TOOL_SEARCH=true` (Claude Code 2.1.72+).
> 
> Adds a section to the MCP tutorial covering env var and `~/.claude/settings.json` setup, plus `auto:N` mode. The Claude Code quickstart troubleshooting now points at that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172efe5d32307edac54fb0089f02ba77227bf587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->