### PR TITLE
docs(release_notes): add v1.97.1 release notes (Docker-only release)

### DIFF
--- a/release_notes/v1.97.1/index.md
+++ b/release_notes/v1.97.1/index.md
@@ -1,0 +1,62 @@
+---
+title: "v1.97.1 - Dependency Refresh"
+slug: "v1-97-1"
+date: 2026-09-01T00:00:00
+authors:
+  - name: Krrish Dholakia
+    title: CEO, LiteLLM
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: CTO, LiteLLM
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+  - name: Yuneng Jiang
+    title: Senior Full Stack Engineer, LiteLLM
+    url: https://www.linkedin.com/in/yuneng-david-jiang-455676139/
+    image_url: https://avatars.githubusercontent.com/u/171294688?v=4
+hide_table_of_contents: false
+---
+
+## Deploy this version
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+-e STORE_MODEL_IN_DB=True \
+-p 4000:4000 \
+docker.litellm.ai/berriai/litellm:1.97.1
+```
+
+</TabItem>
+<TabItem value="pip" label="Pip">
+
+```bash
+pip install litellm==1.97.1
+```
+
+</TabItem>
+</Tabs>
+
+`v1.97.1` is a maintenance patch on top of [`v1.97.0`](/release_notes/v1.97.0/v1-97-0). It carries no product changes. Five third-party dependencies move to current releases, one Docker image's own pin catches up with them, and two expired scanner exemptions are removed.
+
+On the Python side, `RestrictedPython` moves to 8.5, `sqlparse` to 0.6.0 and `pypdf` to 6.15.0, each the smallest step that keeps the release current. The `RestrictedPython` update also raises the `proxy` extra's floor to `>=8.5,<9.0`, matching the range used on the development branch, so a `pip install litellm[proxy]` resolves the same minimum the image does. If you pin `RestrictedPython` below 8.5 alongside `litellm[proxy]`, adjust that pin when you upgrade.
+
+In the Admin UI's lockfile, `nanoid` moves to 3.3.18 and `browserslist` to 4.28.8. Neither is a direct dependency, so nothing in the dashboard's declared dependencies changes; `browserslist` brings its own build-data packages along with it. The dashboard was rebuilt against the new lockfile to confirm it is sound.
+
+The `build_from_pip` Docker image pins `pypdf` outside the main lock and had been left behind at 6.7.5. It now installs 6.15.0, the same release the lock resolves. This image is a build variant and is not the published proxy image.
+
+Two `pypdf` entries in `osv-scanner.toml` carry an `ignoreUntil` date that has already passed, so they no longer suppress anything. They are removed.
+
+### What's Changed
+
+- chore(deps): refresh stale dependency pins and cut 1.97.1 - [PR #39200](https://github.com/BerriAI/litellm/pull/39200)
+
+## Full Changelog
+
+https://github.com/BerriAI/litellm/compare/v1.97.0...v1.97.1

--- a/release_notes/v1.97.1/index.md
+++ b/release_notes/v1.97.1/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.97.1 - Dependency Refresh"
+title: "v1.97.1 - Docker-Only Maintenance Release"
 slug: "v1-97-1"
-date: 2026-09-01T00:00:00
+date: 2026-09-02T00:10:30
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -18,13 +18,15 @@ authors:
 hide_table_of_contents: false
 ---
 
+:::info This is a Docker-only release
+
+`v1.97.1` is distributed as container images. There is no PyPI package for this version, so `pip install litellm==1.97.1` will not resolve. If you install LiteLLM from PyPI, stay on `1.97.0`; everything in this release is either a container-image build fix or a dependency refresh that only reaches you through the image.
+
+This release also does not move the `latest` tag. The current stable line is [`v1.99.0`](/release_notes/v1.99.0/v1-99-0).
+
+:::
+
 ## Deploy this version
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs>
-<TabItem value="docker" label="Docker">
 
 ```bash
 docker run \
