### PR TITLE
docs(release_notes): promote v1.99.0 to stable

### DIFF
--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.98.0: Provisioned Throughput Billing, Shadow Evals & Routing Groups](/release_notes/v1.98.0/v1-98-0)
+### [v1.99.0: Dark Mode, CLI OAuth Login & Batch Billing](/release_notes/v1.99.0/v1-99-0)
 
-_August 22, 2026_
+_September 1, 2026_
 
-Provisioned throughput is billed as reserved capacity, with `ptu_count` and `cost_per_ptu_per_hour` on a deployment driving a per-model flat cost by active hour while per-token billing is switched off there, so a team paying for reserved capacity is not charged twice for the same traffic; a shadow eval job that samples a slice of one key's successful traffic, replays it through the auto-router in a detached task that never serves a response or adds latency, and has an LLM judge compare both answers blind, so the router can be measured before it is adopted; routing groups that are callable models, where `model=<group_name>` routes across the union of member deployments with the group's own strategy, appears in `/v1/models` for Claude Code and Codex discovery, and is grantable on keys and teams; six `x-litellm-response-cost-*` headers that split a response's cost into input, cache read, cache creation, output, reasoning, and tool usage; TPM reservations that follow declared output size per key, per team, and per model instead of one static floor for every tenant; and the largest step yet in the Admin UI's move off antd and Tremor, with 75 UI pull requests carrying the navbar, playground, usage, cost tracking, the log details drawer, and much of the shared component library onto shadcn. Note that the Langfuse metadata blob is now sourced from a StandardLoggingPayload allowlist, so roughly 20 fields no longer appear on the generation.
+The Admin UI's migration off antd and Tremor is complete, with `@tremor/react`, `antd` and `@ant-design/icons` dropped from the dashboard's dependencies and the dashboard now on React 19; dark mode ships with a light/dark/system toggle, semantic status tokens, and theme-aware logos, surfaces and code blocks; `lite login` becomes a real OAuth flow with authorization code plus PKCE, storing the credential and refresh token in the OS keychain, and `lite login --config-claude` wires up Claude Code at login; batch spend is accounted for end to end, with enqueued-token rate limiting that refunds on completion, atomic cost claims so multi-pod polling cannot double-bill, and billing for cancelled and failed batches that still produced output; provisioned throughput can be declared in `config.yaml`; and the complexity router becomes operator-configurable with custom classifier plugins, tier sets, and per-model reasoning effort. This stable also folds in the v1.99.0-rc.2 fixes.
 
 ---
 
@@ -22,6 +22,7 @@ Provisioned throughput is billed as reserved capacity, with `ptu_count` and `cos
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.99.0](/release_notes/v1.99.0/v1-99-0)   | Sep 1, 2026  | Dark mode, CLI OAuth login, end-to-end batch billing       |
 | [v1.98.0](/release_notes/v1.98.0/v1-98-0)   | Aug 22, 2026 | Provisioned throughput billing, auto-router shadow evals, callable routing groups |
 | [v1.97.0](/release_notes/v1.97.0/v1-97-0)   | Aug 15, 2026 | Tool-result guardrails, auto-router deployment affinity, admin viewer parity |
 | [v1.96.0](/release_notes/v1.96.0/v1-96-0)   | Aug 9, 2026  | MCP entitlements, Redis config sync, auto-router context, GPT-5.6 price cut |

--- a/release_notes/v1.99.0/index.md
+++ b/release_notes/v1.99.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.99.0rc1 - Dark Mode, CLI OAuth Login & Batch Billing"
-slug: "v1-99-0-rc-1"
-date: 2026-08-22T18:00:01
+title: "v1.99.0 - Dark Mode, CLI OAuth Login & Batch Billing"
+slug: "v1-99-0"
+date: 2026-09-01T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,18 +30,24 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.99.0-rc.1
+docker.litellm.ai/berriai/litellm:1.99.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.99.0rc1
+pip install litellm==1.99.0
 ```
 
 </TabItem>
 </Tabs>
