### PR TITLE
docs(otel v2, team logging): a tenant's langfuse_host routes, and team admins manage their own callbacks

### DIFF
--- a/docs/observability/opentelemetry_v2.md
+++ b/docs/observability/opentelemetry_v2.md
@@ -683,7 +683,7 @@ This is the same key/team callback mechanism described in [Team/Key based loggin
 
 | Preset | Callback | Fields on the key or team | What varies per tenant |
 |---|---|---|---|
-| Langfuse | `langfuse_otel` | `langfuse_public_key`, `langfuse_secret_key` | The Langfuse project traces land in |
+| Langfuse | `langfuse_otel` | `langfuse_public_key`, `langfuse_secret_key`, `langfuse_host` | The Langfuse project traces land in, and the host they are sent to |
 | Arize AX | `arize` | `arize_space_id` (or the deprecated `arize_space_key`), `arize_api_key` | The Arize space |
 | Weave (W&B) | `weave_otel` | `wandb_api_key`, `weave_project_id` | The W&B account and Weave project |
 | New Relic | `newrelic` | `newrelic_api_key`, `newrelic_region` (`us` or `eu`, default `us`) | The New Relic account and its data center |
@@ -733,7 +733,9 @@ Existing keys take the same field on `/key/update`. You can also fill both of th
 
 The key wins outright over the team. If a key has any `metadata.logging` entry, the team's callbacks are not consulted at all rather than merged with the key's, so a key that overrides one backend has to restate the others it still wants.
 
-Only the OTLP headers vary per tenant, plus New Relic's region endpoint, which is picked from a fixed us/eu table. The exporter's host stays whatever the preset resolved at boot, so `langfuse_host` on a key or team does not move that tenant's traces to a different Langfuse host under v2.
+A tenant's `langfuse_host` moves its traces to that host, the same way it does under v1. Give it alongside the key pair it belongs to: a host on its own is ignored and the tenant stays on the proxy-wide endpoint, because otherwise the request would move the destination while still carrying the proxy's own credentials.
+
+Every other preset varies only its OTLP headers per tenant, plus New Relic's region endpoint, which is picked from a fixed us/eu table. Their exporter host stays whatever the preset resolved at boot.
 
 Credentials scope to the exporter their own preset contributed. A request carrying one tenant's Arize key never rewrites the headers of a co-configured Langfuse or self-hosted collector exporter, so a tenant's key cannot leak to a backend it was not meant for. Those other exporters do still receive the request's spans, with their own proxy-wide credentials.
 

--- a/docs/proxy/team_logging.md
+++ b/docs/proxy/team_logging.md
@@ -78,6 +78,13 @@ Navigate to your configured logging provider and check if you received the logs 
 <br />
 
 ### API Usage
+
+#### Who can call these
+
+A proxy admin, an org admin of the team's organization, and an admin of the team itself can list, set and remove that team's callbacks. Everyone else gets a 403, and an admin of one team cannot read another team's.
+
+`POST /team/{team_id}/disable_logging` is the exception: it stays proxy-admin only. A team admin who wants to turn one integration off uses `DELETE /team/{team_id}/callback/{callback_name}`.
+
 ### Set Callbacks Per Team
 
 #### 1. Set callback for team 


### PR DESCRIPTION
## TLDR

Two statements on these pages stop being true when BerriAI/litellm#37564 and BerriAI/litellm#37667 land.

The OTel v2 page currently says a tenant's `langfuse_host` does not move its traces. #37564 makes it move them, so the sentence is corrected and the preset table's Langfuse row picks up `langfuse_host` as a per-tenant field. The correction also states the precondition: a host counts only alongside the key pair it belongs to, because a lone host would move the destination while the exporter still carried the proxy's own credentials.

The team logging page never said who may call the team callback endpoints. #37667 lets a team's own admin and an org admin of its organization manage that team's callbacks, so the API section gains a short "Who can call these", including that `disable_logging` stays proxy-admin only.

## Type

Documentation

## Merge order

These land with the code PRs, not before them.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->