### PR TITLE
docs(response_api): document allow_unmanaged_response_ids and the default 403

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -125,6 +125,7 @@ general_settings:
   disable_reset_budget: boolean  # turn off reset budget scheduled task
   disable_adding_master_key_hash_to_db: boolean  # turn off storing master key hash in db, for spend tracking
   disable_responses_id_security: boolean  # turn off response ID security checks that prevent users from accessing other users' responses
+  allow_unmanaged_response_ids: boolean  # let keys address response IDs this proxy never issued, e.g. raw provider IDs
   disable_auto_add_proxy_admin_to_teams: boolean  # if true, a proxy admin calling /team/new is no longer auto-added to the new team as team admin
   enforce_fallback_model_access: boolean  # if true, router_settings fallbacks only run when the calling key, team and project may call the fallback model
   enable_jwt_auth: boolean  # allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims
@@ -263,6 +264,7 @@ router_settings:
 | disable_reset_budget | boolean | If true, turns off reset budget scheduled task |
 | disable_adding_master_key_hash_to_db | boolean | If true, turns off storing master key hash in db |
 | disable_responses_id_security | boolean | If true, disables response ID security checks that prevent users from accessing response IDs from other users. When false (default), response IDs are encrypted with user information to ensure users can only access their own responses. Applies to /v1/responses endpoints |
+| allow_unmanaged_response_ids | boolean | If true, lets keys address response IDs this proxy never issued, such as raw provider IDs or IDs handed out before response ID encryption was on. When false (default), those IDs are refused with 403 because the proxy cannot tell who owns them. IDs the proxy did issue stay owner-checked either way. Applies to /v1/responses endpoints |
 | disable_auto_add_proxy_admin_to_teams | boolean | Default `false`. When a user calls `/team/new`, LiteLLM auto-adds that caller to the new team as a team admin. Set this to `true` so proxy admins are no longer auto-added; members you explicitly list in `members_with_roles` are still added, and non-admin callers (e.g. internal users) are still auto-added. Also toggleable from the Admin UI under **Settings > Router Settings > General Settings**. |
 | enforce_fallback_model_access | boolean | Default `false`. When `true`, a fallback configured in `router_settings` (`fallbacks`, `context_window_fallbacks`, `content_policy_fallbacks`, `default_fallbacks`) only runs if the calling key, its team and its project are allowed to call the fallback model; unauthorized targets are skipped and the primary model's error is returned when none remain. [More information here](reliability#enforce-key-model-access-on-fallbacks) |
 | enable_jwt_auth | boolean | allow proxy admin to auth in via jwt tokens with 'litellm_proxy_admin' in claims. [Doc on JWT Tokens](token_auth) |

--- a/docs/response_api.md
+++ b/docs/response_api.md
@@ -1076,6 +1076,28 @@ general_settings:
 
 This allows any user to access any response ID.
 
+### Response IDs this proxy did not issue
+
+The proxy can only tell who owns a response when it issued that response's ID itself. An ID in any other shape, a raw provider ID or one handed out before response ID encryption was on, carries no owner, so the proxy refuses it with 403 on retrieve, cancel, delete, input items, and on `previous_response_id`:
+
+```json
+{
+  "error": {
+    "message": "Forbidden. This response id was not issued by this proxy, so the proxy cannot tell who owns it.",
+    "code": 403
+  }
+}
+```
+
+Deployments that pass provider response IDs straight through on purpose, or that still have clients holding older IDs, turn the refusal off with `allow_unmanaged_response_ids`:
+
+```yaml
+general_settings:
+  allow_unmanaged_response_ids: true
+```
+
+IDs the proxy did issue stay owner-checked either way, and proxy admin keys are exempt from both checks. `disable_responses_id_security: true` turns off the whole feature, this refusal included.
+
 ## Supported Responses API Parameters
 
 | Provider | Supported Parameters |


### PR DESCRIPTION
Documents the response-id ownership behavior that ships with BerriAI/litellm#39548

A response ID the proxy never issued carries no owner, so the proxy now refuses it with 403 on retrieve, cancel, delete, input items, and on `previous_response_id`. Deployments that pass provider IDs straight through set `general_settings.allow_unmanaged_response_ids: true` to keep working. Only `disable_responses_id_security` was documented before, so the new setting and the new default both needed a home

Two places: a "Response IDs this proxy did not issue" subsection under Response ID Security in `docs/response_api.md`, and the yaml block plus the settings table in `docs/proxy/config_settings.md`

Docs-only, no code touched. `node scripts/check-writing-style.js docs blog release_notes` passes locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no code or configuration behavior changes in this PR.
> 
> **Overview**
> **Documents** the Responses API behavior where IDs the proxy never issued (raw provider IDs or pre-encryption IDs) are **rejected with 403** by default on retrieve, cancel, delete, input items, and `previous_response_id`.
> 
> Adds **`general_settings.allow_unmanaged_response_ids`** to the proxy config YAML sample and settings reference in `config_settings.md`, and a new **"Response IDs this proxy did not issue"** section in `response_api.md` with the error shape, opt-in YAML, and how this relates to **`disable_responses_id_security`** (proxy-issued IDs stay owner-checked; admin keys exempt).
> 
> Docs-only; no runtime changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6265903b6e3e46045d182e9e54c8d13714f9f28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->