### PR TITLE
blog: Auto Router tab on the blog listing

### DIFF
--- a/blog/fusion_terminal_bench_benchmark/index.md
+++ b/blog/fusion_terminal_bench_benchmark/index.md
@@ -7,7 +7,7 @@ authors:
 image: ./lite-fusion-light.png
 description: "LiteLLM Auto Router Fusion ran three models on the same task and synthesized their work, solving 14 of 21 Terminal-Bench tasks against 9 for Claude Fable-5 alone. Total spend rose 36%, cost per solved task fell 12%, and turn latency went up 5x."
 keywords: [model fusion, best of n, llm ensemble, terminal bench, llm benchmarks, model routing, litellm, agent benchmarks]
-tags: [routing, benchmarks, cost, engineering]
+tags: [routing, auto-router, benchmarks, cost, engineering]
 hide_table_of_contents: false
 ---
 

--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -6,6 +6,7 @@ import styles from './styles.module.css';
 
 const TABS = [
   {id: 'all', label: 'All'},
+  {id: 'autorouter', label: 'Auto Router'},
   {id: 'engineering', label: 'Engineering'},
   {id: 'ideas', label: 'Ideas'},
   {id: 'security', label: 'Security'},
@@ -15,6 +16,7 @@ const TABS = [
 const SECURITY_TAGS = ['security', 'incident-report'];
 const INFRA_TAGS = ['performance', 'reliability', 'infrastructure'];
 const IDEAS_TAGS = ['ideas', 'thesis'];
+const AUTOROUTER_TAGS = ['complexity-router', 'auto-router'];
 
 function hasTag(item, tagSet) {
   const tags = item.content?.metadata?.tags || [];
@@ -23,6 +25,7 @@ function hasTag(item, tagSet) {
 
 function filterItems(items, tab) {
   if (tab === 'all') return items;
+  if (tab === 'autorouter') return items.filter(i => hasTag(i, AUTOROUTER_TAGS));
   if (tab === 'security') return items.filter(i => hasTag(i, SECURITY_TAGS));
   if (tab === 'infrastructure') return items.filter(i => hasTag(i, INFRA_TAGS));
   if (tab === 'ideas') return items.filter(i => hasTag(i, IDEAS_TAGS));


### PR DESCRIPTION
## What this does

Adds an **Auto Router** filter tab to the blog listing at `/blog`, placed right after All. It shows every Auto Router post in one place: 13 posts today, from the v2 announcement through the Heuristic v2 and Fusion launches.

The tab filters on tags, the same way the Security, Ideas, and Performance tabs do. It matches `complexity-router` or `auto-router`. Every Auto Router post already carries `complexity-router`; the fusion benchmark post did not, so it gains `auto-router`. The Engineering tab is unchanged and still lists these posts.

Companion to #1154, which adds the Auto Router docs tab.

## Verification

`docusaurus build` passes. Verified locally that the tab lists all 13 router posts and the other tabs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDh6RDFY6Ji4wShb9zJm4E