### PR TITLE
docs: add image_edit health check mode

### DIFF
--- a/docs/proxy/health.md
+++ b/docs/proxy/health.md
@@ -101,6 +101,7 @@ The health check picks the operation to test from the model's `model_info.mode`.
 | `realtime` | realtime session |
 | `ocr` | OCR |
 | `video_generation` | video generation |
+| `image_edit` | image edit |
 
 For a wildcard route (`*` in `litellm_params.model`), set `health_check_model` to the concrete model the probe should call. With `mode` unset on a wildcard route, `max_tokens` is left unset on the probe request.
 


### PR DESCRIPTION
Adds the image_edit row to the health check mode table in docs/proxy/health.md. Companion to BerriAI/litellm#38291, which adds health check support for deployments with mode: image_edit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the health check mode reference; no runtime or configuration behavior changes in this PR.
> 
> **Overview**
> Documents **`image_edit`** in the proxy health-check **Model modes** table in `docs/proxy/health.md`, so operators can set `model_info.mode: image_edit` and have probes use the image-edit API instead of default chat completion.
> 
> This is documentation only and aligns with the implementation PR that adds health-check support for `image_edit` deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59349e86ef9be816102e8cfb21a4baab033c1b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->