### PR TITLE
docs(vertex): add Gemini audio transcription page

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -437,7 +437,7 @@ For more information about Gemini's TTS capabilities and available voices, see t
 
 :::info
 
-LiteLLM supports `gemini-3.5-transcribe` on `/v1/audio/transcriptions` and `gemini-3.5-transcribe-live` on `/v1/realtime`.
+LiteLLM supports `gemini-3.5-transcribe` on `/v1/audio/transcriptions` and `gemini-3.5-transcribe-live` on `/v1/realtime`. Using Vertex AI instead of an API key? See [Vertex AI Audio Transcription](./vertex_transcription.md).
 
 :::
 

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 | Provider Route on LiteLLM | `vertex_ai/` |
 | Link to Provider Doc | [Vertex AI ↗](https://cloud.google.com/vertex-ai) |
 | Base URL | 1. Regional endpoints<br/>`https://{vertex_location}-aiplatform.googleapis.com/`<br/>2. Global endpoints (limited availability)<br/>`https://aiplatform.googleapis.com/`|
-| Supported Operations | [`/chat/completions`](#sample-usage), `/completions`, [`/embeddings`](#embedding-models), [`/audio/speech`](/docs/providers/vertex_speech), [`/fine_tuning`](#fine-tuning-apis), [`/batches`](/docs/providers/vertex_batch), [`/files`](/docs/providers/vertex_batch), `/images`, [`/rerank`](#rerank-api) |
+| Supported Operations | [`/chat/completions`](#sample-usage), `/completions`, [`/embeddings`](#embedding-models), [`/audio/speech`](/docs/providers/vertex_speech), [`/audio/transcriptions`](/docs/providers/vertex_transcription), [`/fine_tuning`](#fine-tuning-apis), [`/batches`](/docs/providers/vertex_batch), [`/files`](/docs/providers/vertex_batch), `/images`, [`/rerank`](#rerank-api) |
 
 :::tip Vertex AI vs Gemini API
 | Model Format | Provider | Auth Required |

--- a/docs/providers/vertex_transcription.md
+++ b/docs/providers/vertex_transcription.md
@@ -1,0 +1,92 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Vertex AI Audio Transcription
+
+| Property | Details |
+|-------|-------|
+| Description | Gemini speech-to-text on Vertex AI via the OpenAI `/v1/audio/transcriptions` endpoint |
+| Provider Route on LiteLLM | `vertex_ai/gemini-3.5-transcribe-preview` |
+| Supported OpenAI Params | `language`, `response_format` (`json`, `text`) |
+
+Gemini transcribe models on Vertex AI are served from the `global` location, which LiteLLM uses by default when no `vertex_location` is set. If you set a regional location (in config, `litellm.vertex_location`, or the `VERTEXAI_LOCATION` / `VERTEX_LOCATION` env vars), that value takes precedence and Vertex returns a 404 for regions where the model is unavailable, so pin `vertex_location: global` for these models.
+
+Prefer an API key over a GCP service account? The same model is available through [Google AI Studio](./gemini.md#audio-transcription-speech-to-text) as `gemini/gemini-3.5-transcribe`.
+
+## Quick Start
+
+### LiteLLM Python SDK
+
+```python showLineNumbers title="Gemini Transcribe Quick Start"
+from litellm import transcription
+
+audio_file = open("speech.wav", "rb")
+response = transcription(
+    model="vertex_ai/gemini-3.5-transcribe-preview",
+    file=audio_file,
+    language="en",
+    vertex_project="your-project-id",
+    vertex_credentials="/path/to/service_account.json",
+)
+print(response.text)
+```
+
+### LiteLLM AI Gateway
+
+**1. Setup config.yaml**
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gemini-transcribe
+    litellm_params:
+      model: vertex_ai/gemini-3.5-transcribe-preview
+      vertex_project: "your-project-id"
+      vertex_credentials: "/path/to/service_account.json"
+```
+
+**2. Start the proxy**
+
+```bash title="Start LiteLLM Proxy"
+litellm --config /path/to/config.yaml
+```
+
+**3. Make requests**
+
+<Tabs>
+<TabItem value="curl" label="curl">
+
+```bash showLineNumbers title="Gemini Transcribe Quick Start"
+curl http://0.0.0.0:4000/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-1234" \
+  -F file=@speech.wav \
+  -F model=gemini-transcribe \
+  -F language=en
+```
+
+</TabItem>
+<TabItem value="openai-sdk" label="OpenAI Python SDK">
+
+```python showLineNumbers title="Gemini Transcribe Quick Start"
+import openai
+
+client = openai.OpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000")
+
+audio_file = open("speech.wav", "rb")
+response = client.audio.transcriptions.create(
+    model="gemini-transcribe",
+    file=audio_file,
+    language="en",
+)
+print(response.text)
+```
+
+</TabItem>
+</Tabs>
+
+## Supported Params
+
+`language` accepts two-letter codes or BCP-47 tags and is normalized to BCP-47 before being sent to Gemini. `response_format` supports `json` (default) and `text`; Gemini transcription on Vertex AI returns no word timestamps, so `verbose_json`, `srt`, and `vtt` are rejected with a 400 unless `drop_params` is set, in which case they are dropped and the plain transcript is returned.
+
+## Usage and Cost Tracking
+
+Vertex AI reports token usage split by modality, and LiteLLM tracks audio input tokens and text output tokens separately, so spend logs and the `x-litellm-response-cost` header reflect Google's published per-token audio transcription pricing.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1055,6 +1055,7 @@ const sidebars = {
             "providers/vertex_embedding",
             "providers/vertex_image",
             "providers/vertex_speech",
+            "providers/vertex_transcription",
             "providers/vertex_batch",
             "providers/vertex_ocr",
             "providers/vertex_ai_agent_engine",


### PR DESCRIPTION
## TLDR

Documents the new Vertex AI Gemini audio transcription support shipped in BerriAI/litellm#38740: a dedicated provider page for `vertex_ai/gemini-3.5-transcribe-preview` on `/v1/audio/transcriptions`, a sidebar entry under Vertex AI, the `/audio/transcriptions` operation added to the Vertex overview table, and a cross-link from the AI Studio transcription section

The page covers the `global`-only location default and the env var precedence gotcha, the supported params (`language`, `response_format` json/text with the timestamp formats rejected), SDK and proxy quick starts, and modality-split usage and cost tracking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact.
> 
> **Overview**
> Adds **Vertex AI Audio Transcription** documentation for `vertex_ai/gemini-3.5-transcribe-preview` on OpenAI-compatible `/v1/audio/transcriptions`, including SDK and proxy quick starts, supported params, `global` location guidance, and modality-based cost tracking.
> 
> Wires the new page into the docs site: **Vertex AI** sidebar entry, `/audio/transcriptions` on the Vertex overview **Supported Operations** table, and a cross-link from the Google AI Studio transcription section to the Vertex page (and back for API-key users).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47595b4979ac52bc69f86c8d9cb1b1c04a9eb910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->