### PR TITLE
docs: document OpenAI workload identity federation env vars

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1270,7 +1270,10 @@ router_settings:
 | OPENAI_API_KEY | API key for OpenAI services
 | OPENAI_CHATGPT_API_BASE | Alternative to CHATGPT_API_BASE. Base URL for ChatGPT API
 | OPENAI_FILE_SEARCH_COST_PER_1K_CALLS | Cost per 1000 calls for OpenAI file search. Default is 0.0025
+| OPENAI_IDENTITY_PROVIDER_ID | Identity provider ID (`idp_...`) for OpenAI workload identity federation. When this, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` are all set and no OpenAI API key is configured, the proxy authenticates `openai/` models by exchanging the OIDC token for a short-lived bearer (RFC 8693). Requires `openai>=2.32.0`
+| OPENAI_IDENTITY_TOKEN_FILE | Path to the OIDC subject token file used for OpenAI workload identity federation, e.g. the Kubernetes projected service account token path
 | OPENAI_ORGANIZATION | Organization identifier for OpenAI
+| OPENAI_SERVICE_ACCOUNT_ID | OpenAI platform service account ID (`user-...`) that workload identity federation authenticates as. Unrelated to LiteLLM virtual-key service accounts
 | OPENAPI_URL | The path to the OpenAPI JSON endpoint. **By default this is "/openapi.json"**
 | OPENID_BASE_URL | Base URL for OpenID Connect services
 | OPENID_CLIENT_ID | Client ID for OpenID Connect authentication


### PR DESCRIPTION
Documents OPENAI_IDENTITY_PROVIDER_ID, OPENAI_SERVICE_ACCOUNT_ID, and OPENAI_IDENTITY_TOKEN_FILE in the config settings reference. These land in BerriAI/litellm#38995 and its docs-check CI (test_env_keys.py) fails until this merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the config reference; no runtime or auth behavior is modified in this PR.
> 
> **Overview**
> Adds three entries to the proxy **environment variables** reference in `config_settings.md` for OpenAI workload identity federation.
> 
> **`OPENAI_IDENTITY_PROVIDER_ID`**, **`OPENAI_IDENTITY_TOKEN_FILE`**, and **`OPENAI_SERVICE_ACCOUNT_ID`** are documented together: when all are set and no OpenAI API key is configured, `openai/` models authenticate via OIDC token exchange (RFC 8693) for a short-lived bearer. Notes the `openai>=2.32.0` requirement and clarifies that **`OPENAI_SERVICE_ACCOUNT_ID`** is the OpenAI platform service account (`user-...`), not LiteLLM virtual-key service accounts.
> 
> This aligns the docs with the implementation in BerriAI/litellm#38995 so `test_env_keys.py` docs-check CI can pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4d6e9bc24118e7b8b75a5a3ce7b4603a8bccab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->