### PR TITLE
docs(anthropic_unified): document cache_control ttl stripping and the cache_control_ttl opt-in

### DIFF
--- a/docs/anthropic_unified/native_passthrough.md
+++ b/docs/anthropic_unified/native_passthrough.md
@@ -19,9 +19,29 @@ model_list:
       supported_endpoints: ["/v1/chat/completions", "/v1/messages"]
 ```
 
-With the opt-in, a request to the proxy's `/v1/messages` is POSTed to `{api_base}/v1/messages` with the Anthropic body unchanged. A trailing `/v1` on `api_base` is stripped first, so `https://inference.example.com/v1` and `https://inference.example.com` both resolve to `https://inference.example.com/v1/messages`. LiteLLM sends `Authorization: Bearer <api_key>` unless the request already carries an `Authorization` or `x-api-key` header, defaults `anthropic-version` to `2023-06-01`, and forwards `anthropic-beta` headers, both the ones the caller sent and the ones LiteLLM adds for features like context management. Streaming and response parsing work the same way they do for a native Anthropic deployment
+With the opt-in, a request to the proxy's `/v1/messages` is POSTed to `{api_base}/v1/messages` with the Anthropic body unchanged, apart from `cache_control` (see below). A trailing `/v1` on `api_base` is stripped first, so `https://inference.example.com/v1` and `https://inference.example.com` both resolve to `https://inference.example.com/v1/messages`. LiteLLM sends `Authorization: Bearer <api_key>` unless the request already carries an `Authorization` or `x-api-key` header, defaults `anthropic-version` to `2023-06-01`, and forwards `anthropic-beta` headers, both the ones the caller sent and the ones LiteLLM adds for features like context management. Streaming and response parsing work the same way they do for a native Anthropic deployment
 
 Without the opt-in the deployment behaves as before and the request is translated. `/v1/chat/completions` calls to the same deployment are not affected either way
+
+## `cache_control` is reduced to its portable core
+
+Strict implementations of the Messages API reject Anthropic-only `cache_control` extensions such as `ttl` with `cache_control.ttl: 1h is not supported`, and clients like Claude Code send `{"type": "ephemeral", "ttl": "1h"}` on every prompt block whenever 1h prompt caching is on. So by default every `cache_control` in the forwarded body is reduced to `{"type": "ephemeral"}`, at the request level and in system blocks, tools, message content blocks, and `tool_result` content. Application data such as `tool_use.input` and tool `input_schema` is never touched
+
+When the upstream honors `ttl`, keep it with `cache_control_ttl: true` in `model_info`:
+
+```yaml
+model_list:
+  - model_name: my-open-model
+    litellm_params:
+      model: openai/some-open-model
+      api_base: https://inference.example.com/v1
+      api_key: os.environ/EXAMPLE_API_KEY
+    model_info:
+      supported_endpoints: ["/v1/chat/completions", "/v1/messages"]
+      cache_control_ttl: true
+```
+
+Deployments of providers with built-in Anthropic Messages support (`anthropic/`, `bedrock/`, `vertex_ai/`, and others) keep forwarding `cache_control` as sent
 
 Test it with an Anthropic-only feature in the request:
 


### PR DESCRIPTION
## TLDR

The native passthrough page says the Anthropic body is forwarded unchanged. As of BerriAI/litellm#38790 that is no longer quite true: every `cache_control` in the forwarded body is reduced to `{"type": "ephemeral"}` because strict Messages API implementations reject Anthropic-only extensions such as `ttl` (`cache_control.ttl: 1h is not supported`), which Claude Code sends whenever 1h prompt caching is on. This documents the stripping, where it applies (request, system, tools, message content blocks, `tool_result` content, never `tool_use.input` or `input_schema`), and the new `model_info.cache_control_ttl: true` opt-in for upstreams that honor `ttl`

Wording and the yaml were checked against the code in BerriAI/litellm#38790: `OpenAILikeAnthropicMessagesConfig`, `normalize_cache_control_in_anthropic_payload`, and the `model_info.cache_control_ttl` read in the messages handler

## User Flow

Before: an operator whose passthrough deployment points at an upstream that honors `ttl` sees 1h caching silently become 5m after upgrading, and the page gives no hint why

1. They open https://docs.litellm.ai/docs/anthropic_unified/native_passthrough and read that the body is forwarded unchanged
2. They send `POST http://localhost:4000/v1/messages` with `cache_control: {"type": "ephemeral", "ttl": "1h"}` and the upstream reports a 5m cache, with nothing on the page explaining the difference

After: the same operator reads the new section, sets the opt-in, and gets 1h caching back

1. They open https://docs.litellm.ai/docs/anthropic_unified/native_passthrough and find the `cache_control` section explaining the default stripping and why it exists
2. They add `cache_control_ttl: true` under the deployment's `model_info` as shown in the yaml
3. They send the same `POST http://localhost:4000/v1/messages` and the upstream receives `ttl: 1h` as sent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior impact in this PR.
> 
> **Overview**
> Updates the **native `/v1/messages` passthrough** doc so it no longer claims the Anthropic body is forwarded unchanged. The intro now notes an exception for **`cache_control`**, with a dedicated section explaining default behavior.
> 
> **By default**, forwarded `cache_control` objects are reduced to `{"type": "ephemeral"}` (dropping Anthropic-only fields like `ttl`) across the request, system blocks, tools, message content, and `tool_result` content—while leaving `tool_use.input` and tool `input_schema` alone. This matches strict Messages API upstreams and clients such as Claude Code that send `ttl: "1h"`.
> 
> Operators whose upstream supports **`ttl`** can set **`model_info.cache_control_ttl: true`** (with an example YAML snippet). The doc also states that built-in Anthropic-capable provider prefixes keep full `cache_control` as sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9eb61b7d94240f53e6c3f0fa88fc0a3164bf4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->