### PR TITLE
docs: update GCP Terraform example to Gemini 3.7 Flash

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -432,8 +432,11 @@ module "litellm" {
 
   proxy_config = {
     model_list = [{
-      model_name = "gemini-2.5-pro"
-      litellm_params = { model = "vertex_ai/gemini-2.5-pro" }
+      model_name = "gemini-3.7-flash"
+      litellm_params = {
+        model           = "vertex_ai/gemini-3.7-flash"
+        vertex_location = "global"
+      }
     }]
   }
 }


### PR DESCRIPTION
## Summary

Updates the Google Cloud Terraform deployment example from Gemini 2.5 Pro to Gemini 3.7 Flash

Sets `vertex_location = "global"` because Gemini 3.7 Flash is available through the `global`, `us`, and `eu` Vertex AI locations

## Verification

- `npm run lint:writing`
- `NODE_OPTIONS=--experimental-global-webcrypto npm run build`

The build completed successfully. Existing Docusaurus warnings were unchanged and unrelated to this example

Fixes BerriAI/litellm#37990
