### PR TITLE
docs(passthrough): managed ids cover streamed responses and use the real passthrough prefix

### DIFF
--- a/docs/proxy/passthrough_managed_ids.md
+++ b/docs/proxy/passthrough_managed_ids.md
@@ -1,6 +1,6 @@
 # Passthrough Managed IDs
 
-When you use LiteLLM's passthrough endpoints (e.g. `/openai/v1/files`, `/azure/openai/batches`) the upstream provider returns its own raw IDs such as `file-abc123` or `batch_xyz`. By default those IDs are returned directly to your client, which means:
+When you use LiteLLM's passthrough endpoints (e.g. `/openai_passthrough/v1/files`, `/azure/openai/batches`) the upstream provider returns its own raw IDs such as `file-abc123` or `batch_xyz`. By default those IDs are returned directly to your client, which means:
 
 - Any user who guesses or intercepts another user's `file-abc123` can use it.
 - You have no proxy-level record of who owns what.
@@ -27,18 +27,24 @@ The feature requires:
 - A database configured for the proxy (Prisma / PostgreSQL).
 - The `managed_files` enterprise hook to be available.
 
-The feature is active only for **OpenAI** and **Azure OpenAI** passthrough routes.
+The feature is active only for **OpenAI** (`/openai_passthrough/...`) and **Azure OpenAI** (`/azure/openai/...`) passthrough routes.
+
+:::info `/openai/v1/files`, `/openai/v1/batches`, and `/openai/v1/responses` are not passthrough routes
+
+Those three paths are served by LiteLLM's native endpoints, exactly like `/v1/files`, `/v1/batches`, and `/v1/responses`, so `passthrough_managed_object_ids` never sees them. To isolate tenants there, use [`require_managed_files`](./litellm_managed_files) for files and batches and the built-in Responses API ownership checks for responses. The passthrough prefix for OpenAI is `/openai_passthrough`.
+
+:::
 
 ## Native managed endpoints vs passthrough
 
 | | Native managed endpoints | Passthrough with managed IDs |
 |---|---|---|
-| **URL prefix** | `/v1/files`, `/v1/batches` | `/openai/v1/files`, `/azure/openai/batches` |
+| **URL prefix** | `/v1/files`, `/v1/batches` | `/openai_passthrough/v1/files`, `/azure/openai/batches` |
 | **Routing** | LiteLLM internal logic; model-based routing | Direct forward to upstream provider |
 | **Credential resolution** | Via `model_list` router | Via `PassthroughEndpointRouter` / env vars |
 | **Use when** | You want LiteLLM to pick the right deployment automatically, or you need cross-provider batching | You want to call a provider API directly (e.g. fine-tuning, responses, custom endpoints) but still need proxy-level access control |
 | **ID management** | Always managed by LiteLLM | Managed IDs only when `passthrough_managed_object_ids: true` |
-| **Streaming ID minting** | Supported | **Not yet supported** (output IDs in streaming responses are not rewritten) |
+| **Streaming ID minting** | Supported | Supported for `POST /v1/responses` with `stream: true` (the `response.id` in every event is rewritten) |
 
 ## Supported endpoints
 
@@ -66,6 +72,8 @@ These are the specific routes where LiteLLM will mint a managed ID for raw provi
 | Azure | `POST` | `/v1/responses` | `id` (`resp_`) |
 | Azure | `GET` | `/v1/responses/{response_id}` | `id` (`resp_`) |
 | Azure | `DELETE` | `/v1/responses/{response_id}` | `id` (`resp_`) |
+
+`POST /v1/responses` with `stream: true` is covered as well. The proxy records the response as the caller's own from the first `response.created` event and rewrites the `response.id` inside every event as the stream is relayed, so a streamed response is owned and protected exactly like a non-streamed one.
 
 ### Managed ID resolution (INPUT)
 
@@ -159,10 +167,10 @@ The managed ID must map to a real row in the proxy database. A guessed, forged, 
 
 ## How list endpoints work
 
