### PR TITLE
docs(anthropic-unified): strict now follows the request flag on the Responses bridge

### DIFF
--- a/docs/anthropic_unified/messages_to_responses_mapping.md
+++ b/docs/anthropic_unified/messages_to_responses_mapping.md
@@ -21,7 +21,7 @@ The transformation lives in `litellm/llms/anthropic/experimental_pass_through/re
 | `tools` | `tools` | Format-translated — see the tools section below |
 | `tool_choice` | `tool_choice` | Type-remapped — see the tool_choice section below |
 | `thinking` | `reasoning` | Budget tokens mapped to effort level — see the thinking section below |
-| `output_format` or `output_config.format` | `text` | Wrapped as `{"format": {"type": "json_schema", "name": "structured_output", "schema": ..., "strict": true}}` |
+| `output_format` or `output_config.format` | `text` | Wrapped as `{"format": {"type": "json_schema", "name": "structured_output", "schema": ..., "strict": ...}}`. `strict` is copied from the request's `strict` flag and defaults to `false`, so schemas with optional properties pass through; set `strict: true` to opt into OpenAI strict mode, which requires every property in `required` |
 | `context_management` | `context_management` | Converted from Anthropic dict to OpenAI array format — see the context_management section below |
 | `metadata.user_id` | `user` | Extracted from the metadata object and truncated to 64 characters |
 | `metadata.user_id` | `prompt_cache_key` | Same value, truncated to 64 characters (OpenAI's key limit), so one user's requests keep hitting the same prompt cache. Not set when `user_id` is empty or null. A `prompt_cache_key` sent in the request body wins over the derived one |


### PR DESCRIPTION
## TLDR

BerriAI/litellm#38211 changed the /v1/messages to Responses API bridge so `text.format.strict` is read from the request's `output_format.strict` (or `output_config.format.strict`) and defaults to `false` instead of being hardcoded `true`. The mapping table still said the wrapper always sends `"strict": true`, so this updates that row to describe the new default and how to opt into strict mode

## Proof

Before: the `output_format` row in [Messages to Responses mapping](https://docs.litellm.ai/docs/anthropic_unified/messages_to_responses_mapping) reads `"strict": true`

After: the row says `strict` is copied from the request's flag, defaults to `false` so schemas with optional properties pass through, and `strict: true` opts into OpenAI strict mode

`node scripts/check-writing-style.js docs/anthropic_unified/messages_to_responses_mapping.md` reports no prose em dashes and 0 vocabulary warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Updates the **Messages → Responses** parameter table so the `output_format` / `output_config.format` row matches current bridge behavior for structured output.
> 
> The doc no longer says the mapped `text.format` wrapper always sends **`"strict": true`**. It now states that **`strict`** is taken from the request’s **`strict`** flag, **defaults to `false`** (so JSON schemas with optional fields work), and **`strict: true`** opts into OpenAI strict mode where every property must appear in **`required`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2f23d5d7b9ba82805268491f622e187e059924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->