### PR TITLE
docs(vllm): document the rerank truncation params forwarded by hosted_vllm

### DIFF
--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -309,6 +309,54 @@ curl -L -X POST 'http://0.0.0.0:4000/rerank' \
 </TabItem>
 </Tabs>
 
+### Truncating long documents
+
+vLLM's `/rerank` endpoint takes its own truncation controls, and LiteLLM forwards them to `hosted_vllm` rerank models whenever they are set. Without one of them, a document longer than the reranker's context window fails with a context length error
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `truncate_prompt_tokens` | integer | Truncate each query and document pair to this many tokens before scoring |
+| `truncation_side` | `left` or `right` | Which end of the input is cut off |
+| `max_tokens_per_doc` | integer | Cap each document at this many tokens |
+| `max_tokens_per_query` | integer | Cap the query at this many tokens |
+
+An invalid value, such as `truncation_side: "middle"`, returns a 400 before anything is sent to vLLM
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import rerank
+
+response = rerank(
+    model="hosted_vllm/your-rerank-model",
+    query="What is the capital of the United States?",
+    documents=["<a document longer than the reranker context window>"],
+    truncate_prompt_tokens=512,
+    truncation_side="left",
+)
+print(response)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/rerank' \
+-H 'Authorization: Bearer sk-1234' \
+-H 'Content-Type: application/json' \
+-d '{
+    "model": "my-rerank-model",
+    "query": "What is the capital of the United States?",
+    "documents": ["<a document longer than the reranker context window>"],
+    "truncate_prompt_tokens": 512,
+    "truncation_side": "left"
+}'
+```
+
+</TabItem>
+</Tabs>
+
 ## Send Video URL to VLLM
 
 Example Implementation from VLLM [here](https://github.com/vllm-project/vllm/pull/10020)


### PR DESCRIPTION
Adds a "Truncating long documents" subsection to the vLLM provider page's Rerank section. It lists the four vLLM truncation controls that LiteLLM now forwards on `hosted_vllm` rerank requests (`truncate_prompt_tokens`, `truncation_side`, `max_tokens_per_doc`, `max_tokens_per_query`), notes that an invalid value returns a 400 before the request reaches vLLM, and shows an SDK and a proxy curl example

Pairs with BerriAI/litellm#39363, which ships the forwarding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to `docs/providers/vllm.md` with no runtime or API behavior changes in this PR.
> 
> **Overview**
> Adds a **Truncating long documents** subsection under the vLLM **Rerank** docs, describing how LiteLLM forwards vLLM’s rerank truncation controls on `hosted_vllm` models.
> 
> The new content documents four parameters (`truncate_prompt_tokens`, `truncation_side`, `max_tokens_per_doc`, `max_tokens_per_query`), explains that oversized documents fail without truncation, and notes that invalid values (e.g. `truncation_side: "middle"`) yield a **400** before the request hits vLLM. SDK and proxy curl examples show `truncate_prompt_tokens` and `truncation_side`.
> 
> This pairs with the implementation PR that adds the forwarding behavior; this change is documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce2441090f284d7a6ecfbe890bb06fae154080c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->