### PR TITLE
docs: use the real internal_user_viewer role value

### DIFF
--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -272,7 +272,7 @@ Use `GENERIC_USER_ROLE_ATTRIBUTE` to specify which attribute in the SSO token co
 - `proxy_admin` - Admin over the platform
 - `proxy_admin_viewer` - Can login, view all keys, view all spend (read-only)
 - `internal_user` - Can login, view/create/delete their own keys, view their spend
-- `internal_user_view_only` - Can login, view their own keys, view their own spend
+- `internal_user_viewer` - Can login, view their own keys, view their own spend
 
 Nested attribute paths are supported (e.g., `claims.role` or `attributes.litellm_role`).
 

--- a/docs/proxy/cost_tracking.md
+++ b/docs/proxy/cost_tracking.md
@@ -291,7 +291,7 @@ By default, non-admin callers are **scoped to their own data**:
 | Caller role | `/spend/keys` | `/spend/users` |
 |-------------|---------------|----------------|
 | `proxy_admin` / `proxy_admin_viewer` | All keys | All users (or `?user_id=` for one row) |
-| `internal_user` / `internal_user_view_only` | Keys where `user_id` matches the caller | Only the caller's row |
+| `internal_user` / `internal_user_viewer` | Keys where `user_id` matches the caller | Only the caller's row |
 | Non-admin with no `user_id` on the key | Empty list `[]` | Empty list `[]` |
 
 An internal user who passes `?user_id=` for **another** user receives **HTTP 403** (not a silently filtered list).

--- a/docs/proxy/saml_sso.md
+++ b/docs/proxy/saml_sso.md
@@ -115,7 +115,7 @@ Under **Attribute Statements**, add the attributes your proxy will read. The def
 | `firstName` | `user.firstName` |
 | `lastName` | `user.lastName` |
 
-If you want to control user roles from Okta, add a **Group Attribute Statement** or a custom attribute named `role` with a value of `proxy_admin`, `proxy_admin_viewer`, `internal_user`, or `internal_user_view_only`.
+If you want to control user roles from Okta, add a **Group Attribute Statement** or a custom attribute named `role` with a value of `proxy_admin`, `proxy_admin_viewer`, `internal_user`, or `internal_user_viewer`.
 
 #### Step 2: Copy the IdP metadata URL
 
@@ -203,7 +203,7 @@ LiteLLM auto-detects common SAML attribute names (URN/OID and friendly names) fo
 | `SAML_ATTRIBUTE_ROLE` | `role`, `roles`, `litellm_role` | Attribute mapped to the LiteLLM user role |
 | `SAML_ATTRIBUTE_TEAM_IDS` | `teams`, `team_ids`, `groups` | Attribute mapped to LiteLLM team IDs |
 
-The role attribute value must be one of: `proxy_admin`, `proxy_admin_viewer`, `internal_user`, or `internal_user_view_only`.
+The role attribute value must be one of: `proxy_admin`, `proxy_admin_viewer`, `internal_user`, or `internal_user_viewer`.
 
 ## Configuration reference
 

--- a/docs/proxy/token_auth.md
+++ b/docs/proxy/token_auth.md
@@ -1054,7 +1054,7 @@ general_settings:
 **Supported LiteLLM Roles:**
 - `proxy_admin`: Full administrative access
 - `internal_user`: Standard user access
-- `internal_user_view_only`: Read-only access
+- `internal_user_viewer`: Read-only access
 
 #### 3. Example JWT Token
 

--- a/docs/tutorials/scim_litellm.md
+++ b/docs/tutorials/scim_litellm.md
@@ -105,7 +105,7 @@ This behavior is independent of `litellm_settings.scim_upsert_user`. That settin
 
 ## Assigning the proxy admin role
 
-By default, newly provisioned SCIM users receive the role configured in `litellm_settings.default_internal_user_params.user_role`. If no role is configured, LiteLLM assigns `internal_user_view_only`. Existing users retain their current role.
+By default, newly provisioned SCIM users receive the role configured in `litellm_settings.default_internal_user_params.user_role`. If no role is configured, LiteLLM assigns `internal_user_viewer`. Existing users retain their current role.
 
 Configure `scim_admin_group` to manage global roles through SCIM group membership:
 


### PR DESCRIPTION
Fixes BerriAI/litellm#33690.

The SSO, SAML, JWT, SCIM, and cost tracking pages all document a LiteLLM role called `internal_user_view_only`. That value does not exist. `LitellmUserRoles` in `litellm/proxy/_types.py` names the enum member `INTERNAL_USER_VIEW_ONLY`, but its string value is `internal_user_viewer`, and `is_valid_litellm_user_role` resolves a role by looking the string up in `_value2member_map_`. That is an exact, case-insensitive comparison against values with no aliasing, so `internal_user_view_only` never matches a role.

The failure mode is quiet, which is what makes it worth correcting. An operator following the Generic OIDC section of the admin UI SSO page, or the Okta setup in the SAML page, copies the documented string into their identity provider role claim. The claim then fails to resolve, and the user silently falls back to an existing or default role instead of the read-only role the operator intended. Nothing surfaces the bad role string, so the page that caused the problem is the last place anyone thinks to look.

`admin_ui_sso.md` also contradicted itself. The Azure section already used the correct `internal_user_viewer` while the Generic OIDC section above it did not, so two people configuring two different providers from the same page ended up with different results.

This corrects all six occurrences, in `docs/proxy/admin_ui_sso.md`, `docs/proxy/saml_sso.md` (two), `docs/proxy/token_auth.md`, `docs/tutorials/scim_litellm.md`, and `docs/proxy/cost_tracking.md`. Only the role string changed; no surrounding wording was touched.

One note for the reviewer: `docs/proxy/access_control.md` marks `internal_user_viewer` as deprecated in favor of team and organization roles. I left that alone, since correcting the value people are copying today seemed worth keeping separate from any deprecation guidance.

Verified with `npm run build`, which completed successfully with no broken links, and `npm run lint:writing`, which reports no findings in any changed file. For transparency, `lint:writing` already exits non-zero on ten pre-existing em dashes in `blog/` frontmatter, all unrelated to this change.
