### PR TITLE
docs(mcp): agent-bound keys get the same permission intersection as the agent-id header

### DIFF
--- a/docs/mcp_control.md
+++ b/docs/mcp_control.md
@@ -44,11 +44,13 @@ Permissions can be set at six distinct levels. When more than one level applies 
 | **Key** | `object_permission.mcp_servers` / `object_permission.mcp_access_groups` on the virtual key | If the key has an explicit list, it's used. |
 | **Team** | Same fields on the team | If both key and team have lists, the result is the **intersection** (only servers in both). If only the team has a list, the key inherits it. |
 | **End user** | Same fields on the `LiteLLM_EndUserTable` row matching `x-litellm-end-user-id` | Intersected with the running result. Skipped if no end-user-id is present on the request. |
-| **Agent** | Same fields on the agent identified by `x-litellm-agent-id` | Intersected with the running result. Skipped if no agent-id is present. |
+| **Agent** | Same fields on the agent identified by `x-litellm-agent-id`, or the agent the key is bound to (`agent_id` set at key generation) | Intersected with the running result. Skipped if no agent applies. |
 | **Internal user** | Same fields on the internal user (the human) the request authenticated as | Intersected with the running result, so it can only narrow. Skipped if that user carries no entitlement. |
 | **Organization** | Same fields on the org owning the key/team | Acts as a **ceiling**; the final allowed-server set is intersected with the org's list. If the org has no list, no additional restriction. |
 
 If no level has a list, the request can access **every** MCP server (open by default).
+
+A key bound to an agent (`agent_id` passed to `/key/generate`) gets the same treatment as a request carrying `x-litellm-agent-id`: the agent's list is intersected with the key's on every request the key makes. Granting a server to the key alone is not enough; the agent must also hold the grant (via the Admin UI agent edit form or `PATCH /v1/agents/{agent_id}`), otherwise requests scoped to that server are denied with an error naming the agent.
 
 ```mermaid
 flowchart TD
@@ -68,7 +70,7 @@ flowchart TD
     J -->|No| L[Keep current]
     K --> M
     L --> M
-    M{agent-id present and agent has list?}
+    M{agent-id header or key-bound agent has list?}
     M -->|Yes| N[Intersect with agent list]
     M -->|No| O[Keep current]
     N --> S


### PR DESCRIPTION
## TLDR

The MCP Permission Hierarchy page did not say that a key bound to an agent (agent_id at /key/generate) gets the agent's MCP grant list intersected in, the same way a request carrying x-litellm-agent-id does. Customers granted a server to the key, saw zero tools, and had nothing in the docs explaining why.

- Agent row of the hierarchy table now covers key-bound agents
- New paragraph spells out the intersection and how to grant the server to the agent (Admin UI agent edit form or PATCH /v1/agents/{agent_id})
- Mermaid flowchart node updated to match

Pairs with BerriAI/litellm#39234, which makes the denial a clear error instead of a silent empty tool list. Merge after that PR lands so the docs describe shipped behavior.

Resolves LIT-6377 (docs part)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/mcp_control.md`; no runtime or API behavior is modified in this PR.
> 
> **Overview**
> **MCP Permission Hierarchy** docs now state that agent-level MCP grants apply not only when `x-litellm-agent-id` is sent, but also when the virtual key was created with `agent_id` on `/key/generate`.
> 
> The **Agent** table row and the permission flowchart node are updated to cover both cases. A new paragraph explains that the agent’s `mcp_servers` list is **intersected** with the key’s on every request, so granting a server on the key alone is insufficient—the agent must also be granted access (Admin UI or `PATCH /v1/agents/{agent_id}`)—and that denials can surface as an error naming the agent (aligned with the companion behavior PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db60bed4741acaa0090e97720e6d962444f4afa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->