### PR TITLE
docs: document dotenv loading opt-out

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1151,6 +1151,7 @@ router_settings:
 | LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES | Maximum retries for parallel requests in LiteLLM
 | LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRY_TIMEOUT | Timeout for retries of parallel requests in LiteLLM
 | LITELLM_DISABLE_ACCESS_LOG_PATHS | Comma-separated list of URL paths to exclude from uvicorn access logs (e.g., `/health,/metrics`). Useful for suppressing noisy health-check log entries. |
+| LITELLM_DISABLE_DOTENV | Set to `1`, `true`, `t`, `yes`, or `y` (case-insensitive) before importing LiteLLM to prevent the SDK and proxy CLI from implicitly loading `.env` files. When unset or false, implicit loading remains enabled in development mode. `LITELLM_MODE=PRODUCTION` continues to disable `.env` loading regardless of this setting
 | LITELLM_DISABLE_LAZY_LOADING | When set to "1", "true", "yes", or "on", disables lazy loading of attributes (currently only affects encoding/tiktoken). This ensures encoding is initialized before VCR starts recording HTTP requests, fixing VCR cassette creation issues. See [issue #18659](https://github.com/BerriAI/litellm/issues/18659)
 | LITELLM_DISABLE_NO_REDIS_WARNING | When set to "true", hides the Admin UI banner shown while no Redis is configured. Set it only on single-worker deployments; see [What Needs Redis](./redis_requirements.md).
 | LITELLM_DISABLE_REDACT_SECRETS | When set to "true", disables automatic redaction of secrets (API keys, tokens, credentials) from proxy log output. Secret redaction is enabled by default.


### PR DESCRIPTION
## Summary

Documents `LITELLM_DISABLE_DOTENV` in the environment variable reference, including its accepted truthy values, pre-import requirement, default development behavior, and interaction with `LITELLM_MODE=PRODUCTION`

This accompanies https://github.com/BerriAI/litellm/pull/39292 and resolves its documentation validation failure

## Testing

Validated with `npm run lint:writing` and LiteLLM's environment-key documentation scanner