### PR TITLE
docs(cli_sso): document the verification code pre-fill flag and point the classic login flow at --pkce

### DIFF
--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -63,6 +63,19 @@ lite whoami
 ```
 :::
 
+#### Pre-fill the verification code
+
+By default the browser page that finishes `lite login` asks you to type the verification code the terminal printed. To have `lite login` open that page with the code already filled in, so you only confirm it and click Continue, set on the proxy:
+
+```yaml
+general_settings:
+  allow_cli_sso_verification_uri_complete: true
+```
+
+The flag is off by default because typing the code by hand is what ties the browser page to the terminal that started the login. With the flag on, still check that the pre-filled code matches the one the terminal printed before you confirm it. Older `lite` versions open the page without the code either way, so upgrade the CLI as well
+
+If that browser is already signed in to your SSO provider and you would rather skip the code entirely, run `lite login --pkce` instead: one Approve click and the terminal prints `Login successful!`. See [Browser sign-in with PKCE](#browser-sign-in-with-pkce)
+
 #### Attribution metadata (OIDC claims)
 
 Map allowlisted OIDC claims into the LiteLLM user's `metadata` and return them to the CLI in `/sso/cli/poll` as `attribution_metadata`. Use this for stable attribution fields (for example employment type or cost center) without parsing large group lists in the client.
@@ -138,6 +151,8 @@ Example poll response (after SSO completes):
    ```
 
    This will open a browser window to authenticate. If you have connected LiteLLM Proxy to your SSO provider, you should be able to login with your SSO credentials. Once logged in, you can use the CLI to make requests to the LiteLLM Gateway.
+
+   The browser page asks for the verification code the terminal printed. To skip typing it, either have the proxy [pre-fill the verification code](#pre-fill-the-verification-code) or, when the browser already holds your SSO session, use [`lite login --pkce`](#browser-sign-in-with-pkce), which needs no code at all
 
    The credential goes into your OS keychain, and `lite login` prints where it landed. On a machine with no keychain it falls back to `~/.litellm/token.json` with owner-only permissions. See [the `lite login` credential](./management_cli.md#the-lite-login-credential) for the details and for how to turn keychain storage off
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -331,6 +331,7 @@ router_settings:
 | litellm_key_header_name | str | If set, allows passing LiteLLM keys as a custom header. [Doc on custom headers](./virtual_keys.md#pass-litellm-key-in-custom-header) |
 | moderation_model | str | The default model to use for moderation. |
 | custom_sso | str | Path to a python file that implements custom SSO logic. [Doc on custom SSO](./custom_sso.md) |
+| allow_cli_sso_verification_uri_complete | boolean | Default `false`. When `true`, `POST /sso/cli/start` also returns `verification_uri_complete`, and `lite login` opens the browser verification page with the code already filled in so the user only confirms it. Off by default so the code has to be typed by hand. [Doc on CLI SSO](./cli_sso.md#pre-fill-the-verification-code) |
 | allow_client_side_credentials | boolean | If true, allows passing client side credentials to the proxy. (Useful when testing finetuning models) [Doc on client side credentials](./virtual_keys.md) |
 | admin_only_routes | List[str] | (Enterprise Feature) List of routes that are only accessible to admin users. [Doc on admin only routes](/docs/proxy/public_routes#define-public-admin-only-and-allowed-routes) |
 | use_azure_key_vault | boolean | If true, load keys from azure key vault | 


### PR DESCRIPTION
## TLDR

`lite login` users who already have a browser SSO session still had to copy a verification code from the terminal into the browser, and nothing in the docs told them that `lite login --pkce` skips the code entirely or that the proxy can pre-fill it

This adds a "Pre-fill the verification code" section to the CLI SSO page (the `allow_cli_sso_verification_uri_complete` flag, why it is off by default, and the `--pkce` alternative for a browser that already holds the SSO session), points the classic Step 3 login flow at both options, and documents the flag in the `general_settings` table

## Pairs with

The CLI side that makes the flag reach `lite login` users is BerriAI/litellm#39428. It landed ahead of that PR: the page already tells older `lite` versions to upgrade, so nothing it says is wrong on an older CLI

## Linear ticket

Resolves LIT-6636

## Type

📖 Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth logic modifications.
> 
> **Overview**
> **Documents CLI SSO options** that reduce manual verification-code entry during `lite login`, which were previously easy to miss.
> 
> Adds a **Pre-fill the verification code** section on the CLI SSO page for `general_settings.allow_cli_sso_verification_uri_complete`: default-off behavior, the security tradeoff (manual typing ties browser to terminal), and a note to upgrade the CLI. It also points readers at **`lite login --pkce`** when the browser already has an SSO session.
> 
> Updates the **Step 3 login** walkthrough to link both shortcuts, and adds **`allow_cli_sso_verification_uri_complete`** to the `general_settings` reference table in `config_settings.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce61446ef56cab04852f088f63b54cd7ea2a9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
