### PR TITLE
docs: remove default_team_disabled, point to key_generation_settings

### DIFF
--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -436,21 +436,20 @@ general_settings:
 
 For Microsoft Entra ID, group membership is read from the Microsoft Graph API instead; follow [this tutorial](../tutorials/msft_sso.md). For SAML, team ids come from assertion attributes; see [SAML SSO](./saml_sso.md).
 
-### Disable `Default Team` on Admin UI
+### Restrict Personal Key Creation
 
-Use this if you want to hide the Default Team on the Admin UI
+Use this if you want to stop users from creating personal keys (keys with no team). This is enforced on `/key/generate`, so it applies to both the Admin UI and direct API calls
 
-The following logic will apply
-- If team assigned don't show `Default Team`
-- If no team assigned then they should see `Default Team`
-
-Set `default_team_disabled: true` on your litellm config.yaml
+Set `key_generation_settings` on your litellm config.yaml
 
 ```yaml
-general_settings:
-  master_key: sk-1234
-  default_team_disabled: true # OR you can set env var PROXY_DEFAULT_TEAM_DISABLED="true"
+litellm_settings:
+  key_generation_settings:
+    personal_key_generation:
+      allowed_user_roles: ["proxy_admin"]
 ```
+
+See [Restricting Key Generation](./virtual_keys.md#restricting-key-generation) for all options
 
 ### Use Username, Password when SSO is on
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -319,7 +319,6 @@ router_settings:
 | custom_key_update | str | Custom function for key updates. Required if `custom_key_generate` policies should also apply to key edits [Doc on custom key update](./virtual_keys.md#custom-keyupdate) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |
 | embedding_model | str | The default model to use for embeddings - ignores model set in request |
-| default_team_disabled | boolean | If true, users cannot create 'personal' keys (keys with no team_id). |
 | alert_to_webhook_url | Dict[str] | [Specify a webhook url for each alert type.](./alerting.md#map-slack-channels-to-alert-type) |
 | key_management_settings | List[Dict[str, Any]] | Settings for key management system (e.g. AWS KMS, Azure Key Vault) [Doc on key management](../secret.md) |
 | allow_user_auth | boolean | (Deprecated) old approach for user authentication. |


### PR DESCRIPTION
default_team_disabled has no effect in current versions. The only code that ever read it was a dropdown filter in the old user dashboard, removed in v1.82.1 when the Virtual Keys page was rebuilt, and it was never enforced on the backend. A customer set it based on these docs and internal users could still create personal keys with no budget or expiration (verified live at HEAD)

The same behavior is available today, enforced server-side on /key/generate, via:

```yaml
litellm_settings:
  key_generation_settings:
    personal_key_generation:
      allowed_user_roles: ["proxy_admin"]
```

This PR removes the default_team_disabled row from config_settings.md and replaces the "Disable Default Team on Admin UI" section in admin_ui_sso.md with the key_generation_settings config, linking to the existing Restricting Key Generation section in virtual_keys.md

Resolves LIT-6272