### PR TITLE
docs(data_security): correct vendor certification answers

### DIFF
--- a/docs/data_security.md
+++ b/docs/data_security.md
@@ -66,9 +66,7 @@ Point of contact email address for security incidents: krrish@berri.ai
 Point of contact email address for general security-related questions: krrish@berri.ai 
 
 Has the Vendor been audited / certified? 
-- SOC 2 Type I. Certified.
 - SOC 2 Type II. In progress. ETA September 15th, 2026.
-- ISO 27001. Certified.
 
 Has an information security management system been implemented? 
 - Yes - [CodeQL](https://codeql.github.com/) and an ISMS covering multiple security domains.

--- a/docs/data_security.md
+++ b/docs/data_security.md
@@ -66,9 +66,9 @@ Point of contact email address for security incidents: krrish@berri.ai
 Point of contact email address for general security-related questions: krrish@berri.ai 
 
 Has the Vendor been audited / certified? 
-- SOC 2 Type I. Certified. Report available upon request on Enterprise plan.
-- SOC 2 Type II. In progress. Certificate available by April 15th, 2025.
-- ISO 27001. Certified. Report available upon request on Enterprise plan.
+- SOC 2 Type I. Certified.
+- SOC 2 Type II. In progress. ETA September 15th, 2026.
+- ISO 27001. Certified.
 
 Has an information security management system been implemented? 
 - Yes - [CodeQL](https://codeql.github.com/) and an ISMS covering multiple security domains.

--- a/docs/learn/enterprise_quickstart.md
+++ b/docs/learn/enterprise_quickstart.md
@@ -695,7 +695,7 @@ items={[
   {
     icon: "🔒",
     title: "Data Security",
-    description: "SOC 2, ISO 27001, data regions, and compliance FAQs.",
+    description: "Self-hosted data handling, vulnerability reporting, and compliance FAQs.",
     to: "/docs/data_security",
   },
   {


### PR DESCRIPTION
Corrects the vendor certification answers on the Data Privacy and Security page. The SOC 2 Type I entry is removed because we are not SOC 2 Type I certified, and the ISO 27001 entry is removed because that recertification process only begins once we receive the SOC 2 Type II report. What remains is the SOC 2 Type II entry, whose ETA was stale at April 15th, 2025 and now reads September 15th, 2026.

The Data Security card on the enterprise quickstart page advertised the page as covering "SOC 2, ISO 27001, data regions, and compliance FAQs", so it now describes what the page actually covers.

Generated with [Claude Code](https://claude.com/claude-code)