### PR TITLE
docs(a2a): semantic search over the agent registry and the agent_search MCP tool

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -456,3 +456,48 @@ curl -X POST "http://localhost:4000/a2a/my-agent" \
 Want to create a central registry so your team can discover what agents are available within your company?
 
 Use the [AI Hub](./proxy/ai_hub) to make agents public and discoverable across your organization. This allows developers to browse available agents without needing to rebuild them.
+
+### Search the registry
+
+`GET /v1/agents` lists every agent the key can reach. Add `query=<task>` to rank those same agents by semantic similarity between the task and each agent's name, description, and skills. Pick the embedding model first:
+
+```yaml title="config.yaml" showLineNumbers
+model_list:
+  - model_name: text-embedding-3-small
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  agent_search_embedding_model: text-embedding-3-small
+```
+
+```console title="Rank agents for a task" showLineNumbers
+$ curl -s "http://localhost:4000/v1/agents?query=translate+a+pdf+document&top_k=3" \
+    -H "Authorization: Bearer $LITELLM_KEY" | jq -c '.[] | {agent_name, search_score}'
+{"agent_name":"document-translator","search_score":0.6732403392080719}
+{"agent_name":"trip-planner","search_score":0.1121043964671429}
+{"agent_name":"warehouse-sql-analyst","search_score":0.0946962275274791}
+```
+
+`top_k` defaults to 5 and caps at 100. Each result is the normal agent object plus a `search_score` (cosine similarity, higher is better). Ranking only ever covers agents the key is allowed to see, so a key restricted to two agents gets those two back whatever the query. Without `agent_search_embedding_model` a `query` returns `400 agent_search_not_configured`; if the embedding call fails, the request returns `503 agent_search_unavailable`. Agent embeddings are computed once per process and reused until the agent card changes.
+
+MCP clients get the same search as a virtual tool. A key with `mcp_tool_search_enabled: true` on its `object_permission` sees `agent_search(query, top_k)` next to `mcp_tool_search` and `mcp_tool_call` on `tools/list`, over both `/mcp/` and `/mcp-rest`:
+
+```console title="agent_search over /mcp-rest" showLineNumbers
+$ curl -s -X POST http://localhost:4000/mcp-rest/tools/call \
+    -H "Authorization: Bearer $KEY" \
+    -d '{"name":"agent_search","arguments":{"query":"check how many units are left in stock","top_k":1}}' \
+  | jq -r '.content[0].text | fromjson'
+[
+  {
+    "agent_id": "b21b8787-8b9e-4c5f-a45c-3f5e4061d70e",
+    "agent_name": "warehouse-sql-analyst",
+    "description": "Answers questions about stock by running SQL queries against the inventory database",
+    "skills": [{"name": "Query stock levels", "description": "Run a SQL query against the inventory database and summarize the stock levels it returns", "tags": ["sql", "analytics"]}],
+    "score": 0.37912064119364597
+  }
+]
+```
+
+See [MCP Tool Search](./mcp_tool_search.md) for how to enable the virtual tools on a key.

--- a/docs/mcp_tool_search.md
+++ b/docs/mcp_tool_search.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # MCP Tool Search
 
