### PR TITLE
docs(blog): correct the gpt-6-astra reasoning effort levels

### DIFF
--- a/blog/gpt_6_astra/index.md
+++ b/blog/gpt_6_astra/index.md
@@ -114,6 +114,6 @@ The `flex` service tier is billed at half the standard rate and `priority` at do
 
 ## Notes
 
-- `gpt-6-astra` supports `reasoning_effort` values `none`, `low`, `medium`, `high`, and `xhigh`; `minimal` is not accepted.
+- `gpt-6-astra` accepts `reasoning_effort` values `low`, `medium`, `high`, and `xhigh` on Chat Completions, plus `max` on the Responses API; `none` and `minimal` are rejected, so `temperature` cannot be used with it.
 - Availability is rolling out through the API; check your OpenAI account for model access.
 - See the [OpenAI provider docs](../../docs/providers/openai) for the full parameter reference.


### PR DESCRIPTION
## TLDR

Problem this solves:

- The gpt-6-astra launch post says `reasoning_effort: none` works on the model
- OpenAI rejects `none` and `minimal` on it, and accepts `max` only on the Responses API

How it solves it:

- Rewrites the Notes bullet with the levels verified against the live API

## Linear ticket

Resolves LIT-6741

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction in a blog post; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Notes** bullet in the GPT-6 Astra launch post so it matches the live OpenAI API instead of listing `none` as supported.
> 
> The note now states Chat Completions accepts **`low`**, **`medium`**, **`high`**, and **`xhigh`**, Responses API adds **`max`**, and **`none`** / **`minimal`** are rejected—with a reminder that **`temperature`** is not usable when reasoning is in play.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a361d0fcf76b32cd8dc3f80c0c78698dda4a2c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->