+
+:::note
+
+PyPI and Docker artifacts for this release were built from different SHAs, but are expected to be functionally the same.
+
+:::
 
 :::danger Breaking Changes
 
@@ -55,12 +61,36 @@ pip install litellm==1.99.0rc1
 
 ## Key Highlights
 
-- **The Admin UI's migration off antd and Tremor is complete** - `@tremor/react`, `antd`, and `@ant-design/icons` are all removed from the dashboard's dependencies, with the last components, the shared primitives, and every form ported onto shadcn (base-vega) and react-hook-form. 115 UI pull requests land in this window, and the dashboard is now on React 19
+- **The Admin UI's migration off antd and Tremor is complete** - `@tremor/react`, `antd`, and `@ant-design/icons` are all removed from the dashboard's dependencies, with the last components, the shared primitives, and every form ported onto shadcn (base-vega) and react-hook-form. 130 UI pull requests land in this window, and the dashboard is now on React 19
 - **Dark mode ships** - a light/dark/system toggle in the top bar, semantic status tokens for success, warning and info, a dark variant of the LiteLLM logo, and an admin-supplied dark variant of a custom logo. Hardcoded Tailwind palette classes across the dashboard are mapped onto theme tokens so surfaces, form controls, inline styles and code blocks all follow the theme
 - **`lite login` is a real OAuth flow** - the CLI now authenticates with an authorization code plus PKCE against the proxy, stores the credential and the refresh token in the OS keychain rather than a `token.json` on disk, and `lite login --config-claude` wires Claude Code up at login
 - **Batch spend is accounted for end to end** - enqueued-token rate limiting admits batches against a token budget and refunds on completion or cancellation, cost rows are claimed atomically so multi-pod polling cannot double-bill, cancelled and failed batches that still produced output are billed, a single undecodable output line no longer zeroes a batch's spend, and Bedrock batches can be cancelled through `POST /v1/batches/{id}/cancel`
 - **Provisioned throughput can be declared in `config.yaml`** - a PTU reservation no longer has to be created through the API; the rollup accrues flat cost for config-declared deployments, refuses an incomplete reservation the way the endpoints do, requires an operator-declared id, and warns when a config declares PTU while attribution is switched off
 - **The complexity router is operator-configurable** - operator-defined tier sets for the LLM classifier, custom classifier plugins via `classifier_type: custom`, a plan-mode tier floor for coding-agent clients, a business classification rubric preset, and per-model reasoning effort in the tier editor
