### PR TITLE
docs: match /v1/responses/input_tokens example response to the live API shape

### DIFF
--- a/docs/count_tokens.md
+++ b/docs/count_tokens.md
@@ -146,7 +146,7 @@ response = httpx.post(
 )
 
 print(response.json())
-# {"input_tokens": 7}
+# {"object": "response.input_tokens", "input_tokens": 13}
 ```
 
 </TabItem>
@@ -154,7 +154,7 @@ print(response.json())
 
 **Response:**
 ```json
-{"input_tokens": 7}
+{"object": "response.input_tokens", "input_tokens": 13}
 ```
 
 ### Anthropic Format: `/v1/messages/count_tokens`


### PR DESCRIPTION
The example response for POST /v1/responses/input_tokens shows {"input_tokens": 7}, but both OpenAI and the LiteLLM proxy endpoint (BerriAI/litellm PR pending, LIT-6366) return {"object": "response.input_tokens", "input_tokens": 13} for the example's exact body. Updates the two example outputs to the real shape and count

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **OpenAI-format** proxy examples in `count_tokens.md` so they match what callers actually get from `POST /v1/responses/input_tokens`.
> 
> The documented response changes from `{"input_tokens": 7}` to **`{"object": "response.input_tokens", "input_tokens": 13}`** in both the Python `httpx` sample comment and the standalone **Response** JSON block, reflecting the OpenAI Responses API shape and the token count for the documented request body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630de90f80d8e0f544661e01a6ec8d2e00d13683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->