### PR TITLE
docs: add OpenZoo provider page

### DIFF
--- a/docs/providers/openzoo.md
+++ b/docs/providers/openzoo.md
@@ -7,10 +7,10 @@ import TabItem from '@theme/TabItem';
 
 | Property | Details |
 |-------|-------|
-| Description | OpenZoo is a pay-per-call AI gateway serving open models over an OpenAI-compatible API. There is no signup: any API key value is accepted and usage is billed per call via x402 or card. |
+| Description | OpenZoo is a pay-per-call AI gateway. The default target is the local `npx openzoo` proxy, which is OpenAI-compatible and pays each call over x402 from a local burner wallet. No account. The proxy ignores the API key, so any non-empty value works. |
 | Provider Route on LiteLLM | `openzoo/` |
 | Link to Provider Doc | [OpenZoo Documentation ↗](https://openzoo.fun) |
-| Base URL | `https://api.openzoo.fun/v1` |
+| Base URL | `http://localhost:8402/v1` (the local `npx openzoo` proxy; override with `OPENZOO_API_BASE`) |
 | Supported Operations | [`/chat/completions`](#usage---litellm-python-sdk) |
 
 <br />
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 **We support ALL OpenZoo chat models, just set `openzoo/` as a prefix when sending completion requests**
 
-The live model catalog, including current per-token pricing, is served at `https://api.openzoo.fun/v1/models`.
+The live model catalog, including current per-token pricing, is served at `GET /v1/models` on both the local proxy and the hosted `https://api.openzoo.fun/v1/models` (free, no key).
 
 ## Available Models
 
@@ -32,11 +32,19 @@ All three models support reasoning and function calling.
 
 ## Required Variables
 
-OpenZoo has no account system, so there is no key to fetch. Set any non-empty value and requests are billed per call.
+Start the local proxy first. It listens on `http://localhost:8402/v1` and pays each call over x402 from a local burner wallet, so there is no account and no key to fetch.
+
+```shell showLineNumbers title="Start the OpenZoo proxy"
+npx openzoo
+```
+
+The proxy ignores the API key, but LiteLLM still needs a value, so set any non-empty string.
 
 ```python showLineNumbers title="Environment Variables"
-os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works with the local proxy
 ```
+
+If LiteLLM runs in Docker, point `OPENZOO_API_BASE` at `http://host.docker.internal:8402/v1`.
 
 ## Usage - LiteLLM Python SDK
 
@@ -47,7 +55,7 @@ import os
 import litellm
 from litellm import completion
 
-os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works with the local proxy
 
 messages = [{"content": "Hello, how are you?", "role": "user"}]
 
@@ -67,7 +75,7 @@ import os
 import litellm
 from litellm import completion
 
-os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works with the local proxy
 
 messages = [{"content": "Write a short story about AI", "role": "user"}]
 
@@ -89,7 +97,7 @@ import os
 import litellm
 from litellm import completion
 
-os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works with the local proxy
 
 tools = [{
     "type": "function",
@@ -135,18 +143,18 @@ model_list:
       api_key: os.environ/OPENZOO_API_KEY
 ```
 
-## Custom API Base
+## Hosted Endpoint and Custom API Base
 
-OpenZoo also ships a local gateway, started with `npx openzoo`, which listens on `http://localhost:8402/v1`. Point LiteLLM at it, or at any other compatible endpoint, in either of two ways.
+The hosted gateway at `https://api.openzoo.fun/v1` answers `POST /v1/chat/completions` with `402 Payment Required` unless the caller pays over x402 or presents an OpenZoo subscription key of the form `ozk_live_...`. LiteLLM cannot pay x402 itself, so use the hosted endpoint only with a subscription key. Any other compatible base URL is set the same way.
 
-**Option 1: Environment variable**
+**Option 1: Environment variables**
 
-```python showLineNumbers title="Custom API Base via env var"
+```python showLineNumbers title="Hosted endpoint via env vars"
 import os
 from litellm import completion
 
-os.environ["OPENZOO_API_BASE"] = "http://localhost:8402/v1"
-os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+os.environ["OPENZOO_API_BASE"] = "https://api.openzoo.fun/v1"
+os.environ["OPENZOO_API_KEY"] = "ozk_live_..."  # subscription key required on the hosted endpoint
 
 response = completion(
     model="openzoo/z-ai/glm-5.3-flash",
@@ -156,14 +164,14 @@ response = completion(
 
 **Option 2: Pass directly**
 
-```python showLineNumbers title="Custom API Base via parameter"
+```python showLineNumbers title="Hosted endpoint via parameters"
 from litellm import completion
 
 response = completion(
     model="openzoo/z-ai/glm-5.3-flash",
     messages=[{"content": "Hello!", "role": "user"}],
-    api_base="http://localhost:8402/v1",
-    api_key="sk-openzoo",
+    api_base="https://api.openzoo.fun/v1",
+    api_key="ozk_live_...",
 )
 ```
 

--- a/docs/providers/openzoo.md
+++ b/docs/providers/openzoo.md
@@ -1,0 +1,190 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# OpenZoo
+
+## Overview
+
+| Property | Details |
+|-------|-------|
+| Description | OpenZoo is a pay-per-call AI gateway serving open models over an OpenAI-compatible API. There is no signup: any API key value is accepted and usage is billed per call via x402 or card. |
+| Provider Route on LiteLLM | `openzoo/` |
+| Link to Provider Doc | [OpenZoo Documentation ↗](https://openzoo.fun) |
+| Base URL | `https://api.openzoo.fun/v1` |
+| Supported Operations | [`/chat/completions`](#usage---litellm-python-sdk) |
+
+<br />
+<br />
+
+**We support ALL OpenZoo chat models, just set `openzoo/` as a prefix when sending completion requests**
+
+The live model catalog, including current per-token pricing, is served at `https://api.openzoo.fun/v1/models`.
+
+## Available Models
+
+| Model | Description | Context Window | Max Output |
+|-------|-------------|----------------|------------|
+| `openzoo/z-ai/glm-5.3-flash` | Z.ai GLM-5.3 Flash, a fast agentic coding model | 1,310,720 tokens | 131,072 tokens |
+| `openzoo/qwen/qwen3.7-flash` | Alibaba Qwen3.7 Flash, a low-cost general model | 1,000,000 tokens | 65,536 tokens |
+| `openzoo/nvidia/nemotron-3.5-lightning` | NVIDIA Nemotron 3.5 Lightning, a compact reasoning model | 262,144 tokens | 131,072 tokens |
+
+All three models support reasoning and function calling.
+
+## Required Variables
+
+OpenZoo has no account system, so there is no key to fetch. Set any non-empty value and requests are billed per call.
+
+```python showLineNumbers title="Environment Variables"
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+```
+
+## Usage - LiteLLM Python SDK
+
+### Non-streaming
+
+```python showLineNumbers title="OpenZoo Non-streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+
+messages = [{"content": "Hello, how are you?", "role": "user"}]
+
+# OpenZoo call
+response = completion(
+    model="openzoo/z-ai/glm-5.3-flash",
+    messages=messages
+)
+
+print(response)
+```
+
+### Streaming
+
+```python showLineNumbers title="OpenZoo Streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+
+messages = [{"content": "Write a short story about AI", "role": "user"}]
+
+# OpenZoo call with streaming
+response = completion(
+    model="openzoo/z-ai/glm-5.3-flash",
+    messages=messages,
+    stream=True
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+### Function Calling
+
+```python showLineNumbers title="OpenZoo Function Calling"
+import os
+import litellm
+from litellm import completion
+
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "The city, e.g. Toronto"
+                }
+            },
+            "required": ["city"]
+        }
+    }
+}]
+
+messages = [{"role": "user", "content": "What's the weather in Toronto?"}]
+
+response = completion(
+    model="openzoo/z-ai/glm-5.3-flash",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto"
+)
+
+print(response)
+```
+
+## Usage - LiteLLM Proxy Server
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: glm-5.3-flash
+    litellm_params:
+      model: openzoo/z-ai/glm-5.3-flash
+      api_key: os.environ/OPENZOO_API_KEY
+  - model_name: qwen3.7-flash
+    litellm_params:
+      model: openzoo/qwen/qwen3.7-flash
+      api_key: os.environ/OPENZOO_API_KEY
+```
+
+## Custom API Base
+
+OpenZoo also ships a local gateway, started with `npx openzoo`, which listens on `http://localhost:8402/v1`. Point LiteLLM at it, or at any other compatible endpoint, in either of two ways.
+
+**Option 1: Environment variable**
+
+```python showLineNumbers title="Custom API Base via env var"
+import os
+from litellm import completion
+
+os.environ["OPENZOO_API_BASE"] = "http://localhost:8402/v1"
+os.environ["OPENZOO_API_KEY"] = "sk-openzoo"  # any value works
+
+response = completion(
+    model="openzoo/z-ai/glm-5.3-flash",
+    messages=[{"content": "Hello!", "role": "user"}],
+)
+```
+
+**Option 2: Pass directly**
+
+```python showLineNumbers title="Custom API Base via parameter"
+from litellm import completion
+
+response = completion(
+    model="openzoo/z-ai/glm-5.3-flash",
+    messages=[{"content": "Hello!", "role": "user"}],
+    api_base="http://localhost:8402/v1",
+    api_key="sk-openzoo",
+)
+```
+
+## Supported OpenAI Parameters
+
+- `temperature`
+- `max_tokens`
+- `max_completion_tokens`
+- `top_p`
+- `frequency_penalty`
+- `presence_penalty`
+- `stop`
+- `n`
+- `stream`
+- `stream_options`
+- `tools`
+- `tool_choice`
+- `response_format`
+- `seed`
+- `logit_bias`
+- `logprobs`
+- `top_logprobs`
+
+`max_completion_tokens` is sent upstream as `max_tokens`.

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -761,8 +761,8 @@ router_settings:
 | OPENAI_LIKE_API_BASE | Base URL for the `openai_like` provider, used to reach any OpenAI-compatible endpoint
 | OPENAI_LIKE_API_KEY | API key for the `openai_like` provider. Left empty when unset, since some OpenAI-compatible servers need no key
 | OPENAI_PROJECT | OpenAI project ID sent on OpenAI requests, equivalent to passing `project`
-| OPENZOO_API_BASE | Base URL for OpenZoo. Default is https://api.openzoo.fun/v1
-| OPENZOO_API_KEY | API key for OpenZoo. Any non-empty value works, since OpenZoo has no signup and bills per call
+| OPENZOO_API_BASE | Base URL for OpenZoo. Default is http://localhost:8402/v1, the local `npx openzoo` proxy. The hosted https://api.openzoo.fun/v1 needs an ozk_live_ subscription key
+| OPENZOO_API_KEY | API key for OpenZoo. Any non-empty value works with the local proxy, which ignores it and pays per call over x402. Must be an ozk_live_ subscription key when OPENZOO_API_BASE is the hosted endpoint
 | OR_API_KEY | API key for OpenRouter, read after `OPENROUTER_API_KEY`
 | OVHCLOUD_API_BASE | Base URL for OVHcloud AI Endpoints
 | PARALLEL_AI_API_BASE | Base URL for the Parallel AI search provider

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -761,6 +761,8 @@ router_settings:
 | OPENAI_LIKE_API_BASE | Base URL for the `openai_like` provider, used to reach any OpenAI-compatible endpoint
 | OPENAI_LIKE_API_KEY | API key for the `openai_like` provider. Left empty when unset, since some OpenAI-compatible servers need no key
 | OPENAI_PROJECT | OpenAI project ID sent on OpenAI requests, equivalent to passing `project`
+| OPENZOO_API_BASE | Base URL for OpenZoo. Default is https://api.openzoo.fun/v1
+| OPENZOO_API_KEY | API key for OpenZoo. Any non-empty value works, since OpenZoo has no signup and bills per call
 | OR_API_KEY | API key for OpenRouter, read after `OPENROUTER_API_KEY`
 | OVHCLOUD_API_BASE | Base URL for OVHcloud AI Endpoints
 | PARALLEL_AI_API_BASE | Base URL for the Parallel AI search provider

--- a/sidebars.js
+++ b/sidebars.js
@@ -1187,6 +1187,7 @@ const sidebars = {
         "providers/oci",
         "providers/ollama",
         "providers/openrouter",
+        "providers/openzoo",
         "providers/sarvam",
         "providers/ovhcloud",
         {


### PR DESCRIPTION
**Updated: the page now documents the local proxy as the default; see below.** The first revision gave `https://api.openzoo.fun/v1` as the base URL and said any `OPENZOO_API_KEY` value works there. That was wrong: the hosted gateway answers `POST /v1/chat/completions` with `402 Payment Required` unless the caller pays x402 or presents an OpenZoo subscription key (`ozk_live_...`). Only `GET /v1/models` is free.

Adds a provider page for [OpenZoo](https://openzoo.fun), modeled on `docs/providers/scx_ai.md`, plus one sidebar line and the two env-var rows in `docs/proxy/config_settings.md`.

Companion to the code PR registering the `openzoo` JSON provider in BerriAI/litellm (#39092, branch `feature/add-openzoo-provider`), whose default `api_base` is `http://localhost:8402/v1`: the local `npx openzoo` proxy (npm `openzoo`), OpenAI-compatible, paying each call over x402 from a local burner wallet. No account. The proxy ignores the API key, so the page keeps the `sk-openzoo` placeholder and tells the reader to run `npx openzoo` first (Docker: `host.docker.internal`). A "Hosted Endpoint and Custom API Base" section states that `https://api.openzoo.fun/v1` requires an `ozk_live_...` subscription key. No em dashes or emojis in added lines per the writing lint.

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
