### PR TITLE
docs(mcp): document upstream_token_header for gateway-fronted MCP servers

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -249,6 +249,8 @@ mcp_servers:
   | `oauth2_token_exchange` | `Authorization: Bearer <exchanged_token>` — RFC 8693 On-Behalf-Of. See [MCP OBO Auth](./mcp_obo_auth.md) |
   | `aws_sigv4` | Per-request AWS SigV4 signature. See [MCP AWS SigV4](./mcp_aws_sigv4.md) |
 
+  The header shown above is the default. Set `upstream_token_header` on the server to send the resolved token somewhere other than `Authorization`, which is what an MCP server behind an API gateway usually needs. See [MCP OAuth](./mcp_oauth.md#sending-the-token-on-a-different-header)
+
   Note: the header table above describes the managed SSE/HTTP transport path. The OpenAPI-tool path emits `Authorization: ApiKey <value>` instead of `X-API-Key` for `auth_type: api_key`; the deprecated `x-mcp-auth` broadcast header also uses the `ApiKey` form.
 
 - **Extra Headers**: Optional list of additional header names that should be forwarded from client to the MCP server

--- a/docs/mcp_oauth.md
+++ b/docs/mcp_oauth.md
@@ -235,6 +235,45 @@ mcp_servers:
     scopes: ["mcp:read", "mcp:write"]  # optional
 ```
 
+### Sending the token on a different header
+
+By default the token LiteLLM resolves goes out as `Authorization: Bearer <token>`, which is what
+almost every MCP server expects. Some deployments put the MCP server behind an API gateway that
+reads its own credential from a private header, and the server behind the gateway still wants its
+own bearer on `Authorization`. That needs two credentials on the same request.
+
+Set `upstream_token_header` to name the header the resolved token should use. Anything you configure
+under `static_headers` is then left alone, so a second credential reaches the server behind the
+gateway untouched.
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  my_mcp_server:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: oauth2
+    oauth2_flow: client_credentials
+    client_id: os.environ/MCP_CLIENT_ID
+    client_secret: os.environ/MCP_CLIENT_SECRET
+    token_url: "https://auth.example.com/oauth/token"
+    upstream_token_header: "esb-oauth"
+    static_headers:
+      Authorization: "Bearer os.environ/UPSTREAM_MCP_TOKEN"
+```
+
+Each request to the MCP server then carries both:
+
+```
+esb-oauth: Bearer <the token LiteLLM minted>
+Authorization: Bearer <the token you configured>
+```
+
+Leaving `upstream_token_header` unset keeps the default, so existing servers are unaffected. The
+value must be a valid HTTP header name; the proxy refuses to start on a malformed one, and the
+management API rejects it with a 400.
+
+In the UI the same setting is the **Token Header** field in the OAuth section of the MCP server
+form, and it applies to the interactive flow and the token-exchange modes as well as M2M.
+
 ### How It Works
 
 1. On first MCP request, LiteLLM POSTs to `token_url` with `grant_type=client_credentials`

--- a/docs/mcp_obo_auth.md
+++ b/docs/mcp_obo_auth.md
@@ -71,6 +71,46 @@ mcp_servers:
 | `audience` | Recommended | Resource identifier for the MCP server. LiteLLM sends this as the token exchange `audience`. |
 | `scopes` | Optional | Scopes LiteLLM requests for the exchanged token. LiteLLM joins the list into the OAuth `scope` parameter. |
 | `subject_token_type` | Optional | RFC 8693 subject token type. Defaults to `urn:ietf:params:oauth:token-type:access_token`. |
+| `upstream_token_header` | Optional | Which upstream header carries the exchanged token. Defaults to `Authorization`. See [sending the token on a different header](#sending-the-exchanged-token-on-a-different-header). |
+
+### Sending the exchanged token on a different header
+
+By default the exchanged token goes out as `Authorization: Bearer <token>`. When the MCP server sits
+behind an API gateway that reads its own credential from a private header, and the server behind the
+gateway still expects its own bearer on `Authorization`, both credentials have to travel on the same
+request.
+
+Set `upstream_token_header` to name the header the exchanged token should use. Anything under
+`static_headers` is then left alone, so a shared credential still reaches the server behind the
+gateway.
+
+```yaml title="config.yaml" showLineNumbers
+mcp_servers:
+  my_mcp_server:
+    url: "https://gateway.example.com/mcp"
+    auth_type: oauth2_token_exchange
+    token_exchange_endpoint: "https://idp.example.com/token"
+    client_id: os.environ/MCP_CLIENT_ID
+    client_secret: os.environ/MCP_CLIENT_SECRET
+    audience: "api://esb"
+    upstream_token_header: "esb-oauth"
+    static_headers:
+      Authorization: "Bearer os.environ/UPSTREAM_MCP_TOKEN"
+```
+
+Each upstream request then carries both, with the exchanged token scoped to the calling user:
+
+```
+esb-oauth: Bearer <token exchanged for this user>
+Authorization: Bearer <the shared token you configured>
+```
+
+The exchanged token is still cached per user, so a short-lived token does not mean an exchange on
+every request. Leaving `upstream_token_header` unset keeps the default.
+
+If a redirect from the upstream crosses origin, the custom header is dropped rather than forwarded,
+the same way HTTP clients drop `Authorization`. An upstream that legitimately redirects across
+origins will not see the credential on the second hop.
 
 ## Token Exchange Request
 


### PR DESCRIPTION
Documents the new per-server `upstream_token_header` setting shipping in BerriAI/litellm#38456

Covers the case where an MCP server sits behind an API gateway that reads its own credential from a private header while the server behind it still expects a bearer on `Authorization`, which needs two credentials on one request

Changes:
- `docs/mcp_oauth.md` gains a "Sending the token on a different header" section under M2M, with the config, what the upstream then receives, and a note that leaving it unset keeps today's behavior
- `docs/mcp.md` cross-references it from the auth-type table, where the default header per auth type is listed

There is a canonical MCP auth and header reference in progress, so this may want folding into that once it lands