### PR TITLE
docs(skills): semantic search over the LiteLLM-hosted skill registry and the skill_search MCP tool

### DIFF
--- a/docs/mcp_tool_search.md
+++ b/docs/mcp_tool_search.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # MCP Tool Search
 
-Swap the full MCP catalog for a fixed set of virtual tools (`mcp_tool_search`, `mcp_tool_call`, `agent_search`) so a key with hundreds of tools available only ever exposes three on `tools/list`. The LLM searches by keyword, gets back the ranked matches, then calls the discovered tool by name. `agent_search` does the same for the [A2A agent registry](./a2a.md#search-the-registry), ranked by embeddings instead of keywords.
+Swap the full MCP catalog for a fixed set of virtual tools (`mcp_tool_search`, `mcp_tool_call`, `agent_search`, `skill_search`) so a key with hundreds of tools available only ever exposes four on `tools/list`. The LLM searches by keyword, gets back the ranked matches, then calls the discovered tool by name. `agent_search` does the same for the [A2A agent registry](./a2a.md#search-the-registry) and `skill_search` for the [LiteLLM-hosted skill registry](./skills.md#semantic-search-over-litellm-hosted-skills), both ranked by embeddings instead of keywords.
 
 :::info Related Documentation
 - [MCP Overview](./mcp.md)
@@ -30,7 +30,7 @@ curl -X POST http://localhost:4000/key/generate \
 ```console title="2. tools/list returns only the virtual tools" showLineNumbers
 $ curl -s http://localhost:4000/mcp-rest/tools/list \
     -H "Authorization: Bearer $KEY" | jq '[.tools[].name]'
-["mcp_tool_search", "mcp_tool_call", "agent_search"]
+["mcp_tool_search", "mcp_tool_call", "agent_search", "skill_search"]
 ```
 
 ```console title="3. Search discovers the real tools" showLineNumbers
@@ -67,7 +67,7 @@ async with streamablehttp_client(
 
         tools = await session.list_tools()
         print([t.name for t in tools.tools])
-        # ['mcp_tool_search', 'mcp_tool_call', 'agent_search']
+        # ['mcp_tool_search', 'mcp_tool_call', 'agent_search', 'skill_search']
 
         found = await session.call_tool("mcp_tool_search", {"query": "add numbers"})
         print(found.content[0].text)
@@ -97,11 +97,12 @@ The default is merged **after** the caller-scope validation runs, so it never tu
 
 ## How it works
 
-When `mcp_tool_search_enabled: true` is set on a key's `object_permission`, both the streamable-http endpoint (`/mcp/`) and the REST surface (`/mcp-rest/tools/list`) return exactly three tools regardless of how many MCP servers the key can reach:
+When `mcp_tool_search_enabled: true` is set on a key's `object_permission`, both the streamable-http endpoint (`/mcp/`) and the REST surface (`/mcp-rest/tools/list`) return exactly four tools regardless of how many MCP servers the key can reach:
 
 - `mcp_tool_search(query, top_k=5)` returns the ranked list of real tools that match the query.
 - `mcp_tool_call(tool_name, arguments)` executes one of the tools the LLM discovered through search.
 - `agent_search(query, top_k=5)` returns the A2A agents the key can reach, ranked by semantic similarity to the task described in `query`. It needs `litellm_settings.agent_search_embedding_model`; see [Search the registry](./a2a.md#search-the-registry).
+- `skill_search(query, top_k=5)` returns the LiteLLM-hosted skills (`custom_llm_provider=litellm_proxy`) the key can reach, ranked by semantic similarity. It needs `litellm_settings.skill_search_embedding_model`; see [Semantic Search over LiteLLM-Hosted Skills](./skills.md#semantic-search-over-litellm-hosted-skills).
 
 Both handlers run through the same filtered catalog and dispatch path as the normal `/tools/call` route, so search only surfaces tools the key is already allowed to see, and calls still resolve through `_get_allowed_mcp_servers` and `execute_mcp_tool`.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -496,7 +496,7 @@ Each result carries a `search_score` (cosine similarity to the query) and, unlik
 
 ### Authorization
 
-Search only ranks the skills the calling key can already access — the same visibility rules `GET /v1/skills` already enforces apply before ranking runs, so search cannot be used to enumerate skills outside a key's scope.
+Search only ranks the skills the calling key can already access: the same visibility rules `GET /v1/skills` already enforces apply before ranking runs, so search cannot be used to enumerate skills outside a key's scope.
 
 ## **Supported Providers**
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -448,7 +448,7 @@ This tells the API that `SKILL.md` belongs to the `test-skill` directory.
 `custom_llm_provider=litellm_proxy` skills (stored in the proxy's own database rather than proxied to Anthropic) support ranking by semantic similarity, so a caller can describe what they need instead of paging through the whole registry.
 
 :::info Related Documentation
-- [MCP Tool Search](./mcp_tool_search.md#search-the-skill-registry) for the `skill_search` MCP virtual tool
+- [MCP Tool Search](./mcp_tool_search.md#how-it-works) for the `skill_search` MCP virtual tool
 :::
 
 ### Enable it

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -443,9 +443,65 @@ This tells the API that `SKILL.md` belongs to the `test-skill` directory.
 ```
 
 
+## **Semantic Search over LiteLLM-Hosted Skills**
+
+`custom_llm_provider=litellm_proxy` skills (stored in the proxy's own database rather than proxied to Anthropic) support ranking by semantic similarity, so a caller can describe what they need instead of paging through the whole registry.
+
+:::info Related Documentation
+- [MCP Tool Search](./mcp_tool_search.md#search-the-skill-registry) for the `skill_search` MCP virtual tool
+:::
+
+### Enable it
+
+Set an embedding model in `litellm_settings`:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: text-embedding-3-small
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  skill_search_embedding_model: text-embedding-3-small
+```
+
+### Search over REST
+
+Pass `query` (and optionally `top_k`, default 5) to `GET /v1/skills`:
+
+```bash showLineNumbers title="search_skills.sh"
+curl "http://0.0.0.0:4000/v1/skills?custom_llm_provider=litellm_proxy&query=summarize+a+pdf&top_k=5" \
+  -H "Authorization: Bearer $LITELLM_KEY"
+```
+
+Each result carries a `search_score` (cosine similarity to the query) and, unlike a plain list, a populated `description` field:
+
+```json showLineNumbers
+{
+  "data": [
+    {
+      "id": "litellm_skill_...",
+      "display_title": "Document Summarizer",
+      "description": "Reads a PDF and produces a short summary",
+      "search_score": 0.71,
+      ...
+    }
+  ],
+  "has_more": false
+}
+```
+
+`query` is only supported for `custom_llm_provider=litellm_proxy`; passing it with any other provider returns a `400 skill_search_unsupported_provider`. If `skill_search_embedding_model` isn't set, the same request returns `400 skill_search_not_configured` naming the setting to add.
+
+### Authorization
+
+Search only ranks the skills the calling key can already access — the same visibility rules `GET /v1/skills` already enforces apply before ranking runs, so search cannot be used to enumerate skills outside a key's scope.
+
 ## **Supported Providers**
 
 | Provider | Link to Usage |
 |----------|---------------|
 | Anthropic | [Usage](#quick-start---create-a-skill) |
+| LiteLLM (self-hosted) | [Semantic Search](#semantic-search-over-litellm-hosted-skills) |
 


### PR DESCRIPTION
Documents the semantic search feature added over the LiteLLM-hosted skill registry (`custom_llm_provider=litellm_proxy`): the `GET /v1/skills?query=` REST contract and the `skill_search` MCP virtual tool, mirroring how `agent_search` is documented for the A2A registry.

Merge after https://github.com/BerriAI/litellm/pull/39401

## Linear ticket

Resolves LIT-6749
