### PR TITLE
docs(caching): add ACL guidance for restricted Redis/Valkey users

### DIFF
--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -100,6 +100,25 @@ and keys will be stored like:
 litellm.caching.caching:<hash>
 ```
 
+#### Restricted ACL users (Redis 7+ / Valkey)
+
+If your security policy requires the proxy to connect as a least-privilege user instead of `default`, set a namespace (as above) and grant that user the namespace's key pattern and channel pattern plus the commands it needs:
+
+```bash
+ACL SETUSER litellm-proxy on '>your-password' '~litellm:*' '&litellm:*' +@all
+```
+
+replacing `litellm` with your namespace. With a namespace set, every key the proxy writes lives under `<namespace>:`, so `~<namespace>:*` covers all of them. Without a namespace the proxy's keys have assorted names, so there is no practical key pattern to scope an ACL to
+
+The channel grant matters too: Redis 7+ and Valkey create ACL users with `resetchannels`, which denies all pub/sub channels. The proxy subscribes to channels for config sync and auth cache invalidation, and without `&<namespace>:*` (or `&litellm_proxy.*` when no namespace is set) your logs will repeat `No permissions to access a channel; reconnecting in 5s` every few seconds and config changes will only propagate on the periodic reload
+
+Two more things to know when scoping ACLs:
+
+- The `general_settings.coordination_redis` block (for pointing coordination at a different Redis than your response cache) also accepts `namespace`, so its user can be scoped the same way
+- When coordination Redis is configured through `REDIS_HOST` / `REDIS_PORT` environment variables alone (no `cache_params` redis block), it cannot carry a namespace, so its keys are unprefixed and the connecting user needs an unscoped key grant
+
+If you see `No permissions to access a key` in the proxy logs and spend tracking repeatedly logs `Restoring N transaction sets to in-memory queues`, the connecting user's ACL is missing one of the grants above. On proxy versions without [the namespace delimiter fix](https://github.com/BerriAI/litellm/pull/38403), internal keys whose literal names begin with the namespace string (for example `litellm_spend_update_buffer` under namespace `litellm`) were written outside the namespace and denied even with the grants in place; upgrade if the denied keys in your Redis `ACL LOG` show up unprefixed
+
 #### Redis Cluster
 
 <Tabs>


### PR DESCRIPTION
## TLDR

Adds a "Restricted ACL users (Redis 7+ / Valkey)" section to the proxy caching doc: the exact `ACL SETUSER` grant a scoped cache user needs (`~litellm:*` keys plus `&litellm:*` channels), why `resetchannels` makes the channel grant mandatory, and a troubleshooting note for the "No permissions to access a key" symptom that BerriAI/litellm#38403 fixes

Operators running the proxy against a locked-down Redis or Valkey currently have no documented guidance on scoping an ACL to the cache namespace, and the channel half of the grant is easy to miss because Redis 7+ denies all pub/sub channels by default

## Related

Documents the operational side of BerriAI/litellm#38403 (cache namespace delimiter fix, Resolves LIT-3373 there)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration code modifications.
> 
> **Overview**
> Adds a **Restricted ACL users (Redis 7+ / Valkey)** subsection right after the Redis namespace example in `docs/proxy/caching.md`.
> 
> It documents how to run the proxy as a least-privilege Redis user: set a `cache_params` namespace, then grant `~<namespace>:*` for keys and `&<namespace>:*` for pub/sub (with an example `ACL SETUSER` command). It explains why namespaces matter for scoping, why Redis 7+ **`resetchannels`** makes channel ACLs mandatory (config sync / auth invalidation), and what breaks without them (repeated channel permission errors and delayed config reloads).
> 
> The section also notes **`general_settings.coordination_redis`** can use the same namespace pattern, while **`REDIS_HOST` / `REDIS_PORT`-only** coordination cannot, so ACLs may need broader key access. A troubleshooting blurb ties **`No permissions to access a key`** and spend-buffer restore logs to missing grants, and points operators at upgrading past the namespace delimiter fix in #38403 when unprefixed internal keys still fail ACL checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf0be39399ce01907ce371a4f07c485bff38137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->