### PR TITLE
docs(release_notes): promote v1.98.0 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.97.0: Tool-Result Guardrails, Deployment Affinity & Viewer Parity](/release_notes/v1.97.0/v1-97-0)
+### [v1.98.0: Provisioned Throughput Billing, Shadow Evals & Routing Groups](/release_notes/v1.98.0/v1-98-0)
 
-_August 15, 2026_
+_August 22, 2026_
 
-A per-guardrail `scan_only_tool_results` flag that scans and masks tool output while system, user, and assistant content passes through untouched, so an agent platform can keep injection detection on untrusted tool results without its own harness prompts tripping the filter; auto-router `deployment_affinity` on by default, pinning a session to the deployment it used before so the provider prompt cache stays warm while every turn is still classified on its own merits; a new `LiteLLM_DailyGatewayRequests` table written by the ASGI request-metrics middleware, so successful and failed request counts survive spend logging being off and come with a by-endpoint breakdown; read parity for `proxy_admin_viewer` across roughly fifteen endpoints that previously compared against `PROXY_ADMIN` exactly; four caller-scoped `spend/report` endpoints for keys, users, teams, and organizations; a correctness sweep over managed files and batches covering deterministic unified output file ids and unparseable rows; and an admin-published, dismissible markdown banner rendered on every dashboard page. Note that request-parameter checks now apply to path and form inputs as well as the body.
+Provisioned throughput is billed as reserved capacity, with `ptu_count` and `cost_per_ptu_per_hour` on a deployment driving a per-model flat cost by active hour while per-token billing is switched off there, so a team paying for reserved capacity is not charged twice for the same traffic; a shadow eval job that samples a slice of one key's successful traffic, replays it through the auto-router in a detached task that never serves a response or adds latency, and has an LLM judge compare both answers blind, so the router can be measured before it is adopted; routing groups that are callable models, where `model=<group_name>` routes across the union of member deployments with the group's own strategy, appears in `/v1/models` for Claude Code and Codex discovery, and is grantable on keys and teams; six `x-litellm-response-cost-*` headers that split a response's cost into input, cache read, cache creation, output, reasoning, and tool usage; TPM reservations that follow declared output size per key, per team, and per model instead of one static floor for every tenant; and the largest step yet in the Admin UI's move off antd and Tremor, with 75 UI pull requests carrying the navbar, playground, usage, cost tracking, the log details drawer, and much of the shared component library onto shadcn. Note that the Langfuse metadata blob is now sourced from a StandardLoggingPayload allowlist, so roughly 20 fields no longer appear on the generation.
 
 ---
 
@@ -22,6 +22,7 @@ A per-guardrail `scan_only_tool_results` flag that scans and masks tool output w
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.98.0](/release_notes/v1.98.0/v1-98-0)   | Aug 22, 2026 | Provisioned throughput billing, auto-router shadow evals, callable routing groups |
 | [v1.97.0](/release_notes/v1.97.0/v1-97-0)   | Aug 15, 2026 | Tool-result guardrails, auto-router deployment affinity, admin viewer parity |
 | [v1.96.0](/release_notes/v1.96.0/v1-96-0)   | Aug 9, 2026  | MCP entitlements, Redis config sync, auto-router context, GPT-5.6 price cut |
 | [v1.95.0](/release_notes/v1.95.0/v1-95-0)   | Aug 1, 2026  | Claude Opus 5, MCP gateway DCR, Rust `/v1/messages`, SAML 2.0 SSO |

