### PR TITLE
docs(cursor): say the Cursor CLI cannot target LiteLLM and map its invalid-key warning

### DIFF
--- a/docs/pass_through/cursor.md
+++ b/docs/pass_through/cursor.md
@@ -11,7 +11,7 @@ Pass-through endpoints for the [Cursor Cloud Agents API](https://docs.cursor.com
 
 Just replace `https://api.cursor.com` with `LITELLM_PROXY_BASE_URL/cursor` 🚀
 
-This route fronts the Cloud Agents REST API only. The Cursor CLI (`agent --endpoint`) does not talk to `api.cursor.com` and cannot use it, see [Cursor CLI](../tutorials/cursor_integration.md#cursor-cli-cursor-agent).
+This route fronts the Cloud Agents REST API only. Cursor CLI agent sessions log in to `api2.cursor.sh` by default (`agent --endpoint` only moves that login), not to `api.cursor.com`, so they cannot use this route, see [Cursor CLI](../tutorials/cursor_integration.md#cursor-cli-cursor-agent).
 
 **Supported endpoints:**
 

--- a/docs/pass_through/cursor.md
+++ b/docs/pass_through/cursor.md
@@ -11,6 +11,8 @@ Pass-through endpoints for the [Cursor Cloud Agents API](https://docs.cursor.com
 
 Just replace `https://api.cursor.com` with `LITELLM_PROXY_BASE_URL/cursor` 🚀
 
+This route fronts the Cloud Agents REST API only. The Cursor CLI (`agent --endpoint`) does not talk to `api.cursor.com` and cannot use it, see [Cursor CLI](../tutorials/cursor_integration.md#cursor-cli-cursor-agent).
+
 **Supported endpoints:**
 
 | Endpoint | Method | Description |

--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -7,7 +7,7 @@ Route Cursor IDE requests through LiteLLM for unified logging, budget controls, 
 :::info
 **Supported modes:** Ask, Plan, Agent. With the base URL override, agent mode requires LiteLLM v1.97.0+, which translates the Responses API request shapes Cursor's agent sends to the chat completions path. Cursor gates custom API keys by mode and model on its side, so coverage follows what Cursor enables.
 
-Cursor does not officially support AI Gateways, our work here is best effort from reverse engineering their APIs.
+Cursor does not officially support AI Gateways, our work here is best effort from reverse engineering their APIs. The Cursor CLI (`agent` / `cursor-agent`) cannot target LiteLLM at all, see [Cursor CLI](#cursor-cli-cursor-agent).
 :::
 
 :::warning Override OpenAI Base URL missing?
@@ -169,11 +169,31 @@ For official instructions on configuring MCP integration with Cursor, please ref
 
 LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api.cursor.com` get the same credential management and logging. See [Cursor Cloud Agents](../pass_through/cursor.md).
 
+## Cursor CLI (cursor-agent)
+
+The Cursor CLI (`agent`, also installed as `cursor-agent`) cannot target LiteLLM, or any other gateway. Its `--endpoint` flag and `CURSOR_API_ENDPOINT` variable pick which Cursor backend the CLI logs in to, not an OpenAI-compatible API: on startup the CLI posts your key to `<endpoint>/auth/exchange_user_api_key` to trade it for Cursor session tokens, and every request after that is a Cursor-private RPC. Cursor does not document the flag and does not offer custom keys or endpoints in the CLI ([open feature request](https://forum.cursor.com/t/cursor-cli-custom-endpoint-and-api-key-support/129424)).
+
+Pointing the CLI at a proxy fails before any model is reached (verified on Cursor CLI 2026.08.31):
+
+```shell
+export CURSOR_API_KEY=<LITELLM_VIRTUAL_KEY>
+agent --endpoint https://your-litellm-proxy.com
+```
+
+```
+⚠ Warning: The provided API key is invalid.
+The API key was loaded from the CURSOR_API_KEY environment variable.
+Please check you have the right key, create a new one, or authenticate without it.
+```
+
+The CLI prints this warning for any answer other than Cursor session tokens, so a proxy without that route (LiteLLM answers 404 at the root and 401 under `/cursor`) looks exactly like a wrong Cursor key, and nothing on the proxy side can change the message. To route Cursor through LiteLLM use the Cursor IDE setup on this page; for a terminal agent that supports custom endpoints, see [Claude Code](./claude_responses_api.md), [Codex CLI](./openai_codex.md), [Gemini CLI](./litellm_gemini_cli.md), or [OpenCode](./opencode_integration.md).
+
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | Model not responding | Check base URL ends with `/cursor` and key has model access |
+| `The provided API key is invalid` from the Cursor CLI (`agent` / `cursor-agent`) | The Cursor CLI cannot use a gateway: `--endpoint` selects a Cursor backend, not an OpenAI-compatible API, so its login fails with this warning on any proxy. See [Cursor CLI](#cursor-cli-cursor-agent) |
 | `Invalid API key` / `Unauthorized User API key` | Cursor shows this when the proxy answers 401. The API Key field must hold a LiteLLM virtual key (it starts with `sk-`); a placeholder value is rejected |
 | `User API Key Rate limit exceeded` | Cursor shows this for any 429 or 5xx from the proxy, so the cause is not always a rate limit. Look up those requests in the LiteLLM logs (they arrive with `User-Agent: Cursor/1.0`) for the real error. Frequent causes are rpm or tpm limits on the key, since each Cursor request carries a system prompt of about 25k tokens, and provider 429s |
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |

--- a/docs/tutorials/cursor_integration.md
+++ b/docs/tutorials/cursor_integration.md
@@ -171,9 +171,9 @@ LiteLLM can also front the Cursor Cloud Agents API, so agents launched over `api
 
 ## Cursor CLI (cursor-agent)
 
-The Cursor CLI (`agent`, also installed as `cursor-agent`) cannot target LiteLLM, or any other gateway. Its `--endpoint` flag and `CURSOR_API_ENDPOINT` variable pick which Cursor backend the CLI logs in to, not an OpenAI-compatible API: on startup the CLI posts your key to `<endpoint>/auth/exchange_user_api_key` to trade it for Cursor session tokens, and every request after that is a Cursor-private RPC. Cursor does not document the flag and does not offer custom keys or endpoints in the CLI ([open feature request](https://forum.cursor.com/t/cursor-cli-custom-endpoint-and-api-key-support/129424)).
+The Cursor CLI (`agent`, also installed as `cursor-agent`) cannot target LiteLLM or any other gateway. Its `--endpoint` flag and `CURSOR_API_ENDPOINT` variable pick which Cursor backend the CLI logs in to, not an OpenAI-compatible API: on startup the CLI posts your key to `<endpoint>/auth/exchange_user_api_key` to trade it for Cursor session tokens, and every request after that is a Cursor-private RPC. Cursor does not document the flag and does not offer a custom endpoint or an OpenAI-compatible key in the CLI ([open feature request](https://forum.cursor.com/t/cursor-cli-custom-endpoint-and-api-key-support/129424)); its one bring-your-own-credentials option, `agent bedrock`, still routes through Cursor's backend.
 
-Pointing the CLI at a proxy fails before any model is reached (verified on Cursor CLI 2026.08.31):
+Pointing the CLI at a proxy fails before any model is reached (verified on the public Cursor CLI 2026.08.31 build):
 
 ```shell
 export CURSOR_API_KEY=<LITELLM_VIRTUAL_KEY>
@@ -186,14 +186,14 @@ The API key was loaded from the CURSOR_API_KEY environment variable.
 Please check you have the right key, create a new one, or authenticate without it.
 ```
 
-The CLI prints this warning for any answer other than Cursor session tokens, so a proxy without that route (LiteLLM answers 404 at the root and 401 under `/cursor`) looks exactly like a wrong Cursor key, and nothing on the proxy side can change the message. To route Cursor through LiteLLM use the Cursor IDE setup on this page; for a terminal agent that supports custom endpoints, see [Claude Code](./claude_responses_api.md), [Codex CLI](./openai_codex.md), [Gemini CLI](./litellm_gemini_cli.md), or [OpenCode](./opencode_integration.md).
+The CLI prints this warning for any answer below 500 that does not carry Cursor session tokens (a 5xx gets a fixed `Failed to reach the Cursor API` error instead), so a proxy without that route (LiteLLM answers 404 at the root and 401 under `/cursor`) looks exactly like a wrong Cursor key, and no text from the proxy ever reaches the screen. To route Cursor through LiteLLM use the Cursor IDE setup on this page; for a terminal agent that supports custom endpoints, see [Claude Code](./claude_responses_api.md), [Codex CLI](./openai_codex.md), [Gemini CLI](./litellm_gemini_cli.md), or [OpenCode](./opencode_integration.md).
 
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | Model not responding | Check base URL ends with `/cursor` and key has model access |
-| `The provided API key is invalid` from the Cursor CLI (`agent` / `cursor-agent`) | The Cursor CLI cannot use a gateway: `--endpoint` selects a Cursor backend, not an OpenAI-compatible API, so its login fails with this warning on any proxy. See [Cursor CLI](#cursor-cli-cursor-agent) |
+| `The provided API key is invalid` from the Cursor CLI (`agent` / `cursor-agent`) | The Cursor CLI cannot use a gateway: `--endpoint` selects a Cursor backend, not an OpenAI-compatible API, so its login fails with this warning on any proxy that lacks Cursor's auth route. See [Cursor CLI](#cursor-cli-cursor-agent) |
 | `Invalid API key` / `Unauthorized User API key` | Cursor shows this when the proxy answers 401. The API Key field must hold a LiteLLM virtual key (it starts with `sk-`); a placeholder value is rejected |
 | `User API Key Rate limit exceeded` | Cursor shows this for any 429 or 5xx from the proxy, so the cause is not always a rate limit. Look up those requests in the LiteLLM logs (they arrive with `User-Agent: Cursor/1.0`) for the real error. Frequent causes are rpm or tpm limits on the key, since each Cursor request carries a system prompt of about 25k tokens, and provider 429s |
 | Agent mode not working | Upgrade to LiteLLM v1.97.0+ and confirm the model supports custom API keys in Cursor |


### PR DESCRIPTION
## TLDR

Says on the Cursor integration page that the Cursor CLI (`agent` / `cursor-agent`) cannot target LiteLLM, why its `--endpoint` flag fails with `The provided API key is invalid`, and which paths do work (the Cursor IDE setup on that page, or a terminal agent that supports custom endpoints), plus a troubleshooting row for the warning and a note on the Cloud Agents passthrough page that `/cursor` fronts the Cloud Agents REST API only

## User Flow

Before: the flow fails at step 3, where the CLI rejects the LiteLLM key with a warning that nothing in the docs explains

1. The user opens https://docs.litellm.ai/docs/tutorials/cursor_integration to route Cursor through the gateway; the page covers the Cursor IDE only and never mentions the CLI
2. They create a virtual key in the LiteLLM dashboard and run `export CURSOR_API_KEY=<litellm-key>` then `agent --endpoint https://your-litellm-proxy.com`
3. The CLI sends `POST https://your-litellm-proxy.com/auth/exchange_user_api_key`, gets a 404, prints `⚠ Warning: The provided API key is invalid.` and exits before the TUI opens
4. They retry with `--endpoint https://your-litellm-proxy.com/cursor` (a 401 this time) and with `--api-key` instead of the env var: the same warning every time, so they open a support ticket

After: the flow ends at step 1, where the page tells them the CLI path is a dead end and what to use instead

1. The user opens https://docs.litellm.ai/docs/tutorials/cursor_integration; the info box at the top says the Cursor CLI cannot target LiteLLM and links to the new **Cursor CLI (cursor-agent)** section, which shows the exact warning the CLI prints, explains that `--endpoint` selects a Cursor backend rather than an OpenAI-compatible API, and points to the IDE setup or to Claude Code, Codex CLI, Gemini CLI, or OpenCode for a terminal agent
2. A user who already ran the CLI and searches the troubleshooting table for `The provided API key is invalid` finds a row mapping it to that section
3. A user reading https://docs.litellm.ai/docs/pass_through/cursor sees, under the endpoint table, that the `/cursor` route fronts the Cloud Agents REST API only and that the CLI cannot use it

## Why

A customer pointed the Cursor CLI at their LiteLLM gateway with `--endpoint` and got `The provided API key is invalid`, which reads as a key problem. Verified on Cursor CLI 2026.08.31 against a proxy at staging tip: the CLI trades the key for Cursor session tokens at `<endpoint>/auth/exchange_user_api_key` and speaks Cursor-private RPCs after that, so no gateway can serve it, and the CLI prints the same warning for a 404, a 401, or a wrong Cursor key. Cursor does not document `--endpoint` and has an open, unanswered feature request for custom endpoints in the CLI, so the docs now say so up front instead of letting users discover it by trial

## Linear ticket

Resolves LIT-6658

## Screenshots / Proof of Fix

QA at head `b7806044` (docs-only, both pages verified on a local Docusaurus dev server built from this branch)

Before (published docs today and the real CLI against a LiteLLM proxy at staging tip `2ade3e16a9`, 2 uvicorn workers, run interactively under tmux with a virtual key that serves `GET /v1/models` and a real `gpt-5.6` chat completion fine):

```
$ curl -sL https://docs.litellm.ai/docs/tutorials/cursor_integration | grep -o -i 'cursor-agent\|cursor cli\|--endpoint' | sort | uniq -c
(no output: the page never mentions the CLI)

$ export CURSOR_API_KEY=<LITELLM_VIRTUAL_KEY>
$ agent -e http://127.0.0.1:25546
⚠ Warning: The provided API key is invalid.
The API key was loaded from the CURSOR_API_KEY environment variable.
Please check you have the right key, create a new one, or authenticate without it.
  proxy access log: "POST /auth/exchange_user_api_key HTTP/1.1" 404 Not Found

$ agent -e http://127.0.0.1:25546/cursor
⚠ Warning: The provided API key is invalid.
The API key was loaded from the CURSOR_API_KEY environment variable.
Please check you have the right key, create a new one, or authenticate without it.
  proxy access log: "POST /cursor/auth/exchange_user_api_key HTTP/1.1" 401 Unauthorized

$ agent --api-key <LITELLM_VIRTUAL_KEY> --endpoint http://127.0.0.1:25546
⚠ Warning: The provided API key is invalid.
Please check you have the right key, create a new one, or authenticate without it.

$ agent        # control: same LiteLLM key against Cursor's default endpoint
⚠ Warning: The provided API key is invalid.
The API key was loaded from the CURSOR_API_KEY environment variable.
Please check you have the right key, create a new one, or authenticate without it.
```

After (this branch served by `docusaurus start`):

```
$ # http://127.0.0.1:28909/docs/tutorials/cursor_integration rendered in a browser, text read off the DOM

[info box at the top of the page, last sentence]
Cursor does not officially support AI Gateways, our work here is best effort from reverse engineering their APIs. The Cursor CLI (agent / cursor-agent) cannot target LiteLLM at all, see Cursor CLI.

[new section, anchor #cursor-cli-cursor-agent]
Cursor CLI (cursor-agent)
The Cursor CLI (agent, also installed as cursor-agent) cannot target LiteLLM or any other gateway. Its --endpoint flag and CURSOR_API_ENDPOINT variable pick which Cursor backend the CLI logs in to, not an OpenAI-compatible API: on startup the CLI posts your key to <endpoint>/auth/exchange_user_api_key to trade it for Cursor session tokens, and every request after that is a Cursor-private RPC. Cursor does not document the flag and does not offer a custom endpoint or an OpenAI-compatible key in the CLI (open feature request); its one bring-your-own-credentials option, agent bedrock, still routes through Cursor's backend.
Pointing the CLI at a proxy fails before any model is reached (verified on the public Cursor CLI 2026.08.31 build):
  export CURSOR_API_KEY=<LITELLM_VIRTUAL_KEY>
  agent --endpoint https://your-litellm-proxy.com
  ⚠ Warning: The provided API key is invalid.
  The API key was loaded from the CURSOR_API_KEY environment variable.
  Please check you have the right key, create a new one, or authenticate without it.
The CLI prints this warning for any answer below 500 that does not carry Cursor session tokens (a 5xx gets a fixed Failed to reach the Cursor API error instead), so a proxy without that route (LiteLLM answers 404 at the root and 401 under /cursor) looks exactly like a wrong Cursor key, and no text from the proxy ever reaches the screen. To route Cursor through LiteLLM use the Cursor IDE setup on this page; for a terminal agent that supports custom endpoints, see Claude Code, Codex CLI, Gemini CLI, or OpenCode.

[troubleshooting table, new row]
The provided API key is invalid from the Cursor CLI (agent / cursor-agent) | The Cursor CLI cannot use a gateway: --endpoint selects a Cursor backend, not an OpenAI-compatible API, so its login fails with this warning on any proxy that lacks Cursor's auth route. See Cursor CLI

[links in the new text, all resolve on this branch]
Cursor CLI -> #cursor-cli-cursor-agent
open feature request -> https://forum.cursor.com/t/cursor-cli-custom-endpoint-and-api-key-support/129424
Claude Code -> /docs/tutorials/claude_responses_api
Codex CLI -> /docs/tutorials/openai_codex
Gemini CLI -> /docs/tutorials/litellm_gemini_cli
OpenCode -> /docs/tutorials/opencode_integration

$ # http://127.0.0.1:28909/docs/pass_through/cursor rendered the same way, paragraph under the endpoint table
This route fronts the Cloud Agents REST API only. Cursor CLI agent sessions log in to api2.cursor.sh by default (agent --endpoint only moves that login), not to api.cursor.com, so they cannot use this route, see Cursor CLI.
Cursor CLI -> /docs/tutorials/cursor_integration#cursor-cli-cursor-agent
```

- The CLI itself behaves the same after this PR; the limit is on Cursor's side and the page now says so before the user tries it
- The warning text in the new section is the exact screen output of Cursor CLI 2026.08.31, captured from the tmux pane

## Caveats

The section is bound to Cursor CLI 2026.08.31: it quotes that build's warning text and names the `/auth/exchange_user_api_key` login route, so a CLI that rewords the warning or gains custom-endpoint support makes the section and the troubleshooting row stale. The version is named inline so a reader on a newer CLI can tell, and the linked forum thread is where that change would show up first

The "or any other gateway" claim comes from the CLI bundle (the login route plus Cursor-private RPCs afterwards), not from trying other gateways; a gateway that imitates Cursor's session-token exchange is out of scope for these docs
