### PR TITLE
docs: add GigaChat passthrough page and GIGACHAT_ACCESS_TOKEN env reference

### DIFF
--- a/docs/pass_through/gigachat.md
+++ b/docs/pass_through/gigachat.md
@@ -1,0 +1,93 @@
+# GigaChat
+
+Pass-through endpoints for GigaChat - call the provider-specific endpoint in native format (no translation).
+
+| Feature | Supported | Notes |
+|-------|-------|-------|
+| Cost Tracking | ✅ | supported for `/chat/completions` and `/embeddings` |
+| Logging | ✅ | works across all integrations |
+| Streaming | ✅ | |
+
+Just replace `https://gigachat.devices.sberbank.ru/api/v1` with `LITELLM_PROXY_BASE_URL/gigachat`
+
+## Quick Start
+
+1. Add your GigaChat credentials to your environment
+
+```bash
+export GIGACHAT_CREDENTIALS="your-authorization-key"
+
+# Optional: defaults to GIGACHAT_API_PERS
+export GIGACHAT_SCOPE="GIGACHAT_API_PERS"
+```
+
+Instead of credentials, you can supply a pre-issued token directly with `GIGACHAT_ACCESS_TOKEN`.
+
+:::info
+
+The GigaChat API is served with certificates from the Russian Trusted Root CA, which most systems do not trust by default. Either [install the certificate chain](https://developers.sber.ru/docs/ru/gigachat/certificates) or run the proxy with `ssl_verify: false`.
+
+:::
+
+2. Start LiteLLM Proxy
+
+```bash
+litellm
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+3. Test it!
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/gigachat/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+    "model": "GigaChat-2",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+
+## Examples
+
+Anything after `http://0.0.0.0:4000/gigachat` is treated as a provider-specific route, and handled accordingly.
+
+Key Changes:
+
+| **Original Endpoint**                                | **Replace With**                  |
+|------------------------------------------------------|-----------------------------------|
+| `https://gigachat.devices.sberbank.ru/api/v1`          | `http://0.0.0.0:4000/gigachat` (LITELLM_PROXY_BASE_URL="http://0.0.0.0:4000")      |
+| `bearer $GIGACHAT_ACCESS_TOKEN`                                 | `bearer anything` (use `bearer LITELLM_VIRTUAL_KEY` if Virtual Keys are setup on proxy)                    |
+
+### **Example 1: Chat completions (streaming)**
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/gigachat/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer $LITELLM_API_KEY' \
+-d '{
+    "model": "GigaChat-2",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+}'
+```
+
+### **Example 2: Embeddings**
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/gigachat/embeddings' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer $LITELLM_API_KEY' \
+-d '{
+    "model": "EmbeddingsGigaR",
+    "input": ["Hello!"]
+}'
+```
+
+### **Example 3: List models**
+
+```bash
+curl -L -X GET 'http://0.0.0.0:4000/gigachat/models' \
+-H 'Authorization: Bearer $LITELLM_API_KEY'
+```

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -724,6 +724,7 @@ router_settings:
 | GALADRIEL_API_BASE | Base URL for Galadriel. Default is https://api.galadriel.com/v1
 | GDC_API_BASE | Base URL for GDC
 | GDC_API_KEY | API key for GDC
+| GIGACHAT_ACCESS_TOKEN | Pre-issued access token for GigaChat, used directly instead of exchanging credentials at `GIGACHAT_AUTH_URL`
 | GIGACHAT_API_BASE | Base URL for GigaChat
 | GIGACHAT_API_KEY | Credentials for GigaChat, read after `GIGACHAT_CREDENTIALS` and exchanged for an access token at `GIGACHAT_AUTH_URL`
 | GIGACHAT_AUTH_URL | OAuth token endpoint used to exchange GigaChat credentials for an access token. Defaults to the GigaChat production auth URL

--- a/sidebars.js
+++ b/sidebars.js
@@ -928,6 +928,7 @@ const sidebars = {
             "pass_through/cohere",
             "pass_through/comprehend_medical",
             "pass_through/cursor",
+            "pass_through/gigachat",
             "pass_through/google_ai_studio",
             "pass_through/langfuse",
             "pass_through/mistral",


### PR DESCRIPTION
Adds a pass_through/gigachat page covering the new `/gigachat/{endpoint}` passthrough route shipping in BerriAI/litellm#25886 (chat completions, embeddings, streaming, cost tracking), registers it in the sidebar, and adds the `GIGACHAT_ACCESS_TOKEN` row to the environment variables reference so the code repo's documentation check passes once that PR lands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or proxy behavior changes in this diff.
> 
> **Overview**
> Adds **GigaChat** to the pass-through docs so clients can hit `LITELLM_PROXY_BASE_URL/gigachat` instead of the native Sber API base URL, with paths forwarded unchanged.
> 
> The new page covers setup (`GIGACHAT_CREDENTIALS`, optional `GIGACHAT_SCOPE`, or `GIGACHAT_ACCESS_TOKEN`), Russian Trusted Root CA / `ssl_verify` guidance, and curl examples for chat completions (including streaming), embeddings, and listing models. It also notes cost tracking on `/chat/completions` and `/embeddings`, plus logging and streaming support.
> 
> **`sidebars.js`** links `pass_through/gigachat` under Pass-through Endpoints. **`config_settings.md`** documents **`GIGACHAT_ACCESS_TOKEN`** as a pre-issued token that skips credential exchange at `GIGACHAT_AUTH_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e68eb65242f55fcb284dafa1345b5b0463cbc1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->