### PR TITLE
docs(openai): document workload identity federation per deployment, credential, and env

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -175,6 +175,53 @@ os.environ["OPENAI_ORGANIZATION"] = "your-org-id"       # OPTIONAL
 os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 ```
 
+### Workload Identity Federation (no API key)
+
+Instead of a static `OPENAI_API_KEY`, the proxy can authenticate to OpenAI with workload identity federation: it reads an OIDC token from a file (for example a Kubernetes projected service account token), exchanges it for a short-lived OpenAI bearer token, and refreshes that token before it expires. This needs `openai>=2.32.0`.
+
+You need three values from the OpenAI platform: the identity provider id (`idp_...`), the service account id (`user-...`) the workload authenticates as, and the path of the token file inside the pod.
+
+<Tabs>
+<TabItem value="wif-env" label="Environment (proxy-wide default)">
+
+```bash
+export OPENAI_IDENTITY_PROVIDER_ID="idp_..."
+export OPENAI_SERVICE_ACCOUNT_ID="user-..."
+export OPENAI_IDENTITY_TOKEN_FILE="/var/run/secrets/tokens/openai"
+```
+
+Every `openai/` deployment that has no `api_key` then uses federation.
+
+</TabItem>
+<TabItem value="wif-config" label="config.yaml (per deployment)">
+
+```yaml
+model_list:
+  - model_name: gpt-5.6
+    litellm_params:
+      model: openai/gpt-5.6
+      openai_identity_provider_id: idp_...
+      openai_service_account_id: user-...
+      openai_identity_token_file: /var/run/secrets/tokens/openai
+```
+
+Values set on a deployment take precedence over the environment variables, so different deployments can federate as different service accounts.
+
+</TabItem>
+<TabItem value="wif-ui" label="Admin UI (credential)">
+
+1. Open Models + Endpoints, go to the Credentials tab and click Add Credential
+2. Pick OpenAI as the provider, then Workload Identity Federation (token file) as the authentication method
+3. Fill in the identity provider id, the service account id and the token file path, then save
+4. In Add Model, pick OpenAI, choose the model, and select the credential under Existing Credentials. The API key field disappears because the credential carries the federation settings
+
+</TabItem>
+</Tabs>
+
+A static key always wins: when the deployment, the credential, or `OPENAI_API_KEY` carries an API key, federation is not used. Federation also only applies when the API base is `https://api.openai.com` or a regional host such as `https://eu.api.openai.com`; a custom `api_base` pointing at another OpenAI-compatible server keeps using the key.
+
+Only proxy admins can set these fields on a deployment or a credential, since the token file path decides which workload identity the proxy exchanges. Chat completions, the Responses API, and embeddings use federation; image, audio, transcription, moderation, files, batches, fine-tuning, and assistants calls still read `OPENAI_API_KEY`.
+
 ### OpenAI Chat Completion Models
 
 | Model Name            | Function Call                                                   |

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1291,7 +1291,7 @@ router_settings:
 | OPENAI_API_KEY | API key for OpenAI services
 | OPENAI_CHATGPT_API_BASE | Alternative to CHATGPT_API_BASE. Base URL for ChatGPT API
 | OPENAI_FILE_SEARCH_COST_PER_1K_CALLS | Cost per 1000 calls for OpenAI file search. Default is 0.0025
-| OPENAI_IDENTITY_PROVIDER_ID | Identity provider ID (`idp_...`) for OpenAI workload identity federation. When this, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` are all set and no OpenAI API key is configured, the proxy authenticates `openai/` models by exchanging the OIDC token for a short-lived bearer (RFC 8693). Requires `openai>=2.32.0`
+| OPENAI_IDENTITY_PROVIDER_ID | Identity provider ID (`idp_...`) for OpenAI workload identity federation. When this, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` are all set and no OpenAI API key is configured, the proxy authenticates `openai/` models by exchanging the OIDC token for a short-lived bearer (RFC 8693). These env vars are the proxy-wide default; the same three values can be set per deployment or per credential as `openai_identity_provider_id`, `openai_service_account_id`, and `openai_identity_token_file`, which take precedence. See [OpenAI workload identity federation](../providers/openai#workload-identity-federation-no-api-key). Requires `openai>=2.32.0`
 | OPENAI_IDENTITY_TOKEN_FILE | Path to the OIDC subject token file used for OpenAI workload identity federation, e.g. the Kubernetes projected service account token path
 | OPENAI_ORGANIZATION | Organization identifier for OpenAI
 | OPENAI_SERVICE_ACCOUNT_ID | OpenAI platform service account ID (`user-...`) that workload identity federation authenticates as. Unrelated to LiteLLM virtual-key service accounts


### PR DESCRIPTION
## TLDR

Documents OpenAI workload identity federation (no API key) for the proxy: the env vars as the proxy-wide default, the per-deployment trio in config.yaml, and the Admin UI credential flow. Pairs with BerriAI/litellm#39613, which adds the per-credential and per-deployment fields plus the Add Model form selector, so this merges after that PR lands

## Changes

`docs/providers/openai.md` gains a "Workload Identity Federation (no API key)" section with the three setup routes and the rules that apply: a static key always wins, federation only targets `api.openai.com` and its regional hosts, only proxy admins can set the fields, and only chat completions, the Responses API, and embeddings federate today

The `OPENAI_IDENTITY_PROVIDER_ID` row in `docs/proxy/config_settings.md` now says the env vars are the default, names the per-deployment and per-credential field names that take precedence, and links to the new section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modified.
> 
> **Overview**
> Adds **OpenAI workload identity federation** documentation so proxy operators can authenticate without a static `OPENAI_API_KEY`.
> 
> **`docs/providers/openai.md`** introduces a **Workload Identity Federation (no API key)** section: OIDC token file exchange (requires `openai>=2.32.0`), three setup paths via tabs—proxy-wide env vars, per-deployment `litellm_params` (`openai_identity_provider_id`, `openai_service_account_id`, `openai_identity_token_file`), and Admin UI credential + Add Model flow—and operational rules (API key wins, federation only for official OpenAI API hosts, admin-only configuration, limited to chat completions / Responses / embeddings).
> 
> **`docs/proxy/config_settings.md`** expands the **`OPENAI_IDENTITY_PROVIDER_ID`** env var description to state env is the default, name the per-deployment/credential fields that override it, and link to the new OpenAI provider section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bef5c458f6e8556a5df73d509491ad822a6e7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->