### PR TITLE
docs(email): show how to add budget alert emails to an existing key

### DIFF
--- a/docs/proxy/email.md
+++ b/docs/proxy/email.md
@@ -127,9 +127,29 @@ curl -X POST 'http://0.0.0.0:4000/key/generate' \
 
 With the key above, spend of $50 emails the owner, $75 emails the owner and finance, and $100 emails on-call. Recipients can be a list or a comma separated string, and the key owner's email is always included alongside whoever you configure. Each threshold sends at most one email per key per `EMAIL_BUDGET_ALERT_TTL`. A 100% threshold still fires on the request that exhausts the budget, because the alert check runs before the request is rejected.
 
-Configuring `max_budget_alert_emails` on a key replaces the default 80% alert for that key. To change thresholds on an existing key, send the same `metadata` block to `/key/update`.
+Configuring `max_budget_alert_emails` on a key replaces the default 80% alert for that key. There is no UI field for this yet, so set it through `/key/generate` or `/key/update`.
 
-There is no UI field for this yet, so set it through `/key/generate` or `/key/update`.
+To add thresholds to a key that already exists, read the key's current metadata first and send it back with the new field included. `/key/update` replaces the whole `metadata` object rather than merging into it, so posting only `max_budget_alert_emails` drops every other metadata field the key already had.
+
+```shell showLineNumbers
+KEY="sk-your-existing-key"
+
+MERGED=$(curl -s -X GET "http://0.0.0.0:4000/key/info?key=$KEY" \
+  -H 'Authorization: Bearer sk-1234' | python3 -c '
+import sys, json
+metadata = json.load(sys.stdin)["info"].get("metadata") or {}
+metadata["max_budget_alert_emails"] = {
+    "50": ["owner@your-company.com"],
+    "75": ["owner@your-company.com", "finance@your-company.com"],
+    "100": ["oncall@your-company.com"],
+}
+print(json.dumps(metadata))')
+
+curl -X POST 'http://0.0.0.0:4000/key/update' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d "{\"key\": \"$KEY\", \"metadata\": $MERGED}"
+```
 
 #### Default thresholds for every key
 


### PR DESCRIPTION
## What

Follow-up to #1099, which said to send "the same `metadata` block to `/key/update`" for an existing key. That's a footgun as written, so this replaces it with a read-modify-write example and spells out why.

`/key/update` overwrites the whole `metadata` object instead of merging into it, so a customer following the old line to add `max_budget_alert_emails` to a key silently loses every other metadata field on that key.

## Verified on a live proxy

Created a key with existing metadata, then updated it with only the new field:

```
$ curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias":"budget-alert-doc-test-2","max_budget":100,"metadata":{"existing_note":"keep-me"}}'

$ curl -s -X POST http://localhost:4000/key/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key":"sk-rfnhfg98Ey_7Db3bnchkiQ","metadata":{"max_budget_alert_emails":{"50":["a@x.com"]}}}'

$ curl -s -X GET "http://localhost:4000/key/info?key=sk-rfnhfg98Ey_7Db3bnchkiQ" -H "Authorization: Bearer sk-1234"
    "metadata": {
        "max_budget_alert_emails": {
            "50": [
                "a@x.com"
            ]
        }
    },
```

`existing_note` is gone. Running the merge snippet this PR documents instead keeps it:

```
$ curl -s -X GET "http://localhost:4000/key/info?key=$KEY" -H "Authorization: Bearer sk-1234"
{
  "tags": [
    "prod"
  ],
  "existing_note": "keep-me",
  "max_budget_alert_emails": {
    "50": [
      "owner@company.com"
    ],
    "75": [
      "owner@company.com",
      "finance@company.com"
    ],
    "100": [
      "oncall@company.com"
    ]
  }
}
```

Test keys were deleted afterwards.