### PR TITLE
docs: update Morph provider guide

### DIFF
--- a/docs/providers/morph.md
+++ b/docs/providers/morph.md
@@ -1,123 +1,156 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Morph
 
-LiteLLM supports all models on [Morph](https://morphllm.com)
+Morph serves open weight models and code editing models through an OpenAI compatible API. Use the `morph/` prefix in LiteLLM requests
 
-## Overview
+| Property | Details |
+| --- | --- |
+| Provider route on LiteLLM | `morph/` |
+| API base | `https://api.morphllm.com/v1` |
+| API key | `MORPH_API_KEY` |
+| Supported LiteLLM endpoint | `/chat/completions` |
+| Morph docs | [Open source models](https://docs.morphllm.com/sdk/components/fast-models) |
+| Dedicated capacity | [Dedicated inference](https://www.morphllm.com/dedicated-inference) |
 
-Morph provides specialized AI models designed for agentic workflows, particularly excelling at precise code editing and manipulation. Their "Apply" models enable targeted code changes without full file rewrites, making them ideal for AI agents that need to make intelligent, context-aware code modifications.
+## API key
 
-## API Key
-```python
-import os 
-os.environ["MORPH_API_KEY"] = "your-api-key"
-```
-
-## Sample Usage
-
-```python
-from litellm import completion
-
-# set env variable 
-os.environ["MORPH_API_KEY"] = "your-api-key"
-
-messages = [
-    {"role": "user", "content": "Write a Python function to calculate factorial"}
-]
-
-## Morph v3 Fast - Optimized for speed
-response = completion(
-    model="morph/morph-v3-fast",
-    messages=messages,
-)
-print(response)
-
-## Morph v3 Large - Most capable model
-response = completion(
-    model="morph/morph-v3-large", 
-    messages=messages,
-)
-print(response)
-```
-
-## Sample Usage - Streaming
-```python
-from litellm import completion
-
-# set env variable
-os.environ["MORPH_API_KEY"] = "your-api-key"
-
-messages = [
-    {"role": "user", "content": "Write a Python function to calculate factorial"}
-]
-
-## Morph v3 Fast with streaming
-response = completion(
-    model="morph/morph-v3-fast",
-    messages=messages,
-    stream=True,
-)
-
-for chunk in response:
-    print(chunk)
-```
-
-## Supported Models
-
-| Model Name               | Function Call                              | Description | Context Window |
-|--------------------------|--------------------------------------------|-----------------------|----------------|
-| morph-v3-fast            | `completion('morph/morph-v3-fast', messages)` | Fastest model, optimized for quick responses | 16k tokens |
-| morph-v3-large           | `completion('morph/morph-v3-large', messages)` | Most capable model for complex tasks | 16k tokens |
-
-## Usage - LiteLLM Proxy Server
-
-Here's how to use Morph with the LiteLLM Proxy Server:
-
-1. Save API key in your environment
 ```bash
 export MORPH_API_KEY="your-api-key"
 ```
 
-2. Add model to config.yaml
-```yaml
-model_list:
-  - model_name: morph-v3-fast
-    litellm_params:
-      model: morph/morph-v3-fast
-      
-  - model_name: morph-v3-large
-    litellm_params:
-      model: morph/morph-v3-large
+## Supported models
+
+The current serverless models are listed below. Morph publishes the live catalog, context windows, and prices at [`/api/models/json`](https://www.morphllm.com/api/models/json)
+
+| Model | LiteLLM model | Context | Input types |
+| --- | --- | --- | --- |
+| Kimi K3 | `morph/morph-kimik3` | 1M | Text, image |
+| Kimi K3 Fast | `morph/morph-kimik3-fast` | 1M | Text, image |
+| GLM 5.3 | `morph/morph-glm53-744b` | 1M | Text |
+| GLM 5.3 Flash | `morph/morph-glm53flash` | 1M | Text, image, video |
+| DeepSeek V4 Flash 0731 | `morph/morph-dsv4flash` | 1M | Text |
+| Morph v3 Fast Apply | `morph/morph-v3-fast` | 262K | Text |
+| Morph v3 Large Apply | `morph/morph-v3-large` | 262K | Text |
+
+## Python SDK
+
+```python
+import os
+
+from litellm import completion
+
+os.environ["MORPH_API_KEY"] = "your-api-key"
+
+response = completion(
+    model="morph/morph-glm53-744b",
+    messages=[{"role": "user", "content": "Explain prefix caching in two sentences."}],
+)
+
+print(response.choices[0].message.content)
 ```
 
-3. Start the proxy server
+### Streaming
+
+```python
+from litellm import completion
+
+response = completion(
+    model="morph/morph-glm53-744b",
+    messages=[{"role": "user", "content": "Write a small Python rate limiter."}],
+    stream=True,
+)
+
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
+```
+
+## LiteLLM Proxy
+
+Add Morph models to `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: morph-glm
+    litellm_params:
+      model: morph/morph-glm53-744b
+      api_key: os.environ/MORPH_API_KEY
+
+  - model_name: morph-kimi
+    litellm_params:
+      model: morph/morph-kimik3
+      api_key: os.environ/MORPH_API_KEY
+```
+
+Start the proxy:
+
 ```bash
 litellm --config config.yaml
 ```
 
-## Advanced Usage
+Call it with any OpenAI compatible client:
 
-### Setting API Base
+<Tabs>
+<TabItem value="python" label="OpenAI Python">
+
 ```python
-import litellm 
+from openai import OpenAI
 
-# set custom api base
-response = completion(
-    model="morph/morph-v3-large",
-    messages=[{"role": "user", "content": "Hello, world!"}],
-    api_base="https://api.morphllm.com/v1"
+client = OpenAI(
+    api_key="your-litellm-key",
+    base_url="http://localhost:4000",
 )
-print(response)
+
+response = client.chat.completions.create(
+    model="morph-glm",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
+)
+
+print(response.choices[0].message.content)
 ```
 
-### Setting API Key
-```python 
-import litellm 
+</TabItem>
+<TabItem value="curl" label="cURL">
 
-# set api key via completion
+```bash
+curl http://localhost:4000/chat/completions \
+  -H "Authorization: Bearer your-litellm-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "morph-glm",
+    "messages": [{"role": "user", "content": "Hello from LiteLLM"}]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Dedicated inference endpoints
+
+Morph also offers reserved capacity behind an isolated OpenAI compatible endpoint. Set `api_base` to the URL returned when the endpoint is provisioned and keep the `morph/` provider prefix:
+
+```yaml
+model_list:
+  - model_name: dedicated-deepseek
+    litellm_params:
+      model: morph/your-dedicated-model
+      api_base: https://your-endpoint.morphllm.com/v1
+      api_key: os.environ/MORPH_API_KEY
+```
+
+See [Morph dedicated inference](https://www.morphllm.com/dedicated-inference) for available models, capacity planning, and deployment through the Morph CLI
+
+## Custom API base
+
+Set `MORPH_API_BASE` for all Morph requests, or pass `api_base` on one request:
+
+```python
+from litellm import completion
+
 response = completion(
-    model="morph/morph-v3-large",
-    messages=[{"role": "user", "content": "Hello, world!"}],
-    api_key="your-api-key"
+    model="morph/morph-glm53-744b",
+    messages=[{"role": "user", "content": "Hello"}],
+    api_base="https://api.morphllm.com/v1",
 )
-print(response)
 ```


### PR DESCRIPTION
## Summary

The Morph provider page only covered two Apply models and listed outdated 16K context limits. This updates it for the current Morph catalog and links model data to the live source

The guide now includes current Kimi K3, GLM 5.3, GLM 5.3 Flash, DeepSeek V4 Flash, and Apply model IDs. It also adds working Python SDK, streaming, LiteLLM Proxy, custom API base, and dedicated inference examples

The matching provider metadata and request parameter update is in [LiteLLM PR #39242](https://github.com/BerriAI/litellm/pull/39242)

## Validation

`npm run lint:writing` passes with no prose em dashes

`npm run build` generates the complete Docusaurus site successfully
