### PR TITLE
docs(bedrock_mantle): gpt-5.5 and gpt-5.4 context window is 1.05M

### DIFF
--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -242,8 +242,8 @@ os.environ['BEDROCK_MANTLE_REGION'] = "us-east-1"  # or use AWS_REGION
 
 | Model | Endpoint | Context Window | Input (per 1M tokens) | Output (per 1M tokens) |
 |-------|----------|---------------|----------------------|------------------------|
-| `openai.gpt-5.5` | `/responses` | 272K | $5.50 | $33.00 |
-| `openai.gpt-5.4` | `/responses` | 272K | $2.75 | $16.50 |
+| `openai.gpt-5.5` | `/responses` | 1.05M | $5.50 | $33.00 |
+| `openai.gpt-5.4` | `/responses` | 1.05M | $2.75 | $16.50 |
 | `openai.gpt-oss-120b` | `/chat/completions` | 131K | $0.15 | $0.60 |
 | `openai.gpt-oss-20b` | `/chat/completions` | 131K | $0.075 | $0.30 |
 | `openai.gpt-oss-safeguard-120b` | `/chat/completions` | 131K | $0.15 | $0.60 |


### PR DESCRIPTION
Bedrock Mantle enforces a 1,050,000-token prompt maximum for `openai.gpt-5.5` and `openai.gpt-5.4` (verified live: it serves 1,030,590-token prompts and rejects at 1,050,000), and BerriAI/litellm#38368 raises the gateway's cost-map ceiling to match, so the supported-models table's 272K rows are stale

Pricing columns are unchanged: AWS documents no long-context tier for these two models

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table correction with no runtime or configuration behavior changes in this PR.
> 
> **Overview**
> Updates the Bedrock Mantle **Supported Models** table so **`openai.gpt-5.5`** and **`openai.gpt-5.4`** list a **1.05M** context window instead of **272K**, matching live Mantle limits and the gateway cost-map ceiling from the related change.
> 
> **Input/output pricing** for those rows is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3ea033641b5fe6f63a2e436bebef1ad4ebe360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->