@@ -33,30 +35,33 @@ docker run \
 docker.litellm.ai/berriai/litellm:1.97.1
 ```
 
-</TabItem>
-<TabItem value="pip" label="Pip">
+The `litellm`, `litellm-database` and `litellm-non_root` variants are all published at this tag on both GHCR and Docker Hub, each cosign-signed as usual.
 
-```bash
-pip install litellm==1.97.1
-```
+## What's in it
 
-</TabItem>
-</Tabs>
+`v1.97.1` is a maintenance patch on top of [`v1.97.0`](/release_notes/v1.97.0/v1-97-0). It carries no product changes: one fix that makes the images build again, and a refresh of five third-party dependencies.
 
-`v1.97.1` is a maintenance patch on top of [`v1.97.0`](/release_notes/v1.97.0/v1-97-0). It carries no product changes. Five third-party dependencies move to current releases, one Docker image's own pin catches up with them, and two expired scanner exemptions are removed.
+### Image builds
 
-On the Python side, `RestrictedPython` moves to 8.5, `sqlparse` to 0.6.0 and `pypdf` to 6.15.0, each the smallest step that keeps the release current. The `RestrictedPython` update also raises the `proxy` extra's floor to `>=8.5,<9.0`, matching the range used on the development branch, so a `pip install litellm[proxy]` resolves the same minimum the image does. If you pin `RestrictedPython` below 8.5 alongside `litellm[proxy]`, adjust that pin when you upgrade.
+Every image built from `stable/1.97.x` had started failing. The Dockerfiles pin their base image by digest, but `apk add python3` resolves against Wolfi's live package repository at build time, so the digest pin never held the Python version, and Wolfi had moved `python3` on to 3.14. `uvloop` 0.21.0 has no 3.14 wheel, so `uv sync` fell back to building it from source and the build died there. The `migrations` image failed one step earlier and for a different reason: its pinned base ships glibc 2.43, while Wolfi's current `python-3.13` needs 2.44.
 
-In the Admin UI's lockfile, `nanoid` moves to 3.3.18 and `browserslist` to 4.28.8. Neither is a direct dependency, so nothing in the dashboard's declared dependencies changes; `browserslist` brings its own build-data packages along with it. The dashboard was rebuilt against the new lockfile to confirm it is sound.
+All six Dockerfiles now pin `python-3.13` explicitly, pass `--python python3.13` to each `uv sync`, and set `UV_PYTHON_DOWNLOADS=0` so a missing interpreter fails loudly rather than silently pulling one down. The `migrations` image moves to the glibc 2.44 base. This is the same pair of failures that took down the 1.99.0 pipeline, fixed there first and cherry-picked back here.
 
-The `build_from_pip` Docker image pins `pypdf` outside the main lock and had been left behind at 6.7.5. It now installs 6.15.0, the same release the lock resolves. This image is a build variant and is not the published proxy image.
+### Dependency refresh
+
+On the Python side, `RestrictedPython` moves to 8.5, `sqlparse` to 0.6.0 and `pypdf` to 6.15.0, each the smallest step that keeps the release current. The `RestrictedPython` update also raises the `proxy` extra's floor to `>=8.5,<9.0`, matching the range used on the development branch. That floor only matters if you build your own package from this branch, since there is no PyPI artifact for 1.97.1.
+
+In the Admin UI's lockfile, `nanoid` moves to 3.3.18 and `browserslist` to 4.28.8. Neither is a direct dependency, so nothing in the dashboard's declared dependencies changes; `browserslist` brings its own build-data packages along with it. The dashboard bundle in this image was rebuilt against the new lockfile.
+
+The `build_from_pip` Docker image pins `pypdf` outside the main lock and had been left behind at 6.7.5. It now installs 6.15.0, the same release the lock resolves. That image is a build variant and is not the published proxy image.
 
 Two `pypdf` entries in `osv-scanner.toml` carry an `ignoreUntil` date that has already passed, so they no longer suppress anything. They are removed.
 
 ### What's Changed
 
 - chore(deps): refresh stale dependency pins and cut 1.97.1 - [PR #39200](https://github.com/BerriAI/litellm/pull/39200)
+- fix(docker): pin apk python to 3.13 and bump wolfi-base on stable/1.97.x - [PR #39212](https://github.com/BerriAI/litellm/pull/39212)
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.97.0...v1.97.1
+https://github.com/BerriAI/litellm/compare/v1.97.0...474d7e50f09de2cbfe1c141ac29aca5246e0c0d7


### PR DESCRIPTION
Release notes for `v1.97.1`, the maintenance patch on `stable/1.97.x`.

1.97.1 published container images and nothing on PyPI: the pipeline skipped every PyPI component, the GitHub release dispatch and the git tag, and left `latest` where it was. The notes lead with that so nobody goes looking for a wheel that isn't there.

Covers both PRs in the release: the dependency refresh (BerriAI/litellm#39200) and the Docker build fix that landed after it (BerriAI/litellm#39212), which is what makes the images build on this line at all.

Verified with a full `npm run build`: exits 0, page renders at `/release_notes/v1.97.1/v1-97-1`, no broken links reported against it.
