### PR TITLE
docs(together_ai): document reasoning controls via chat_template_kwargs

### DIFF
--- a/docs/providers/togetherai.md
+++ b/docs/providers/togetherai.md
@@ -208,6 +208,81 @@ print(response)
 ```
 
 
+## Reasoning controls via `chat_template_kwargs`
+
+Together steers its reasoning models through a request-level `chat_template_kwargs` object ([Together docs](https://docs.together.ai/docs/deepseek-v3-1#hybrid-reasoning-model)). LiteLLM passes it through untouched on the SDK and on every proxy endpoint (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`), streaming included, so any key Together documents for your model works as is. Together validates the keys server-side and silently ignores ones a model does not support.
+
+### Toggling thinking on hybrid models
+
+Hybrid reasoning models (e.g. `Qwen/Qwen3.5-9B`) think by default; `{"thinking": false}` turns it off.
+
+<Tabs>
+<TabItem value="sdk" label="LiteLLM SDK Usage">
+
+```python
+from litellm import completion
+import os
+
+os.environ["TOGETHERAI_API_KEY"] = "your-api-key"
+
+response = completion(
+    model="together_ai/Qwen/Qwen3.5-9B",
+    messages=[{"role": "user", "content": "What is 17*23? Answer with just the number."}],
+    chat_template_kwargs={"thinking": False},
+)
+print(response.choices[0].message.content)  # direct answer, no reasoning_content
+```
+</TabItem>
+
+<TabItem value="proxy" label="LiteLLM Proxy Usage">
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3.5-9B",
+    "messages": [{"role": "user", "content": "What is 17*23? Answer with just the number."}],
+    "chat_template_kwargs": {"thinking": false}
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+### Preserved thinking across turns
+
+Models like `zai-org/GLM-5.2` clear prior-turn reasoning from the prompt by default. Sending `{"clear_thinking": false}` keeps it, provided you replay each assistant turn's `reasoning_content` unmodified alongside its `content`. LiteLLM forwards the replayed `reasoning_content` to Together and strips its own bookkeeping fields (`thinking_blocks`, `provider_specific_fields`) from the outbound request, so replaying a LiteLLM response object verbatim is safe.
+
+```python
+from litellm import completion
+import os
+
+os.environ["TOGETHERAI_API_KEY"] = "your-api-key"
+
+first = completion(
+    model="together_ai/zai-org/GLM-5.2",
+    messages=[{"role": "user", "content": "Pick a secret two-digit number. Reply with only the sum of its digits."}],
+)
+
+followup = completion(
+    model="together_ai/zai-org/GLM-5.2",
+    messages=[
+        {"role": "user", "content": "Pick a secret two-digit number. Reply with only the sum of its digits."},
+        {
+            "role": "assistant",
+            "content": first.choices[0].message.content,
+            "reasoning_content": first.choices[0].message.reasoning_content,
+        },
+        {"role": "user", "content": "What was the secret number? Reply with only the number."},
+    ],
+    chat_template_kwargs={"clear_thinking": False},
+)
+print(followup.choices[0].message.content)  # recalls the number from the replayed reasoning
+```
+
+Anthropic-SDK clients pointed at the proxy's `/v1/messages` endpoint get the same behavior by replaying the assistant `thinking` blocks and passing `chat_template_kwargs: {"clear_thinking": false}` at the top level of the request.
+
 ## Rerank 
 
 ### Usage


### PR DESCRIPTION
Adds a "Reasoning controls via chat_template_kwargs" section to the Together AI provider page. It covers the request-level passthrough on the SDK and all proxy endpoints, toggling thinking off on hybrid models, and preserved thinking on GLM-5.2 via clear_thinking false with a reasoning_content replay example. Pairs with BerriAI/litellm#38275, which pins the passthrough and strips litellm-internal fields from outbound requests while keeping reasoning_content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **Reasoning controls via `chat_template_kwargs`** section to the Together AI provider docs, placed before the existing Rerank section.
> 
> It documents that LiteLLM forwards Together’s request-level `chat_template_kwargs` unchanged on the SDK and proxy routes (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, including streaming). **Toggling thinking on hybrid models** is covered with SDK and proxy examples using `{"thinking": false}` on models like `Qwen/Qwen3.5-9B`.
> 
> **Preserved thinking across turns** explains `{"clear_thinking": false}` for models such as `zai-org/GLM-5.2`, with a multi-turn example that replays assistant `reasoning_content`, and notes that LiteLLM strips internal fields (`thinking_blocks`, `provider_specific_fields`) on outbound requests so responses can be replayed safely. Anthropic-SDK clients via `/v1/messages` are mentioned for the same pattern with `thinking` blocks.
> 
> This is documentation-only and references the companion implementation PR for passthrough and field stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e458a4c0658c01c104a9be738217fd03c14c4ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->