### PR TITLE
docs(meta): add Muse Voice realtime setup

### DIFF
--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -5,18 +5,19 @@ import TabItem from '@theme/TabItem';
 
 | Property | Details |
 |-------|-------|
-| Description | Meta's Model API provides access to Meta's Muse Spark family of reasoning models. |
+| Description | Meta's Model API provides access to Muse Spark reasoning models and Muse Voice transcription. |
 | Provider Route on LiteLLM | `meta/` |
-| Supported Endpoints | `/chat/completions`, `/responses`, `/v1/messages` |
+| Supported Endpoints | `/chat/completions`, `/responses`, `/v1/messages`, `/v1/realtime` |
 | API Reference | [Meta Model API Reference ↗](https://dev.meta.ai/docs) |
 
 ## Required Variables
 
 ```python showLineNumbers title="Environment Variables"
-os.environ["META_API_KEY"] = ""  # your Meta Model API key
+os.environ["META_API_KEY"] = ""   # chat and responses; realtime fallback
+os.environ["MODEL_API_KEY"] = ""  # preferred for Muse Voice realtime
 ```
 
-Requests go to `https://api.meta.ai/v1` by default. Set `META_API_BASE` to override the API base.
+Requests go to `https://api.meta.ai/v1` by default. Set `META_API_BASE` to override the API base. Muse Voice realtime uses `MODEL_API_KEY` first and falls back to `META_API_KEY`.
 
 ## Supported Models
 
@@ -27,10 +28,23 @@ We actively maintain the list of models, pricing, token window, etc. [here](http
 | Model ID | Input context length | Input Modalities | Output Modalities |
 | --- | --- | --- | --- |
 | `muse-spark-1.1` | 1M | Text, Image, Video, PDF | Text |
+| `muse-voice-transcribe-1.0` | N/A | Audio | Text |
 
 `muse-spark-1.1` supports function calling, parallel function calling, structured outputs, prompt caching, web search grounding, and reasoning via `reasoning_effort` (`"minimal"` through `"xhigh"`).
 
 The API also natively exposes the Anthropic Messages format, so LiteLLM forwards `/v1/messages` requests to `https://api.meta.ai/v1/messages` untranslated, preserving Anthropic-only features like thinking blocks.
+
+## Muse Voice Realtime Transcription
+
+Connect to the LiteLLM proxy with:
+
+```text
+ws://localhost:4000/v1/realtime?model=meta/muse-voice-transcribe-1.0&intent=transcription
+```
+
+Send an OpenAI-compatible `session.update`, followed by `input_audio_buffer.append` events containing base64-encoded mono PCM16 audio. Muse Voice accepts 16 kHz and 24 kHz input. LiteLLM returns OpenAI-compatible speech boundary, transcription delta, completed transcript, and duration usage events.
+
+Muse Voice is realtime-only. Batch or file transcription endpoints are not supported.
 
 ## Usage - LiteLLM Python SDK
 

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -8,7 +8,8 @@ import TabItem from '@theme/TabItem';
 | Description | Meta's Model API provides access to Muse Spark reasoning models and Muse Voice transcription. |
 | Provider Route on LiteLLM | `meta/` |
 | Supported Endpoints | `/chat/completions`, `/responses`, `/v1/messages`, `/v1/realtime` |
-| API Reference | [Meta Model API Reference ↗](https://dev.meta.ai/docs) |
+| Developer Portal | [Meta Model API ↗](https://dev.meta.ai/) |
+| Speech-to-Text Reference | [Muse Voice transcription ↗](https://dev.meta.ai/docs/speech-to-text) |
 
 ## Required Variables
 

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -38,7 +38,7 @@ The API also natively exposes the Anthropic Messages format, so LiteLLM forwards
 
 ## Muse Voice Realtime Transcription
 
-LiteLLM serves Muse Voice through the proxy's OpenAI-compatible `/v1/realtime` endpoint. You speak the OpenAI Realtime transcription protocol to the proxy; LiteLLM opens a session to `wss://api.meta.ai/v1/asr/realtime`, streams your PCM16 audio to Muse as binary frames, and turns Muse's transcript frames back into OpenAI transcription events. Any WebSocket client works, and the [Python example](#example-python-client) below is a complete push to talk session.
+LiteLLM serves Muse Voice through the proxy's OpenAI-compatible `/v1/realtime` endpoint. Clients speak the OpenAI Realtime transcription protocol; LiteLLM streams their PCM16 audio to `wss://api.meta.ai/v1/asr/realtime` as binary frames and maps Muse's transcript frames back to OpenAI events. The [Python example](#example-python-client) below is a complete push to talk session.
 
 ### 1. Add the model to your config
 
@@ -50,7 +50,7 @@ model_list:
       api_key: os.environ/META_API_KEY
 ```
 
-`api_key` can be omitted when `META_API_KEY` is set in the proxy environment. `api_base` is optional and must be an absolute `wss://` or `https://` URL: LiteLLM keeps its host and port, replaces the path with `/v1/asr/realtime`, and rejects `http://`, `ws://`, embedded credentials and URL fragments. `META_API_BASE` is not consulted for realtime sessions.
+`api_key` falls back to `META_API_KEY`. `api_base` is optional and must be an absolute `wss://` or `https://` URL; LiteLLM keeps its host and port and replaces the path with `/v1/asr/realtime`. `http://`, `ws://`, embedded credentials and URL fragments are rejected, and `META_API_BASE` is ignored for realtime sessions.
 
 ```bash showLineNumbers title="Start LiteLLM Proxy"
 litellm --config config.yaml
@@ -64,11 +64,13 @@ litellm --config config.yaml
 ws://localhost:4000/v1/realtime?model=muse-voice-transcribe&intent=transcription
 ```
 
-Send your proxy key as `Authorization: Bearer <key>`. `model` is the `model_name` from your config and must be present: with `intent=transcription` alone the proxy routes to its default OpenAI transcription model. `intent=transcription` marks the session as transcription-only and pins any model named in a later `session.update` to the one you were authorized for. Once the proxy has connected to Meta, and before the Muse handshake, LiteLLM emits a `session.created` event with `object: realtime.transcription_session` so clients that wait for it do not stall.
+Authenticate with `Authorization: Bearer <proxy key>`. `model` is the `model_name` from your config and is required; `intent=transcription` alone routes to the proxy's default OpenAI transcription model. `intent=transcription` makes the session transcription-only and pins any model named in `session.update` to the one you were authorized for.
+
+LiteLLM emits `session.created` with `object: realtime.transcription_session` once it has connected to Meta, before the Muse handshake.
 
 ### 3. Configure the session
 
-Send one `session.update` (or `transcription_session.update`). Muse's own handshake acknowledgement is relayed as `session.updated`; any further `session.update` is ignored for the rest of the session. The GA layout below is recommended. The beta layout (`input_audio_format: "pcm16"` plus `input_audio_transcription`) is also accepted at 24 kHz; do not mix the two layouts in one update. Audio events sent before `session.updated` arrives are buffered and replayed once Muse acknowledges the session, so you can start streaming right after `session.update`.
+Send one `session.update` (or `transcription_session.update`). Muse's acknowledgement comes back as `session.updated`, and any later update is ignored. Audio sent before `session.updated` is buffered and replayed, so you can start streaming right away.
 
 ```json showLineNumbers title="session.update"
 {
@@ -86,9 +88,16 @@ Send one `session.update` (or `transcription_session.update`). Muse's own handsh
 }
 ```
 
-`format.type` must be `audio/pcm`, `rate` must be `16000` or `24000`, and `channels` must be `1`; when `format` is omitted LiteLLM assumes mono 24 kHz. `transcription.model` is optional. With `intent=transcription` the proxy replaces whatever you send with the provider model from your config, `muse-voice-transcribe-1.0`, and `session.updated` echoes that value; without `intent=transcription` only `muse-voice-transcribe-1.0` or `meta/muse-voice-transcribe-1.0` is accepted. `transcription.language` is optional and biases recognition toward one language, given as a name or an ISO 639 code; a region suffix is ignored, so `en-US`, `zh-Hans` and `pt-BR` all work. Muse Voice supports Arabic, Bengali, Dutch, English, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Mandarin Chinese, Marathi, Polish, Portuguese, Spanish, Tagalog, Tamil, Telugu, Thai, Turkish and Vietnamese. Any other transcription setting, such as `prompt`, is dropped with a warning in the proxy log.
+| Field | Rules |
+| --- | --- |
+| `format` | `type` must be `audio/pcm`, `rate` must be `16000` or `24000`, `channels` must be `1`. Omitted means mono 24 kHz. |
+| `transcription.model` | Optional. With `intent=transcription` the proxy replaces it with `muse-voice-transcribe-1.0`; without it, only `muse-voice-transcribe-1.0` or `meta/muse-voice-transcribe-1.0` is accepted. |
+| `transcription.language` | Optional bias toward one language, as a name or ISO 639 code. Region suffixes are ignored, so `en-US`, `zh-Hans` and `pt-BR` work. |
+| `turn_detection` | Selects the mode (table below). Any `type` other than `server_vad` is rejected; an object without `type` means server VAD. |
+| Anything else | Dropped with a warning in the proxy log. |
+| Beta layout | `input_audio_format: "pcm16"` plus `input_audio_transcription` is accepted at 24 kHz. Do not mix the two layouts in one update. |
 
-`turn_detection` selects the mode. LiteLLM rejects any `turn_detection.type` other than `server_vad`; an object without `type` is treated as server VAD.
+Supported languages: Arabic, Bengali, Dutch, English, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Mandarin Chinese, Marathi, Polish, Portuguese, Spanish, Tagalog, Tamil, Telugu, Thai, Turkish and Vietnamese.
 
 | | Push to talk | Server VAD |
 | --- | --- | --- |
@@ -96,43 +105,47 @@ Send one `session.update` (or `transcription_session.update`). Muse's own handsh
 | Turn boundaries | One turn per session; you decide when it ends | Muse detects utterances; each gets its own `item_id` |
 | Ending the turn | `input_audio_buffer.commit` flushes buffered audio and ends the Muse stream | `input_audio_buffer.commit` only flushes; send `input_audio_buffer.end` when you are done |
 
-An invalid `session.update` (unsupported rate, channel count, turn detection type or language) ends the session without an `error` event: the proxy drops the connection and the client sees close code `1006` with an empty reason. The validation message appears only in the proxy log at debug level, as `Error in client ack messages: ...`. Protocol violations after setup, such as an append over four seconds, invalid base64 or an odd number of PCM bytes, end the session the same way.
+An invalid `session.update` (bad rate, channel count, turn detection type or language) closes the connection with code `1006` and no `error` event; the reason is logged at debug level as `Error in client ack messages: ...`. Protocol violations after setup, such as an append over four seconds, invalid base64 or an odd number of PCM bytes, close the same way.
 
 ### 4. Stream audio
 
-Send `input_audio_buffer.append` events whose `audio` field is base64 mono PCM16 at the configured rate. Each append may carry at most four seconds of audio; LiteLLM repackets the stream into 80 ms binary frames and paces them to Muse at real time. `input_audio_buffer.clear` drops any partial frame LiteLLM is still holding; audio already forwarded to Muse cannot be recalled. Every other client event, including `response.create`, is dropped because the session is transcription-only.
+`input_audio_buffer.append` carries base64 mono PCM16 at the configured rate, at most four seconds per event. LiteLLM repackets the audio into 80 ms binary frames and paces them to Muse in real time. `input_audio_buffer.clear` drops the partial frame LiteLLM is still holding; audio already sent to Muse cannot be recalled. Every other client event, including `response.create`, is dropped.
 
-In server VAD mode Muse expects audio to keep arriving at real time. Stream silence during pauses and send `input_audio_buffer.end` (a LiteLLM event, not part of the OpenAI protocol) when you are finished; when a client simply stops sending, Meta closes the upstream socket with code `1008` (`Ingress below real-time`) and the proxy relays that as an `error` event followed by a `1008` close.
+Server VAD needs audio to keep arriving in real time. Stream silence during pauses and send `input_audio_buffer.end` (a LiteLLM event, not part of the OpenAI protocol) when you are finished. If the client simply stops sending, Meta closes with code `1008` (`Ingress below real-time`), which the proxy relays as an `error` event followed by a `1008` close.
 
 ### 5. Read transcripts
 
 | Event | Fields | When |
 | --- | --- | --- |
 | `session.created` | `session.object: realtime.transcription_session` | On connect, before the Muse handshake |
-| `session.updated` | Normalized session: `format` without `channels`, `model` as `muse-voice-transcribe-1.0`, `language` as its full name (`en` becomes `English`) | After Muse accepts your `session.update` |
+| `session.updated` | Normalized session: no `channels`, `model` is `muse-voice-transcribe-1.0`, `language` is the full name (`en` becomes `English`) | After Muse accepts your `session.update` |
 | `input_audio_buffer.speech_started` | `item_id` | Muse detects the start of a turn |
 | `conversation.item.input_audio_transcription.delta` | `item_id`, `content_index: 0`, `delta` | Partial transcript text |
 | `input_audio_buffer.speech_stopped` | `item_id` | Muse detects the end of a turn |
-| `conversation.item.input_audio_transcription.completed` | `item_id`, `content_index: 0`, `transcript`, and `usage: {"type": "duration", "seconds": 1.36}` when Muse reported newly processed audio since the previous `completed` | Final transcript for the turn |
-| `error` | `error.type: server_error` with `error.message` either `Meta Muse realtime transcription failed` or, before a non-1000 close, `upstream websocket closed with code <N>: <reason>` | Muse reported a failure or closed abnormally |
+| `conversation.item.input_audio_transcription.completed` | `item_id`, `content_index: 0`, `transcript`; `usage: {"type": "duration", "seconds": 1.36}` when Muse processed new audio since the previous `completed` | Final transcript for the turn |
+| `error` | `error.type: server_error`; `error.message` is `Meta Muse realtime transcription failed`, or `upstream websocket closed with code <N>: <reason>` before a non-1000 close | Muse reported a failure or closed abnormally |
 
-Overlapping turns are emitted independently as their frames arrive, correlated by `item_id`. When Muse has no more segments it closes the session with code `1000` and the proxy relays that close, normally with Meta's reason `No more transcript segments`.
+Turns may overlap and are correlated by `item_id`. When Muse has no more segments it closes with code `1000`, normally with reason `No more transcript segments`, and the proxy relays that close.
 
 ### Pricing and usage
 
-`meta/muse-voice-transcribe-1.0` is priced per second of input audio (`input_cost_per_second` in the model cost map). `usage.seconds` on a `completed` event is the audio Muse processed since the last billed point, silence included, so it can exceed the length of the utterance. Audio processed after the last `completed` event, such as trailing silence, is billed when the session closes so the spend log matches what Meta charged. The proxy log does not contain transcript text, apart from the first 80 characters of a guardrail-blocked transcript at warning level; transcripts are stored in the spend log's messages unless message logging is turned off.
+Muse Voice is billed per second of input audio (`input_cost_per_second` in the model cost map). `usage.seconds` is the audio Muse processed since the last billed point, silence included, so it can exceed the utterance length. Audio after the last `completed` event, such as trailing silence, is billed when the session closes.
+
+Transcripts are stored in the spend log's messages unless message logging is turned off. The proxy log carries no transcript text, apart from the first 80 characters of a guardrail-blocked transcript at warning level.
 
 ### Guardrails
 
-Guardrails with `mode: realtime_input_transcription` run on every completed transcript; see [Realtime Guardrails](/docs/proxy/guardrails/realtime_guardrails). The `completed` event reaches the client before the guardrail runs and partial deltas are not checked. A block then produces an `error` event with `type: guardrail_violation` and `code: content_policy_violation`, and `on_violation: end_session` closes the socket with code `1000`. Guardrails can also be selected per connection with a `guardrails=name1,name2` query parameter.
+Guardrails with `mode: realtime_input_transcription` run on each completed transcript; see [Realtime Guardrails](/docs/proxy/guardrails/realtime_guardrails). The `completed` event reaches the client before the guardrail runs, and deltas are not checked. A block sends an `error` event with `type: guardrail_violation` and `code: content_policy_violation`; `on_violation: end_session` also closes the socket with code `1000`.
+
+Select guardrails per connection with a `guardrails=name1,name2` query parameter.
 
 :::warning
-When a `realtime_input_transcription` guardrail is configured, LiteLLM's shared realtime guardrail code rewrites a client's `turn_detection: null` into `{"create_response": false}` before Muse sees it. That runs push to talk clients in server VAD mode: `input_audio_buffer.commit` no longer ends the Muse stream, and a client that stops streaming after it is disconnected with close code `1008`. Server VAD clients are unaffected.
+With a `realtime_input_transcription` guardrail configured, LiteLLM rewrites a client's `turn_detection: null` into `{"create_response": false}` before Muse sees it, so push to talk clients run in server VAD mode: `input_audio_buffer.commit` no longer ends the stream, and a client that stops streaming is disconnected with code `1008`. Server VAD clients are unaffected.
 :::
 
 ### Example Python client
 
-Push to talk session: configure, stream a mono PCM16 WAV file in 100 ms chunks, commit, then read events until the proxy closes the socket.
+Push to talk: configure, stream a mono PCM16 WAV file in 100 ms chunks, commit, then read events until the proxy closes the socket.
 
 ```python showLineNumbers title="Muse Voice push to talk client"
 import asyncio

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -50,7 +50,7 @@ model_list:
       api_key: os.environ/META_API_KEY
 ```
 
-`api_key` is the only required credential. `api_base` is optional and must be an absolute `wss://` or `https://` URL: LiteLLM keeps its host and port, replaces the path with `/v1/asr/realtime`, and rejects `http://`, `ws://`, embedded credentials and URL fragments. `META_API_BASE` is not consulted for realtime sessions.
+`api_key` can be omitted when `META_API_KEY` is set in the proxy environment. `api_base` is optional and must be an absolute `wss://` or `https://` URL: LiteLLM keeps its host and port, replaces the path with `/v1/asr/realtime`, and rejects `http://`, `ws://`, embedded credentials and URL fragments. `META_API_BASE` is not consulted for realtime sessions.
 
 ```bash showLineNumbers title="Start LiteLLM Proxy"
 litellm --config config.yaml
@@ -64,11 +64,11 @@ litellm --config config.yaml
 ws://localhost:4000/v1/realtime?model=muse-voice-transcribe&intent=transcription
 ```
 
-Send your proxy key as `Authorization: Bearer <key>`. `model` is the `model_name` from your config, and `intent=transcription` marks the session as transcription-only and pins any model named in a later `session.update` to the one you were authorized for. LiteLLM emits a `session.created` event with `object: realtime.transcription_session` as soon as the socket opens, before the Muse handshake, so clients that wait for it do not stall.
+Send your proxy key as `Authorization: Bearer <key>`. `model` is the `model_name` from your config and must be present: with `intent=transcription` alone the proxy routes to its default OpenAI transcription model. `intent=transcription` marks the session as transcription-only and pins any model named in a later `session.update` to the one you were authorized for. Once the proxy has connected to Meta, and before the Muse handshake, LiteLLM emits a `session.created` event with `object: realtime.transcription_session` so clients that wait for it do not stall.
 
 ### 3. Configure the session
 
-Send one `session.update` (or `transcription_session.update`). Muse's own handshake acknowledgement is relayed as `session.updated`; any further `session.update` is ignored for the rest of the session. The GA layout below is recommended. The beta layout (`input_audio_format: "pcm16"` plus `input_audio_transcription`) is also accepted at 24 kHz, but one update cannot mix the two layouts.
+Send one `session.update` (or `transcription_session.update`). Muse's own handshake acknowledgement is relayed as `session.updated`; any further `session.update` is ignored for the rest of the session. The GA layout below is recommended. The beta layout (`input_audio_format: "pcm16"` plus `input_audio_transcription`) is also accepted at 24 kHz; do not mix the two layouts in one update. Audio events sent before `session.updated` arrives are buffered and replayed once Muse acknowledges the session, so you can start streaming right after `session.update`.
 
 ```json showLineNumbers title="session.update"
 {
@@ -86,9 +86,9 @@ Send one `session.update` (or `transcription_session.update`). Muse's own handsh
 }
 ```
 
-`format.type` must be `audio/pcm`, `rate` must be `16000` or `24000`, and `channels` must be `1`; when `format` is omitted LiteLLM assumes mono 24 kHz. `transcription.model` is optional; the proxy rewrites it to the model you connected with, so any other value is overwritten rather than honored. `transcription.language` is optional and biases recognition toward one language, given as a name or an ISO 639 code; a region suffix is ignored, so `en-US`, `zh-Hans` and `pt-BR` all work. Muse Voice supports Arabic, Bengali, Dutch, English, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Mandarin Chinese, Marathi, Polish, Portuguese, Spanish, Tagalog, Tamil, Telugu, Thai, Turkish and Vietnamese. Any other transcription setting, such as `prompt`, is dropped with a warning in the proxy log.
+`format.type` must be `audio/pcm`, `rate` must be `16000` or `24000`, and `channels` must be `1`; when `format` is omitted LiteLLM assumes mono 24 kHz. `transcription.model` is optional. With `intent=transcription` the proxy replaces whatever you send with the provider model from your config, `muse-voice-transcribe-1.0`, and `session.updated` echoes that value; without `intent=transcription` only `muse-voice-transcribe-1.0` or `meta/muse-voice-transcribe-1.0` is accepted. `transcription.language` is optional and biases recognition toward one language, given as a name or an ISO 639 code; a region suffix is ignored, so `en-US`, `zh-Hans` and `pt-BR` all work. Muse Voice supports Arabic, Bengali, Dutch, English, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Mandarin Chinese, Marathi, Polish, Portuguese, Spanish, Tagalog, Tamil, Telugu, Thai, Turkish and Vietnamese. Any other transcription setting, such as `prompt`, is dropped with a warning in the proxy log.
 
-`turn_detection` selects the mode. LiteLLM rejects every `turn_detection.type` other than `server_vad`.
+`turn_detection` selects the mode. LiteLLM rejects any `turn_detection.type` other than `server_vad`; an object without `type` is treated as server VAD.
 
 | | Push to talk | Server VAD |
 | --- | --- | --- |
@@ -96,35 +96,35 @@ Send one `session.update` (or `transcription_session.update`). Muse's own handsh
 | Turn boundaries | One turn per session; you decide when it ends | Muse detects utterances; each gets its own `item_id` |
 | Ending the turn | `input_audio_buffer.commit` flushes buffered audio and ends the Muse stream | `input_audio_buffer.commit` only flushes; send `input_audio_buffer.end` when you are done |
 
-An invalid `session.update` (unsupported rate, channel count, turn detection type or language) is rejected and the connection is dropped; the reason is written to the proxy debug log.
+An invalid `session.update` (unsupported rate, channel count, turn detection type or language) ends the session without an `error` event: the proxy drops the connection and the client sees close code `1006` with an empty reason. The validation message appears only in the proxy log at debug level, as `Error in client ack messages: ...`. Protocol violations after setup, such as an append over four seconds, invalid base64 or an odd number of PCM bytes, end the session the same way.
 
 ### 4. Stream audio
 
 Send `input_audio_buffer.append` events whose `audio` field is base64 mono PCM16 at the configured rate. Each append may carry at most four seconds of audio; LiteLLM repackets the stream into 80 ms binary frames and paces them to Muse at real time. `input_audio_buffer.clear` drops any partial frame LiteLLM is still holding; audio already forwarded to Muse cannot be recalled. Every other client event, including `response.create`, is dropped because the session is transcription-only.
 
-In server VAD mode Muse expects audio to keep arriving at real time. Stream silence during pauses and send `input_audio_buffer.end` when you are finished; when a client simply stops sending, Meta closes the upstream socket with code `1008` (`Ingress below real-time`) and the proxy relays that as an `error` event followed by a `1008` close.
+In server VAD mode Muse expects audio to keep arriving at real time. Stream silence during pauses and send `input_audio_buffer.end` (a LiteLLM event, not part of the OpenAI protocol) when you are finished; when a client simply stops sending, Meta closes the upstream socket with code `1008` (`Ingress below real-time`) and the proxy relays that as an `error` event followed by a `1008` close.
 
 ### 5. Read transcripts
 
 | Event | Fields | When |
 | --- | --- | --- |
 | `session.created` | `session.object: realtime.transcription_session` | On connect, before the Muse handshake |
-| `session.updated` | Configured `audio.input.format`, `transcription` and `turn_detection` | After Muse accepts your `session.update` |
+| `session.updated` | Normalized session: `format` without `channels`, `model` as `muse-voice-transcribe-1.0`, `language` as its full name (`en` becomes `English`) | After Muse accepts your `session.update` |
 | `input_audio_buffer.speech_started` | `item_id` | Muse detects the start of a turn |
 | `conversation.item.input_audio_transcription.delta` | `item_id`, `content_index: 0`, `delta` | Partial transcript text |
 | `input_audio_buffer.speech_stopped` | `item_id` | Muse detects the end of a turn |
-| `conversation.item.input_audio_transcription.completed` | `item_id`, `transcript`, `usage: {"type": "duration", "seconds": 1.36}` | Final transcript for the turn |
-| `error` | `error.type: server_error`, `error.message: Meta Muse realtime transcription failed` | Muse reported a failure |
+| `conversation.item.input_audio_transcription.completed` | `item_id`, `content_index: 0`, `transcript`, and `usage: {"type": "duration", "seconds": 1.36}` when Muse reported newly processed audio since the previous `completed` | Final transcript for the turn |
+| `error` | `error.type: server_error` with `error.message` either `Meta Muse realtime transcription failed` or, before a non-1000 close, `upstream websocket closed with code <N>: <reason>` | Muse reported a failure or closed abnormally |
 
-Overlapping turns are emitted independently as their frames arrive, correlated by `item_id`. When Muse has no more segments the proxy closes the socket with code `1000` and reason `No more transcript segments`.
+Overlapping turns are emitted independently as their frames arrive, correlated by `item_id`. When Muse has no more segments it closes the session with code `1000` and the proxy relays that close, normally with Meta's reason `No more transcript segments`.
 
 ### Pricing and usage
 
-`meta/muse-voice-transcribe-1.0` is priced per second of input audio (`input_cost_per_second` in the model cost map). Each `completed` event carries the billed duration of its turn in `usage.seconds`, and audio Muse consumed after the last turn, such as trailing silence, is billed when the session closes so the spend log matches what Meta charged. LiteLLM's debug log never contains transcript text or raw Muse frames.
+`meta/muse-voice-transcribe-1.0` is priced per second of input audio (`input_cost_per_second` in the model cost map). `usage.seconds` on a `completed` event is the audio Muse processed since the last billed point, silence included, so it can exceed the length of the utterance. Audio processed after the last `completed` event, such as trailing silence, is billed when the session closes so the spend log matches what Meta charged. The proxy log does not contain transcript text, apart from the first 80 characters of a guardrail-blocked transcript at warning level; transcripts are stored in the spend log's messages unless message logging is turned off.
 
 ### Guardrails
 
-Guardrails with `mode: realtime_input_transcription` run on every completed transcript; see [Realtime Guardrails](/docs/proxy/guardrails/realtime_guardrails). A blocked transcript produces an `error` event with `type: guardrail_violation` and `code: content_policy_violation`, and `on_violation: end_session` then closes the socket with code `1000`.
+Guardrails with `mode: realtime_input_transcription` run on every completed transcript; see [Realtime Guardrails](/docs/proxy/guardrails/realtime_guardrails). The `completed` event reaches the client before the guardrail runs and partial deltas are not checked. A block then produces an `error` event with `type: guardrail_violation` and `code: content_policy_violation`, and `on_violation: end_session` closes the socket with code `1000`. Guardrails can also be selected per connection with a `guardrails=name1,name2` query parameter.
 
 :::warning
 When a `realtime_input_transcription` guardrail is configured, LiteLLM's shared realtime guardrail code rewrites a client's `turn_detection: null` into `{"create_response": false}` before Muse sees it. That runs push to talk clients in server VAD mode: `input_audio_buffer.commit` no longer ends the Muse stream, and a client that stops streaming after it is disconnected with close code `1008`. Server VAD clients are unaffected.
@@ -181,7 +181,8 @@ async def main():
                 if event["type"] == "conversation.item.input_audio_transcription.delta":
                     print(event["delta"], end="", flush=True)
                 elif event["type"] == "conversation.item.input_audio_transcription.completed":
-                    print(f"\n{event['transcript']} ({event['usage']['seconds']} s)")
+                    seconds = event.get("usage", {}).get("seconds")  # absent when Muse reported no new audio
+                    print(f"\n{event['transcript']} ({seconds} s)")
         except websockets.exceptions.ConnectionClosedOK:
             pass  # close code 1000: no more transcript segments
 

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -14,11 +14,10 @@ import TabItem from '@theme/TabItem';
 ## Required Variables
 
 ```python showLineNumbers title="Environment Variables"
-os.environ["META_API_KEY"] = ""   # chat and responses; realtime fallback
-os.environ["MODEL_API_KEY"] = ""  # preferred for Muse Voice realtime
+os.environ["META_API_KEY"] = ""  # your Meta Model API key
 ```
 
-Requests go to `https://api.meta.ai/v1` by default. Set `META_API_BASE` to override the API base. Muse Voice realtime uses `MODEL_API_KEY` first and falls back to `META_API_KEY`.
+Chat, Responses and Messages requests go to `https://api.meta.ai/v1` by default; set `META_API_BASE` to override that base. Muse Voice realtime uses the same `META_API_KEY` and connects to `wss://api.meta.ai/v1/asr/realtime`; see [Muse Voice Realtime Transcription](#muse-voice-realtime-transcription) for how to point it elsewhere.
 
 ## Supported Models
 
@@ -33,19 +32,171 @@ We actively maintain the list of models, pricing, token window, etc. [here](http
 
 `muse-spark-1.1` supports function calling, parallel function calling, structured outputs, prompt caching, web search grounding, and reasoning via `reasoning_effort` (`"minimal"` through `"xhigh"`).
 
+`muse-voice-transcribe-1.0` is a realtime speech-to-text model served over the proxy's `/v1/realtime` WebSocket and billed per second of audio. It is realtime only: `/v1/audio/transcriptions` and other batch or file transcription endpoints are not supported.
+
 The API also natively exposes the Anthropic Messages format, so LiteLLM forwards `/v1/messages` requests to `https://api.meta.ai/v1/messages` untranslated, preserving Anthropic-only features like thinking blocks.
 
 ## Muse Voice Realtime Transcription
 
-Connect to the LiteLLM proxy with:
+LiteLLM serves Muse Voice through the proxy's OpenAI-compatible `/v1/realtime` endpoint. You speak the OpenAI Realtime transcription protocol to the proxy; LiteLLM opens a session to `wss://api.meta.ai/v1/asr/realtime`, streams your PCM16 audio to Muse as binary frames, and turns Muse's transcript frames back into OpenAI transcription events. Any WebSocket client works, and the [Python example](#example-python-client) below is a complete push to talk session.
 
-```text
-ws://localhost:4000/v1/realtime?model=meta/muse-voice-transcribe-1.0&intent=transcription
+### 1. Add the model to your config
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: muse-voice-transcribe
+    litellm_params:
+      model: meta/muse-voice-transcribe-1.0
+      api_key: os.environ/META_API_KEY
 ```
 
-Send an OpenAI-compatible `session.update`, followed by `input_audio_buffer.append` events containing base64-encoded mono PCM16 audio. Muse Voice accepts 16 kHz and 24 kHz input. LiteLLM returns OpenAI-compatible speech boundary, transcription delta, completed transcript, and duration usage events.
+`api_key` is the only required credential. `api_base` is optional and must be an absolute `wss://` or `https://` URL: LiteLLM keeps its host and port, replaces the path with `/v1/asr/realtime`, and rejects `http://`, `ws://`, embedded credentials and URL fragments. `META_API_BASE` is not consulted for realtime sessions.
 
-Muse Voice is realtime-only. Batch or file transcription endpoints are not supported.
+```bash showLineNumbers title="Start LiteLLM Proxy"
+litellm --config config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+### 2. Connect
+
+```text
+ws://localhost:4000/v1/realtime?model=muse-voice-transcribe&intent=transcription
+```
+
+Send your proxy key as `Authorization: Bearer <key>`. `model` is the `model_name` from your config, and `intent=transcription` marks the session as transcription-only and pins any model named in a later `session.update` to the one you were authorized for. LiteLLM emits a `session.created` event with `object: realtime.transcription_session` as soon as the socket opens, before the Muse handshake, so clients that wait for it do not stall.
+
+### 3. Configure the session
+
+Send one `session.update` (or `transcription_session.update`). Muse's own handshake acknowledgement is relayed as `session.updated`; any further `session.update` is ignored for the rest of the session. The GA layout below is recommended. The beta layout (`input_audio_format: "pcm16"` plus `input_audio_transcription`) is also accepted at 24 kHz, but one update cannot mix the two layouts.
+
+```json showLineNumbers title="session.update"
+{
+  "type": "session.update",
+  "session": {
+    "type": "transcription",
+    "audio": {
+      "input": {
+        "format": {"type": "audio/pcm", "rate": 24000, "channels": 1},
+        "transcription": {"model": "meta/muse-voice-transcribe-1.0", "language": "en"},
+        "turn_detection": null
+      }
+    }
+  }
+}
+```
+
+`format.type` must be `audio/pcm`, `rate` must be `16000` or `24000`, and `channels` must be `1`; when `format` is omitted LiteLLM assumes mono 24 kHz. `transcription.model` is optional; the proxy rewrites it to the model you connected with, so any other value is overwritten rather than honored. `transcription.language` is optional and biases recognition toward one language, given as a name or an ISO 639 code; a region suffix is ignored, so `en-US`, `zh-Hans` and `pt-BR` all work. Muse Voice supports Arabic, Bengali, Dutch, English, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Mandarin Chinese, Marathi, Polish, Portuguese, Spanish, Tagalog, Tamil, Telugu, Thai, Turkish and Vietnamese. Any other transcription setting, such as `prompt`, is dropped with a warning in the proxy log.
+
+`turn_detection` selects the mode. LiteLLM rejects every `turn_detection.type` other than `server_vad`.
+
+| | Push to talk | Server VAD |
+| --- | --- | --- |
+| `turn_detection` | `null` | omitted, or `{"type": "server_vad"}` |
+| Turn boundaries | One turn per session; you decide when it ends | Muse detects utterances; each gets its own `item_id` |
+| Ending the turn | `input_audio_buffer.commit` flushes buffered audio and ends the Muse stream | `input_audio_buffer.commit` only flushes; send `input_audio_buffer.end` when you are done |
+
+An invalid `session.update` (unsupported rate, channel count, turn detection type or language) is rejected and the connection is dropped; the reason is written to the proxy debug log.
+
+### 4. Stream audio
+
+Send `input_audio_buffer.append` events whose `audio` field is base64 mono PCM16 at the configured rate. Each append may carry at most four seconds of audio; LiteLLM repackets the stream into 80 ms binary frames and paces them to Muse at real time. `input_audio_buffer.clear` drops any partial frame LiteLLM is still holding; audio already forwarded to Muse cannot be recalled. Every other client event, including `response.create`, is dropped because the session is transcription-only.
+
+In server VAD mode Muse expects audio to keep arriving at real time. Stream silence during pauses and send `input_audio_buffer.end` when you are finished; when a client simply stops sending, Meta closes the upstream socket with code `1008` (`Ingress below real-time`) and the proxy relays that as an `error` event followed by a `1008` close.
+
+### 5. Read transcripts
+
+| Event | Fields | When |
+| --- | --- | --- |
+| `session.created` | `session.object: realtime.transcription_session` | On connect, before the Muse handshake |
+| `session.updated` | Configured `audio.input.format`, `transcription` and `turn_detection` | After Muse accepts your `session.update` |
+| `input_audio_buffer.speech_started` | `item_id` | Muse detects the start of a turn |
+| `conversation.item.input_audio_transcription.delta` | `item_id`, `content_index: 0`, `delta` | Partial transcript text |
+| `input_audio_buffer.speech_stopped` | `item_id` | Muse detects the end of a turn |
+| `conversation.item.input_audio_transcription.completed` | `item_id`, `transcript`, `usage: {"type": "duration", "seconds": 1.36}` | Final transcript for the turn |
+| `error` | `error.type: server_error`, `error.message: Meta Muse realtime transcription failed` | Muse reported a failure |
+
+Overlapping turns are emitted independently as their frames arrive, correlated by `item_id`. When Muse has no more segments the proxy closes the socket with code `1000` and reason `No more transcript segments`.
+
+### Pricing and usage
+
+`meta/muse-voice-transcribe-1.0` is priced per second of input audio (`input_cost_per_second` in the model cost map). Each `completed` event carries the billed duration of its turn in `usage.seconds`, and audio Muse consumed after the last turn, such as trailing silence, is billed when the session closes so the spend log matches what Meta charged. LiteLLM's debug log never contains transcript text or raw Muse frames.
+
+### Guardrails
+
+Guardrails with `mode: realtime_input_transcription` run on every completed transcript; see [Realtime Guardrails](/docs/proxy/guardrails/realtime_guardrails). A blocked transcript produces an `error` event with `type: guardrail_violation` and `code: content_policy_violation`, and `on_violation: end_session` then closes the socket with code `1000`.
+
+:::warning
+When a `realtime_input_transcription` guardrail is configured, LiteLLM's shared realtime guardrail code rewrites a client's `turn_detection: null` into `{"create_response": false}` before Muse sees it. That runs push to talk clients in server VAD mode: `input_audio_buffer.commit` no longer ends the Muse stream, and a client that stops streaming after it is disconnected with close code `1008`. Server VAD clients are unaffected.
+:::
+
+### Example Python client
+
+Push to talk session: configure, stream a mono PCM16 WAV file in 100 ms chunks, commit, then read events until the proxy closes the socket.
+
+```python showLineNumbers title="Muse Voice push to talk client"
+import asyncio
+import base64
+import json
+import wave
+
+import websockets
+
+URL = "ws://localhost:4000/v1/realtime?model=muse-voice-transcribe&intent=transcription"
+HEADERS = {"Authorization": "Bearer sk-1234"}  # your proxy API key
+
+
+def pcm_chunks(path, chunk_ms=100):
+    with wave.open(path) as w:  # mono PCM16 at 16 kHz or 24 kHz
+        rate, frames = w.getframerate(), w.readframes(w.getnframes())
+    step = rate * 2 * chunk_ms // 1000
+    return rate, [frames[i : i + step] for i in range(0, len(frames), step)]
+
+
+async def main():
+    rate, chunks = pcm_chunks("question.wav")
+    async with websockets.connect(URL, additional_headers=HEADERS) as ws:
+        print(json.loads(await ws.recv())["type"])  # session.created
+        await ws.send(json.dumps({
+            "type": "session.update",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": rate},
+                        "transcription": {"model": "meta/muse-voice-transcribe-1.0"},
+                        "turn_detection": None,
+                    }
+                },
+            },
+        }))
+        print(json.loads(await ws.recv())["type"])  # session.updated
+        for chunk in chunks:
+            await ws.send(json.dumps({"type": "input_audio_buffer.append", "audio": base64.b64encode(chunk).decode()}))
+            await asyncio.sleep(0.1)
+        await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+        try:
+            while True:
+                event = json.loads(await ws.recv())
+                if event["type"] == "conversation.item.input_audio_transcription.delta":
+                    print(event["delta"], end="", flush=True)
+                elif event["type"] == "conversation.item.input_audio_transcription.completed":
+                    print(f"\n{event['transcript']} ({event['usage']['seconds']} s)")
+        except websockets.exceptions.ConnectionClosedOK:
+            pass  # close code 1000: no more transcript segments
+
+
+asyncio.run(main())
+```
+
+```text
+session.created
+session.updated
+What is the weather in Paris?
+What is the weather in Paris? (1.36 s)
+```
+
+For server VAD, send `"turn_detection": {"type": "server_vad"}` instead of `None`, keep streaming (silence included) for as long as the microphone is open, and finish with `{"type": "input_audio_buffer.end"}`. Each detected utterance arrives with its own `item_id`.
 
 ## Usage - LiteLLM Python SDK
 

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -12,6 +12,7 @@ Supported Providers:
 - Google AI Studio (Gemini)
 - Vertex AI
 - Bedrock
+- Meta Muse Voice, transcription only ([see full docs](/docs/providers/meta#muse-voice-realtime-transcription))
 
 ## Proxy Usage
 


### PR DESCRIPTION
## Summary

Documents Meta Muse Voice realtime transcription as shipped in BerriAI/litellm#39395.

`docs/providers/meta.md` now drops the `MODEL_API_KEY` story (the code reads only `META_API_KEY`, or `api_key` in `litellm_params`) and replaces the short Muse Voice blurb with a full section: proxy config, the `/v1/realtime?intent=transcription` connection URL, the GA `session.update` shape with the accepted `audio/pcm` rates and channel count, `language` handling and the supported language list, the push to talk versus server VAD mode table (`turn_detection: null` plus `input_audio_buffer.commit`, or `server_vad` plus `input_audio_buffer.end`), the `input_audio_buffer.append` limits and which client events are dropped, the emitted event table with `item_id` and `usage.seconds`, per second pricing and trailing duration billing on close, the `api_base` override rule, guardrail behaviour with the push to talk caveat, and a runnable Python `websockets` client.

`docs/realtime.md` lists Meta Muse Voice under Supported Providers.

The `session.update` rules are a field table and the longer paragraphs are split into short blocks, so the section reads as reference material rather than prose.

## Validation

`node scripts/check-writing-style.js docs blog release_notes` passes. `python3 scripts/check-docs.py docs` (from main, the branch predates the script) reports no findings for `docs/providers/meta.md` or `docs/realtime.md`. `npm run build` succeeds and the built page renders the `#muse-voice-realtime-transcription` anchor that `docs/realtime.md` links to.

The Python example was run unchanged (apart from port and WAV path) against a local proxy on the PR branch with a real Meta API key; it printed the exact output shown in the page and the proxy logged `response_cost: 6.8e-05` for the 1.36 s clip.

Every behavioural claim on the page was then checked line by line against the implementation (close codes, when `usage` is present on `completed`, the `intent=transcription` model rewrite, what the logs and spend log contain) and corrected where the first draft overstated it.

LiteLLM `tests/documentation_tests/test_env_keys.py` still finds `META_API_KEY` in the docs.
