### PR TITLE
docs(cursor): add Azure OpenAI fallback for builds without the base URL override

### DIFF
--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -121,7 +121,9 @@ Fill in the fields:
 
 ### 2. Add a custom model
 
-Cursor's built-in models reject custom API keys with `This model does not support custom API keys`, so you must add and select a custom model. Click **+ Add Custom Model**, enter a name that does not collide with a built-in model (e.g. `litellm-claude`), enable it, and select it in the chat model picker.
+While the Azure OpenAI toggle is on, only custom models work. Cursor refuses its own models (Composer, Cursor Grok) with `This model does not support custom API keys`, and it still routes built-in Claude and GPT models to your proxy, but in Anthropic Messages or Azure Responses formats that the chat completions deployment route rejects, so those chats hang. Click **+ Add Custom Model**, enter a name that does not collide with a built-in model (e.g. `litellm-claude`), enable it, and select it in the chat model picker.
+
+To use Composer or another built-in model on your Cursor subscription, turn the Azure OpenAI toggle off; turn it back on to route through LiteLLM again.
 
 :::warning The Deployment Name decides the model
 On this path, Cursor sends every request to `/openai/deployments/<Deployment Name>/chat/completions`, and LiteLLM serves the model the path names. The custom model you pick in Cursor is only a label: picking a different custom model does not change which model answers. To switch models, edit the **Deployment Name** in the Azure OpenAI settings. Keep a single enabled custom model so the picker cannot mislead you.
@@ -174,6 +176,7 @@ LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |
 | Cursor does not list your LiteLLM models | Upgrade to LiteLLM v1.97.0+, which serves `GET /cursor/models`. Earlier versions do not serve that route and answer 401 or 404. Verify with `curl <LITELLM_PROXY_BASE_URL>/cursor/models -H "Authorization: Bearer <LITELLM_VIRTUAL_KEY>"` |
 | `The model "X" is already available as "Y"` | Cursor blocks names that match its built-in models. Add the model under a distinct public model name (see the warning in step 3) |
