### PR TITLE
docs(openai): correct the documented default reasoning_effort for gpt-5.2

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -623,7 +623,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 | `gpt-5.1-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5.1-codex-mini` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5.1-codex-max` | `adaptive` | `low`, `medium`, `high`, `xhigh` (no `minimal`) |
-| `gpt-5.2` | `medium` | `none`, `low`, `medium`, `high`, `xhigh` |
+| `gpt-5.2` | `none` | `none`, `low`, `medium`, `high`, `xhigh` |
 | `gpt-5.2-pro` | `high` | `low`, `medium`, `high`, `xhigh` |
 | `gpt-5.5` | `medium` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
 | `gpt-5.5-pro` | `high` | `minimal`, `low`, `medium`, `high`, `xhigh` |


### PR DESCRIPTION
## What was wrong

The `reasoning_effort` table in `docs/providers/openai.md` gave `gpt-5.2` a default of `medium`.

## How it was checked

If a model's default effort really were `medium`, leaving `reasoning_effort` unset would behave
identically to passing `medium` explicitly. It does not:

| `gpt-5.2`, `temperature: 0` | result |
|---|---|
| `reasoning_effort` unset | accepts |
| `reasoning_effort: "none"` | accepts |
| `reasoning_effort: "medium"` | **rejects** |

Unset tracks `none`, not `medium`.

The controls are what make that conclusive rather than suggestive, since they show the method
identifies a genuinely medium-defaulting model:

| model | table says | unset behaviour | agrees? |
|---|---|---|---|
| `gpt-5.1` | `none` | accepts | yes |
| `gpt-5.2` | `medium` | **accepts** | **no** |
| `gpt-5.5` | `medium` | rejects | yes |

Reproduced three times, and `gpt-5.2-2025-12-11` answers the same way. Only the "Default (when
not set)" cell changes; the Supported Values column is untouched, since these probes say nothing
about which effort values the model accepts.

## Scope note

This is the temperature restriction's view of the default, which is the property the table's
default column is load-bearing for. I did not find a way to read the effort level back directly:
the responses carry `reasoning_tokens: 0` for every effort, so that channel cannot distinguish
the levels.

## One more row looks wrong, not changed here

`gpt-5-nano` is documented as defaulting to `none` with `none` among its supported values, but it
rejects `temperature: 0` at every effort including an explicit `none`, and litellm's own model map
records `supports_none_reasoning_effort: false` and `supports_minimal_reasoning_effort: true` for
it. Its siblings `gpt-5` and `gpt-5-mini` are documented as `medium` with `minimal, low, medium,
high`, and it behaves identically to both, so the row looks like it was copied from the
`gpt-5-nano`-shaped entry of a later generation. I have left it alone because these probes can
prove the current value is wrong but not which value is right, and guessing one is how the table
got into this state.


---

Re-applies #1064 (reverted in #1065). Hold merging this until the corresponding code fix lands, so the docs change ships together with the fix.
