### PR TITLE
docs(containers): document model_list credentials for create and list

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -184,6 +184,20 @@ $ litellm
 # RUNNING on http://0.0.0.0:4000
 ```
 
+The OpenAI key can also live in `model_list` instead of the environment. Pass that deployment's `model` in the create body or as a `model` query param on list, and the proxy calls OpenAI with the deployment's `api_key` and `api_base`. Retrieve, delete, and container file calls need no `model`: the ID a routed create returns encodes the deployment, so they route on their own
+
+```yaml
+model_list:
+  - model_name: gpt-5.6
+    litellm_params:
+      model: openai/gpt-5.6
+      api_key: os.environ/OPENAI_API_KEY_TEAM_A
+```
+
+```bash
+$ litellm --config config.yaml
+```
+
 **Custom Provider Specification**
 
 You can specify the custom LLM provider in multiple ways (priority order):
@@ -229,10 +243,27 @@ curl -X POST "http://localhost:4000/v1/containers?custom_llm_provider=openai" \
     }'
 ```
 
+```bash
+# With model_list credentials: name the deployment
+curl -X POST "http://localhost:4000/v1/containers" \
+    -H "Authorization: Bearer sk-1234" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "name": "My Container",
+        "model": "gpt-5.6"
+    }'
+```
+
 **List Containers**
 
 ```bash
 curl "http://localhost:4000/v1/containers?limit=20&order=desc" \
+    -H "Authorization: Bearer sk-1234"
+```
+
+```bash
+# With model_list credentials: name the deployment
+curl "http://localhost:4000/v1/containers?model=gpt-5.6&limit=20&order=desc" \
     -H "Authorization: Bearer sk-1234"
 ```
 
@@ -284,6 +315,15 @@ print(f"Container Name: {container.name}")
 print(f"Created at: {container.created_at}")
 ```
 
+With `model_list` credentials, name the deployment in `extra_body`:
+
+```python
+container = client.containers.create(
+    name="test-container",
+    extra_body={"model": "gpt-5.6"}
+)
+```
+
 ### List Containers
 
 ```python
@@ -295,6 +335,15 @@ containers = client.containers.list(
 print(f"Found {len(containers.data)} containers")
 for container in containers.data:
     print(f"  - {container.id}: {container.name}")
+```
+
+With `model_list` credentials, name the deployment in `extra_query`, since list is a GET:
+
+```python
+containers = client.containers.list(
+    limit=20,
+    extra_query={"model": "gpt-5.6"}
+)
 ```
 
 ### Retrieve a Container


### PR DESCRIPTION
## TLDR

The proxy section of docs/containers.md only shows a global `OPENAI_API_KEY`. With BerriAI/litellm#39220, container create and list use `model_list` credentials when the request names a deployment (`model` in the create body, `?model=` on list), so this documents that path: a `model_list` config example under Setup, a curl for create and for list naming the deployment, and the matching OpenAI SDK calls (`extra_body` on create, `extra_query` on list since it is a GET). It also says why retrieve, delete, and container file calls need no `model`: the ID a routed create returns already encodes the deployment

Verified against a live proxy at that PR's tip with the OpenAI key only in `model_list`: create with `"model"` returns 200, list with `?model=` returns 200, and both fail (401 and 500) without it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to containers proxy usage; no runtime or security logic changes in this PR.
> 
> **Overview**
> **Proxy setup and examples now cover per-deployment OpenAI credentials from `model_list`**, not only a global `OPENAI_API_KEY`.
> 
> The LiteLLM Proxy section adds a short explanation that create/list should pass the deployment name (`model` in the JSON body or `?model=` on list) so the proxy uses that entry’s `api_key` and `api_base`. It includes a sample `model_list` YAML, matching **curl** snippets for create and list, and **OpenAI Python client** patterns (`extra_body` on create, `extra_query` on list because list is GET). It also clarifies that **retrieve, delete, and container file** calls do not need `model` because routed create IDs already encode the deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4a75f1321ba46fc9666b4905b925fc7a5edae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->