### PR TITLE
docs(presidio): large content chunking and presidio_analyze_chunk_size_bytes

### DIFF
--- a/docs/proxy/guardrails/pii_masking_v2.md
+++ b/docs/proxy/guardrails/pii_masking_v2.md
@@ -283,6 +283,21 @@ guardrails:
 - `presidio_score_thresholds.<ENTITY>`: apply only to that entity
 - If both `ALL` and an entity override exist, `ALL` applies globally and the entity override takes precedence for that entity
 
+### Large content chunking
+
+Presidio analyzer deployments commonly cap the `/analyze` request body size (for example at 1 MB), and analyzer latency grows with payload size. LiteLLM automatically splits any single content block larger than `presidio_analyze_chunk_size_bytes` (default: `500000` UTF-8 bytes) into overlapping chunks, analyzes the chunks concurrently, and merges the detections back onto the original text, so large content blocks are masked correctly instead of failing with `HTTP 413`.
+
+```yaml
+guardrails:
+  - guardrail_name: "presidio-pii"
+    litellm_params:
+      guardrail: presidio
+      mode: "pre_call"
+      presidio_analyze_chunk_size_bytes: 500000 # optional, default 500000
+```
+
+Set it below your analyzer deployment's request body limit, leaving headroom for the rest of the analyze payload (entities list, ad-hoc recognizers).
+
 ### Supported Entity Types
 
 LiteLLM Supports all Presidio entity types. See the complete list of presidio entity types [here](https://microsoft.github.io/presidio/supported_entities/).

--- a/docs/proxy/guardrails/pii_masking_v2.md
+++ b/docs/proxy/guardrails/pii_masking_v2.md
@@ -285,7 +285,7 @@ guardrails:
 
 ### Large content chunking
 
-Presidio analyzer deployments commonly cap the `/analyze` request body size (for example at 1 MB), and analyzer latency grows with payload size. LiteLLM automatically splits any single content block larger than `presidio_analyze_chunk_size_bytes` (default: `500000` UTF-8 bytes) into overlapping chunks, analyzes the chunks concurrently, and merges the detections back onto the original text, so large content blocks are masked correctly instead of failing with `HTTP 413`.
+Presidio analyzer deployments commonly cap the `/analyze` request body size (for example at 1 MB), and analyzer latency grows with payload size. LiteLLM automatically splits any single content block whose serialized `/analyze` body would exceed `presidio_analyze_chunk_size_bytes` (default: `500000` bytes, measured on the JSON-escaped form the analyzer receives) into overlapping chunks, analyzes the chunks with a bounded fan-out, and merges the detections back onto the original text, so large content blocks are masked correctly instead of failing with `HTTP 413`.
 
 ```yaml
 guardrails:


### PR DESCRIPTION
Documents the new optional `presidio_analyze_chunk_size_bytes` litellm_param and the automatic chunking of oversized content blocks before Presidio /analyze calls.

Pairs with BerriAI/litellm#38483 (Resolves LIT-4785). Config key only, no env var, so merge order with the code PR does not matter.

Docs build passes locally (npm run build).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->