### PR TITLE
docs(proxy): document NO_OPENAPI and a combined production docs lockdown

### DIFF
--- a/docs/proxy/configs.md
+++ b/docs/proxy/configs.md
@@ -705,6 +705,28 @@ NO_REDOC="True"
 
 in your environment, and restart the proxy. 
 
+### Disable OpenAPI schema
+
+To disable the raw OpenAPI schema (defaults to `<your-proxy-url>/openapi.json`), set 
+
+```env
+NO_OPENAPI="True"
+```
+
+in your environment, and restart the proxy. 
+
+### Restrict all API documentation for production/air-gapped deployments
+
+Swagger, Redoc and the raw OpenAPI schema are three independent surfaces, each disabled by its own env var. To fully lock down a production or air-gapped deployment, set all three: 
+
+```env
+NO_DOCS="True"
+NO_REDOC="True"
+NO_OPENAPI="True"
+```
+
+Restart the proxy after setting these. `/docs`, `/redoc` and `/openapi.json` then all 404 with no schema in the response, while inference and management routes are unaffected.
+
 ### Use CONFIG_FILE_PATH for proxy (Easier Azure container deployment)
 
 1. Setup config.yaml


### PR DESCRIPTION
## Summary

`NO_DOCS` and `NO_REDOC` each had their own "Disable X" section under Extras in `docs/proxy/configs.md`. `NO_OPENAPI` only appeared in the env var reference table, with no worked example, so an operator following the documented pattern for the other two could still leave the raw `/openapi.json` schema reachable.

- Add a "Disable OpenAPI schema" section matching the existing two
- Add a "Restrict all API documentation for production/air-gapped deployments" section showing all three set together, since they are three independent surfaces with one combined recommended policy

## Linear ticket

Resolves LIT-6745

## Test plan

- `npm ci && npm run build` succeeds; the only warnings are pre-existing (unrelated pages, plus a pre-existing control character in this same file at a byte offset far from this edit, confirmed present on `origin/main` before this change)