+
+## Included from v1.99.0-rc.2
+
+This stable also carries everything that landed on the release line after the rc.1 cut, shipped in v1.99.0-rc.2 and included here:
+
+- **[Anthropic](../../docs/providers/anthropic)**
+    - Translate `tool_result` document blocks in the `/v1/messages` bridge - [PR #38251](https://github.com/BerriAI/litellm/pull/38251)
+- **Dashboard (dark mode follow-ups)**
+    - Make provider logos readable in dark mode - [PR #38588](https://github.com/BerriAI/litellm/pull/38588)
+    - One-click theme toggle and matching Docs/Blog styling in the top bar - [PR #38601](https://github.com/BerriAI/litellm/pull/38601)
+    - Make code blocks and the logs JSON viewer follow the theme in dark mode - [PR #38771](https://github.com/BerriAI/litellm/pull/38771), [PR #38778](https://github.com/BerriAI/litellm/pull/38778)
+    - Make playground chat bubbles theme-aware, and theme the created-key box - [PR #37978](https://github.com/BerriAI/litellm/pull/37978), [PR #37985](https://github.com/BerriAI/litellm/pull/37985)
+- **Dashboard (bug fixes)**
+    - Open select popups below the trigger instead of over it - [PR #38554](https://github.com/BerriAI/litellm/pull/38554)
+    - Stop server-searched comboboxes from clobbering picks and queries, and let the paginated search select keep what the user types - [PR #38574](https://github.com/BerriAI/litellm/pull/38574), [PR #38475](https://github.com/BerriAI/litellm/pull/38475)
+    - Keep a deleted-from search query instead of blanking the box - [PR #38830](https://github.com/BerriAI/litellm/pull/38830)
+    - Keep focus in the add model public name input while typing, and restore its tooltip layout - [PR #38366](https://github.com/BerriAI/litellm/pull/38366), [PR #37986](https://github.com/BerriAI/litellm/pull/37986)
+    - Restore the reopen control for the log drawer's trace sidebar - [PR #38782](https://github.com/BerriAI/litellm/pull/38782)
+    - Stack the policy flow builder below the popup layer so guardrail options render - [PR #38273](https://github.com/BerriAI/litellm/pull/38273)
+    - Drop stray text next to Close in the model connection test dialog - [PR #38852](https://github.com/BerriAI/litellm/pull/38852)
+- **Docker**
+    - Pin the image builds' apk python to 3.13 and bump wolfi-base for glibc 2.44 - [PR #38917](https://github.com/BerriAI/litellm/pull/38917), [PR #38973](https://github.com/BerriAI/litellm/pull/38973)
+- **End-to-End Testing**
+    - De-flake the select-anchoring, router-fallback, vertex realtime and vision fixture specs (test-only) - [PR #38848](https://github.com/BerriAI/litellm/pull/38848), [PR #38862](https://github.com/BerriAI/litellm/pull/38862)
 
 ## New Providers and Endpoints
 
@@ -453,13 +483,13 @@ Documentation now lives in [BerriAI/litellm-docs](https://github.com/BerriAI/lit
 
 ### PR roll-up by ownership area
 
-PRs by ownership area (total: 433)
+PRs by ownership area (total: 451)
 
-- UI: 115
-- Other (CI / chore / tests / build / version bumps): 65
+- UI: 130
+- Other (CI / chore / tests / build / version bumps): 67
 - Spend / Budgets / Rate Limits: 48
 - Performance: 44
-- Models & Providers: 42
+- Models & Providers: 43
 - LLM API Endpoints: 41
 - Logging: 23
 - Auth & Management: 22
@@ -499,4 +529,4 @@ Three fixes in this release reached the repository as maintainer-pushed copies s
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.98.0-rc.1...v1.99.0-rc.1
+https://github.com/BerriAI/litellm/compare/v1.98.0...v1.99.0

--- a/release_notes/v1.99.0/index.md
+++ b/release_notes/v1.99.0/index.md
@@ -45,7 +45,7 @@ pip install litellm==1.99.0
 
 :::note
 
-PyPI and Docker artifacts for this release were built from different SHAs, but are expected to be functionally the same.
+PyPI and Docker artifacts for this release were built from different SHAs, but are expected to be functionally the same. PyPI was built from [`d0c8667`](https://github.com/BerriAI/litellm/commit/d0c86678ed3c8951a2c47ed1b1fabcf8de65b553) and Docker from [`fa647f7`](https://github.com/BerriAI/litellm/commit/fa647f742d7baefe8eb1181899d9c81b41559772).
 
 :::
 


### PR DESCRIPTION
Promotes the v1.99.0rc1 release notes to stable, following the v1.98.0 promotion (#994): folder renamed to v1.99.0, title, slug, date, Docker tag, pip install and Full Changelog range moved onto the stable form, and the changelog landing page now leads with v1.99.0

Everything that reached the release line after the rc.1 cut is listed in a dedicated 'Included from v1.99.0-rc.2' section: the Anthropic /v1/messages tool_result document fix, fifteen dashboard dark mode and bug fixes, the Docker python 3.13 pin, and two test-only e2e de-flake backports. The ownership roll-up moves 433 to 451 accordingly

A note above Breaking Changes states that PyPI and Docker artifacts for this release were built from different SHAs but are expected to be functionally the same

The Docker tag in the deploy block (1.99.0) is verified live on GHCR. The v1.99.0 git tag is not cut yet, so the Full Changelog compare link will 404 until it lands