### PR TITLE
Clean Claude Code picker names via model_info.display_name

### DIFF
--- a/docs/tutorials/claude_non_anthropic_models.md
+++ b/docs/tutorials/claude_non_anthropic_models.md
@@ -271,6 +271,22 @@ You can also add individual model entries manually via `ANTHROPIC_CUSTOM_MODEL_O
 
 :::
 
+### 7. Show a Clean Name in the Picker with `display_name`
+
+The `/model` picker only keeps gateway models whose id contains `claude` or `anthropic`, so a non-Anthropic model needs a claude-flavored name like `kimi-k3-claude-compatible` to appear at all; the picker then shows that raw id as the label. To keep the id for routing but show a friendlier label, set `display_name` under the model's `model_info`:
+
+```yaml
+model_list:
+  - model_name: kimi-k3-claude-compatible
+    litellm_params:
+      model: moonshot/kimi-k3
+      api_key: os.environ/MOONSHOT_API_KEY
+    model_info:
+      display_name: Kimi K3
+```
+
+The Anthropic-shaped `GET /v1/models` response now returns `"display_name": "Kimi K3"` for that entry, so the picker lists **Kimi K3** (labeled From gateway) while every request keeps using the `kimi-k3-claude-compatible` id. Models without a `display_name` keep showing their id, and the OpenAI-shaped listing is unaffected; nothing gets duplicated in other harnesses.
+
 ## How It Works
 
 LiteLLM acts as a unified interface that:


### PR DESCRIPTION
Documents the new per-model `model_info.display_name` (BerriAI/litellm#39238) in the Claude Code tutorial: the Anthropic-shaped `/v1/models` returns it as the display_name, so the `/model` picker shows a clean label while the claude-flavored id keeps routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **section 7** to the Claude Code non-Anthropic models tutorial, documenting **`model_info.display_name`** so gateway models can keep a claude-flavored `model_name` for routing and picker eligibility while showing a friendlier label in `/model`.
> 
> The new text explains why non-Anthropic models often need ids containing `claude` or `anthropic`, includes a **`config.yaml` example** (e.g. `kimi-k3-claude-compatible` → **Kimi K3**), and notes that the Anthropic-shaped **`GET /v1/models`** response exposes `display_name` for the picker while ids without `display_name` and OpenAI-shaped listings behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a753429959baceb87ef13013aa6aa82667aafe33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->