### PR TITLE
docs(auto_router): explain what context window a router reports

### DIFF
--- a/docs/auto_router/setup.md
+++ b/docs/auto_router/setup.md
@@ -82,4 +82,5 @@ model_list:
 
 - Claude Code populates its model picker from `/v1/models` and keeps only names containing `claude` or `anthropic`. Name the router accordingly, or set `ANTHROPIC_MODEL` directly.
 - On Claude for Teams or Enterprise, the exact router name must be on the organization allowlist. The check runs client-side, so a rejected router leaves nothing in gateway logs.
+- A router advertises no context window until you declare one in `model_info`, and Claude Code applies its own default regardless. Both sides: [context window](/docs/proxy/auto_routing#context-window).
 - Tutorial: [Auto Router with Claude Code and Claude Desktop](/docs/tutorials/claude_code_autorouter).

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -126,6 +126,16 @@ Every knob v2 exposes. All fields on `complexity_router_config` are optional exc
       # Marker pair whose blocks are stripped before classification
       reminder_markers: ["<system-reminder>", "</system-reminder>"]   # default
 
+      # Escalate a prompt that provably does not fit the decided tier, before dispatch
+      enable_context_window_escalation: true   # default
+      context_window_escalation_buffer: 0.95   # default; prompt must fit within this fraction of the window
+
+      # Send image-bearing requests to a tier that can see them
+      modality_routing: false   # default; set true to opt in
+
+      # Classify new user asks only, carrying the decision through continuation turns
+      classification_mode: every_request   # default; or user_turn
+
       # Thompson-sample within the tier's pool
       adaptive: true
 
@@ -528,6 +538,62 @@ writes = 0 if warm else cache_creation
         role: system
     complexity_router_config: {...}
 ```
+
+## Context window
+
+An auto router entry is a marker rather than a callable model, so it carries no provider metadata of its own and advertises no context window until you declare one. The number is not derived from the tier models: not the minimum across them, not the maximum, and not the window of `complexity_router_default_model`. Tiers hold model names the proxy resolves at request time, and nothing in the model-info path walks that list. Until you declare a window, `GET /v1/models` omits `max_input_tokens` and `max_output_tokens` for the router entirely, and `/model_group/info` reports `null` for both.
+
+Declare it in `model_info` on the router entry:
+
+```yaml title="config.yaml"
+- model_name: smart-router
+  litellm_params:
+    model: auto_router/complexity_router
+    complexity_router_config:
+      tiers:
+        SIMPLE:    gpt-4o-mini
+        REASONING: gpt-5.5
+    complexity_router_default_model: gpt-4o
+  model_info:
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+```
+
+Both values then appear on `/v1/models`, `/model/info`, and `/model_group/info`, which is what clients and the LiteLLM UI read. They are advisory. Nothing gates, escalates, or rejects a request against the window declared on the router entry, so pick a number that describes the router honestly to callers; the smallest window a request might land on is the conservative choice, and the largest is the optimistic one.
+
+Where a `model_name` fronts both a router marker and ordinary deployments, `/model_group/info` reports the largest `max_input_tokens` in that group rather than the smallest, since model-group metadata aggregates by maximum across deployments.
+
+:::info Cost fields read zero on a router entry
+
+`/model_group/info` reports `input_cost_per_token` and `output_cost_per_token` as `0.0` for an auto router, and its `providers` as an empty string, because custom pricing on a strategy alias is deliberately excluded from the cost map. Spend is still tracked against the tier model that served the request, so those zeros are a gap in this metadata view rather than untracked usage.
+
+:::
+
+### What enforces the window
+
+Routing resolves first. The router picks a tier, the marker drops out of the candidate pool, and everything after that is ordinary model-group behavior applied to the selected model: deployment selection, cooldowns, tag routing, and context-window pre-call checks against that deployment's own `max_input_tokens`. Enforcement therefore depends on `router_settings.enable_pre_call_checks: true` and on a window being declared or resolvable for the tier deployments, never on the router entry. See [Context Window Fallbacks](./reliability.md#context-window-fallbacks-pre-call-checks--fallbacks).
+
+`context_window_fallbacks` are resolved against the tier the router selected first and the name the client called second, so a chain keyed on either `smart-router` or the tier's own model group is honored.
+
+`auto_router_max_input_chars` is unrelated to any of this. It truncates the text handed to the embedding model that matches routes on a semantic router, and defaults to 2000 characters.
+
+### Context-window escalation
+
+From v1.101.0 the complexity router checks whether the decided tier can hold the prompt before dispatch and moves the request when it provably cannot. This is on by default.
+
+```yaml title="config.yaml"
+complexity_router_config:
+  enable_context_window_escalation: true   # default
+  context_window_escalation_buffer: 0.95   # default
+```
+
+The estimate covers the whole prompt footprint, including the top-level `system` block, Responses API `instructions`, and serialized tool definitions, which carry most of the payload on coding-agent traffic. A tier model qualifies when the count fits within `context_window_escalation_buffer` of its declared window, so the default keeps 5% of headroom instead of gambling on prompts that land near the limit. Where only some of the tier's models fit, the tier keeps the request and the pick narrows to those; where none fit, the request moves to the lowest higher tier holding a model that provably fits.
+
+Unknown windows are left alone in both directions. A model group with no resolvable window is never escalated away from, because its misfit cannot be proven, and never escalated onto, because its fit cannot be proven either. A group counts as unproven if even one of its deployments lacks a window, since the group is only as safe as its smallest member. When nothing anywhere provably fits, the classified tier stands and the request dispatches, so escalation never raises on its own and never diverts to `complexity_router_default_model`.
+
+The window escalation reads is `model_info.max_input_tokens` on each tier deployment, falling back to the model cost map. Declaring a window on the router entry has no effect here. Escalated decisions log `context_escalated` alongside the tier the classifier originally picked, and they are never session-pinned, so routing comes back down when the session does.
+
+Both keys belong inside `complexity_router_config`. Setting either one level up, directly under `litellm_params`, is rejected at load and on management-endpoint writes rather than silently ignored.
 
 ## Effort ladders
 

--- a/docs/tutorials/claude_code_autorouter.md
+++ b/docs/tutorials/claude_code_autorouter.md
@@ -64,6 +64,14 @@ To get the router into the `/model` picker rather than only into the startup mod
 
 For Claude Desktop, enter the proxy URL and virtual key under **Developer > Configure Third-Party Inference**, then pick the router in the model list. The [Claude Desktop integration guide](./claude_desktop_cowork.md) walks the dialog screen by screen.
 
+## Context window shown in the client
+
+The window LiteLLM advertises for the router and the window Claude Code works to are separate numbers, and the proxy cannot push its value into the client. Claude Code applies its own default for a model name it does not recognize as one of Anthropic's, which a gateway-served router name never is. Setting `max_input_tokens` in the router's `model_info` changes what `/v1/models` and the LiteLLM UI report without moving what the client displays or when it compacts, so a mismatch between the two is expected rather than a sign the router is misconfigured.
+
+Configure the client separately. `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, or `autoCompactWindow` in `.claude/settings.json`, sets the context window Claude Code targets before auto-compaction, and `autoCompactEnabled` turns compaction off. See Claude Code's [model configuration](https://code.claude.com/docs/en/model-config) reference.
+
+The same split applies to any harness pointed at a router: the number it shows comes from its own defaults for a name it does not know, so it has to be set in the harness. What the proxy enforces is unaffected either way, because [context-window checks and escalation](../proxy/auto_routing.md#context-window) run against the tier model the router actually picked rather than against the router name.
+
 ## Scope the virtual key to the router
 
 Give Claude clients a key scoped to the router alone.
@@ -86,6 +94,7 @@ Model discovery lists whatever the key can reach, and Claude Desktop's **Test co
 | Router never shows up in the picker even though `availableModels` lists it | Relying on discovery with a name that lacks `claude`/`anthropic`, so it never gets discovered in the first place | Rename it, or add it directly with `ANTHROPIC_CUSTOM_MODEL_OPTION` instead of depending on discovery |
 | Test connection fails naming a model you never selected | Key discovers models beyond the router and the probe picks one of them | Scope the virtual key to the router |
 | Router missing from `/v1/models` and the Models page after an edit | Older builds did not relink the in-memory router registry when a deployment was replaced | Restart the proxy to reload it from the database, and upgrade to a release containing [PR #34564](https://github.com/BerriAI/litellm/pull/34564) |
+| Context window in the client looks wrong for the router | Claude Code applies its own default for a model name it does not recognize; the proxy value is advisory | Set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` or `autoCompactWindow` on the client. `model_info.max_input_tokens` on the router changes only what `/v1/models` and the UI report |
 
 ## Related
 

--- a/docs/tutorials/claude_non_anthropic_models.md
+++ b/docs/tutorials/claude_non_anthropic_models.md
@@ -287,6 +287,12 @@ model_list:
 
 The Anthropic-shaped `GET /v1/models` response now returns `"display_name": "Kimi K3"` for that entry, so the picker lists **Kimi K3** (labeled From gateway) while every request keeps using the `kimi-k3-claude-compatible` id. Models without a `display_name` keep showing their id, and the OpenAI-shaped listing is unaffected; nothing gets duplicated in other harnesses.
 
+### 8. Context Window Reported for a Gateway Model
+
+Claude Code applies its own default context window to a model name it does not recognize as one of Anthropic's, and every gateway-served name falls into that category. Declaring `max_input_tokens` under a model's `model_info` changes what `GET /v1/models`, `/model/info`, and the LiteLLM UI report, and it drives the proxy's own [context-window pre-call checks](../proxy/reliability.md#context-window-fallbacks-pre-call-checks--fallbacks), but it does not change the figure the client shows or when the client compacts.
+
+Set that side in Claude Code with `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, or `autoCompactWindow` in `.claude/settings.json`; see [model configuration](https://code.claude.com/docs/en/model-config). A model whose real window is smaller than what the client assumes is the case worth checking, since the client will keep filling context the provider will then reject. Routers have the same split, covered in [Auto Router with Claude Code and Claude Desktop](./claude_code_autorouter.md#context-window-shown-in-the-client).
+
 ## How It Works
 
 LiteLLM acts as a unified interface that:


### PR DESCRIPTION
Closes LIT-6332. From Pylon #7940, where a customer running an Auto Router asked which context size a smart-router reports and whether it is the minimum across its models.

It is neither the minimum nor the maximum, and that was nowhere in the docs. An `auto_router/...` entry is a marker rather than a callable model, so it carries no provider metadata: `/v1/models` omits `max_input_tokens` and `max_output_tokens` entirely and `/model_group/info` returns `null` for both until an operator declares them in `model_info`. The tier models are never consulted, and neither is `complexity_router_default_model`.

The new `## Context window` section in the Auto Routing reference states that, shows how to declare a window, and is explicit that the declared value is advisory. Nothing gates, escalates, or rejects against the window on the router entry; enforcement happens after routing, against the selected tier deployment's own `max_input_tokens`, and needs `router_settings.enable_pre_call_checks: true`. It also covers how `context_window_fallbacks` resolve for a router, notes that `auto_router_max_input_chars` is an embedding-input limit rather than a context window, and flags that an auto router group reports `input_cost_per_token: 0.0` because alias pricing is excluded from the cost map, so nobody reads those zeros as untracked spend.

While in that file I added `enable_context_window_escalation` and `context_window_escalation_buffer` to the Full config block, which claims to list every knob v2 exposes and was missing both despite escalation being on by default from v1.101.0. `modality_routing` and `classification_mode` were missing from the same block and are now included. A subsection explains what escalation does: it estimates the whole prompt footprint including the system block, Responses API `instructions`, and serialized tool definitions, escalates only when a misfit is provable, leaves unknown windows alone in both directions, and never raises or diverts to the default model on its own.

The customer's follow-up was that Claude Code showed one number and another harness showed a different one regardless of the proxy. That is a separate mechanism and is now documented in the Claude Code auto router tutorial and in the non-Anthropic models tutorial: a harness applies its own default to a gateway model name it does not recognize, so `model_info.max_input_tokens` cannot move what the client displays or when it compacts, and the client side has to be set with `CLAUDE_CODE_AUTO_COMPACT_WINDOW` or `autoCompactWindow`. The rule is stated generally so it transfers to other harnesses.

One deliberate omission: the customer was told in Slack to use `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, which does not appear in Claude Code's published environment variable reference, so it is not in these docs. The documented `autoCompactWindow` controls are used instead, and no specific default figure is claimed since that behavior is undocumented.

`npm run build` passes, which matters here because the repo sets `onBrokenAnchors: 'throw'`; the new cross-page anchors were verified in the generated HTML.
