### PR TITLE
docs: mention the Crossplane provider alongside Terraform

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -444,7 +444,7 @@ Three GCP-specific caveats. First, always override `image_registry`: it defaults
 </TabItem>
 </Tabs>
 
-To manage LiteLLM resources (keys, teams, models) as code once the stack is up, use [terraform-provider-litellm](https://github.com/BerriAI/terraform-provider-litellm).
+To manage LiteLLM resources (keys, teams, models) as code once the stack is up, use [terraform-provider-litellm](https://github.com/BerriAI/terraform-provider-litellm). If you run the proxy on Kubernetes and reconcile the rest of your platform with [Crossplane](https://crossplane.io/) instead of Terraform, the community [provider-litellm](https://github.com/TheCodingSheikh/provider-litellm) exposes the same management API as Kubernetes custom resources, so models, teams and budgets are applied with `kubectl` and reconciled continuously alongside your cluster state.
 
 ## Other platforms
 

--- a/docs/proxy/model_management.md
+++ b/docs/proxy/model_management.md
@@ -51,11 +51,13 @@ For production deployments, use one primary source of truth for model definition
 | Approach | Storage | Restart required for model changes? | Best for |
 | --- | --- | --- | --- |
 | `config.yaml` | Configuration file | Yes. Reload or restart the proxy tasks after changing the file. | GitOps workflows where every model change is deployed with the application. |
-| Admin UI, management API, or Terraform | LiteLLM database | No. Changes apply to new requests after the write succeeds. | Day-2 operations, frequent model changes, and centralized automation. |
+| Admin UI, management API, Terraform, or Crossplane | LiteLLM database | No. Changes apply to new requests after the write succeeds. | Day-2 operations, frequent model changes, and centralized automation. |
 
 LiteLLM can load file-based and database-backed models at the same time, but using both as model-management systems creates two sources of truth. A model loaded from `config.yaml` remains owned by that file and cannot be edited or deleted through the UI. Keep model definitions in one system, and continue using `config.yaml` or environment variables for infrastructure settings that are not exposed through the management API.
 
 The [LiteLLM Terraform provider](https://github.com/BerriAI/terraform-provider-litellm) calls the same management API used by the Admin UI. It persists resources in the LiteLLM database, so you do not need to build a separate REST client or restart the proxy for model changes.
+
+On Kubernetes, the community [provider-litellm](https://github.com/TheCodingSheikh/provider-litellm) Crossplane provider calls that same management API from inside the cluster. Models, teams, budgets and guardrails are declared as Kubernetes custom resources, which lets Argo CD or Flux own them the way they already own the rest of the platform, and lets the controller correct drift if a model is edited out of band.
 
 ## Automation (API)
 


### PR DESCRIPTION
## What this changes

Two docs pages already tell readers to use `terraform-provider-litellm` for managing LiteLLM resources as code:

- `docs/proxy/deploy.md`, at the end of the Terraform deployment section
- `docs/proxy/model_management.md`, in "Choose one source of truth for models"

This adds Crossplane as a second option in both places, for teams who run the proxy on Kubernetes and reconcile the rest of their platform with Crossplane rather than Terraform. The provider calls the same management API the Admin UI and the Terraform provider call, so the guidance about the database being the source of truth still holds. It only changes how the writes are driven: Kubernetes custom resources reconciled by a controller, so Argo CD or Flux can own LiteLLM models, teams and budgets the same way they own everything else in the cluster.

The table row in `model_management.md` gains "or Crossplane", and each page gains one sentence. Nothing else moves.

## Notes

- No em dashes, and no `utilize` / `leverage` / `seamless`, per CONTRIBUTING and CLAUDE.md.
- Only two existing paragraphs are touched, so `sidebars.js` needs no update.
- Disclosure: I maintain the linked project ([provider-litellm](https://github.com/TheCodingSheikh/provider-litellm)). It is community maintained and Apache 2.0, and it wraps the `ncecere/litellm` Terraform provider for its resource coverage. Happy to reword or drop the description if you would rather phrase it differently, or to word it generically if you prefer not to name a specific community project.
