### PR TITLE
docs(proxy): document SENDGRID_REPLY_TO_EMAIL for SendGrid emails

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1432,6 +1432,7 @@ router_settings:
 | SENDGRID_API_KEY | API key for SendGrid email service
 | RESEND_API_KEY | API key for Resend email service
 | SENDGRID_SENDER_EMAIL | Email address used as the sender in SendGrid email transactions 
+| SENDGRID_REPLY_TO_EMAIL | Optional Reply-To address for SendGrid emails. When unset, replies go to the sender address
 | SPEND_LOGS_URL | URL for retrieving spend logs
 | SPEND_LOG_CLEANUP_BATCH_SIZE | Number of logs deleted per batch during cleanup. Default is 1000
 | STALE_OBJECT_CLEANUP_BATCH_SIZE | Max number of stale managed objects updated per cleanup cycle. Default is 1000

--- a/docs/proxy/email.md
+++ b/docs/proxy/email.md
@@ -72,6 +72,7 @@ set the following env variables
 ```shell showLineNumbers
 SENDGRID_API_KEY="SG.1234"
 SENDGRID_SENDER_EMAIL="notifications@your-domain.com"
+SENDGRID_REPLY_TO_EMAIL="support@your-domain.com" # optional: where replies go; defaults to the sender address
 ```
 
 ```yaml showLineNumbers title="proxy_config.yaml"


### PR DESCRIPTION
## TLDR

BerriAI/litellm#39734 adds an optional `SENDGRID_REPLY_TO_EMAIL` env var to the SendGrid email integration: when it is set, the notification emails the proxy sends (user invites, key created, budget alerts) carry it as their Reply-To, so recipients who hit reply no longer write to the no-reply sender. This documents it in the two places the SendGrid setup is described: the env block in the SendGrid tab of docs/proxy/email.md and the environment variables table in docs/proxy/config_settings.md

## Relevant issues

BerriAI/litellm#37578

## Linear ticket

Related to LIT-6943

## Caveats

### Low

- Held until BerriAI/litellm#39734 merges, so the site never documents a variable the proxy does not read yet; once both land, the variable is documented ahead of the release that carries it