-`GET /openai/v1/files` and `GET /openai/v1/batches` (and their Azure equivalents) are **fully intercepted**. The request is never forwarded to the upstream provider. Instead, the proxy queries its own database and returns only the rows the caller owns:
+`GET /openai_passthrough/v1/files` and `GET /openai_passthrough/v1/batches` (and their Azure equivalents) are **fully intercepted**. The request is never forwarded to the upstream provider. Instead, the proxy queries its own database and returns only the rows the caller owns:
 
 ```
-GET /openai/v1/files
+GET /openai_passthrough/v1/files
                                      ┌─────────────────────────────┐
                          admin key?  │  WHERE {}                   │
                                      │  (all rows)                 │
@@ -182,15 +190,21 @@ Pagination parameters `limit`, `after`, and `before` are supported and map direc
 
 A caller with no `user_id` and no `team_id` always receives an empty list; the proxy never falls back to an unscoped query.
 
+## Objects the proxy never saw
+
+Ownership is recorded when an object is created through the passthrough route with the feature on. A file, batch, or response created before you enabled it, or created straight against the provider with the same API key, has no owner on the proxy side, so any key allowed on the passthrough route can still reach it by its raw provider ID (see the limitation below). LiteLLM deliberately does not try to claim those objects for anyone.
+
+When those pre-existing objects must be isolated too, the strict option is to stop sharing one provider key across tenants: define one [custom passthrough endpoint](./pass_through) per team, each carrying that team's own provider API key in its `headers`, and restrict every team to its endpoint with `allowed_passthrough_routes` in the team's metadata. The provider then scopes visibility itself, and managed IDs keep working on top of that.
+
 ## Limitations
 
-### Streaming responses - output ID minting not supported
+### Streaming is only rewritten for responses
 
-When the upstream returns a **streaming** (SSE) response, managed IDs are **not minted** for raw provider IDs in the stream chunks. The client receives the raw upstream IDs.
+`POST /v1/responses` streams are the only SSE responses that carry a mintable ID, so those are the only streams the proxy rewrites. Every other streaming passthrough response is relayed untouched.
 
-### Raw IDs are passed through unchanged
+### Raw IDs only work for their owner
 
-If you send a raw provider ID (e.g. `file-abc123`) instead of a managed ID, the proxy passes it through without any ownership check. The permission system only applies to strings that decode as passthrough managed IDs.
+If you send a raw provider ID (e.g. `file-abc123`) instead of a managed ID, the proxy checks whether it belongs to a managed resource before forwarding it. A raw ID that maps to another caller's resource is refused with **404** (the same answer as an unknown managed ID, so callers cannot probe which IDs exist). The owner's own raw ID is forwarded. A raw ID the proxy has never recorded is forwarded without an ownership check, which is what makes the objects above reachable.
 
 ### IDs are provider-scoped
 


### PR DESCRIPTION
Companion to BerriAI/litellm#38320 (passthrough managed ids for streamed responses)

The page previously used `/openai/v1/files` and `/openai/v1/batches` as its example routes. On a live proxy those paths are served by the unified native endpoints, which are matched before the generic passthrough router, so `passthrough_managed_object_ids` never sees them and a user following the docs got no protection and no error. Every example now uses the real passthrough prefixes (`/openai_passthrough/...`, `/azure/openai/...`) and an admonition spells out that the three `/openai/v1/*` object routes are native endpoints with their own controls

Also documents what the linked PR adds and what stays out of scope: streamed `POST /v1/responses` is now owned and rewritten from the first `response.created` event; objects the proxy never saw (created before the flag, or provider-direct) stay unowned, with one custom passthrough endpoint per team carrying that team's own provider key as the strict isolation option; raw provider ids that map to another caller's resource are refused with 404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior modified in this PR.
> 
> **Overview**
> Updates **Passthrough Managed IDs** documentation so examples match real proxy routing and reflect behavior from the companion implementation PR.
> 
> **Route corrections:** All OpenAI passthrough examples now use `/openai_passthrough/...` instead of `/openai/v1/...`, with an info callout explaining that `/openai/v1/files`, `/openai/v1/batches`, and `/openai/v1/responses` are **native** routes (use `require_managed_files` or Responses ownership there, not passthrough managed IDs).
> 
> **Streaming:** The comparison table and limitations now state that **`POST /v1/responses` with `stream: true`** rewrites `response.id` from the first `response.created` event through the stream; other SSE passthrough streams are still relayed unchanged.
> 
> **Ownership edge cases:** New section on objects the proxy never recorded (pre-flag or provider-direct), plus per-team custom passthrough endpoints with separate provider keys as the strict isolation pattern. **Raw provider IDs** are documented as owner-checked when mapped to a managed resource (**404** for another tenant’s ID); unrecorded raw IDs still pass through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b00b703ed2de04bcad54233144990c0e8106f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->