### PR TITLE
docs: document LITELLM_HIDE_SSO_LOGIN_NOTICE env var

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -927,6 +927,7 @@ router_settings:
 | DIRECT_URL | Direct URL for service endpoint
 | DISABLE_ADMIN_UI | Toggle to disable the admin UI
 | LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT | Flag to hide the "Default Credentials" info card on the admin UI login page (`/ui/login` and `/fallback/login`). Useful when UI credentials are managed via `UI_USERNAME` / `UI_PASSWORD` or SSO and the hardcoded hint about `admin` + `MASTER_KEY` becomes misleading or is flagged by security scanners. **Default is false**
+| LITELLM_HIDE_SSO_LOGIN_NOTICE | Flag to hide the "Single Sign-On (SSO) is enabled" notice on the admin UI login page (`/ui/login`) that explains auto-redirect-to-SSO is opt-in. Can also be set via `general_settings.hide_sso_login_notice` in `config.yaml`. **Default is false**
 | LITELLM_ENABLE_HSTS | Flag to send the `Strict-Transport-Security` response header on proxy and UI responses. Only takes effect for deployments served over HTTPS. **Default is false**
 | DISABLE_AIOHTTP_TRANSPORT | Flag to disable aiohttp transport. When this is set to True, litellm will use httpx instead of aiohttp. **Default is False**
 | DISABLE_AIOHTTP_TRUST_ENV | Flag to disable aiohttp trust environment. When this is set to True, litellm will not trust the environment for aiohttp eg. `HTTP_PROXY` and `HTTPS_PROXY` environment variables will not be used when this is set to True. **Default is False**


### PR DESCRIPTION
Documents the new LITELLM_HIDE_SSO_LOGIN_NOTICE environment variable added in https://github.com/BerriAI/litellm/pull/39449, which hides the SSO-enabled notice on the admin UI login page.