### PR TITLE
docs(proxy): clean up managed batches page

### DIFF
--- a/docs/proxy/managed_batches.md
+++ b/docs/proxy/managed_batches.md
@@ -2,27 +2,22 @@
 
 :::info
 
-This is a free LiteLLM Enterprise feature.
-
-Available via the `litellm[proxy]` package or any `litellm` docker image.
+Available with the `litellm[proxy]` package or any `litellm` docker image. No Enterprise license is required.
 
 :::
 
-
-| Feature | Description | Comments |
+| Feature | Supported | Comments |
 | --- | --- | --- |
 | Proxy | ✅ |  |
-| SDK | ❌ | Requires postgres DB for storing file ids |
+| SDK | ❌ | Requires a Postgres DB for storing file ids |
 | Available across all [Batch providers](../batches#supported-providers) | ✅ |  |
-
 
 ## Overview
 
 Use this to:
 
-- Loadbalance across multiple Azure Batch deployments
+- Load balance across multiple Azure Batch deployments
 - Control batch model access by key/user/team (same as chat completion models)
-
 
 ## (Proxy Admin) Usage
 
@@ -30,8 +25,8 @@ Here's how to give developers access to your Batch models.
 
 ### 1. Setup config.yaml
 
-- specify `mode: batch` for each model: Allows developers to know this is a batch model.
-- optionally skip pre-read of batch input files for specific batch providers/models (useful for large files on custom vLLM batch deployments).
+- Specify `mode: batch` for each model so developers can tell this is a batch model.
+- Optionally skip the pre-read of batch input files for specific batch providers or models (useful for large files on custom vLLM batch deployments).
 
 ```yaml showLineNumbers title="litellm_config.yaml"
 model_list:
@@ -40,15 +35,15 @@ model_list:
       model: azure/gpt-4o-mini-general-deployment
       api_base: os.environ/AZURE_API_BASE
       api_key: os.environ/AZURE_API_KEY
-    model_info: 
-      mode: batch # 👈 SPECIFY MODE AS BATCH, to tell user this is a batch model
+    model_info:
+      mode: batch # tells developers this is a batch model
   - model_name: "gpt-4o-batch"
     litellm_params:
       model: azure/gpt-4o-mini-special-deployment
       api_base: os.environ/AZURE_API_BASE_2
       api_key: os.environ/AZURE_API_KEY_2
-    model_info: 
-      mode: batch # 👈 SPECIFY MODE AS BATCH, to tell user this is a batch model
+    model_info:
+      mode: batch # tells developers this is a batch model
 
 general_settings:
   # Optional: do not charge batch input files against TPM/RPM
@@ -61,7 +56,6 @@ general_settings:
 litellm_settings:
   # Optional: require target_model_names on POST /v1/files (blocks classic file uploads)
   # require_managed_files: true
-
 ```
 
 By default, LiteLLM reads each batch input file before submission and charges its tokens and record count against the caller's TPM and RPM limits. This can add latency for large files. Use the settings above only when batch submissions do not need to be included in TPM or RPM accounting. To govern batch submissions by outstanding batch work instead of per-minute windows, see [Enqueued-token limits](../batches#enqueued-token-limits). For details and limitations, see [How rate limiting works for the Batches API](../batches#how-rate-limiting-for-batches-api-works).
@@ -69,39 +63,34 @@ By default, LiteLLM reads each batch input file before submission and charges it
 ### 2. Create Virtual Key
 
 ```bash showLineNumbers title="create_virtual_key.sh"
-curl -L -X POST 'https://{PROXY_BASE_URL}/key/generate' \
+curl -L -X POST 'https://${PROXY_BASE_URL}/key/generate' \
 -H 'Authorization: Bearer ${PROXY_API_KEY}' \
 -H 'Content-Type: application/json' \
 -d '{"models": ["gpt-4o-batch"]}'
 ```
 
-
-You can now use the virtual key to access the batch models (See Developer flow).
+You can now use the virtual key to access the batch models (see [Developer Usage](#developer-usage)).
 
 ## (Developer) Usage
 
-Here's how to create a LiteLLM managed file and execute Batch CRUD operations with the file. 
+Here's how to create a LiteLLM managed file and execute Batch CRUD operations with the file.
 
-### 1. Create request.jsonl 
+### 1. Create request.jsonl
 
 - Check models available via `/model_group/info`
 - See all models with `mode: batch`
-- Set `model` in .jsonl to the model from `/model_group/info`
+- Set `model` in the .jsonl to the model from `/model_group/info`
 
 ```json showLineNumbers title="request.jsonl"
 {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-batch", "messages": [{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": "Hello world!"}],"max_tokens": 1000}}
 {"custom_id": "request-2", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-batch", "messages": [{"role": "system", "content": "You are an unhelpful assistant."},{"role": "user", "content": "Hello world!"}],"max_tokens": 1000}}
 ```
 
-Expectation:
+LiteLLM translates the model name to the Azure deployment specific value (e.g. `gpt-4o-mini-general-deployment`).
 
-- LiteLLM translates this to the azure deployment specific value (e.g. `gpt-4o-mini-general-deployment`)
+### 2. Upload File
 
-### 2. Upload File 
-
-Specify `target_model_names: "<model-name>"` to enable LiteLLM managed files and request validation.
-
-model-name should be the same as the model-name in the request.jsonl
+Specify `target_model_names: "<model-name>"` to enable LiteLLM managed files and request validation. The model name must match the `model` in request.jsonl.
 
 ```python showLineNumbers title="create_batch.py"
 from openai import OpenAI
@@ -120,33 +109,30 @@ batch_input_file = client.files.create(
 print(batch_input_file)
 ```
 
+**Where is the file written?**
 
-**Where is the file written?**:
-
-All gpt-4o-batch deployments (gpt-4o-mini-general-deployment, gpt-4o-mini-special-deployment) will be written to. This enables loadbalancing across all gpt-4o-batch deployments in Step 3.
+All gpt-4o-batch deployments (gpt-4o-mini-general-deployment, gpt-4o-mini-special-deployment) will be written to. This enables load balancing across all gpt-4o-batch deployments in Step 3.
 
 ### 3. Create + Retrieve the batch
 
 ```python showLineNumbers title="create_batch.py"
 ...
 # Create batch
-batch = client.batches.create( 
+batch = client.batches.create(
     input_file_id=batch_input_file.id,
     endpoint="/v1/chat/completions",
     completion_window="24h",
     metadata={"description": "Test batch job"},
 )
 print(batch)
+batch_id = batch.id
 
 # Retrieve batch
-
-batch_response = client.batches.retrieve(
-    batch_id
-)
+batch_response = client.batches.retrieve(batch_id)
 status = batch_response.status
 ```
 
-### 4. Retrieve Batch Content 
+### 4. Retrieve Batch Content
 
 ```python showLineNumbers title="create_batch.py"
 ...
@@ -165,7 +151,7 @@ print(file_response.text)
 client.batches.list(limit=10, extra_query={"target_model_names": "gpt-4o-batch"})
 ```
 
-### [Coming Soon] Cancel a batch
+### 6. Cancel a batch
 
 ```python showLineNumbers title="create_batch.py"
 ...
@@ -173,33 +159,25 @@ client.batches.list(limit=10, extra_query={"target_model_names": "gpt-4o-batch"}
 client.batches.cancel(batch_id)
 ```
 
-
-
 ## E2E Example
 
 ```python showLineNumbers title="create_batch.py"
 import json
-from pathlib import Path
 from openai import OpenAI
 
 """
-litellm yaml: 
+litellm yaml:
 
 model_list:
     - model_name: gpt-4o-batch
       litellm_params:
         model: azure/gpt-4o-my-special-deployment
         api_key: ..
-        api_base: .. 
+        api_base: ..
 
 ---
-request.jsonl: 
-{
-    {
-        ...,
-        "body":{"model": "gpt-4o-batch", ...}}
-    }
-}
+request.jsonl:
+{"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-batch", ...}}
 """
 
 client = OpenAI(
@@ -213,11 +191,10 @@ batch_input_file = client.files.create(
     purpose="batch",
     extra_body={"target_model_names": "gpt-4o-batch"}
 )
-print(batch_input_file) 
-
+print(batch_input_file)
 
 # Create batch
-batch = client.batches.create( # UPDATE BATCH ID TO FILE ID 
+batch = client.batches.create(
     input_file_id=batch_input_file.id,
     endpoint="/v1/chat/completions",
     completion_window="24h",
@@ -227,10 +204,7 @@ print(batch)
 batch_id = batch.id
 
 # Retrieve batch
-
-batch_response = client.batches.retrieve( # LOG VIRTUAL MODEL NAME
-    batch_id
-)
+batch_response = client.batches.retrieve(batch_id)
 status = batch_response.status
 
 print(f"status: {status}, output_file_id: {batch_response.output_file_id}")
@@ -242,28 +216,21 @@ if not output_file_id:
     output_file_id = batch_response.error_file_id
 
 if output_file_id:
-    file_response = client.files.content(
-        output_file_id
-    )
+    file_response = client.files.content(output_file_id)
     raw_responses = file_response.text.strip().split("\n")
 
-    with open(
-        Path.cwd().parent / "unified_batch_output.json", "w"
-    ) as output_file:
+    with open("unified_batch_output.jsonl", "w") as output_file:
         for raw_response in raw_responses:
             json.dump(json.loads(raw_response), output_file)
             output_file.write("\n")
-## List Batch
 
-list_batch_response = client.batches.list( # LOG VIRTUAL MODEL NAME
+# List batches
+list_batch_response = client.batches.list(
     extra_query={"target_model_names": "gpt-4o-batch"}
 )
 
-## Cancel Batch
-
-batch_response = client.batches.cancel( # LOG VIRTUAL MODEL NAME
-    batch_id
-)
+# Cancel batch
+batch_response = client.batches.cancel(batch_id)
 status = batch_response.status
 
 print(f"status: {status}")
@@ -273,17 +240,8 @@ print(f"status: {status}")
 
 ### Where are my files written?
 
-When a `target_model_names` is specified, the file is written to all deployments that match the `target_model_names`.
+When `target_model_names` is specified, the file is written to all deployments that match it. No additional infrastructure is required.
 
-No additional infrastructure is required.
+### Could the batch be created on one deployment (e.g. eastus-01) but a subsequent retrieve be routed to a different deployment (e.g. eastus2-01)?
 
-## Could the batch be created at the eastus-01 deployment but a subsequent get of the batch could be routed to (a different) eastus2-01 deployment ?
-
-**A.** You can loadbalance b/w multiple models for the initial create batch. Once that's created - we return a file id, which encodes the model deployment used, so it's sticky and only sends any get/delete to that deployment. 
-
-
-
-
-
-
-
+No. LiteLLM load balances between deployments for the initial batch create. The returned batch id encodes the deployment that was used, so retrieve, cancel and file content calls are sticky to that deployment.


### PR DESCRIPTION
Cleanup pass on `docs/proxy/managed_batches.md`; no new content.

The info banner previously said "This is a free LiteLLM Enterprise feature", which reads as a contradiction. It now says the feature is available with the `litellm[proxy]` package or any `litellm` docker image and that no Enterprise license is required.

The "[Coming Soon] Cancel a batch" heading was stale: cancel is handled by the managed files hook and the page's own E2E example already called it. It is now step 6. The create + retrieve snippet used `batch_id` without defining it, so `batch_id = batch.id` is added. The E2E example loses its leftover dev comments ("UPDATE BATCH ID TO FILE ID", "LOG VIRTUAL MODEL NAME"), gets a valid request.jsonl in its docstring, and writes output to the current directory as `.jsonl` instead of the parent directory as `.json`.

The FAQ answer about deployment stickiness said the returned file id encodes the deployment; it is the batch id. Both FAQ questions are now `###` under the FAQ heading (the second was a top-level `##`). Remaining changes are cosmetic: the feature table's "Description" column is renamed "Supported" since it holds checkmarks, "Loadbalance" becomes "load balance", the curl placeholders use `${...}` consistently, and double blank lines and trailing whitespace are removed.

https://claude.ai/code/session_01BC8ryFjdJAW2iMYeEZFwHR
