### PR TITLE
docs(guardrails): document Bedrock streaming buffer and audit-only flags

### DIFF
--- a/docs/proxy/guardrails/bedrock.md
+++ b/docs/proxy/guardrails/bedrock.md
@@ -142,6 +142,36 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 </Tabs>
 
+## Streaming
+
+Streaming responses are scanned on `post_call`. By default the stream is buffered: every chunk is withheld until the assembled response passes one ApplyGuardrail OUTPUT scan, so no flagged content reaches the client before a block. The client sees nothing until the scan completes, then the whole response arrives in one burst.
+
+For latency-sensitive clients (interactive chat, coding agents), you can keep the stream flowing and run the scan in audit mode instead:
+
+```yaml
+guardrails:
+  - guardrail_name: "bedrock-post-guard"
+    litellm_params:
+      guardrail: bedrock
+      mode: "post_call"
+      guardrailIdentifier: ff6ujrregl1q
+      guardrailVersion: "DRAFT"
+      streaming_buffer_until_moderated: false
+      streaming_end_of_stream_only: true
+```
+
+Chunks now stream to the client as they arrive, and one OUTPUT scan runs over the assembled response at end of stream. A violation still terminates the stream with the guardrail's block message, but content that already streamed has been seen: this is detect-and-log, not prevention. Either way the scan result is recorded in `guardrail_information` on the request's spend log.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `streaming_buffer_until_moderated` | `true` | Withhold every streamed chunk until end-of-stream moderation passes, so no flagged chunk reaches the client before a block |
+| `streaming_end_of_stream_only` | `false` | Scan streamed output once, over the assembled response, instead of per sampled chunk |
+| `streaming_sampling_rate` | `5` | When not buffering and not end-of-stream-only, scan the accumulated text every Nth chunk. Must be at least 1 |
+
+With `streaming_buffer_until_moderated: false` alone, the guardrail scans the accumulated response every `streaming_sampling_rate` chunks while streaming. Each sampled scan is a separate ApplyGuardrail call over all text so far, so it adds mid-stream latency and repeated Bedrock text-unit charges. Pair it with `streaming_end_of_stream_only: true` unless you need mid-stream blocking.
+
+These settings apply to both `/v1/chat/completions` and native `/v1/messages` streams.
+
 ## Resource-less Checks: InvokeGuardrailChecks
 
 With the [InvokeGuardrailChecks API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeGuardrailChecks.html) you don't need to create a guardrail in AWS. Instead, define the checks inline in your config; Bedrock returns a score per check, and LiteLLM blocks the request when a score reaches your threshold.

--- a/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/proxy/guardrails/custom_guardrail.md
@@ -166,6 +166,8 @@ For **streaming responses**, `post_call` guardrails run on the fully assembled r
 
 To filter or block streaming content in real-time, use `async_post_call_streaming_iterator_hook` instead, which processes chunks as they arrive.
 
+Built-in guardrails that implement `apply_guardrail` (for example [Bedrock](./bedrock#streaming)) take the opposite default on streams: LiteLLM buffers every chunk until the assembled response passes moderation, so a block lands before any content reaches the client. Set `streaming_buffer_until_moderated: false` together with `streaming_end_of_stream_only: true` on such a guardrail to get the audit-only behavior described above, with no added time-to-first-token.
+
 :::
 
 <details>


### PR DESCRIPTION
## TLDR

Documents the three streaming flags the Bedrock guardrail now honors in BerriAI/litellm#38722: `streaming_buffer_until_moderated`, `streaming_end_of_stream_only`, and `streaming_sampling_rate`. The Bedrock guardrail page gets a section showing the audit-only combination (buffering off, one end-of-stream scan) and what a block looks like once chunks have already streamed. The custom guardrail page gets the two-line note that these keys live under `litellm_params`

## Relevant issues

Pairs with BerriAI/litellm#38722 (Resolves LIT-6412 there); this PR should land once that one merges

## Type

📖 Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to guardrail guides; no runtime or configuration code modified.
> 
> **Overview**
> Adds a **Streaming** section to the Bedrock guardrails doc that explains default `post_call` stream behavior (buffer until moderation passes) and how to switch to **audit-only** streaming via `streaming_buffer_until_moderated: false` and `streaming_end_of_stream_only: true`, including tradeoffs (detect-and-log vs prevention, `guardrail_information` on spend logs). Documents **`streaming_buffer_until_moderated`**, **`streaming_end_of_stream_only`**, and **`streaming_sampling_rate`** in a defaults table and notes cost/latency when sampling mid-stream without end-of-stream-only.
> 
> Updates the custom guardrail streaming note to contrast hook-based `post_call` (audit-only after delivery) with built-in **`apply_guardrail`** providers like Bedrock, which buffer by default and can opt into the same audit-only pattern through those `litellm_params` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a208bebf3abf252a3d5a6421241daab596c114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->