-| `This model does not support custom API keys` | You selected a Cursor built-in model. Select the custom model you added instead |
+| `This model does not support custom API keys` | You selected a Cursor-native model (Composer, Cursor Grok) while a custom API key is enabled. Select the custom model you added, or disable the Azure OpenAI toggle to use Cursor's models on your subscription |
+| Chat hangs with a built-in model picked while Azure OpenAI is enabled | Cursor still routes built-in Claude and GPT models to your proxy, in formats the deployment route rejects. Select the custom model you added |
 | No **Override OpenAI Base URL** setting | Your Cursor build does not offer it. Use the [Azure OpenAI fallback](#fallback-azure-openai-settings) |
 | Azure fallback always answers with the same model | Expected: the **Deployment Name** decides the model, whichever custom model is picked. Edit the Deployment Name to switch |

--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -5,7 +5,13 @@ import Image from '@theme/IdealImage';
 Route Cursor IDE requests through LiteLLM for unified logging, budget controls, and access to any model.
 
 :::info
-**Supported modes:** Ask, Plan, Agent. Agent mode requires LiteLLM v1.97.0+, which translates the Responses API request shapes Cursor's agent sends to the chat completions path. Cursor gates custom API keys by mode and model on its side, so coverage follows what Cursor enables.
+**Supported modes:** Ask, Plan, Agent. With the base URL override, agent mode requires LiteLLM v1.97.0+, which translates the Responses API request shapes Cursor's agent sends to the chat completions path. Cursor gates custom API keys by mode and model on its side, so coverage follows what Cursor enables.
+
+Cursor does not officially support AI Gateways, our work here is best effort from reverse engineering their APIs.
+:::
+
+:::warning Override OpenAI Base URL missing?
+Newer Cursor builds no longer show the **Override OpenAI Base URL** setting on every plan. If your Cursor does not have it, use the [Azure OpenAI fallback](#fallback-azure-openai-settings) below instead of the setup in this section.
 :::
 
 ## Quick Reference
@@ -93,6 +99,40 @@ Send a message. All requests now route through LiteLLM.
 
 ---
 
+## Fallback: Azure OpenAI settings
+
+If your Cursor build has no **Override OpenAI Base URL** setting, Cursor's Azure OpenAI settings still accept a custom base URL and route traffic to your LiteLLM proxy. This path uses LiteLLM's Azure-compatible `/openai/deployments/<deployment>/chat/completions` route, which has been in LiteLLM since 2023, so it needs no proxy upgrade. Ask, Plan, and Agent modes all work over it (verified on Cursor 3.17.21); Cursor's Azure client sends plain chat completions requests for agent mode too, so the v1.97.0 requirement from the base URL override path does not apply here.
+
+| Setting | Value |
+|---------|-------|
+| Base URL | `<LITELLM_PROXY_BASE_URL>` (no `/cursor` suffix) |
+| Deployment Name | Public Model Name from LiteLLM |
+| API Key | Your LiteLLM Virtual Key |
+
+### 1. Enable Azure OpenAI
+
+Open **Cursor → Settings → Cursor Settings → Models**, expand **API Keys**, and enable the **Azure OpenAI** toggle. Cursor shows a confirmation dialog warning that some features cannot be billed to an API key; confirm it.
+
+Fill in the fields:
+
+- **Base URL**: your LiteLLM proxy URL, e.g. `https://your-litellm-proxy.com`. Do not append `/cursor`. The proxy must be reachable from the internet: Cursor sends requests from its backend, not from your machine.
+- **Deployment Name**: the LiteLLM public model name to use, e.g. `claude-sonnet-5`. This decides which model serves every request (see the warning below).
+- **API Key**: your LiteLLM virtual key.
+
+### 2. Add a custom model
+
+Cursor's built-in models reject custom API keys with `This model does not support custom API keys`, so you must add and select a custom model. Click **+ Add Custom Model**, enter a name that does not collide with a built-in model (e.g. `litellm-claude`), enable it, and select it in the chat model picker.
+
+:::warning The Deployment Name decides the model
+On this path, Cursor sends every request to `/openai/deployments/<Deployment Name>/chat/completions`, and LiteLLM serves the model the path names. The custom model you pick in Cursor is only a label: picking a different custom model does not change which model answers. To switch models, edit the **Deployment Name** in the Azure OpenAI settings. Keep a single enabled custom model so the picker cannot mislead you.
+:::
+
+### 3. Test
+
+Send a message in Ask mode, then try Agent mode. Requests appear in your LiteLLM logs as chat completions on `/openai/deployments/<Deployment Name>/chat/completions`, attributed to the deployment's model.
+
+---
+
 ## Connecting MCP Servers
 
 You can also connect MCP servers to Cursor via LiteLLM Proxy.
@@ -134,3 +174,6 @@ LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |
 | Cursor does not list your LiteLLM models | Upgrade to LiteLLM v1.97.0+, which serves `GET /cursor/models`. Earlier versions do not serve that route and answer 401 or 404. Verify with `curl <LITELLM_PROXY_BASE_URL>/cursor/models -H "Authorization: Bearer <LITELLM_VIRTUAL_KEY>"` |
 | `The model "X" is already available as "Y"` | Cursor blocks names that match its built-in models. Add the model under a distinct public model name (see the warning in step 3) |
+| `This model does not support custom API keys` | You selected a Cursor built-in model. Select the custom model you added instead |
+| No **Override OpenAI Base URL** setting | Your Cursor build does not offer it. Use the [Azure OpenAI fallback](#fallback-azure-openai-settings) |
+| Azure fallback always answers with the same model | Expected: the **Deployment Name** decides the model, whichever custom model is picked. Edit the Deployment Name to switch |


### PR DESCRIPTION
## TLDR

Newer Cursor builds no longer show the Override OpenAI Base URL setting on every plan, which breaks the documented Cursor -> LiteLLM setup. This adds a verified fallback: Cursor's Azure OpenAI settings still accept a custom base URL, and LiteLLM's long-standing Azure-compatible `/openai/deployments/<deployment>/chat/completions` route serves the traffic with no proxy upgrade

## User Flow

Before:

1. A user on a Cursor build without the override opens the Cursor integration page and finds only the Override OpenAI Base URL setup, which their Cursor does not offer
2. There is no documented way to point Cursor at their LiteLLM proxy, so no requests reach `<LITELLM_PROXY_BASE_URL>/cursor`

After:

1. The same user hits the new warning at the top of the page and follows the Azure OpenAI fallback section
2. They enable Azure OpenAI in Cursor Settings -> Models -> API Keys, set Base URL to `<LITELLM_PROXY_BASE_URL>`, Deployment Name to a LiteLLM public model name, and API Key to their virtual key
3. They add and select a custom model, and Cursor's backend sends Ask, Plan, and Agent traffic to `POST <LITELLM_PROXY_BASE_URL>/openai/deployments/<deployment>/chat/completions?api-version=2024-12-01-preview`, which LiteLLM routes to the deployment's model
4. The new troubleshooting rows explain the `This model does not support custom API keys` error, the hang when a built-in model is picked while the toggle is on, and why the Deployment Name, not the picker, decides the served model

## Proof

Verified on Cursor 3.17.21 against a live LiteLLM gateway (tunnel to a local proxy):

- Ask mode: probe prompt answered through the gateway; proxy access log shows `POST /openai/deployments/litellm-claude/chat/completions?api-version=2024-12-01-preview HTTP/1.1" 200`, body model set to the picked custom model, `stream: true`, routed to the configured provider
- Agent mode: a "change print(41) to print(42) in app.py" task ran a full tool loop (Glob, Read, StrReplace) over the same route, 4 POSTs all 200, and the edit landed in the workspace; bodies are plain chat completions with `tools`, so the Responses translation the `/cursor` path needs for agent mode is not involved
- Built-in model behavior while the toggle is on, verified per family: Composer fails client-side with `This model does not support custom API keys` and nothing reaches the gateway; a built-in Claude model is still routed to the gateway but serialized as Anthropic Messages content blocks on the chat completions route, which LiteLLM rejects, so the chat hangs; a built-in GPT model goes to `POST /openai/responses` and gets a 400. This is why the section requires a custom model and documents toggling Azure off to use built-ins on the Cursor subscription
- The Override OpenAI Base URL flow still works where the toggle exists (also verified on 3.17.21), so the existing setup section stays the primary path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Cursor integration tutorial; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Documents a **fallback path** for Cursor builds that no longer expose **Override OpenAI Base URL**, so users can still route IDE traffic through LiteLLM.
> 
> Adds a prominent warning and a new **Fallback: Azure OpenAI settings** section: point Cursor’s Azure OpenAI **Base URL** at the proxy (without `/cursor`), set **Deployment Name** to a LiteLLM public model, and use a custom model in the picker. The doc explains that this hits `/openai/deployments/<deployment>/chat/completions` (no v1.97.0 `/cursor` agent translation), that **Deployment Name**—not the model picker—chooses the served model, and when to toggle Azure off for built-in Cursor models.
> 
> The intro **info** block now notes gateway support is unofficial, and **Troubleshooting** gains rows for missing override UI, custom-key errors, hangs with built-in models while Azure is on, and the fixed model on the Azure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edadfaf925e64c024e814958ca8486e41565fd8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

