### PR TITLE
docs(helm): document ingress.controller for the componentized chart

### DIFF
--- a/docs/proxy/deploy.md
+++ b/docs/proxy/deploy.md
@@ -175,7 +175,10 @@ redis:
 # one host fronting gateway, backend, and ui
 ingress:
   enabled: true
-  className: "<alb | gce | azure-application-gateway>"
+  className: "<alb | gce | azure-application-gateway | nginx>"
+  # alb (default) or nginx. ingress-nginx's admission webhook rejects the chart's
+  # dotted paths (/favicon.ico, /eu.assemblyai) unless this is nginx
+  controller: alb
   host: llm.example.com
   # optional: routes the chart does not ship a rule for, e.g. a passthrough
   # prefix added after this chart version or a custom


### PR DESCRIPTION
## TLDR

Adds the new `ingress.controller` value to the componentized chart's ingress example in the Helm deploy docs. It ships in BerriAI/litellm#39465: `alb` is the default and `nginx` renders the chart's dotted paths so ingress-nginx's admission webhook accepts them

## Linear ticket

Resolves LIT-6689

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the deploy guide; no runtime or configuration behavior is modified in this PR.
> 
> **Overview**
> Updates the **microservices (`litellm`) Helm** ingress snippet in the production deploy guide to match the componentized chart’s ingress options.
> 
> The example now lists **nginx** alongside ALB/GCE/Azure for `ingress.className`, and documents **`ingress.controller`** (default **`alb`**, or **`nginx`** when using ingress-nginx). The note explains that ingress-nginx’s admission webhook rejects the chart’s dotted paths (e.g. `/favicon.ico`, `/eu.assemblyai`) unless `controller` is set to `nginx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf9f7475646f9ee3029e37cbddb5c9b179ab57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->