### PR TITLE
docs(spend logs): drop the enterprise banner from spend log retention

### DIFF
--- a/docs/proxy/spend_logs_deletion.md
+++ b/docs/proxy/spend_logs_deletion.md
@@ -1,16 +1,8 @@
-# ✨ Maximum Retention Period for Spend Logs
+# Maximum Retention Period for Spend Logs
 
 This walks through how to set the maximum retention period for spend logs. This helps manage database size by deleting old logs automatically.
 
-:::info
-
-✨ This is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+Retention and cleanup are open source. Every setting on this page works without an enterprise license, and the cleanup job does not check license state before it runs.
 
 ### Requirements
 


### PR DESCRIPTION
## Title

docs(spend logs): drop the enterprise banner from spend log retention

## Relevant issues

Context, not fixed by this PR: the enterprise claim was repeated on https://github.com/BerriAI/litellm/issues/16582 citing this page

## Linear ticket

Resolves LIT-6663

## Type

Documentation

## Changes

The retention page carried the enterprise sparkle in its H1 plus an `:::info` block pointing at enterprise pricing and the trial key, but nothing about spend log retention is license gated. `maximum_spend_logs_retention_period`, the cleanup bounds, and `use_spend_logs_partitioning` have no premium check anywhere: `litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py` never mentions `premium_user` or `_license_check`, and the `### SPEND LOG CLEANUP ###` registration block in `proxy_server.py` schedules the job purely on whether a retention period is set. `git log --follow` over the cleanup module shows a gate was never there to begin with, and `docs/enterprise.md` does not list retention as an enterprise feature either.

That banner is where the belief comes from. It has been cited back at us on that issue and repeated in support threads, and the practical cost is real: people running open source hit an oversized `LiteLLM_SpendLogs` table, read this page, and conclude the fix is behind a paywall when it is one `general_settings` key away.

So the banner and the H1 sparkle are gone, replaced by a line stating plainly that retention and cleanup are open source and that the cleanup job does not check license state. Nothing else on the page changes, and no other page needed touching: `ui_logs.md`, `ui_spend_log_settings.md`, `db_sizing.md`, and `config_settings.md` all document the same settings with no enterprise claim, and the sidebar entry sits under Spend Tracking rather than an enterprise group.

## Screenshots / Proof

Verified against `litellm_internal_staging` at `8f56dbe7a3`:

```bash
grep -c "premium_user\|_license_check\|is_premium" litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
```

```
0
```

```bash
sed -n '9506,9512p' litellm/proxy/proxy_server.py
```

```
        ### SPEND LOG CLEANUP ###
        if (
            general_settings.get("maximum_spend_logs_retention_period") is not None
            or general_settings.get("maximum_autorouter_session_retention_period") is not None
            or general_settings.get("maximum_health_check_retention_period") is not None
        ):
            spend_log_cleanup: Final = SpendLogCleanup()
```

To see the rendered page, run `npm run start` in this repo and open http://localhost:3000/docs/proxy/spend_logs_deletion. The title should read "Maximum Retention Period for Spend Logs" with no sparkle, and the blue enterprise callout under it should be gone
