### PR TITLE
docs(blog): correct the Gemini 3.7 Flash promotional end date

### DIFF
--- a/blog/gemini_3_7_flash/index.md
+++ b/blog/gemini_3_7_flash/index.md
@@ -29,7 +29,7 @@ LiteLLM now supports `gemini-3.7-flash` on day 0, on both Google AI Studio (`gem
 
 ## Launch pricing
 
-Gemini 3.7 Flash launches at a 50% discount that runs through December 31, 2027. LiteLLM tracks cost at the promotional rate.
+Gemini 3.7 Flash launches at a 50% discount that runs through December 31, 2026. LiteLLM tracks cost at the promotional rate.
 
 | | Promotional | Standard |
 |---|---|---|


### PR DESCRIPTION
The [Gemini 3.7 Flash post](https://docs.litellm.ai/blog/gemini_3_7_flash) says its 50% launch discount runs through December 31, **2027**. That is a year late.

Google's [pricing page](https://ai.google.dev/gemini-api/docs/pricing) lists Gemini 3.7 Flash at $0.75 / MTok input and $3.75 / MTok output "through December 31, **2026**", going to $1.50 / $7.50 on January 1, 2027. That is the same window as Gemini 3.8 Flash, and matches how [BerriAI/litellm#39340](https://github.com/BerriAI/litellm/pull/39340) describes 3.8 as carrying the "same promo pricing as 3.7 Flash through Dec 31, 2026".

One line, no other changes.

## Note on scope

This PR originally also added the Gemini 3.8 Flash day 0 post. #1127 landed that first, so the duplicate is dropped and only the date correction remains.

## Also worth fixing, outside this PR

[Discussion #36799](https://github.com/BerriAI/litellm/discussions/36799) carries the same wrong date, and its config block says `model: anthropic/gemini-3.7-flash` where it should be `gemini/`. Both need an edit from the author.