### PR TITLE
docs(crowdstrike_aidr): document fail_on_error

### DIFF
--- a/docs/proxy/guardrails/crowdstrike_aidr.md
+++ b/docs/proxy/guardrails/crowdstrike_aidr.md
@@ -63,6 +63,7 @@ guardrails:
                                              # Policy actions are defined in AIDR console.
       api_key: os.environ/CS_AIDR_TOKEN      # CrowdStrike AIDR API token
       api_base: os.environ/CS_AIDR_BASE_URL  # CrowdStrike AIDR base URL
+      fail_on_error: true                    # Optional. Set false to fail open on AIDR errors (default: true)
 ```
 
 ### 3. Start LiteLLM Proxy (AI Gateway)
@@ -226,6 +227,31 @@ The above request should not be blocked, and you should receive a regular LLM re
 </TabItem>
 
 </Tabs>
+
+## Error Handling
+
+`fail_on_error` controls what happens when the AIDR guard API cannot be reached or returns an unusable response. It defaults to `true`, so guardrail errors block the request with an HTTP 500.
+
+Set `fail_on_error: false` to fail open instead: connection failures, timeouts, 4xx/5xx responses, and malformed reply bodies are logged and the request proceeds unmodified. Fail-open calls are recorded in spend logs with the guardrail status `guardrail_failed_to_respond`.
+
+```yaml title="config.yaml - CrowdStrike AIDR guardrail with fail open enabled"
+guardrails:
+  - guardrail_name: crowdstrike-aidr
+    litellm_params:
+      guardrail: crowdstrike_aidr
+      default_on: true
+      mode: []
+      api_key: os.environ/CS_AIDR_TOKEN
+      api_base: os.environ/CS_AIDR_BASE_URL
+      fail_on_error: false                   # Fail open on AIDR guard API errors
+```
+
+Two cases stay strict even with `fail_on_error: false`:
+
+| Case | Behavior |
+|------|----------|
+| AIDR delivers a blocked verdict on a success response, even when the rest of the body cannot be parsed | Request is blocked with HTTP 400 |
+| AIDR delivers a transformed (redacted) response that LiteLLM cannot parse | Request fails with HTTP 500, so delivered redactions are never dropped |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

The CrowdStrike AIDR guardrail page did not mention `fail_on_error`, which BerriAI/litellm#38568 made functional. This adds the param to the Quick Start config example and a new Error Handling section covering the semantics: the default stays fail closed, `fail_on_error: false` fails open on connection failures, timeouts, 4xx/5xx responses, and malformed reply bodies, and fail-open calls land in spend logs as `guardrail_failed_to_respond`. The section also documents the two cases that stay strict under fail open: a blocked verdict on a success response still blocks with HTTP 400, and a transformed response LiteLLM cannot parse fails closed with HTTP 500 so delivered redactions are never dropped.

Validated with `npm run build` (clean).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->