### PR TITLE
docs(vertex): document Veo 3.1 Lite and the size to resolution mapping

### DIFF
--- a/docs/providers/vertex_ai/videos.md
+++ b/docs/providers/vertex_ai/videos.md
@@ -9,8 +9,8 @@ LiteLLM supports Vertex AI's Veo video generation models using the unified OpenA
 |-------|-------|
 | Description | Google Cloud Vertex AI Veo video generation models |
 | Provider Route on LiteLLM | `vertex_ai/` |
-| Supported Models | `veo-2.0-generate-001`, `veo-3.0-generate-preview`, `veo-3.0-fast-generate-preview`, `veo-3.1-generate-preview`, `veo-3.1-fast-generate-preview` |
-| Cost Tracking | ✅ Duration-based pricing |
+| Supported Models | `veo-2.0-generate-001`, `veo-3.0-generate-preview`, `veo-3.0-fast-generate-preview`, `veo-3.1-generate-preview`, `veo-3.1-fast-generate-preview`, `veo-3.1-lite-generate-001` |
+| Cost Tracking | ✅ Duration-based pricing, with 720p and 1080p tiers where Google prices them (Veo 3.1 Lite) |
 | Logging Support | ✅ Full request/response logging |
 | Proxy Server Support | ✅ Full proxy integration with virtual keys |
 | Spend Management | ✅ Budget tracking and rate limiting |
@@ -98,6 +98,9 @@ with open("generated_video.mp4", "wb") as f:
 | veo-3.0-fast-generate-preview | Veo 3.0 fast generation | 8 seconds | Preview |
 | veo-3.1-generate-preview | Veo 3.1 high quality | 10 seconds | Preview |
 | veo-3.1-fast-generate-preview | Veo 3.1 fast | 10 seconds | Preview |
+| veo-3.1-lite-generate-001 | Veo 3.1 Lite, the lowest-cost tier, 720p or 1080p output | 8 seconds | Preview |
+
+Veo 3.1 Lite is priced per second of output at $0.05 for 720p and $0.08 for 1080p, and Veo renders 720p unless a request asks for 1080p. See [Size to Resolution Mapping](#size-to-resolution-mapping) for how to request 1080p through the OpenAI `size` parameter.
 
 ## Video Generation Parameters
 
@@ -106,7 +109,7 @@ LiteLLM converts OpenAI-style parameters to Veo's API shape automatically:
 | OpenAI Parameter | Vertex AI Parameter | Description | Example |
 |------------------|---------------------|-------------|---------|
 | `prompt` | `instances[].prompt` | Text description of the video | "A cat playing" |
-| `size` | `parameters.aspectRatio` | Converted to `16:9` or `9:16` | "1280x720" → `16:9` |
+| `size` | `parameters.aspectRatio`, plus `parameters.resolution` on models with a 1080p price tier | Converted to `16:9` or `9:16`, and to `720p` or `1080p` where the model is priced per resolution | "1920x1080" → `16:9` and `1080p` |
 | `seconds` | `parameters.durationSeconds` | Clip length in seconds | "8" → `8` |
 | `input_reference` | `instances[].image` | Reference image for animation | `open("image.jpg", "rb")` |
 | Provider-specific params | `extra_body` | Forwarded to Vertex API | `{"negativePrompt": "blurry"}` |
@@ -116,6 +119,39 @@ LiteLLM converts OpenAI-style parameters to Veo's API shape automatically:
 - `1280x720`, `1920x1080` → `16:9`
 - `720x1280`, `1080x1920` → `9:16`
 - Unknown sizes default to `16:9`
+
+### Size to Resolution Mapping
+
+Veo picks the output resolution from its own `resolution` parameter, not from the aspect ratio, so a `1920x1080` request that only sets `aspectRatio` still comes back as 720p. For models whose LiteLLM pricing carries a separate 1080p rate (today `veo-3.1-lite-generate-001`), LiteLLM also infers `resolution` from `size`:
+
+| `size` | `aspectRatio` sent | `resolution` sent |
+|--------|--------------------|-------------------|
+| `1280x720` | `16:9` | `720p` |
+| `720x1280` | `9:16` | `720p` |
+| `1920x1080` | `16:9` | `1080p` |
+| `1080x1920` | `9:16` | `1080p` |
+
+Any other `size` value maps to an aspect ratio only and leaves the resolution to Veo's default. Models without a 1080p price tier (Veo 2.0, Veo 3.0, and the other Veo 3.1 variants) never get an inferred `resolution`, so their requests are unchanged. Passing `resolution` yourself, either as a top-level parameter or inside `extra_body`, always wins over the value inferred from `size`.
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/videos' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer sk-1234' \
+--data '{
+  "model": "veo-3.1-lite-generate-001",
+  "prompt": "A slow aerial shot of a lighthouse at sunrise",
+  "seconds": "8",
+  "size": "1920x1080"
+}'
+```
+
+The response `usage` reports the resolution that was requested, and the spend log prices the clip at that tier:
+
+```json
+{"duration_seconds": 8.0, "video_resolution": "1080p"}
+```
+
+An 8 second Veo 3.1 Lite clip therefore costs $0.40 at `1280x720` and $0.64 at `1920x1080`.
 
 ## Async Usage
 
@@ -252,6 +288,8 @@ response = video_generation(
 
 print(response.usage)  # {"duration_seconds": 5.0}
 ```
