### PR TITLE
docs(proxy): off_peak_pricing reasoning and cache-creation rates

### DIFF
--- a/docs/proxy/off_peak_pricing.md
+++ b/docs/proxy/off_peak_pricing.md
@@ -47,7 +47,7 @@ model_info:
 
 ## How the rates apply
 
-An off-peak rate replaces the rate that would otherwise apply rather than discounting it. That includes tiered `above_{N}k` pricing: while a window is open, the flat off-peak rate bills the whole request. The block supports `input_cost_per_token`, `output_cost_per_token`, `output_cost_per_reasoning_token`, `cache_read_input_token_cost`, and `cache_creation_input_token_cost`; any of them left unset falls back to the standard rate. Reasoning tokens on a model with no dedicated reasoning rate follow the output rate, off-peak included, so `output_cost_per_reasoning_token` only matters where the provider prices reasoning separately. The one-hour cache creation rate (`cache_creation_input_token_cost_above_1hr`) is never affected.
+An off-peak rate replaces the rate that would otherwise apply rather than discounting it. That includes tiered `above_{N}k` pricing: while a window is open, the flat off-peak rate bills the whole request. The block supports `input_cost_per_token`, `output_cost_per_token`, `output_cost_per_reasoning_token`, `cache_read_input_token_cost`, and `cache_creation_input_token_cost`; any of them left unset falls back to the standard rate. When `output_cost_per_reasoning_token` is unset, reasoning tokens bill the way they do outside the window: at the model's dedicated reasoning rate if it has one, otherwise at the output rate, off-peak included. The one-hour cache creation rate (`cache_creation_input_token_cost_above_1hr`) is never affected.
 
 A request is priced by its completion time. A request that starts at the standard rate and finishes inside a window bills entirely at the off-peak rate, and one that crosses out of the window bills entirely at the standard rate.
 

--- a/docs/proxy/off_peak_pricing.md
+++ b/docs/proxy/off_peak_pricing.md
@@ -47,7 +47,7 @@ model_info:
 
 ## How the rates apply
 
-An off-peak rate replaces the rate that would otherwise apply rather than discounting it. That includes tiered `above_{N}k` pricing: while a window is open, the flat off-peak rate bills the whole request. The block supports `input_cost_per_token`, `output_cost_per_token`, and `cache_read_input_token_cost`; any of them left unset falls back to the standard rate, and cache creation rates are never affected.
+An off-peak rate replaces the rate that would otherwise apply rather than discounting it. That includes tiered `above_{N}k` pricing: while a window is open, the flat off-peak rate bills the whole request. The block supports `input_cost_per_token`, `output_cost_per_token`, `output_cost_per_reasoning_token`, `cache_read_input_token_cost`, and `cache_creation_input_token_cost`; any of them left unset falls back to the standard rate. Reasoning tokens on a model with no dedicated reasoning rate follow the output rate, off-peak included, so `output_cost_per_reasoning_token` only matters where the provider prices reasoning separately. The one-hour cache creation rate (`cache_creation_input_token_cost_above_1hr`) is never affected.
 
 A request is priced by its completion time. A request that starts at the standard rate and finishes inside a window bills entirely at the off-peak rate, and one that crosses out of the window bills entirely at the standard rate.
 


### PR DESCRIPTION
## TLDR

- `off_peak_pricing` now accepts `output_cost_per_reasoning_token` and `cache_creation_input_token_cost` (BerriAI/litellm#39635)
- The "How the rates apply" paragraph on docs/proxy/off_peak_pricing.md lists all five rate keys and their fallbacks
- The one-hour cache-creation rate is called out as never affected

## Linear ticket

Related to LIT-6887

## Caveats

### Low

- Lands with the code PR; until that ships, the two new keys are documented ahead of the release that carries them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime impact; the new keys may ship in a later release than this doc update.
> 
> **Overview**
> Updates the **How the rates apply** section in `off_peak_pricing` docs so it matches the expanded `off_peak_pricing` block from the related code change.
> 
> The supported rate keys are now listed as five fields, adding **`output_cost_per_reasoning_token`** and **`cache_creation_input_token_cost`**, with unset keys still falling back to standard rates. It also documents reasoning-token billing when the reasoning off-peak key is omitted (dedicated reasoning rate if defined, otherwise output rate, including off-peak output).
> 
> The doc no longer says all cache-creation pricing is excluded from off-peak; it specifies that only **`cache_creation_input_token_cost_above_1hr`** stays on the standard schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbcdd636be34a94dfd8c20a81ed9c1b82997e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->