### PR TITLE
docs: point navbar to Auto Router

### DIFF
--- a/docs/learn/autorouter_cli.md
+++ b/docs/learn/autorouter_cli.md
@@ -12,6 +12,8 @@ The autorouter CLI is early and evolving. Tell us what works, what breaks, and w
 
 :::
 
+For proxy setup and the full configuration reference, see [Auto Routing](../proxy/auto_routing.md).
+
 ## 1. Install the CLI
 
 Install `lite` from the internal staging branch with a single curl command; `uv` is bootstrapped automatically if it is missing.

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -643,4 +643,5 @@ The allowlist check runs client-side, so a router excluded by it leaves nothing 
 ## See also
 
 - Announcement post: [Auto Router v2: one router for complexity, semantic, and adaptive routing](/blog/autorouter-v2)
+- Local Claude Code preview: [Autorouter CLI](../learn/autorouter_cli.md)
 - Legacy semantic router: [Semantic Auto Router (deprecated)](./auto_routing_semantic.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -389,9 +389,9 @@ const config = {
           { to: '/blog', label: 'Blog', position: 'left' },
           {
             type: 'doc',
-            docId: 'learn/autorouter_cli',
+            docId: 'proxy/auto_routing',
             position: 'left',
-            label: 'Autorouter CLI',
+            label: 'Auto Router',
           },
           {
             href: 'https://trust.litellm.ai/',


### PR DESCRIPTION
## Summary

- rename the global navbar item from `Autorouter CLI` to `Auto Router`
- point it to the canonical Auto Routing reference
- cross-link the full reference and the local CLI guide

## Testing

- `npm run build`

The build passes. Docusaurus reports existing warnings on unrelated pages.