+
+For models priced per resolution, `usage` also carries `video_resolution` (`720p` or `1080p`) and the cost uses that tier's per-second rate, as shown in [Size to Resolution Mapping](#size-to-resolution-mapping).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TLDR

The Vertex AI Veo page did not list `veo-3.1-lite-generate-001` and said `size` only becomes `aspectRatio`, so a reader could not tell the gateway supports the model or how to get 1080p output from it. This adds the model to both supported-model tables with its per-second pricing ($0.05 at 720p, $0.08 at 1080p), documents the size to resolution mapping the gateway applies on models priced per resolution, and notes the `video_resolution` field in `usage` that drives the tiered cost

Every number and behavior here was checked against the merged code in BerriAI/litellm#30782 (merge commit 8dd9c4acb1): the `vertex_ai/veo-3.1-lite-generate-001` cost map entry, the `size` to `resolution` table in `VertexAIVideoConfig`, the gate on `output_cost_per_second_1080p`, and the precedence of an explicit `resolution`. The Preview status, 4/6/8 second lengths, and 720p/1080p output come from Google's Vertex AI model page for Veo 3.1 Lite, and the prices from Google's Vertex AI pricing page

## User Flow

Before: a developer who wants a 1080p Veo 3.1 Lite clip through the gateway finds nothing on the page telling them the model exists or how to ask for 1080p

1. They open https://docs.litellm.ai/docs/providers/vertex_ai/videos and scan the Supported Models table, which stops at `veo-3.1-fast-generate-preview`, so they cannot tell whether `veo-3.1-lite-generate-001` is priced or routable on the gateway
2. They read the Video Generation Parameters table, which says `size` is converted to `16:9` or `9:16` and nothing else, so there is no documented way to request 1080p
3. They send `POST http://localhost:4000/v1/videos` with `{"model": "veo-3.1-lite-generate-001", "prompt": "...", "seconds": "8", "size": "1920x1080"}` on a guess, and have no documented expectation for the resolution they get back or the spend they will see

After: the same developer reads the model row, the mapping table, and the worked example, and knows exactly what `1920x1080` does and costs

1. They open https://docs.litellm.ai/docs/providers/vertex_ai/videos and find `veo-3.1-lite-generate-001` in the Supported Models table (8 seconds, Preview) with the $0.05 per second 720p and $0.08 per second 1080p pricing right under it
2. They read the Video Generation Parameters table and the new Size to Resolution Mapping section, which say `1920x1080` sends `aspectRatio: 16:9` and `resolution: 1080p` on that model, that other Veo models are unchanged, and that an explicit `resolution` wins
3. They send the documented `POST http://localhost:4000/v1/videos` with `"size": "1920x1080"` and, as the page says, the response `usage` carries `"video_resolution": "1080p"` and the spend log prices the 8 second clip at $0.64

## Linear ticket

Resolves LIT-6492

## Caveats

- Low: the Supported Models row marks Veo 3.1 Lite as Preview because Google's Vertex AI model page lists it as Preview (released April 2, 2026); when Google moves it to GA the Status cell goes stale like the other Preview rows on the page
- Low: there is no live before/after proof because this PR changes documentation only; the page was verified by `npm run lint:writing` and a full `npm run build`, and every claim was checked against the merged gateway code and Google's own model and pricing pages

## Proof

```bash
npm run lint:writing
# Checked 993 markdown files in: docs, blog, release_notes
# No prose em dashes found.

npm run build
# [SUCCESS] Generated static files in "build".

grep -c 'veo-3.1-lite-generate-001' build/docs/providers/vertex_ai/videos/index.html
# 4
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `docs/providers/vertex_ai/videos.md` with no runtime or security impact.
> 
> **Overview**
> Updates the **Vertex AI Veo** docs so **`veo-3.1-lite-generate-001`** appears in the overview and Supported Models tables, with **720p / 1080p per-second pricing** and clarified **cost tracking** for resolution-tiered models.
> 
> The **`size`** parameter table now explains that LiteLLM can map OpenAI `size` to both **`aspectRatio`** and **`resolution`** on models with a 1080p price tier. A new **Size to Resolution Mapping** section documents the `1280x720` / `1920x1080` (and portrait) mappings, that other Veo models are unchanged, explicit **`resolution`** wins, and includes a proxy **`curl`** example plus **`usage.video_resolution`** and sample spend ($0.40 vs $0.64 for 8s Lite).
> 
> **Cost Tracking** now notes **`video_resolution`** on tiered models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153a0c8139bbcf83d3f718edb9e6a64ab00f8f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->