### PR TITLE
docs(guardrails): show aws_external_id in the bedrock guardrail role example

### DIFF
--- a/docs/proxy/guardrails/bedrock.md
+++ b/docs/proxy/guardrails/bedrock.md
@@ -30,6 +30,7 @@ guardrails:
       guardrailVersion: "DRAFT"              # your guardrail version on bedrock
       aws_region_name: os.environ/AWS_REGION # region guardrail is defined
       aws_role_name: os.environ/AWS_ROLE_ARN # your role with permissions to use the guardrail
+      aws_external_id: os.environ/AWS_EXTERNAL_ID # only if that role's trust policy requires sts:ExternalId
   
 ```
 


### PR DESCRIPTION
## TLDR

BerriAI/litellm#38376 makes the Bedrock guardrail forward `aws_external_id` on `sts:AssumeRole`, so the guardrail docs example that already shows `aws_role_name` now shows where the external id goes for roles whose trust policy requires one

## Relevant PRs

BerriAI/litellm#38376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to a config example; no runtime or security behavior changes in this PR.
> 
> **Overview**
> The Bedrock guardrails **Quick Start** YAML example now includes **`aws_external_id`**, documented as optional and only needed when the assumed role’s trust policy requires **`sts:ExternalId`**.
> 
> This matches the runtime change that forwards **`aws_external_id`** on **`sts:AssumeRole`** when using **`aws_role_name`** for Bedrock guardrails, so cross-account role setups are covered in the same example as region and role ARN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082d53f6a8d658fb2c28d287600e3ace3dd72c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->