### PR TITLE
docs(cursor): map Cursor's error texts to the proxy status behind them

### DIFF
--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -38,6 +38,8 @@ Enable **Override OpenAI Base URL** and enter your proxy URL with `/cursor`:
 https://your-litellm-proxy.com/cursor
 ```
 
+The proxy must be reachable from the internet: Cursor sends the requests from its own servers, not from your machine, with `User-Agent: Cursor/1.0`.
+
 ![](https://colony-recorder.s3.amazonaws.com/files/2025-12-13/6580de2b-3a59-45b2-b7b6-3ab105d87e74/ascreenshot.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA2JDELI43356LVVTC%2F20251213%2Fus-west-1%2Fs3%2Faws4_request&X-Amz-Date=20251213T224156Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=5a1af4ff63d38d51e06d398ed50f10161d690e3e57e9d67c1d23ce5b7ffdefd5)
 
 ### 2. Create Virtual Key
@@ -172,7 +174,8 @@ LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api
 | Issue | Solution |
 |-------|----------|
 | Model not responding | Check base URL ends with `/cursor` and key has model access |
-| Auth errors | Regenerate key; ensure it starts with `sk-` |
+| `Invalid API key` / `Unauthorized User API key` | Cursor shows this when the proxy answers 401. The API Key field must hold a LiteLLM virtual key (it starts with `sk-`); a placeholder value is rejected |
+| `User API Key Rate limit exceeded` | Cursor shows this for any 429 or 5xx from the proxy, so the cause is not always a rate limit. Look up those requests in the LiteLLM logs (they arrive with `User-Agent: Cursor/1.0`) for the real error. Frequent causes are rpm or tpm limits on the key, since each Cursor request carries a system prompt of about 25k tokens, and provider 429s |
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |
 | Cursor does not list your LiteLLM models | Upgrade to LiteLLM v1.97.0+, which serves `GET /cursor/models`. Earlier versions do not serve that route and answer 401 or 404. Verify with `curl <LITELLM_PROXY_BASE_URL>/cursor/models -H "Authorization: Bearer <LITELLM_VIRTUAL_KEY>"` |
 | `The model "X" is already available as "Y"` | Cursor blocks names that match its built-in models. Add the model under a distinct public model name (see the warning in step 3) |


### PR DESCRIPTION
## TLDR

Adds the error texts Cursor actually shows to the troubleshooting table, each mapped to the proxy status behind it, and notes in the base URL step that requests come from Cursor's servers with `User-Agent: Cursor/1.0`

## Why

A user saw "Rate limit exceeded" in Cursor after entering a placeholder API key and read it as a key problem. Verified on Cursor 3.18.25 against a LiteLLM proxy: Cursor renders a 401 as "Invalid API key" and any 429 or 5xx from the base URL as "User API Key Rate limit exceeded", so the table now says what each text stands for and where to look. The old "Auth errors" row named neither the text the user sees nor the cause

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Cursor integration guide; no runtime or security-sensitive code paths.
> 
> **Overview**
> Updates the **Cursor integration** tutorial so setup and troubleshooting match how Cursor actually talks to the LiteLLM proxy.
> 
> In the base URL step, it now states that the proxy must be **publicly reachable**, because Cursor calls it from **its servers** (not the IDE machine) with **`User-Agent: Cursor/1.0`**.
> 
> The troubleshooting table replaces the vague **Auth errors** row with Cursor’s real UI strings tied to proxy behavior: **`Invalid API key` / `Unauthorized User API key`** when the proxy returns **401** (need a real LiteLLM virtual key, not a placeholder), and **`User API Key Rate limit exceeded`** when the proxy returns **any 429 or 5xx**—with guidance to check LiteLLM logs for those requests and common causes (key rpm/tpm, ~25k-token system prompts, upstream 429s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f6c257d4ae7a599bbe251854c19d7365b159f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->