### PR TITLE
docs(proxy): document return_raw_model_name for reading the picked tier

### DIFF
--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -133,6 +133,10 @@ Every knob v2 exposes. All fields on `complexity_router_config` are optional exc
       session_affinity: false   # default; set true to pin
       session_affinity_ttl_seconds: 3600
 
+      # Return the model the router picked in the response body `model` field
+      # instead of restamping it back to the alias the client called
+      return_raw_model_name: false   # default
+
       # Tune heuristic scorer boundaries and weights (all optional)
       tier_boundaries:
         simple_medium:     0.15
@@ -420,51 +424,50 @@ ComplexityRouter: routing decision cause=session_affinity_pin,                  
 
 ## Reading the picked model from the response
 
-The response body `model` field always stays the alias you called (`smart-router`), matching OpenAI semantics: a client should get back the model name it asked for. The tier an auto-routing strategy actually picked is a separate field, `router_model_name`, present on every response an auto router produced.
+By default the response body `model` field stays the alias you called (`smart-router`), matching the OpenAI convention that a client gets back the model name it asked for, and the tier that actually answered is reachable only through the [`x-litellm-model-id` response header](./response_headers.md#litellm-specific-headers). Clients that cannot read response headers, including framework wrappers and streaming consumers that only see body chunks, need the value in the body.
 
-:::info Availability
+Set `return_raw_model_name` on the router to put it there. The proxy then skips the restamp and leaves the resolved model in `model`, on the non-streaming response and on every streaming chunk:
 
-`router_model_name` ships in **v1.99.x** ([PR #37725](https://github.com/BerriAI/litellm/pull/37725)). Before this, the picked tier was only reachable through the [`x-litellm-model-id` response header](./response_headers.md#litellm-specific-headers), which SDKs and frameworks that do not expose response headers, or that consume the response as a stream of body chunks, could not read.
+```yaml
+- model_name: smart-router
+  litellm_params:
+    model: auto_router/complexity_router
+    complexity_router_config:
+      tiers:
+        SIMPLE:    gpt-4o-mini
+        REASONING: gpt-5.5
+      return_raw_model_name: true   # default false
+```
 
-:::
+The same switch is on the auto router tab in the UI, as "Return raw model name".
 
 Non-streaming:
 
 ```json
 {
   "id": "chatcmpl-abc123",
-  "model": "smart-router",
-  "router_model_name": "gpt-5.5",
+  "model": "gpt-5.5",
   "choices": [{"...": "..."}]
 }
 ```
 
-Streaming: the field is written on every SSE chunk, not only the first or the last, so a consumer that reads one chunk in isolation still sees it.
+Streaming, on every SSE chunk rather than only the first or the last:
 
 ```
-data: {"id":"chatcmpl-abc123","model":"smart-router","router_model_name":"gpt-5.5","choices":[{"delta":{"content":"The"},"...":"..."}]}
+data: {"id":"chatcmpl-abc123","model":"gpt-5.5","choices":[{"delta":{"content":"The"},"...":"..."}]}
 
-data: {"id":"chatcmpl-abc123","model":"smart-router","router_model_name":"gpt-5.5","choices":[{"delta":{"content":" sum"},"...":"..."}]}
+data: {"id":"chatcmpl-abc123","model":"gpt-5.5","choices":[{"delta":{"content":" sum"},"...":"..."}]}
 ```
 
-`router_model_name` is the `model_name` of the `model_list` entry the router picked (`gpt-5.5`, `claude-sonnet-5`), the same value logged as `routed_model=` in the [decision log](#decision-log) above, never the alias and never the upstream `litellm_params.model`.
+Because `model` is a standard OpenAI response field, every SDK and framework already carries it through to application code; nothing needs to read raw chunks. In LangChain it arrives as `response_metadata.model_name`, on the final chunk when streaming.
 
-The field is present only when an auto-routing strategy actually selected the deployment for that request. It is absent on a request to a plain, non-auto-routed `model_name`, and it is also absent after a mid-stream fallback moves the request off the tier the router picked. The counterfactual `router_model_name` claimed is no longer the model that answered, so the field is dropped rather than continuing to name the original tier; use `x-litellm-attempted-fallbacks` to detect that a fallback occurred.
+Two things change once the flag is on. Callers stop getting back the alias they sent, which some clients assert on. And the value is the resolved model as the deployment reports it, so a provider-prefixed identifier such as `hosted_vllm/my-model` reaches the client verbatim rather than the `model_list` `model_name` that the [decision log](#decision-log) prints as `routed_model=`.
 
-**LangChain callers:** `@langchain/openai`'s `ChatOpenAI` drops response fields it does not recognize, both at the top level of a chunk and inside `delta`, so `router_model_name` does not reach `response_metadata` or `additional_kwargs` by default. Pass `__includeRawResponse: true` to the constructor (requires `@langchain/openai` >= 0.2.11; the option is marked experimental in LangChain's own types) and read `additional_kwargs.__raw_response.router_model_name` instead:
+:::info No dedicated body field
 
-```js
-const llm = new ChatOpenAI({
-  model: "smart-router",
-  __includeRawResponse: true,
-  configuration: { baseURL: "<proxy base>/v1" },
-});
-for await (const chunk of await llm.stream(prompt)) {
-  const routedModel = chunk.additional_kwargs?.__raw_response?.router_model_name;
-}
-```
+The v1.99 release candidates briefly carried a separate `router_model_name` body field for this ([PR #37725](https://github.com/BerriAI/litellm/pull/37725)), added with LangChain callers in mind. It never reached them: `@langchain/openai` builds `additional_kwargs` and `response_metadata` from fixed key allowlists and drops unknown fields at both the top level of a chunk and inside `delta`, so no proxy-side placement of a namespaced key could work. The field was removed before the stable release in favor of `return_raw_model_name`, which lands in the `model` field that LangChain does propagate.
 
-The raw `openai` SDK and plain HTTP/SSE clients need no such workaround; `router_model_name` is a normal top-level field on every chunk and on the non-streaming response.
+:::
 
 ## Reported savings
 

--- a/docs/proxy/response_headers.md
+++ b/docs/proxy/response_headers.md
@@ -84,7 +84,7 @@ model_list:
 
 ### Auto-routed requests
 
-For a request to an [auto router](./auto_routing.md), the body `model` is the router alias the client called and the headers above still name the deployment that answered. Clients that cannot read response headers, including streaming consumers, can read the picked tier from the `router_model_name` body field instead; see [reading the picked model from the response](./auto_routing.md#reading-the-picked-model-from-the-response).
+For a request to an [auto router](./auto_routing.md), the body `model` is the router alias the client called and the headers above still name the deployment that answered. Clients that cannot read response headers, including streaming consumers, can set `return_raw_model_name` on the router to get the picked tier in the body `model` field instead; see [reading the picked model from the response](./auto_routing.md#reading-the-picked-model-from-the-response).
 
 ### More examples (illustrative)
 


### PR DESCRIPTION
Follows BerriAI/litellm#38429, which removes the `router_model_name` response body field.

That field was added for LangChain callers and never reached them. `@langchain/openai` builds `additional_kwargs` and `response_metadata` from fixed key allowlists and drops unknown fields at both the top level of a chunk and inside `delta`, so no proxy-side placement of a namespaced key could get through; the page's own LangChain recipe worked around that with the experimental `__includeRawResponse` option. `return_raw_model_name` already solves the problem it was reaching for: it puts the resolved model in the standard `model` field, which every SDK carries through and which LangChain surfaces as `response_metadata.model_name`.

"Reading the picked model from the response" now documents that flag: the config snippet, where the toggle lives in the UI, the non-streaming and per-chunk streaming shapes, and the two things that change once it is on (callers stop getting the alias echoed back, and a provider-prefixed identifier reaches the client verbatim rather than the `model_list` `model_name` the decision log prints as `routed_model=`). An admonition explains why there is no dedicated field, for anyone who followed the release-candidate docs; `router_model_name` only ever appeared in `v1.99.0-rc.1` and `v1.100.0-dev.1`, never in a stable release. Also adds the knob to the full config listing and repoints the cross-link on the response headers page.

Both response shapes in the new section were captured from a live proxy against real provider traffic, not written from the code:

```
#### smart-router-raw (non-streaming)
{"model": "claude-haiku-4-5-20251001", "router_model_name": "<absent>"}

#### smart-router-raw (streaming, every chunk)
{"model": "claude-haiku-4-5-20251001", "router_model_name": "<absent>"}
{"model": "claude-haiku-4-5-20251001", "router_model_name": "<absent>"}
{"model": "claude-haiku-4-5-20251001", "router_model_name": "<absent>"}
```