--- a/release_notes/v1.98.0/index.md
+++ b/release_notes/v1.98.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.98.0rc1 - Provisioned Throughput Billing, Shadow Evals & Routing Groups"
-slug: "v1-98-0-rc-1"
-date: 2026-08-15T18:00:01
+title: "v1.98.0 - Provisioned Throughput Billing, Shadow Evals & Routing Groups"
+slug: "v1-98-0"
+date: 2026-08-22T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,14 +30,14 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.98.0-rc.1
+docker.litellm.ai/berriai/litellm:1.98.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.98.0rc1
+pip install litellm==1.98.0
 ```
 
 </TabItem>
@@ -60,7 +60,7 @@ pip install litellm==1.98.0rc1
 - **Routing groups are callable models** - `model=<group_name>` now routes across the union of member deployments using the group's own strategy, group names appear in `/v1/models` so Claude Code and Codex discovery surface them, and they are grantable on keys and teams. The Create Group modal has promised this since day one
 - **Every response can state its own cost breakdown** - six `x-litellm-response-cost-*` headers ship next to the total, where input, cache read, cache creation, output, and tool usage sum exactly to the total and reasoning is a subset of output, so a platform team attributes spend per component with no local pricing table
 - **TPM reservations follow declared output size** - expected output tokens are now declarable per key, per team, and per model instead of one static floor for every tenant, so concurrent requests stop overrunning a team's TPM limit and teams whose models emit far less stop being throttled. No config means byte-identical behavior and no migration
-- **The Admin UI's move off antd and Tremor took its largest step yet** - 74 UI pull requests in this window carry the navbar, playground, guardrails, usage, cost tracking, models and endpoints, team and user surfaces, the log details drawer, the AI Hub, and much of the shared component library onto shadcn (base-vega) primitives. The migration is not finished; both libraries remain dependencies and still back parts of the dashboard
+- **The Admin UI's move off antd and Tremor took its largest step yet** - 75 UI pull requests in this window carry the navbar, playground, guardrails, usage, cost tracking, models and endpoints, team and user surfaces, the log details drawer, the AI Hub, and much of the shared component library onto shadcn (base-vega) primitives. The migration is not finished; both libraries remain dependencies and still back parts of the dashboard
 
 ## New Providers and Endpoints
 
@@ -263,7 +263,7 @@ Beyond the new entries, this release is a large cost-map maintenance pass: 270 e
     - Scope the Virtual Keys and Logs team lists to the caller - [PR #36472](https://github.com/BerriAI/litellm/pull/36472)
     - Show and edit key-level router settings on a virtual key - [PR #36674](https://github.com/BerriAI/litellm/pull/36674)
     - Stop a deselected MCP server keeping its grant on a virtual key, and match the MCP servers count badge to its sibling permission badges - [PR #36840](https://github.com/BerriAI/litellm/pull/36840), [PR #36984](https://github.com/BerriAI/litellm/pull/36984)
-    - Restore playground model filtering by endpoint, and distinguish hosted from local vLLM in the provider dropdown - [PR #36130](https://github.com/BerriAI/litellm/pull/36130), [PR #36974](https://github.com/BerriAI/litellm/pull/36974)
+    - Restore playground model filtering by endpoint, keep `mode: completion` models in the chat dropdown, and distinguish hosted from local vLLM in the provider dropdown - [PR #36130](https://github.com/BerriAI/litellm/pull/36130), [PR #37954](https://github.com/BerriAI/litellm/pull/37954), [PR #36974](https://github.com/BerriAI/litellm/pull/36974)
     - Add NVIDIA Riva to the model provider list - [PR #36769](https://github.com/BerriAI/litellm/pull/36769)
     - Align the spend and budget columns, and rename the models table Status column to Source - [PR #35176](https://github.com/BerriAI/litellm/pull/35176), [PR #37021](https://github.com/BerriAI/litellm/pull/37021)
     - Show zeroed auto-router usage stats when a window has no sessions, and open the classifier prompt editor above the edit auto-router form - [PR #36868](https://github.com/BerriAI/litellm/pull/36868), [PR #36438](https://github.com/BerriAI/litellm/pull/36438)
@@ -380,9 +380,9 @@ Beyond the new entries, this release is a large cost-map maintenance pass: 270 e
 
 ### PR roll-up by ownership area
 
-PRs by ownership area (total: 276)
+PRs by ownership area (total: 277)
 
-- UI: 74
+- UI: 75
 - Models & Providers: 39
 - Spend / Budgets / Rate Limits: 37
 - Other (CI / chore / tests / build / version bumps): 36
@@ -427,4 +427,4 @@ This window added 18 test-only pull requests, 10 of them touching the live e2e s
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.97.0-rc.1...v1.98.0-rc.1
+https://github.com/BerriAI/litellm/compare/v1.97.0...v1.98.0


### PR DESCRIPTION
Renames the `v1.98.0rc1` release-notes folder to `v1.98.0` and moves the title, slug, date, Docker tag, pip install, and Full Changelog range onto the stable form. The changelog landing page now leads with v1.98.0 and gains a Recent Releases row.

One user-facing change landed on `rc/1.98.0` after the `v1.98.0-rc.1` tag and is folded into the dashboard bug list: [PR #37954](https://github.com/BerriAI/litellm/pull/37954), which restores `mode: completion` models in the playground chat dropdown after the endpoint filter from [PR #36130](https://github.com/BerriAI/litellm/pull/36130) hid them; it reached the release line as backport [PR #37955](https://github.com/BerriAI/litellm/pull/37955). No new external contributors in that delta.

The ownership roll-up goes 276 to 277 with UI taking the extra PR, and the shadcn highlight bullet moves from 74 to 75 UI pull requests to stay consistent; that total comes from the release-notes tooling rather than a plain git count, so treat it as an estimate.

The `v1.98.0` tag is not cut yet, so the Full Changelog compare link will 404 until it lands.