### PR TITLE
docs(email): document per-key budget alert emails

### DIFF
--- a/docs/proxy/email.md
+++ b/docs/proxy/email.md
@@ -18,8 +18,8 @@ Send LiteLLM Proxy users emails for specific events.
 
 | Category | Details |
 |----------|---------|
-| Supported Events | • User added as a user on LiteLLM Proxy<br/>• Proxy API Key created for user<br/>• Proxy API Key rotated for user |
-| Supported Email Integrations | • Resend API<br/>• SMTP |
+| Supported Events | • User added as a user on LiteLLM Proxy<br/>• Proxy API Key created for user<br/>• Proxy API Key rotated for user<br/>• Virtual key approaching or crossing its budget |
+| Supported Email Integrations | • Resend API<br/>• SendGrid API<br/>• SMTP |
 
 ## Usage
 
@@ -90,11 +90,11 @@ After creating a new user, they will receive an email invite a the email you spe
 
 ### 3. Configure Budget Alerts (Optional)
 
-Enable budget alert emails by adding "email" to the `alerts` list in your proxy configuration:
+Enable budget alert emails by adding "email" to the `alerting` list in your proxy configuration:
 
 ```yaml showLineNumbers title="proxy_config.yaml"
 general_settings:
-  alerts: ["email"]
+  alerting: ["email"]
 ```
 
 #### Budget Alert Types
@@ -105,12 +105,52 @@ general_settings:
 
 Both alert types send a maximum of one email per 24-hour period to prevent spam.
 
+#### Per-key thresholds and recipients
+
+By default a max budget alert fires at one threshold and goes only to the email of the user who owns the key, so a key with no owner email sends nothing. To choose your own thresholds and notify additional people, set `max_budget_alert_emails` in the key's metadata. Each entry maps a percentage of that key's `max_budget` to the recipients notified once spend crosses it.
+
+```shell showLineNumbers
+curl -X POST 'http://0.0.0.0:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "max_budget": 100,
+    "metadata": {
+      "max_budget_alert_emails": {
+        "50": ["owner@your-company.com"],
+        "75": ["owner@your-company.com", "finance@your-company.com"],
+        "100": ["oncall@your-company.com"]
+      }
+    }
+  }'
+```
+
+With the key above, spend of $50 emails the owner, $75 emails the owner and finance, and $100 emails on-call. Recipients can be a list or a comma separated string, and the key owner's email is always included alongside whoever you configure. Each threshold sends at most one email per key per `EMAIL_BUDGET_ALERT_TTL`. A 100% threshold still fires on the request that exhausts the budget, because the alert check runs before the request is rejected.
+
+Configuring `max_budget_alert_emails` on a key replaces the default 80% alert for that key. To change thresholds on an existing key, send the same `metadata` block to `/key/update`.
+
+There is no UI field for this yet, so set it through `/key/generate` or `/key/update`.
+
+#### Default thresholds for every key
+
+Set `default_key_max_budget_alert_emails` to apply a baseline to all keys. Per-key entries merge into the global config one threshold at a time, so a key inherits the global recipients for a threshold and adds its own on top rather than overwriting them.
+
+```yaml showLineNumbers title="proxy_config.yaml"
+general_settings:
+  alerting: ["email"]
+
+litellm_settings:
+  default_key_max_budget_alert_emails:
+    "80": ["platform-team@your-company.com"]
+```
+
 #### Configuration Options
 
 Customize budget alert behavior using these environment variables:
 
 ```yaml showLineNumbers title=".env"
 # Percentage of max budget that triggers alerts (as decimal: 0.8 = 80%)
+# Only applies to keys without max_budget_alert_emails configured
 EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE=0.8
 
 # Time-to-live for alert deduplication in seconds (default: 24 hours)


### PR DESCRIPTION
## What

Documents the per-virtual-key email budget alert config, which shipped without docs.

A key can carry `metadata.max_budget_alert_emails`, a map of percentage of that key's `max_budget` to the recipients notified when spend crosses it. `litellm_settings.default_key_max_budget_alert_emails` sets the same map as a baseline for every key, and per-key entries merge into the global config one threshold at a time. Both are read in [`_virtual_key_max_budget_alert_check`](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/auth/auth_checks.py) and fanned out by `_handle_multi_threshold_max_budget_alert` in the enterprise email logger.

Also covers the parts people hit without it: the key owner's email is always added to the configured recipients, each threshold dedupes for `EMAIL_BUDGET_ALERT_TTL`, a 100% threshold still fires because the alert check runs before the request is rejected, and there is no UI field so it has to go in through `/key/generate` or `/key/update`.

## Fixes in the same page

The budget alerts snippet said `general_settings: alerts: ["email"]`. The proxy reads `general_settings["alerting"]`, so the documented config was silently doing nothing. Corrected to `alerting`.

The overview table listed only Resend and SMTP even though the page has a SendGrid tab and the proxy picks SendGrid first when `SENDGRID_API_KEY` is set. Added SendGrid, and added budget alerts to the supported events list.