### PR TITLE
docs(gemini): srt and vtt transcription formats are now synthesized from word timestamps

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -498,7 +498,7 @@ curl http://0.0.0.0:4000/v1/audio/transcriptions \
 
 ### Supported Params
 
-`language`, `response_format`, and `timestamp_granularities` are supported. Requesting word timestamps also enables speaker diarization on the underlying Interactions API call. The `srt` and `vtt` response formats currently return the plain transcript.
+`language`, `response_format`, and `timestamp_granularities` are supported. Requesting word timestamps also enables speaker diarization on the underlying Interactions API call. The `srt` and `vtt` response formats are synthesized by LiteLLM from Gemini's word timestamps, so `text` holds the subtitle document; when Gemini returns no timestamps, `text` falls back to the plain transcript.
 
 ### Live Transcription over `/v1/realtime`
 


### PR DESCRIPTION
## TLDR

Updates the Gemini transcription note in docs/providers/gemini.md now that BerriAI/litellm#38561 is merged. The line saying `srt` and `vtt` return the plain transcript is replaced with the new behavior: LiteLLM synthesizes the subtitle document from Gemini's word timestamps into `text`, falling back to the plain transcript only when Gemini returns no timestamps

## Linear ticket

Resolves LIT-6322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **Audio Transcription → Supported Params** section in `docs/providers/gemini.md` to match post-#38561 behavior for Gemini `gemini-3.5-transcribe`.
> 
> The doc no longer says `srt` and `vtt` only return a plain transcript. It now states that LiteLLM **builds subtitle output from Gemini word timestamps** and puts the SRT/VTT document in **`text`**, with **`text` falling back to the plain transcript** when timestamps are missing. Other supported params (e.g. word timestamps and diarization) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b2aceaf5d68e265a4208c73360c3b48c8cd6b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->