### PR TITLE
docs(gemini): document gemini-3.5-transcribe and gemini-3.5-transcribe-live usage

### DIFF
--- a/docs/audio_transcription.md
+++ b/docs/audio_transcription.md
@@ -126,6 +126,7 @@ transcript = client.audio.transcriptions.create(
 - [Fireworks AI](./providers/fireworks_ai.md#audio-transcription)
 - [Groq](./providers/groq.md#speech-to-text---whisper)
 - [Deepgram](./providers/deepgram.md)
+- [Google AI Studio (Gemini)](./providers/gemini.md#audio-transcription-speech-to-text)
 - [Mistral (Voxtral)](./providers/mistral.md#audio-transcription)
 - [OVHcloud AI Endpoints](./providers/ovhcloud.md)
 

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -433,6 +433,96 @@ response = completion(
 
 For more information about Gemini's TTS capabilities and available voices, see the [official Gemini TTS documentation](https://ai.google.dev/gemini-api/docs/speech-generation).
 
+## Audio Transcription (Speech-to-Text)
+
+:::info
+
+LiteLLM supports `gemini-3.5-transcribe` on `/v1/audio/transcriptions` and `gemini-3.5-transcribe-live` on `/v1/realtime`.
+
+:::
+
+### Quick Start
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import transcription
+import os
+
+os.environ["GEMINI_API_KEY"] = "your-api-key"
+
+audio_file = open("speech.wav", "rb")
+response = transcription(
+    model="gemini/gemini-3.5-transcribe",
+    file=audio_file,
+    response_format="verbose_json",
+    timestamp_granularities=["word"],
+)
+print(response.text)
+print(response.words)  # word-level timestamps
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+1. Add the model to your config
+
+```yaml
+model_list:
+  - model_name: gemini-3.5-transcribe
+    litellm_params:
+      model: gemini/gemini-3.5-transcribe
+      api_key: os.environ/GEMINI_API_KEY
+```
+
+2. Start the proxy
+
+```bash
+litellm --config config.yaml
+```
+
+3. Test it
+
+```bash
+curl http://0.0.0.0:4000/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-1234" \
+  -F file=@speech.wav \
+  -F model=gemini-3.5-transcribe \
+  -F response_format=verbose_json \
+  -F "timestamp_granularities[]=word"
+```
+
+</TabItem>
+</Tabs>
+
+### Supported Params
+
+`language`, `response_format`, and `timestamp_granularities` are supported. Requesting word timestamps also enables speaker diarization on the underlying Interactions API call. The `srt` and `vtt` response formats currently return the plain transcript.
+
+### Live Transcription over `/v1/realtime`
+
+`gemini-3.5-transcribe-live` runs over the Realtime websocket. Stream `pcm16` audio with `input_audio_buffer.append` and read transcripts from `conversation.item.input_audio_transcription.completed` events. The Gemini Live API reports no token usage for transcription sessions, so LiteLLM estimates usage (and spend) from the streamed audio duration using Google's published estimator rates.
+
+```python
+import asyncio
+import json
+import websockets
+
+async def main():
+    async with websockets.connect(
+        "ws://0.0.0.0:4000/v1/realtime?model=gemini-3.5-transcribe-live",
+        additional_headers={"Authorization": "Bearer sk-1234"},
+    ) as ws:
+        await ws.send(json.dumps({"type": "input_audio_buffer.append", "audio": "<base64 pcm16 audio>"}))
+        async for message in ws:
+            event = json.loads(message)
+            if event.get("type") == "conversation.item.input_audio_transcription.completed":
+                print(event["transcript"], event.get("usage"))
+
+asyncio.run(main())
+```
+
 ## Passing Gemini Specific Params
 ### Response schema 
 LiteLLM supports sending `response_schema` as a param for Gemini-1.5-Pro on Google AI Studio. 


### PR DESCRIPTION
Adds an Audio Transcription section to the Gemini provider page covering gemini-3.5-transcribe on /v1/audio/transcriptions (SDK and proxy quick starts, supported params) and gemini-3.5-transcribe-live over /v1/realtime with the estimated usage billing note, and links Gemini from the audio transcription supported-providers list

Documents the day-0 support shipped in BerriAI/litellm#38540 (LIT-6311)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no code, auth, or data-handling changes.
> 
> **Overview**
> This PR **documents** Gemini speech-to-text that ships with the related implementation work (not new runtime behavior here).
> 
> On **`docs/providers/gemini.md`**, it adds an **Audio Transcription (Speech-to-Text)** section for **`gemini/gemini-3.5-transcribe`** on `/v1/audio/transcriptions`, with SDK and proxy quick starts, supported params (`language`, `response_format`, `timestamp_granularities`), and notes that word timestamps trigger diarization while **`srt`/`vtt`** currently return plain text.
> 
> It also covers **`gemini-3.5-transcribe-live`** on `/v1/realtime` (pcm16 streaming, `conversation.item.input_audio_transcription.completed` events) and explains that LiteLLM **estimates usage/spend** from audio duration when the Live API omits token usage.
> 
> On **`docs/audio_transcription.md`**, it adds **Google AI Studio (Gemini)** to the supported-providers list with a link to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a46bdce16b7cfea2696a5a02fe5378347d06172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->