### PR TITLE
docs(proxy): document fallback attribution keys in spend logs

### DIFF
--- a/docs/proxy/cost_tracking.md
+++ b/docs/proxy/cost_tracking.md
@@ -150,6 +150,10 @@ The following spend gets tracked in Table `LiteLLM_SpendLogs`
   "total_tokens": 100,
   "completion_tokens": 80,
   "prompt_tokens": 20,
+  "metadata": {
+    "attempted_fallbacks": 0,                                                    # 0 = requested model group served the request
+    "original_model_group": "llama3"                                             # Model group originally requested
+  },
 
 }
 ```

--- a/docs/proxy/reliability.md
+++ b/docs/proxy/reliability.md
@@ -669,6 +669,26 @@ Use a test request that the primary provider rejects with a content-policy error
 Enable pre-call checks and send a test request that exceeds the primary model's configured context window.
 
 
+### Track Fallbacks in Spend Logs
+
+Every spend log row records whether the request was served by the model group the client asked for, or by a fallback. The proxy writes two keys into the `metadata` column of `LiteLLM_SpendLogs`:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `attempted_fallbacks` | int | Number of fallback attempts made. `0` means the requested model group served the request |
+| `original_model_group` | str | The model group the client originally requested |
+
+For example, a request to `gpt-3.5-turbo` that fails over to `claude-fable-5` produces a row with `model_group=claude-fable-5`, `attempted_fallbacks=1`, and `original_model_group=gpt-3.5-turbo`, so fallback-served and directly-served requests stay distinguishable after the fact:
+
+```sql
+SELECT model_group,
+       metadata->>'attempted_fallbacks' AS attempted_fallbacks,
+       metadata->>'original_model_group' AS original_model_group
+FROM "LiteLLM_SpendLogs";
+```
+
+Both keys are set by the proxy and overwrite any client-supplied values of the same name. Rows written before this feature read `null` for both keys.
+
 ### Context Window Fallbacks (Pre-Call Checks + Fallbacks)
 
 **Before call is made** check if a call is within model context window with  **`enable_pre_call_checks: true`**.


### PR DESCRIPTION
BerriAI/litellm#38107 added `attempted_fallbacks` and `original_model_group` to the `LiteLLM_SpendLogs` metadata column, so each spend log row now records whether the requested model group served the request or a fallback did

This documents the two keys in the fallbacks page, with a readback query and the served-by-fallback row shape, and adds them to the spend log entry example on the spend tracking page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->