### PR TITLE
docs(auto_router): say when session affinity is actually needed

### DIFF
--- a/docs/auto_router/prompt_caching.md
+++ b/docs/auto_router/prompt_caching.md
@@ -40,8 +40,11 @@ items={[
 
 ## When to pin anyway
 
-- `session_affinity` is **off by default**. The numbers above show it is not needed for the cache, and pinning forfeits the savings from routing later turns down a tier.
-- Turn it on when a tier switch would change behavior the client depends on, such as a long Claude Code session that should stay on one model.
+- `session_affinity` is **off by default**, and that is the right setting for most routers. The numbers above show it is not needed for the cache, and pinning forfeits the savings from routing later turns down a tier.
+- **Turn it on when a tier switch would change behavior the client depends on.** Two kinds of case:
+  - **Provider state in the history.** History produced by one model can fail on another: an Anthropic `thinking` block or `cache_control` marker replayed to a non-Anthropic tier, or tool-call formats that differ between providers. Pinning keeps the session on the model that produced the history.
+  - **Consistency the user can see.** Each model has its own style. A design workflow that generates layouts, shapes, or components over many turns keeps one look only if every turn comes from the same model; a writing assistant that should keep one voice is the same case.
+- **Single-family ladders rarely need it.** When every tier is the same provider (all Claude, all GPT), history replays cleanly and the cache measurements above apply. Leave it off and let follow-ups route down.
 - A tier with several deployments behind it also needs `deployment_affinity` and the `prompt_caching` pre-call check in `router_settings`, so continuing turns return to the deployment holding the cache.
 - Both together: [Coding agents with load balancing](/docs/auto_router/recommended_configurations#coding-agents-with-load-balancing).
 


### PR DESCRIPTION
Follow-up to #1154. The "When to pin anyway" section on the Prompt Caching page gave one example (a long Claude Code session). It now states the two cases that actually need `session_affinity`, and says outright that most routers should leave it off.

**Provider state in the history.** History produced by one model can fail on another: an Anthropic `thinking` block or `cache_control` marker replayed to a non-Anthropic tier, or tool-call formats that differ between providers. This is the hard case and matches the reasoning in the configuration reference.

**Consistency the user can see.** Each model has its own style, so a design workflow generating layouts or components over many turns, or a writing assistant keeping one voice, needs every turn from the same model.

**Single-family ladders rarely need it.** Same-provider tiers replay history cleanly and the cache measurements on the page already cover the caching objection.

`docusaurus build` passes with the strict link checks; writing-style lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDh6RDFY6Ji4wShb9zJm4E