-Swap the full MCP catalog for a fixed pair of virtual tools (`mcp_tool_search`, `mcp_tool_call`) so a key with hundreds of tools available only ever exposes two on `tools/list`. The LLM searches by keyword, gets back the ranked matches, then calls the discovered tool by name.
+Swap the full MCP catalog for a fixed set of virtual tools (`mcp_tool_search`, `mcp_tool_call`, `agent_search`) so a key with hundreds of tools available only ever exposes three on `tools/list`. The LLM searches by keyword, gets back the ranked matches, then calls the discovered tool by name. `agent_search` does the same for the [A2A agent registry](./a2a.md#search-the-registry), ranked by embeddings instead of keywords.
 
 :::info Related Documentation
 - [MCP Overview](./mcp.md)
@@ -30,7 +30,7 @@ curl -X POST http://localhost:4000/key/generate \
 ```console title="2. tools/list returns only the virtual tools" showLineNumbers
 $ curl -s http://localhost:4000/mcp-rest/tools/list \
     -H "Authorization: Bearer $KEY" | jq '[.tools[].name]'
-["mcp_tool_search", "mcp_tool_call"]
+["mcp_tool_search", "mcp_tool_call", "agent_search"]
 ```
 
 ```console title="3. Search discovers the real tools" showLineNumbers
@@ -67,7 +67,7 @@ async with streamablehttp_client(
 
         tools = await session.list_tools()
         print([t.name for t in tools.tools])
-        # ['mcp_tool_search', 'mcp_tool_call']
+        # ['mcp_tool_search', 'mcp_tool_call', 'agent_search']
 
         found = await session.call_tool("mcp_tool_search", {"query": "add numbers"})
         print(found.content[0].text)
@@ -97,10 +97,11 @@ The default is merged **after** the caller-scope validation runs, so it never tu
 
 ## How it works
 
-When `mcp_tool_search_enabled: true` is set on a key's `object_permission`, both the streamable-http endpoint (`/mcp/`) and the REST surface (`/mcp-rest/tools/list`) return exactly two tools regardless of how many MCP servers the key can reach:
+When `mcp_tool_search_enabled: true` is set on a key's `object_permission`, both the streamable-http endpoint (`/mcp/`) and the REST surface (`/mcp-rest/tools/list`) return exactly three tools regardless of how many MCP servers the key can reach:
 
 - `mcp_tool_search(query, top_k=5)` returns the ranked list of real tools that match the query.
 - `mcp_tool_call(tool_name, arguments)` executes one of the tools the LLM discovered through search.
+- `agent_search(query, top_k=5)` returns the A2A agents the key can reach, ranked by semantic similarity to the task described in `query`. It needs `litellm_settings.agent_search_embedding_model`; see [Search the registry](./a2a.md#search-the-registry).
 
 Both handlers run through the same filtered catalog and dispatch path as the normal `/tools/call` route, so search only surfaces tools the key is already allowed to see, and calls still resolve through `_get_allowed_mcp_servers` and `execute_mcp_tool`.
 
@@ -140,4 +141,4 @@ curl "http://localhost:4000/key/info?key=$KEY" \
 
 ## When to use tool search vs. semantic filter
 
-Both features address large-catalog blowout, but they live at different layers. Tool search is an MCP-layer opt-in per key; the LLM sees two tools and drives discovery itself over the MCP protocol, which suits agent frameworks that speak MCP end to end. The [semantic filter](./mcp_semantic_filter.md) sits on `/v1/responses` and `/v1/chat/completions` and rewrites the tool list on each request using embeddings, which suits chat-completion callers that never touch `/mcp/` directly. They can coexist; a key with tool search on will only expose the two virtual tools even when semantic filtering is enabled upstream.
+Both features address large-catalog blowout, but they live at different layers. Tool search is an MCP-layer opt-in per key; the LLM sees three tools and drives discovery itself over the MCP protocol, which suits agent frameworks that speak MCP end to end. The [semantic filter](./mcp_semantic_filter.md) sits on `/v1/responses` and `/v1/chat/completions` and rewrites the tool list on each request using embeddings, which suits chat-completion callers that never touch `/mcp/` directly. They can coexist; a key with tool search on will only expose the three virtual tools even when semantic filtering is enabled upstream.


### PR DESCRIPTION
## TLDR

- Documents GET /v1/agents?query= and top_k for ranking agents by semantic similarity
- Documents litellm_settings.agent_search_embedding_model and the 400/503 errors
- Adds the agent_search virtual tool to the MCP Tool Search page (three tools, not two)

Pairs with BerriAI/litellm#38609

## Linear ticket

Resolves LIT-6309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or security impact.
> 
> **Overview**
> **Documentation only** — describes agent registry semantic search and the third MCP virtual tool that ships with the paired implementation PR.
> 
> **`docs/a2a.md`** adds a **Search the registry** section: `GET /v1/agents?query=` and `top_k` for embedding-based ranking (name, description, skills), `litellm_settings.agent_search_embedding_model` setup, `search_score` behavior, permission scoping, `400 agent_search_not_configured` / `503 agent_search_unavailable`, embedding cache semantics, and calling the same search via **`agent_search`** on `/mcp/` and `/mcp-rest`.
> 
> **`docs/mcp_tool_search.md`** updates the feature from **two** to **three** virtual tools everywhere (`mcp_tool_search`, `mcp_tool_call`, **`agent_search`**), documents `agent_search` parameters and its link to A2A registry search, and refreshes quick-start examples and the tool-search vs semantic-filter comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f797b1c53cee8da90c476a8e06f8740a757528d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->