### PR TITLE
docs(anthropic_unified): document the supported_endpoints native /v1/messages passthrough opt-in

### DIFF
--- a/docs/anthropic_unified/native_passthrough.md
+++ b/docs/anthropic_unified/native_passthrough.md
@@ -1,6 +1,6 @@
 # Native /v1/messages Passthrough for OpenAI-Compatible Providers
 
-When a deployment's provider has no native Anthropic Messages support, LiteLLM translates each `/v1/messages` request into the provider's own API: `openai/` deployments go through the OpenAI Responses API (see [the parameter mapping](./messages_to_responses_mapping.md)) and everything else goes through `/v1/chat/completions`. That translation drops Anthropic-only request features such as `cache_control`, `thinking`, and `anthropic-beta` headers
+When a deployment's provider has no native Anthropic Messages support, LiteLLM translates each `/v1/messages` request into the provider's own API: `openai/` deployments go through the OpenAI Responses API (see [the parameter mapping](./messages_to_responses_mapping.md)) and everything else goes through `/v1/chat/completions`. That translation only keeps what the target API can express: `cache_control` blocks are dropped, `thinking` is mapped to the provider's own reasoning parameter, and other Anthropic-only request details are approximated or lost
 
 Many OpenAI-compatible servers (self-hosted vLLM, inference hubs, model vendors with an Anthropic-compatible endpoint) also expose the Anthropic Messages API natively. For those, you can opt a deployment into forwarding the Anthropic payload untranslated. Available from v1.92.0
 

--- a/docs/anthropic_unified/native_passthrough.md
+++ b/docs/anthropic_unified/native_passthrough.md
@@ -1,0 +1,59 @@
+# Native /v1/messages Passthrough for OpenAI-Compatible Providers
+
+When a deployment's provider has no native Anthropic Messages support, LiteLLM translates each `/v1/messages` request into the provider's own API: `openai/` deployments go through the OpenAI Responses API (see [the parameter mapping](./messages_to_responses_mapping.md)) and everything else goes through `/v1/chat/completions`. That translation drops Anthropic-only request features such as `cache_control`, `thinking`, and `anthropic-beta` headers
+
+Many OpenAI-compatible servers (self-hosted vLLM, inference hubs, model vendors with an Anthropic-compatible endpoint) also expose the Anthropic Messages API natively. For those, you can opt a deployment into forwarding the Anthropic payload untranslated. Available from v1.92.0
+
+## Opt in with `supported_endpoints`
+
+Add `/v1/messages` to `model_info.supported_endpoints` on the deployment:
+
+```yaml
+model_list:
+  - model_name: my-open-model
+    litellm_params:
+      model: openai/some-open-model
+      api_base: https://inference.example.com/v1
+      api_key: os.environ/EXAMPLE_API_KEY
+    model_info:
+      supported_endpoints: ["/v1/chat/completions", "/v1/messages"]
+```
+
+With the opt-in, a request to the proxy's `/v1/messages` is POSTed to `{api_base}/v1/messages` with the Anthropic body unchanged. A trailing `/v1` on `api_base` is stripped first, so `https://inference.example.com/v1` and `https://inference.example.com` both resolve to `https://inference.example.com/v1/messages`. LiteLLM sends `Authorization: Bearer <api_key>` unless the request already carries an `Authorization` or `x-api-key` header, defaults `anthropic-version` to `2023-06-01`, and forwards `anthropic-beta` headers, both the ones the caller sent and the ones LiteLLM adds for features like context management. Streaming and response parsing work the same way they do for a native Anthropic deployment
+
+Without the opt-in the deployment behaves as before and the request is translated. `/v1/chat/completions` calls to the same deployment are not affected either way
+
+Test it with an Anthropic-only feature in the request:
+
+```bash
+curl http://0.0.0.0:4000/v1/messages \
+  -H "Authorization: Bearer sk-1234" \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "my-open-model",
+    "max_tokens": 64,
+    "system": [{"type": "text", "text": "You are concise", "cache_control": {"type": "ephemeral"}}],
+    "messages": [{"role": "user", "content": "Say hi in three words"}]
+  }'
+```
+
+The response comes back in the provider's native Anthropic shape, including its own `usage` fields such as `cache_creation_input_tokens` and `cache_read_input_tokens`
+
+The opt-in only matters for providers LiteLLM would otherwise translate, such as `openai/` and `custom_openai/` deployments. Providers with built-in Anthropic Messages support (`anthropic/`, `bedrock/`, `vertex_ai/`, and others) already forward natively and ignore it
+
+## `/v1/responses` is not part of the opt-in
+
+`supported_endpoints` does not change how `/v1/responses` is routed. Whether a `/v1/responses` request reaches the provider natively depends on the provider prefix of the deployment's `model`, not on `model_info`:
+
+- A deployment whose `litellm_params.model` is prefixed `openai/` sends `/v1/responses` natively to `{api_base}/responses`. No `supported_endpoints` entry is needed
+- A generic OpenAI-compatible deployment, such as one prefixed `custom_openai/`, is bridged through `/v1/chat/completions` instead, even when `/v1/responses` is listed in `supported_endpoints`
+
+So for an OpenAI-compatible server that natively serves chat completions, the Anthropic Messages API, and the Responses API, use the `openai/` prefix with your `api_base` and add the `/v1/messages` opt-in:
+
+| Deployment `model` | `/v1/messages` with the opt-in | `/v1/messages` without it | `/v1/responses` |
+|---|---|---|---|
+| `openai/<model>` | Native passthrough | Translated via the Responses API | Native |
+| `custom_openai/<model>` | Native passthrough | Translated via `/v1/chat/completions` | Bridged via `/v1/chat/completions` |
+
+Some named OpenAI-compatible providers (for example `hosted_vllm/`) ship their own Responses API support and also send `/v1/responses` natively. Check the provider's page for that

