### PR TITLE
docs(openai): add the day 0 post and provider row for gpt-6-astra

### DIFF
--- a/blog/gpt_6_astra/index.md
+++ b/blog/gpt_6_astra/index.md
@@ -1,0 +1,119 @@
+---
+slug: gpt_6_astra
+title: "Day 0 Support: GPT-6 Astra"
+date: 2026-09-03T11:00:00
+authors:
+  - mateo
+  - krrish
+  - ishaan-alt
+description: "Day 0 support for OpenAI's GPT-6 Astra on LiteLLM, with pricing, reasoning params, and the Responses API bridge."
+tags: [openai, gpt-6, gpt-6-astra, completion, day 0 support]
+hide_table_of_contents: false
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+LiteLLM now supports `gpt-6-astra`, OpenAI's next major model. Route traffic to it through the LiteLLM AI Gateway with the same config you use for every other OpenAI model.
+
+{/* truncate */}
+
+Astra is the first model on the GPT-6 name, and OpenAI's own [research post](https://openai.com/index/ten-advances-in-mathematics-and-theoretical-computer-science/) previewed it producing machine-checked proofs for ten open problems in mathematics and theoretical computer science. Through the API it behaves like the GPT-5 reasoning line: `max_completion_tokens` instead of `max_tokens`, `reasoning_effort` up to `xhigh`, no `temperature` while reasoning is on, prompt caching, and the long-context pricing tier above 272K input tokens.
+
+:::note
+**Cost tracking works on the version you already run.** Hit the **Reload Model Cost Map** button in the Admin UI (or `POST /reload/model_cost_map`) to pull the `gpt-6-astra` pricing from GitHub. This feature is available on `v1.76.0` and above.
+
+**Parameter handling needs the next release.** The GPT-5 reasoning classifier in LiteLLM matched `gpt-5*` names only, so on older versions a `gpt-6-astra` request keeps `max_tokens` and `temperature` as sent and OpenAI rejects them. The fix widening it to GPT-6 is on `main` now and ships in this Saturday's release candidate; until you upgrade, send `max_completion_tokens` yourself and leave `temperature` unset.
+:::
+
+## Usage
+
+<Tabs>
+<TabItem value="proxy" label="LiteLLM Proxy">
+
+**1. Setup config.yaml**
+
+```yaml
+model_list:
+  - model_name: gpt-6-astra
+    litellm_params:
+      model: openai/gpt-6-astra
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+**2. Start the proxy**
+
+```bash
+docker run -d \
+  -p 4000:4000 \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -v $(pwd)/config.yaml:/app/config.yaml \
+  ghcr.io/berriai/litellm:main-latest \
+  --config /app/config.yaml
+```
+
+**3. Test it**
+
+```bash
+curl -X POST "http://0.0.0.0:4000/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  -d '{
+    "model": "gpt-6-astra",
+    "messages": [
+      {"role": "user", "content": "Prove that there are infinitely many primes."}
+    ],
+    "reasoning_effort": "high"
+  }'
+```
+
+</TabItem>
+<TabItem value="sdk" label="LiteLLM Python SDK">
+
+```python
+from litellm import completion
+
+response = completion(
+    model="openai/gpt-6-astra",
+    messages=[
+        {"role": "user", "content": "Prove that there are infinitely many primes."}
+    ],
+    reasoning_effort="high",
+)
+
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+</Tabs>
+
+## Responses API
+
+For agentic and multi-turn workflows, use `/v1/responses` to preserve reasoning state across turns. A `litellm.completion()` call that combines function tools with active reasoning is bridged to `/v1/responses` automatically, the same way it is for GPT-5.4 and newer.
+
+```bash
+curl -X POST "http://0.0.0.0:4000/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  -d '{
+    "model": "gpt-6-astra",
+    "input": "Plan and write a Python script that scrapes a webpage and summarizes it.",
+    "reasoning": {"effort": "high"}
+  }'
+```
+
+## Pricing
+
+Prices are per 1M tokens (USD), shown as short context (≤272K tokens) / long context (>272K tokens).
+
+| Model | Input | Cached input | Cache write | Output |
+|-------|-------|--------------|-------------|--------|
+| `gpt-6-astra` | $10.00 / $20.00 | $1.00 / $2.00 | $12.50 / $25.00 | $50.00 / $75.00 |
+
+The `flex` service tier is billed at half the standard rate and `priority` at double, on both the short and long context tiers, and the Batch API is billed at half the standard input and output rate. Pass `service_tier` on the request and LiteLLM picks the matching rate.
+
+## Notes
+
+- `gpt-6-astra` supports `reasoning_effort` values `none`, `low`, `medium`, `high`, and `xhigh`; `minimal` is not accepted.
+- Availability is rolling out through the API; check your OpenAI account for model access.
+- See the [OpenAI provider docs](../../docs/providers/openai) for the full parameter reference.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -196,6 +196,7 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 | gpt-5.4-2026-03-05 | `response = completion(model="gpt-5.4-2026-03-05", messages=messages)` |
 | gpt-5.5 | `response = completion(model="gpt-5.5", messages=messages)` |
 | gpt-5.5-2026-04-23 | `response = completion(model="gpt-5.5-2026-04-23", messages=messages)` |
+| gpt-6-astra | `response = completion(model="gpt-6-astra", messages=messages)` |
 | gpt-5.2-pro | `response = completion(model="gpt-5.2-pro", messages=messages)` |
 | gpt-5.2-pro-2025-12-11 | `response = completion(model="gpt-5.2-pro-2025-12-11", messages=messages)` |
 | gpt-5.4-pro | `response = completion(model="gpt-5.4-pro", messages=messages)` |


### PR DESCRIPTION
## TLDR

Day 0 post for GPT-6 Astra plus its row in the OpenAI provider model table

- `blog/gpt_6_astra/index.md`: proxy and SDK quickstart, Responses API example, pricing table across the standard, flex, priority, and batch tiers, and the effort values the model accepts
- `docs/providers/openai.md`: `gpt-6-astra` row in the supported models table

Cost tracking works on any release via Reload Model Cost Map once the map is out; the parameter handling (`max_tokens` -> `max_completion_tokens`, dropping `temperature`) ships with https://github.com/BerriAI/litellm/pull/39607 in the next RC, and the post says so with the workaround

## Linear ticket

Resolves LIT-6741

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and blog content only; no runtime, auth, or API behavior changes in this diff.
> 
> **Overview**
> Adds **documentation-only** day 0 coverage for OpenAI **`gpt-6-astra`**: a new blog post and a single row in the OpenAI provider model table.
> 
> The blog post (`blog/gpt_6_astra/index.md`) explains gateway/SDK usage, `/v1/responses`, pricing (short/long context, flex/priority/batch), and supported `reasoning_effort` values. It also calls out **version split**: pricing via **Reload Model Cost Map** on v1.76.0+, while automatic `max_tokens` → `max_completion_tokens` and dropping `temperature` needs the upcoming release (fix on `main` / separate PR)—with a manual workaround until upgrade.
> 
> `docs/providers/openai.md` gains the **`gpt-6-astra`** completion example row alongside other GPT-5.x entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc60309d0bbe697f9c789744048f3ee93f2b105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->