### PR TITLE
docs(search): add Parallel Search examples to generic guides

### DIFF
--- a/docs/integrations/websearch_interception.md
+++ b/docs/integrations/websearch_interception.md
@@ -1,6 +1,6 @@
 # Web Search Integration
 
-Enable transparent server-side web search execution for any LLM provider. LiteLLM automatically intercepts web search tool calls and executes them using your configured search provider (Perplexity, Tavily, etc.).
+Enable transparent server-side web search execution for any LLM provider. LiteLLM automatically intercepts web search tool calls and executes them using your configured search provider (Parallel, Perplexity, Tavily, and others).
 
 ## Quick Start
 
@@ -236,7 +236,14 @@ search_tools:
     litellm_params:
       search_provider: tavily
       api_key: os.environ/TAVILY_API_KEY
+
+  - search_tool_name: parallel-search
+    litellm_params:
+      search_provider: parallel_ai
+      api_key: os.environ/PARALLEL_API_KEY
 ```
+
+To use Parallel Search, set `search_tool_name: parallel-search` in `websearch_interception_params`.
 
 ## Usage Examples
 

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -39,6 +39,8 @@ for result in response.results:
     print(f"Snippet: {result.snippet}\n")
 ```
 
+To use [Parallel AI Search](./parallel_ai.md), set `PARALLEL_API_KEY` and pass `search_provider="parallel_ai"`.
+
 ### Async Usage 
 
 ```python showLineNumbers title="Async Search"
@@ -102,6 +104,11 @@ search_tools:
     litellm_params:
       search_provider: tavily
       api_key: os.environ/TAVILY_API_KEY
+
+  - search_tool_name: parallel-search
+    litellm_params:
+      search_provider: parallel_ai
+      api_key: os.environ/PARALLEL_API_KEY
 ```
 
 Start litellm

--- a/docs/tutorials/claude_code_websearch.md
+++ b/docs/tutorials/claude_code_websearch.md
@@ -60,9 +60,26 @@ search_tools:
       api_key: os.environ/PERPLEXITY_API_KEY
 ```
 
+To use Parallel Search instead, set `PARALLEL_API_KEY` and replace the `litellm_settings` and `search_tools` sections:
+
+```yaml showLineNumbers title="Parallel Search configuration"
+litellm_settings:
+  callbacks: ["websearch_interception"]
+  websearch_interception_params:
+    enabled_providers: [bedrock]
+    search_tool_name: parallel-search
+
+search_tools:
+  - search_tool_name: parallel-search
+    litellm_params:
+      search_provider: parallel_ai
+      api_key: os.environ/PARALLEL_API_KEY
+```
+
 ### 2. Start Proxy
 
 ```bash showLineNumbers title="Start LiteLLM Proxy"
+# For Parallel Search, export PARALLEL_API_KEY=your-key instead.
 export PERPLEXITY_API_KEY=your-key
 litellm --config config.yaml
 ```
@@ -82,7 +99,7 @@ Now use web search in Claude Code - it works with any provider!
 When Claude Code sends a web search request, LiteLLM:
 1. Intercepts the native `web_search` tool
 2. Converts it to LiteLLM's standard format
-3. Executes the search via Perplexity/Tavily
+3. Executes the search using the configured provider, such as Parallel, Perplexity, or Tavily
 4. Returns the final answer to Claude Code
 
 ```mermaid
@@ -90,7 +107,7 @@ sequenceDiagram
     participant CC as Claude Code
     participant LP as LiteLLM Proxy
     participant B as Bedrock/Azure/etc
-    participant P as Perplexity/Tavily
+    participant P as Configured search provider
 
     CC->>LP: Request with web_search tool
     Note over LP: Convert native tool<br/>to LiteLLM format


### PR DESCRIPTION
Adds small Parallel Search examples to the existing Search overview, web search interception guide, and Claude Code tutorial.

The examples use the existing `parallel_ai` provider with `PARALLEL_API_KEY` and explicitly select `parallel-search` for interception. Existing Perplexity and Tavily examples stay in place, and the Claude Code architecture now reflects whichever provider is configured.

Verified with `npm run build` and `npm run lint:writing`.