--- a/sidebars.js
+++ b/sidebars.js
@@ -908,6 +908,7 @@ const sidebars = {
             "anthropic_unified/index",
             "anthropic_unified/structured_output",
             "anthropic_unified/messages_to_responses_mapping",
+            "anthropic_unified/native_passthrough",
           ]
         },
         "count_tokens",


### PR DESCRIPTION
## Summary

Adds `docs/anthropic_unified/native_passthrough.md` under the `/v1/messages` sidebar category. It documents the per-deployment `model_info.supported_endpoints` opt-in that forwards `/v1/messages` to an OpenAI-compatible server untranslated (BerriAI/litellm#31685), what LiteLLM sends on that path (URL, headers, `anthropic-beta` forwarding), and that `/v1/responses` is not part of the opt-in: a deployment whose `litellm_params.model` is prefixed `openai/` sends `/v1/responses` natively with no `supported_endpoints` entry, while a generic OpenAI-compatible deployment such as `custom_openai/` is bridged through `/v1/chat/completions` even when `/v1/responses` is listed

Every claim was checked against BerriAI/litellm `litellm_internal_staging` at 40ff01b987 before writing:

- `litellm/llms/anthropic/experimental_pass_through/messages/handler.py`: `_deployment_passes_through_anthropic_messages` reads `kwargs["model_info"]["supported_endpoints"]` and selects `OpenAILikeAnthropicMessagesConfig` only when the provider has no native Anthropic Messages config. Otherwise `_should_route_to_responses_api` (`_RESPONSES_API_PROVIDERS = {"openai"}`) sends `openai` through the Responses API and everything else through chat completions
- `litellm/llms/openai_like/messages/transformation.py`: `get_complete_url` builds `{api_base}/v1/messages` after stripping a trailing `/v1`; `validate_anthropic_messages_environment` adds `Authorization: Bearer`, `anthropic-version: 2023-06-01`, and `content-type` only when absent, and `should_filter_anthropic_beta_headers` returns `False` so `anthropic-beta` is forwarded
- `litellm/utils.py` `ProviderConfigManager.get_provider_responses_api_config`: `openai` returns `OpenAIResponsesAPIConfig`, `hosted_vllm` returns `HostedVLLMResponsesAPIConfig`, and `custom_openai` has no Responses config, so `litellm/responses/main.py` (`_bridges_to_chat_completions`) bridges it through chat completions. `model_info.supported_endpoints` is never read on that path; the `supported_endpoints` in `litellm/llms/openai_like/providers.json` is a provider-level declaration for JSON providers, which the docs page does not conflate with the per-deployment opt-in
- The first stable tag containing the #31685 merge commit (6d828e5759) is v1.92.0 (`git tag --contains`), so the page says "Available from v1.92.0". The ticket said v1.93.0

## Verification

Live DB-less proxy booted from the litellm checkout at 40ff01b987 with `--detailed_debug`, hitting the real DeepSeek Anthropic-compatible endpoint and the real OpenAI API, no mocks. Config (keys from env):

```yaml
model_list:
  - model_name: messages-native-passthrough
    litellm_params:
      model: openai/deepseek-chat
      api_base: https://api.deepseek.com/anthropic
      api_key: os.environ/DEEPSEEK_API_KEY
    model_info:
      supported_endpoints: ["/v1/chat/completions", "/v1/messages"]
  - model_name: messages-translated
    litellm_params:
      model: custom_openai/deepseek-chat
      api_base: https://api.deepseek.com
      api_key: os.environ/DEEPSEEK_API_KEY
  - model_name: responses-openai-prefix
    litellm_params:
      model: openai/gpt-5.4-mini
      api_base: https://api.openai.com/v1
      api_key: os.environ/OPENAI_API_KEY
  - model_name: responses-custom-provider-optin
    litellm_params:
      model: custom_openai/deepseek-chat
      api_base: https://api.deepseek.com
      api_key: os.environ/DEEPSEEK_API_KEY
    model_info:
      supported_endpoints: ["/v1/chat/completions", "/v1/responses"]
general_settings:
  master_key: sk-1234
```

Leg A, `/v1/messages` with the opt-in. The debug log shows the outbound `POST https://api.deepseek.com/anthropic/v1/messages` and the body is the provider's native Anthropic shape with its cache usage fields:

```bash
curl -sS http://127.0.0.1:43917/v1/messages -H "Authorization: Bearer sk-1234" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" \
  -d '{"model":"messages-native-passthrough","max_tokens":64,"system":[{"type":"text","text":"You are concise","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":"Say hi in three words"}]}'
```

```
{"id":"ae85d78e-614a-44b0-9e6c-935dd5e533cc","type":"message","role":"assistant","model":"messages-native-passthrough","content":[{"type":"text","text":"Hi there, friend."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5,"service_tier":"standard"}}
HTTP 200
```

Leg B, `/v1/messages` on a `custom_openai/` deployment without the opt-in. Same request against `messages-translated`; the debug log shows a chat-completions body sent to `https://api.deepseek.com` with the `cache_control` block dropped:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://api.deepseek.com \
-d '{'model': 'deepseek-chat', 'messages': [{'role': 'system', 'content': [{'type': 'text', 'text': 'You are concise'}]}, {'role': 'user', 'content': 'Say hi in three words'}], 'max_tokens': 64}'
```

Leg C, `/v1/responses` on an `openai/` deployment with no `supported_endpoints`. Outbound `POST https://api.openai.com/v1/responses`, HTTP 200 with a native `resp_...` response:

```bash
curl -sS http://127.0.0.1:43917/v1/responses -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
  -d '{"model":"responses-openai-prefix","input":"Say hi in three words","max_output_tokens":64}'
```

Leg D, `/v1/responses` on a `custom_openai/` deployment that lists `/v1/responses` in `supported_endpoints`. HTTP 200, but the debug log shows the request was bridged: a chat-completions body (`messages`, `max_tokens`) sent to `https://api.deepseek.com`, so the opt-in had no effect on this endpoint:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://api.deepseek.com \
-d '{'model': 'deepseek-chat', 'messages': [{'role': 'user', 'content': 'Say hi in three words'}], 'max_tokens': 64}'
```

Leg E, streaming on the opt-in deployment. Same request as leg A with `"stream": true`; the proxy relays the provider's native Anthropic SSE stream and the debug log shows the same outbound `https://api.deepseek.com/anthropic/v1/messages`:

```
event: message_start
data: {"type":"message_start","message":{"id":"7f459463-3c48-4f46-853a-9fc24f6faa53","type":"message","role":"assistant","model":"deepseek-v4-flash","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0,"service_tier":"standard"}}}

event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
```

Docs checks: `node scripts/check-writing-style.js docs/anthropic_unified/native_passthrough.md` is clean and `npm run build` succeeds

## Linear ticket

Resolves LIT-6331

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes in this PR.
> 
> **Overview**
> Adds **`native_passthrough.md`** under the docs **/v1/messages** section and wires it into **`sidebars.js`**.
> 
> The page explains how to opt a deployment into **untranslated** `/v1/messages` forwarding via `model_info.supported_endpoints` (including `/v1/messages`), what the proxy sends on that path (URL normalization, auth and `anthropic-version` defaults, `anthropic-beta` forwarding), and how behavior differs from the default translation path for `openai/` vs other OpenAI-compatible prefixes.
> 
> It also clarifies that **`supported_endpoints` does not control `/v1/responses` routing**—that depends on the deployment’s `model` provider prefix—with a comparison table for `openai/` vs `custom_openai/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be991388e593ba98bc327c1eeb670149a092de3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->