### PR TITLE
docs(langsmith): describe root-run trace_id override and session_id constraints

### DIFF
--- a/docs/observability/langsmith_integration.md
+++ b/docs/observability/langsmith_integration.md
@@ -193,8 +193,8 @@ response = litellm.completion(
         "project_name": "litellm-completion",                       # langsmith project name
         "run_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",           # langsmith run id
         "parent_run_id": "f8faf8c1-9778-49a4-9004-628cdb0047e5",    # langsmith run parent run id
-        "trace_id": "df570c03-5a03-4cea-8df0-c162d05127ac",         # langsmith run trace id
-        "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82",       # langsmith run session id
+        "trace_id": "df570c03-5a03-4cea-8df0-c162d05127ac",         # langsmith run trace id (root runs override this, see note below)
+        "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82",       # langsmith run session id (must be an existing tracer session)
         "tags": ["model1", "prod-2"],                               # langsmith run tags
         "metadata": {                                               # langsmith run metadata
             "key1": "value1"
@@ -204,6 +204,8 @@ response = litellm.completion(
 )
 print(response)
 ```
+
+A run that posts as a root, meaning it carries neither `parent_run_id` nor `dotted_order`, gets its `trace_id` set to the run id so the batch passes LangSmith's dotted_order validation. Supply `parent_run_id` or `dotted_order` to keep your own `trace_id`. `session_id` must reference a tracer session that already exists in LangSmith and is ignored when it equals `trace_id`, because that shape is produced by the proxy's request-header fan-out rather than a deliberate session
 
 ### Make LiteLLM Proxy use Custom `LANGSMITH_BASE_URL`
 


### PR DESCRIPTION
BerriAI/litellm#38116 makes the LangSmith logger set trace_id to the run id on runs that post as roots, so batches pass LangSmith's dotted_order validation. It also forwards metadata.session_id only when it differs from metadata.trace_id, since the equal pair is produced by the proxy header fan-out and LangSmith rejects a run body session_id that does not name an existing tracer session.

This updates the field reference in the LangSmith integration page to match: a note after the code sample explains when a caller supplied trace_id is kept, and the session_id line now says the value must be an existing tracer session
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->