### PR TITLE
docs(logging): clarify callback identity metadata

### DIFF
--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -340,7 +340,7 @@ Use this to:
 
 ## What gets logged?
 
-Found under `kwargs["standard_logging_object"]`. This is a standard payload, logged for every response.
+Terminal success and failure callback events include `kwargs["standard_logging_object"]` when LiteLLM finishes building the standard payload. Intermediate streaming events and callbacks where payload construction fails can omit it.
 
 [👉 **Standard Logging Payload Specification**](./logging_spec)
 

--- a/docs/proxy/logging_spec.md
+++ b/docs/proxy/logging_spec.md
@@ -1,7 +1,7 @@
 
 # StandardLoggingPayload Specification
 
-Found under `kwargs["standard_logging_object"]`. This is a standard payload, logged for every successful and failed response.
+Terminal success and failure callback events include `kwargs["standard_logging_object"]` when LiteLLM finishes building the standard payload. Custom logging callbacks should read request identity from `kwargs["standard_logging_object"]["metadata"]`, rather than raw `litellm_params` metadata. Optional identity fields are `null` when unavailable. Intermediate streaming events and callbacks where payload construction fails can omit `standard_logging_object`.
 
 ## StandardLoggingPayload
 
@@ -80,6 +80,7 @@ class CostBreakdown(TypedDict, total=False):
 | `user_api_key_org_id` | `Optional[str]` | Organization ID associated with the key |
 | `user_api_key_team_id` | `Optional[str]` | Team ID associated with the key |
 | `user_api_key_user_id` | `Optional[str]` | User ID associated with the key |
+| `user_api_key_end_user_id` | `Optional[str]` | End-user ID associated with the key |
 | `user_api_key_team_alias` | `Optional[str]` | Team alias associated with the key |
 
 ## StandardLoggingMetadata


### PR DESCRIPTION
## Summary

Clarifies that terminal logging callbacks expose identity in `standard_logging_object.metadata`, documents the optional end-user key, and notes that intermediate events can omit the standard payload

## Validation

- `npm run lint:writing`

## Related change

- BerriAI/litellm#38642

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->