### PR TITLE
docs(bedrock-agentcore): document A2A request-scoped session isolation

### DIFF
--- a/docs/providers/bedrock_agentcore.md
+++ b/docs/providers/bedrock_agentcore.md
@@ -311,6 +311,37 @@ curl -X POST http://localhost:4000/a2a/my-agentcore-runtime/message/send \
   }'
 ```
 
+### Session isolation
+
+Each AgentCore runtime session is its own microVM: reusing the same `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` keeps conversation context, and mixing two callers into one session leaks context between them. LiteLLM picks that session id in this order:
+
+1. **`params.message.contextId`** in the A2A request, scoped to the calling API key so two keys can never collide on the same `contextId`. This is the recommended way to isolate sessions per conversation.
+2. **`runtimeSessionId`** in the agent's `litellm_params` (see [Available Parameters](#available-parameters)), used only when the request carries no `contextId`. Every caller that omits `contextId` shares this one session.
+3. A freshly generated id, when neither of the above is set. Every request gets its own session, so multi-turn context is not preserved.
+
+To keep a conversation going across turns, send the same `contextId` on every `message/send` or `message/stream` call for that conversation, and a different `contextId` for each new conversation or end user:
+
+```bash showLineNumbers
+curl -X POST http://localhost:4000/a2a/my-agentcore-runtime/message/send \
+  -H "x-litellm-api-key: Bearer sk-client-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Summarize the latest clinical trial results"}],
+        "messageId": "msg-1",
+        "contextId": "conversation-<a stable id you generate per conversation, e.g. a UUID>"
+      }
+    }
+  }'
+```
+
+AWS requires the runtime session id to be 33-256 characters. LiteLLM prefixes `contextId` with a 16-character hash of the calling key before checking this, so `contextId` itself needs to be at least 16 characters; a UUID (36 characters) comfortably clears it. A `contextId` (or a configured `runtimeSessionId`) outside that range is rejected with HTTP 400 and a JSON-RPC `-32602` error before any request reaches AWS, rather than silently falling back to a shared session.
+
 ### Authentication {#a2a-gateway-authentication}
 
 The AgentCore A2A path supports **two distinct outbound auth modes**, picked automatically based on what's in `litellm_params`:


### PR DESCRIPTION
Documents the session-isolation behavior added in https://github.com/BerriAI/litellm/pull/39371 (LIT-6735): the AgentCore A2A gateway now derives the runtime session id from the A2A request's `contextId`, scoped per calling key, falling back to the agent's configured `runtimeSessionId` and then a generated id, with AWS's 33-256 character bound enforced up front.

Adds a "Session isolation" subsection under the existing "LiteLLM A2A Gateway" section in `docs/providers/bedrock_agentcore.md`, covering the precedence order, how to keep a conversation's turns in one session, and the length requirement on `contextId`.

Not blocking the code PR; can merge independently once the code PR lands.