### PR TITLE
docs(search): add Grounding with Bing (Microsoft Foundry) provider page

### DIFF
--- a/docs/search/bing_grounding.md
+++ b/docs/search/bing_grounding.md
@@ -1,0 +1,149 @@
+# Grounding with Bing Search (Microsoft Foundry)
+
+[Grounding with Bing Search](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/tools/bing-grounding) runs a web search through a model deployment in a [Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/) project, using the project's Responses API. The model performs the search and returns cited results, so search traffic stays inside your Foundry project and is billed by Azure
+
+There are two modes, chosen by whether you set a Grounding with Bing connection:
+
+- **Web search mode** (default): the model's built-in `web_search` tool. It needs no Bing resource and pays no per-search Bing fee, so LiteLLM tracks it at zero cost
+- **Connection mode**: the paid Grounding with Bing (G1) connection, selected with `BING_GROUNDING_CONNECTION_ID`. LiteLLM tracks it at the `bing_grounding/search` map price
+
+Both modes call the same model deployment, whose token usage is billed by Azure on your Foundry account
+
+| | |
+|---|---|
+| Provider ID | `bing_grounding` |
+| Project endpoint | `BING_GROUNDING_PROJECT_ENDPOINT`, or `api_base` |
+| Model deployment | `BING_GROUNDING_MODEL` (required) |
+| Auth (Azure API key) | `api_key`, sent as the `api-key` header |
+| Auth (Entra token) | `BING_GROUNDING_TOKEN`, sent as `Authorization: Bearer` |
+| Auth (azure-identity) | any `DefaultAzureCredential` source, for scope `https://ai.azure.com/.default` |
+| Grounding with Bing connection | `BING_GROUNDING_CONNECTION_ID` (optional, switches to connection mode) |
+
+The project endpoint looks like `https://<account>.services.ai.azure.com/api/projects/<project>`
+
+## LiteLLM Python SDK
+
+```python showLineNumbers title="Grounding with Bing Search"
+import os
+from litellm import search
+
+os.environ["BING_GROUNDING_PROJECT_ENDPOINT"] = "https://<account>.services.ai.azure.com/api/projects/<project>"
+os.environ["BING_GROUNDING_MODEL"] = "gpt-4.1"
+os.environ["BING_GROUNDING_TOKEN"] = "<entra bearer token>"
+
+response = search(
+    query="latest AI developments",
+    search_provider="bing_grounding",
+    max_results=5
+)
+
+for result in response.results:
+    print(f"{result.title}: {result.url}")
+    print(f"Snippet: {result.snippet}\n")
+```
+
+### Authentication
+
+Pass an Azure API key per call, and it rides the `api-key` header:
+
+```python showLineNumbers title="Grounding with Bing Search with an Azure API key"
+response = search(
+    query="latest AI developments",
+    search_provider="bing_grounding",
+    api_key=os.environ["AZURE_AI_API_KEY"]
+)
+```
+
+Or omit `BING_GROUNDING_TOKEN` and `api_key` to mint an Entra token from the standard [azure-identity](https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme) chain (`AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID`, a shared profile, managed identity, or any other `DefaultAzureCredential` source) for scope `https://ai.azure.com/.default`
+
+### Connection mode (paid Grounding with Bing)
+
+Set `BING_GROUNDING_CONNECTION_ID` to the project connection for a Grounding with Bing (G1) resource. The model then searches through that paid connection instead of the built-in tool, and LiteLLM tracks the `bing_grounding/search` cost:
+
+```python showLineNumbers title="Grounding with Bing Search in connection mode"
+os.environ["BING_GROUNDING_CONNECTION_ID"] = (
+    "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices"
+    "/accounts/<account>/projects/<project>/connections/<bing-connection>"
+)
+
+response = search(
+    query="latest AI developments",
+    search_provider="bing_grounding",
+    max_results=5
+)
+```
+
+## LiteLLM AI Gateway
+
+### 1. Setup config.yaml
+
+```yaml showLineNumbers title="config.yaml"
+search_tools:
+  - search_tool_name: bing-grounding-search
+    litellm_params:
+      search_provider: bing_grounding
+```
+
+Set `BING_GROUNDING_PROJECT_ENDPOINT`, `BING_GROUNDING_MODEL`, and one of the auth options in the proxy's environment. `BING_GROUNDING_CONNECTION_ID` is optional and switches to connection mode
+
+### 2. Start the proxy
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+### 3. Test the search endpoint
+
+```bash showLineNumbers title="Test Request"
+curl http://0.0.0.0:4000/v1/search/bing-grounding-search \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "latest AI developments",
+    "max_results": 5
+  }'
+```
+
+## Web search interception
+
+Grounding with Bing Search is a natural backend for [web search interception](../completion/web_search), which serves a model's native `web_search` tool from a search provider. Point the interception at the configured tool:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-5-mini
+    litellm_params:
+      model: openai/gpt-5-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+search_tools:
+  - search_tool_name: bing-grounding-search
+    litellm_params:
+      search_provider: bing_grounding
+
+litellm_settings:
+  callbacks: ["websearch_interception"]
+  websearch_interception_params:
+    enabled_providers: ["openai"]
+    search_tool_name: bing-grounding-search
+```
+
+## Unified Parameters
+
+| Unified spec parameter | Web search mode | Connection mode |
+|---|---|---|
+| `max_results` | caps the returned results after the fact (the built-in tool has no count knob) | maps to the search configuration's `count` |
+| `country` | maps to the approximate `user_location` | _ignored (the connection's `market` wants a full locale, which a bare country code cannot fill)_ |
+| `search_domain_filter` | _ignored (no equivalent)_ | _ignored (no equivalent)_ |
+| `max_tokens_per_page` | _ignored (no equivalent)_ | _ignored (no equivalent)_ |
+
+## Notes
+
+Web search mode is tracked at zero cost because the built-in `web_search` tool pays no per-search Bing fee. Connection mode is tracked at the `bing_grounding/search` map price, the Grounding with Bing (G1) per-search fee. The model deployment's token usage is billed separately by Azure on your Foundry account
+
+The Entra token (`BING_GROUNDING_TOKEN` or one minted via azure-identity) is only sent to the endpoint configured in `BING_GROUNDING_PROJECT_ENDPOINT`, so a caller-supplied `api_base` cannot exfiltrate it. A caller-supplied `api_key` is treated as an Azure API key and sent in the `api-key` header instead
+
+LiteLLM posts to `<project-endpoint>/openai/v1/responses`, appending the path automatically if the endpoint does not already end in it
+
+If the grounded search comes back `failed` or `incomplete` with no results, LiteLLM raises an error rather than returning an empty success, so a failed search is not logged as a normal zero-result hit

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -2,7 +2,7 @@
 
 | Feature | Supported | 
 |---------|-----------|
-| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent`, `agentcore`, `nimble` |
+| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `brave`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup`, `duckduckgo`, `searchapi`, `serper`, `you_com`, `apiserpent`, `agentcore`, `nimble`, `bing_grounding` |
 | Cost Tracking | ✅ |
 | Logging | ✅ |
 | Load Balancing | ❌ |
@@ -210,7 +210,7 @@ See the [official Perplexity Search documentation](https://docs.perplexity.ai/ap
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | string or array | Yes | Search query. Can be a single string or array of strings |
-| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"brave"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, `"searxng"`, `"linkup"`, `"duckduckgo"`, `"searchapi"`, `"serper"`, or `"you_com"` or `"apiserpent"` or `"agentcore"` |
+| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"brave"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, `"searxng"`, `"linkup"`, `"duckduckgo"`, `"searchapi"`, `"serper"`, or `"you_com"` or `"apiserpent"` or `"agentcore"` or `"bing_grounding"` |
 | `search_tool_name` | string | Yes (Proxy) | Name of the search tool configured in `config.yaml` |
 | `max_results` | integer | No | Maximum number of results to return (1-20). Default: 10 |
 | `search_domain_filter` | array | No | List of domains to filter results (max 20 domains) |
@@ -283,6 +283,7 @@ The response follows Perplexity's search format with the following structure:
 | APISerpent | `APISERPENT_API_KEY` | `apiserpent` |
 | Bedrock AgentCore | `AGENTCORE_GATEWAY_URL` (required), AWS credentials or `AGENTCORE_GATEWAY_TOKEN` | `agentcore` |
 | Nimble | `NIMBLE_API_KEY` | `nimble` |
+| Grounding with Bing (Microsoft Foundry) | `BING_GROUNDING_PROJECT_ENDPOINT`, `BING_GROUNDING_MODEL` (required), `api_key` or `BING_GROUNDING_TOKEN` or azure-identity | `bing_grounding` |
 
 See the individual provider documentation for detailed setup instructions and provider-specific parameters.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -972,6 +972,7 @@ const sidebars = {
             "search/apiserpent",
             "search/agentcore",
             "search/nimble",
+            "search/bing_grounding",
           ]
         },
         "skills",


### PR DESCRIPTION
## What

Adds a provider page for the new `bing_grounding` search provider (Grounding with Bing on Microsoft Foundry), documenting both modes (free built-in web_search and the paid Grounding with Bing connection), the auth options (Azure api-key header, Entra `BING_GROUNDING_TOKEN`, or azure-identity), SDK and gateway usage, web search interception, the unified-parameter mapping, and the $0 web_search cost model

## Why

The provider lands in litellm via BerriAI/litellm#38119, so the docs need a page and the search overview needs `bing_grounding` in its supported-providers lists

## Changes

- New `docs/search/bing_grounding.md`
- `docs/search/index.md`: `bing_grounding` added to the top provider list, the `search_provider` param values, and the bottom supported-providers table
- `sidebars.js`: sidebar entry under Search

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or deployment impact.
> 
> **Overview**
> Adds documentation for the **`bing_grounding`** search provider (Grounding with Bing on Microsoft Foundry), aligned with the implementation landing in the main LiteLLM repo.
> 
> **New** `docs/search/bing_grounding.md` covers web search vs paid connection mode (`BING_GROUNDING_CONNECTION_ID`), env vars and auth (Azure `api-key`, Entra/`BING_GROUNDING_TOKEN`, azure-identity), SDK and gateway `search_tools` setup, web search interception, unified-parameter behavior, and cost/error-handling notes.
> 
> **Updates** `docs/search/index.md` so `bing_grounding` appears in the supported-providers feature table, the `search_provider` parameter description, and the env-var reference table. **Registers** the page in `sidebars.js` under `/search`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f333318bfb9e17c0d9e7ccf491e5a99b947b73b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->