### PR TITLE
docs: move master_key from litellm_settings to general_settings

### DIFF
--- a/blog/gemini_3/index.md
+++ b/blog/gemini_3/index.md
@@ -682,7 +682,7 @@ model_list:
       model: gemini/gemini-3-pro-preview
       api_key: os.environ/GEMINI_API_KEY
 
-litellm_settings:
+general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
 ```
 

--- a/docs/tutorials/claude_code_max_subscription.md
+++ b/docs/tutorials/claude_code_max_subscription.md
@@ -51,10 +51,8 @@ model_list:
       model: anthropic/claude-3-5-haiku-20241022
 
 general_settings:
-  forward_client_headers_to_llm_api: true  # Required: forwards OAuth token to Anthropic
-
-litellm_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
+  forward_client_headers_to_llm_api: true  # Required: forwards OAuth token to Anthropic
 ```
 
 :::info Why `forward_client_headers_to_llm_api`?
@@ -275,8 +273,10 @@ model_list:
     litellm_params:
       model: anthropic/claude-3-5-haiku-20241022
 
-litellm_settings:
+general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
   model_group_settings:
     forward_client_headers_to_llm_api:
       - anthropic-claude
@@ -294,11 +294,9 @@ model_list:
       model: anthropic/claude-sonnet-4-20250514
 
 general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
   forward_client_headers_to_llm_api: true
   database_url: "postgresql://..."
-
-litellm_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
 ```
 
 Then create virtual keys with budgets:

--- a/docs/tutorials/claude_non_anthropic_models.md
+++ b/docs/tutorials/claude_non_anthropic_models.md
@@ -335,11 +335,9 @@ router_settings:
 Track usage and set budgets through the LiteLLM UI:
 
 ```yaml
-litellm_settings:
+general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
   database_url: "postgresql://..."  # Enable database for tracking
-  
-general_settings:
   store_model_in_db: true
 ```
 

--- a/docs/tutorials/claude_responses_api.md
+++ b/docs/tutorials/claude_responses_api.md
@@ -53,7 +53,7 @@ model_list:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
 
-litellm_settings:
+general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
 ```
 
@@ -296,7 +296,7 @@ model_list:
       vertex_ai_location: "us-east5"
       vertex_credentials: os.environ/VERTEX_FILE_PATH_ENV_VAR # os.environ["VERTEX_FILE_PATH_ENV_VAR"] = "/path/to/service_account.json"
 
-litellm_settings:
+general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
 ```
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -724,7 +724,7 @@ model_list:
       api_key: os.environ/AZURE_API_KEY # runs os.getenv("AZURE_API_KEY")
       api_version: "2023-07-01-preview"
 
-litellm_settings:
+general_settings:
   master_key: sk-1234
   database_url: postgres://
 ```


### PR DESCRIPTION
## What

`master_key` is only read from `general_settings` (or the `LITELLM_MASTER_KEY` env var). Several config examples put it under `litellm_settings`, where the loader falls through to `setattr(litellm, "master_key", ...)` and nothing ever reads it. Anyone copying those blocks with a literal key gets a proxy that logs "LITELLM_MASTER_KEY is not set" and then accepts any key at all. The examples happen to work as written only because they use `os.environ/LITELLM_MASTER_KEY` and the env var is the fallback, which hides the mistake from the reader.

This moves `master_key` into `general_settings` in the five places it was misplaced. `docs/tutorials/claude_non_anthropic_models.md` and `src/pages/index.md` also had `database_url` in the wrong block, which has the same problem, so those move too. `model_group_settings` stays in `litellm_settings`, where it belongs.

A customer hit this on a real deployment and ended up running an unauthenticated proxy.

## Proof

Before, with `master_key` under `litellm_settings` and `LITELLM_MASTER_KEY` unset:

```
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4111/v1/messages \
    -H "content-type: application/json" \
    -H "x-api-key: sk-totally-bogus-not-the-master-key" \
    -d '{"model":"claude","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
{"type":"error","error":{"type":"invalid_request_error","message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API...\"}}"}}
HTTP 400
```

The bogus key was never checked; the request went to Anthropic and failed upstream on billing. Startup also logged:

```
LiteLLM Proxy:CRITICAL: proxy_server.py:5547 - LITELLM_MASTER_KEY is not set! All requests will be treated as INTERNAL_USER with no admin access.
```

After, with the corrected block from this PR:

```
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4112/v1/messages \
    -H "content-type: application/json" \
    -H "x-api-key: sk-totally-bogus-not-the-master-key" \
    -d '{"model":"claude","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"Authentication Error, Invalid proxy server token passed...","type":"token_not_found_in_db","param":"key","code":"401"}}
HTTP 401

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://127.0.0.1:4112/v1/messages \
    -H "content-type: application/json" \
    -H "x-api-key: sk-repro-8147-secret" \
    -d '{"model":"claude","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
HTTP 400
```

The bogus key is rejected at the door, the real master key passes auth and reaches Anthropic. No CRITICAL warning on startup

## Linear ticket

Resolves LIT-6932
