### PR TITLE
docs(health): document background_health_check_model_groups allowlist

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -353,6 +353,7 @@ router_settings:
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |
 | disable_error_logs | boolean | If true, suppresses error tracking and storage in the database |
 | enable_health_check_routing | boolean | If true, enables health check-driven request routing to avoid unhealthy deployments |
+| background_health_check_model_groups | Optional[List[str]] | Opt-in allowlist of model group names for background health checks. When set, only listed groups are probed and health-check routing applies only to them; unlisted groups keep their configured routing behavior. Defaults to None (all groups) |
 | health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 | enable_mcp_registry | boolean | If true, enables access to the centralized MCP server registry |
 | enforce_rbac | boolean | If true, enables role-based access control (RBAC) for all proxy operations |
@@ -484,6 +485,7 @@ router_settings:
 | search_tools | List[SearchToolTypedDict] | List of search tool configurations for Search API integration. Each tool specifies a search_tool_name and litellm_params with search_provider, api_key, api_base, etc. [Further Docs](../search/index.md) |
 | guardrail_list | List[GuardrailTypedDict] | List of guardrail configurations for guardrail load balancing. Enables load balancing across multiple guardrail deployments with the same guardrail_name. [Further Docs](./guardrails/guardrail_load_balancing.md) |
 | enable_health_check_routing | boolean | If true, enables health check-driven deployment filtering to avoid routing requests to unhealthy deployments |
+| background_health_check_model_groups | Optional[List[str]] | Model groups that background health checks and health-check routing are scoped to. On the proxy this is usually set via `general_settings.background_health_check_model_groups`. Defaults to None (all groups) |
 | health_check_staleness_threshold | integer | Maximum age in seconds for cached health check results before marking deployments as stale |
 | health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 | routing_groups | Optional[List[RoutingGroup]] | List of model groups that each apply their own routing strategy to a subset of models. Each group has a `group_name`, `models` (list of model names matched against the request's model), `routing_strategy`, and optional `routing_strategy_args`. Defaults to None. |

--- a/docs/proxy/health.md
+++ b/docs/proxy/health.md
@@ -82,6 +82,14 @@ model_list:
       disable_background_health_check: true
 ```
 
+To scope the background loop to specific model groups instead of excluding models one by one, set `general_settings.background_health_check_model_groups` to the list of model group names to probe. Only deployments in the listed groups are checked, so `/health` reports only those groups, and [health check routing](./health_check_routing.md) applies only to them; unlisted groups keep their configured routing behavior. Model groups added later are not probed until you add them to the list, and a value that is not a list of strings fails at startup
+
+```yaml
+general_settings:
+  background_health_checks: true
+  background_health_check_model_groups: ["prod-openai"]
+```
+
 For coordinating checks across multiple pods so expensive models are not probed once per pod, see [Shared Health Check State](./shared_health_check.md).
 
 ## Model modes

--- a/docs/proxy/health_check_routing.md
+++ b/docs/proxy/health_check_routing.md
@@ -210,7 +210,7 @@ router_settings:
     TimeoutErrorAllowedFails: 3          # cooldown after 4th timeout
 ```
 
-When `allowed_fails_policy` is set, the binary health check filter is bypassed. Only the cooldown system controls routing exclusion, and it only fires after your configured threshold is crossed.
+When `allowed_fails_policy` is set, the binary health check filter is bypassed. Only the cooldown system controls routing exclusion, and it only fires after your configured threshold is crossed. The exception is when `background_health_check_model_groups` is also set (see Step 5): listed groups then keep the binary filter even with a policy configured.
 
 ### Step 4 (optional): Ignore transient errors
 
@@ -225,6 +225,27 @@ general_settings:
 ```
 
 With this on, only hard failures (401, 404, 5xx) from health checks contribute to cooldown.
+
+### Step 5 (optional): Scope health checks to specific model groups
+
+By default the background loop probes every model group. To opt in only the groups you want managed, list them in `background_health_check_model_groups`:
+
+```yaml
+general_settings:
+  background_health_checks: true
+  health_check_interval: 30
+  enable_health_check_routing: true
+  background_health_check_model_groups: ["prod-openai"]
+```
+
+With an allowlist set:
+
+- Only deployments in the listed groups are probed, so unlisted groups generate no background probe traffic or cost
+- `GET /health` serves the background results, so it reports only the listed groups
+- Health check routing steers traffic only within the listed groups; unlisted groups keep their configured routing strategy and plain request-time retry behavior
+- Model groups added later are excluded until you add them to the list
+- Listed groups keep the binary health filter even when `allowed_fails_policy` is set
+- A value that is not a list of strings fails at proxy startup instead of being silently ignored
 
 
 ## Full example
@@ -271,6 +292,7 @@ router_settings:
 | `health_check_interval` | `general_settings` | `300` | Seconds between full health check cycles |
 | `health_check_staleness_threshold` | `general_settings` | `interval x 2` | Seconds before cached health state is ignored |
 | `health_check_ignore_transient_errors` | `general_settings` | `false` | Ignore 429 and 408 from health checks; these never affect routing |
+| `background_health_check_model_groups` | `general_settings` | `null` | Only probe and health-route the listed model groups; unlisted groups keep normal routing |
 | `cooldown_time` | `router_settings` | `5` | Seconds a deployment stays in cooldown after threshold is crossed |
 | `allowed_fails_policy` | `router_settings` | `null` | Per-error-type failure thresholds before cooldown (see below) |
 


### PR DESCRIPTION
Documents the new `background_health_check_model_groups` allowlist shipping in BerriAI/litellm#38539:

- `config_settings.md`: rows in the general_settings and router_settings reference tables
- `health.md`: how to scope the background loop by model group, next to the existing per-model exclusion
- `health_check_routing.md`: a Step 5 for scoping, the config reference row, and the `allowed_fails_policy` interaction (listed groups keep the binary filter)

The litellm PR's `documentation` and `code-quality` CI jobs check out this repo, so this needs to land first for that PR to go green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents **`background_health_check_model_groups`**, an opt-in allowlist that limits background health probes and health-check routing to named model groups.
> 
> **`config_settings.md`** adds reference rows under `general_settings` and `router_settings` (proxy config typically sets it on `general_settings`).
> 
> **`health.md`** explains how to scope the background loop by group (alternative to per-model `disable_background_health_check`), with a YAML example.
> 
> **`health_check_routing.md`** adds optional **Step 5** (probe traffic, `/health` scope, routing behavior for unlisted groups, startup validation), a config table row, and notes that when the allowlist is set, **listed groups keep the binary health filter even if `allowed_fails_policy` is configured**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105b14a210c7bada7cfbf7312a9e9a87d48f214c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->