### PR TITLE
docs: fix code blocks, fences, links and headings across 136 pages

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -179,7 +179,8 @@ To enable these features, your A2A server must **forward these headers** to any 
 ### Implementation Steps
 
 **Step 1: Extract headers from incoming A2A request**
-```python def get_litellm_headers(request) -> dict:
+```python
+def get_litellm_headers(request) -> dict:
     """Extract X-LiteLLM-* headers from incoming A2A request."""
     all_headers = request.call_context.state.get('headers', {})
     return {
@@ -193,7 +194,8 @@ Pass the extracted headers when making calls back to LiteLLM:
 <Tabs>
 <TabItem value="openai" label="OpenAI SDK" default>
 
-```python from openai import OpenAI
+```python
+from openai import OpenAI
 
 headers = get_litellm_headers(request)
 

--- a/docs/adding_provider/adding_guardrail_support.md
+++ b/docs/adding_provider/adding_guardrail_support.md
@@ -285,7 +285,7 @@ def _has_text_content(self, response: Any) -> bool:
 
 Create `__init__.py` to register the handler with call types:
 
-```text
+```python nolint
 """My Endpoint handler for Unified Guardrails."""
 
 from litellm.llms.{provider}/{endpoint}/guardrail_translation.handler import (

--- a/docs/adding_provider/adding_guardrail_support.md
+++ b/docs/adding_provider/adding_guardrail_support.md
@@ -285,7 +285,7 @@ def _has_text_content(self, response: Any) -> bool:
 
 Create `__init__.py` to register the handler with call types:
 
-```python
+```text
 """My Endpoint handler for Unified Guardrails."""
 
 from litellm.llms.{provider}/{endpoint}/guardrail_translation.handler import (

--- a/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/adding_provider/generic_guardrail_api.md
@@ -110,7 +110,7 @@ Implement `POST /beta/litellm_basic_guardrail_api`
 
 ### Response Format
 
-```json
+```text
 {
   "action": "BLOCKED" | "NONE" | "GUARDRAIL_INTERVENED",
   "blocked_reason": "why content was blocked",  // required if action=BLOCKED

--- a/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/adding_provider/generic_guardrail_api.md
@@ -110,7 +110,7 @@ Implement `POST /beta/litellm_basic_guardrail_api`
 
 ### Response Format
 
-```text
+```json nolint
 {
   "action": "BLOCKED" | "NONE" | "GUARDRAIL_INTERVENED",
   "blocked_reason": "why content was blocked",  // required if action=BLOCKED

--- a/docs/adding_provider/new_rerank_provider.md
+++ b/docs/adding_provider/new_rerank_provider.md
@@ -21,7 +21,7 @@ class YourProviderRerankConfig(BaseRerankConfig):
         # Transform request to RerankRequest spec
         return rerank_request.model_dump(exclude_none=True)
 
-    def transform_rerank_response(self, model: str, raw_response: httpx.Response, ...) -> RerankResponse:
+    def transform_rerank_response(self, model: str, raw_response: httpx.Response, **kwargs) -> RerankResponse:
         # Transform provider response to RerankResponse
         return RerankResponse(**raw_response_json)
 ```
@@ -30,7 +30,7 @@ class YourProviderRerankConfig(BaseRerankConfig):
 ## 2. Register Your Provider
 Add your provider to `litellm.utils.get_provider_rerank_config()`:
 
-```python
+```python nolint
 elif litellm.LlmProviders.YOUR_PROVIDER == provider:
     return litellm.YourProviderRerankConfig()
 ```
@@ -41,7 +41,7 @@ elif litellm.LlmProviders.YOUR_PROVIDER == provider:
 Add a code block to handle when your provider is called. Your provider should use the `base_llm_http_handler.rerank` method
 
 
-```python
+```python nolint
 elif _custom_llm_provider == "your_provider":
     ...
     response = base_llm_http_handler.rerank(
@@ -55,7 +55,7 @@ elif _custom_llm_provider == "your_provider":
         _is_async=_is_async,
         headers=headers or litellm.headers or {},
         client=client,
-        mod el_response=model_response,
+        model_response=model_response,
     )
     ...
 ```

--- a/docs/adding_provider/simple_guardrail_tutorial.md
+++ b/docs/adding_provider/simple_guardrail_tutorial.md
@@ -105,7 +105,7 @@ model_list:
 
 guardrails:
     - guardrail_name: my_guardrail
-        litellm_params:
+      litellm_params:
         guardrail: my_guardrail
         mode: during_call
         api_key: os.environ/MY_GUARDRAIL_API_KEY

--- a/docs/anthropic_count_tokens.md
+++ b/docs/anthropic_count_tokens.md
@@ -123,7 +123,7 @@ model_list:
 
 ```json
 {
-  "input_tokens": <number>
+  "input_tokens": "<number>"
 }
 ```
 

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -119,37 +119,37 @@ print("response from litellm.create_batch=", create_batch_response)
 **Retrieve the Specific Batch and File Content**
 
 ```python
-    # Maximum wait time before we give up
-    MAX_WAIT_TIME = 300  
+# Maximum wait time before we give up
+MAX_WAIT_TIME = 300  
 
-    # Time to wait between each status check
-    POLL_INTERVAL = 5
+# Time to wait between each status check
+POLL_INTERVAL = 5
+
+#Time waited till now 
+waited = 0
+
+# Wait for the batch to finish processing before trying to retrieve output
+# This loop checks the batch status every few seconds (polling)
+
+while True:
+    retrieved_batch = await litellm.aretrieve_batch(
+        batch_id=create_batch_response.id,
+        custom_llm_provider="openai"
+    )
     
-    #Time waited till now 
-    waited = 0
-
-    # Wait for the batch to finish processing before trying to retrieve output
-    # This loop checks the batch status every few seconds (polling)
-
-    while True:
-        retrieved_batch = await litellm.aretrieve_batch(
-            batch_id=create_batch_response.id,
-            custom_llm_provider="openai"
-        )
-        
-        status = retrieved_batch.status
-        print(f"⏳ Batch status: {status}")
-        
-        if status == "completed" and retrieved_batch.output_file_id:
-            print("✅ Batch complete. Output file ID:", retrieved_batch.output_file_id)
-            break
-        elif status in ["failed", "cancelled", "expired"]:
-            raise RuntimeError(f"❌ Batch failed with status: {status}")
-        
-        await asyncio.sleep(POLL_INTERVAL)
-        waited += POLL_INTERVAL
-        if waited > MAX_WAIT_TIME:
-            raise TimeoutError("❌ Timed out waiting for batch to complete.")
+    status = retrieved_batch.status
+    print(f"⏳ Batch status: {status}")
+    
+    if status == "completed" and retrieved_batch.output_file_id:
+        print("✅ Batch complete. Output file ID:", retrieved_batch.output_file_id)
+        break
+    elif status in ["failed", "cancelled", "expired"]:
+        raise RuntimeError(f"❌ Batch failed with status: {status}")
+    
+    await asyncio.sleep(POLL_INTERVAL)
+    waited += POLL_INTERVAL
+    if waited > MAX_WAIT_TIME:
+        raise TimeoutError("❌ Timed out waiting for batch to complete.")
 
 print("retrieved batch=", retrieved_batch)
 # just assert that we retrieved a non None batch

--- a/docs/caching/all_caches.md
+++ b/docs/caching/all_caches.md
@@ -35,7 +35,7 @@ import litellm
 from litellm import completion
 from litellm.caching.caching import Cache
 
-litellm.cache = Cache(type="redis", host=<host>, port=<port>, password=<password>)
+litellm.cache = Cache(type="redis", host="<host>", port="<port>", password="<password>")
 
 # Make completion calls
 response1 = completion(
@@ -569,7 +569,7 @@ litellm.enable_cache()
 Advanced Params
 
 ```python
-litellm.enable_cache(
+def enable_cache(
     type: Optional[Literal["local", "redis", "s3", "gcs", "disk"]] = "local",
     host: Optional[str] = None,
     port: Optional[str] = None,
@@ -578,7 +578,7 @@ litellm.enable_cache(
         List[Literal["completion", "acompletion", "embedding", "aembedding", "atranscription", "transcription"]]
     ] = ["completion", "acompletion", "embedding", "aembedding", "atranscription", "transcription"],
     **kwargs,
-)
+) -> None: ...
 ```
 
 ### Disabling Cache
@@ -593,7 +593,7 @@ litellm.disable_cache()
 Update the Cache params
 
 ```python
-litellm.update_cache(
+def update_cache(
     type: Optional[Literal["local", "redis", "s3", "gcs", "disk"]] = "local",
     host: Optional[str] = None,
     port: Optional[str] = None,
@@ -602,7 +602,7 @@ litellm.update_cache(
         List[Literal["completion", "acompletion", "embedding", "aembedding", "atranscription", "transcription"]]
     ] = ["completion", "acompletion", "embedding", "aembedding", "atranscription", "transcription"],
     **kwargs,
-)
+) -> None: ...
 ```
 
 ## Custom Cache Keys:
@@ -638,10 +638,10 @@ cache = Cache()
 ### 2. Define custom add/get cache functions 
 ```python
 def add_cache(self, result, *args, **kwargs):
-  your logic
+  ...
   
 def get_cache(self, *args, **kwargs):
-  your logic
+  ...
 ```
 
 ### 3. Point cache add/get functions to your add/get functions 
@@ -714,7 +714,7 @@ def __init__(
 
     qdrant_semantic_cache_vector_size: Optional[int] = None,
     **kwargs
-):
+): ...
 ```
 
 ## Logging 
@@ -724,7 +724,7 @@ Cache hits are logged in success events as `kwarg["cache_hit"]`.
 Here's an example of accessing it: 
 
   ```python
-  import litellm
+import litellm
 from litellm.integrations.custom_logger import CustomLogger
 from litellm import completion, acompletion, Cache
 
@@ -732,7 +732,7 @@ from litellm import completion, acompletion, Cache
 class MyCustomHandler(CustomLogger):
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time): 
         print(f"On Success")
-        print(f"Value of Cache hit: {kwargs['cache_hit']"})
+        print(f"Value of Cache hit: {kwargs['cache_hit']}")
 
 async def test_async_completion_azure_caching():
     # set custom callback

--- a/docs/caching/caching_api.md
+++ b/docs/caching/caching_api.md
@@ -12,7 +12,7 @@ litellm.cache = Cache(type="hosted") # init cache to use api.litellm.ai
 # Make completion calls
 response1 = completion(
     model="gpt-3.5-turbo", 
-    messages=[{"role": "user", "content": "Tell me a joke."}]
+    messages=[{"role": "user", "content": "Tell me a joke."}],
     caching=True
 )
 

--- a/docs/caching/local_caching.md
+++ b/docs/caching/local_caching.md
@@ -19,7 +19,7 @@ litellm.cache = Cache()
 # Make completion calls
 response1 = completion(
     model="gpt-3.5-turbo", 
-    messages=[{"role": "user", "content": "Tell me a joke."}]
+    messages=[{"role": "user", "content": "Tell me a joke."}],
     caching=True
 )
 response2 = completion(

--- a/docs/claude_code_context_management.md
+++ b/docs/claude_code_context_management.md
@@ -113,7 +113,7 @@ response = await litellm.anthropic.messages.acreate(
 
 You can also trigger on tool-use count instead of tokens:
 
-```python
+```python nolint
 "trigger": {"type": "tool_uses", "value": 10}   # activate after 10 tool calls
 ```
 

--- a/docs/completion/audio.md
+++ b/docs/completion/audio.md
@@ -269,7 +269,7 @@ Expected Response
       "max_output_tokens": 16384,
       "mode": "chat",
       "supports_audio_output": true, # 👈 supports_audio_output is true
-      "supports_audio_input": true, # 👈 supports_audio_input is true
+      "supports_audio_input": true # 👈 supports_audio_input is true
     },
     {
       "model_group": "llava-hf",
@@ -278,7 +278,7 @@ Expected Response
       "max_output_tokens": null,
       "mode": null,
       "supports_audio_output": true, # 👈 supports_audio_output is true
-      "supports_audio_input": true, # 👈 supports_audio_input is true
+      "supports_audio_input": true # 👈 supports_audio_input is true
     }
   ]
 }

--- a/docs/completion/batching.md
+++ b/docs/completion/batching.md
@@ -212,7 +212,7 @@ print(responses)
 
 ### Output
 
-```json
+```text
 [<ModelResponse chat.completion id=chatcmpl-e673ec8e-4e8f-4c9e-bf26-bf9fa7ee52b9 at 0x103a62160> JSON: {
   "object": "chat.completion",
   "choices": [

--- a/docs/completion/computer_use.md
+++ b/docs/completion/computer_use.md
@@ -30,22 +30,22 @@ from litellm import completion
 os.environ["ANTHROPIC_API_KEY"] = "your-api-key"
 
 # Computer use tool
-    tools = [
-        {
-            "type": "computer_20241022",
-            "name": "computer",
-            "display_height_px": 768,
-            "display_width_px": 1024,
-            "display_number": 0,
-        }
-    ]
-    
-    messages = [
-        {
-            "role": "user", 
-            "content": [
-                {
-                    "type": "text",
+tools = [
+    {
+        "type": "computer_20241022",
+        "name": "computer",
+        "display_height_px": 768,
+        "display_width_px": 1024,
+        "display_number": 0,
+    }
+]
+
+messages = [
+    {
+        "role": "user", 
+        "content": [
+            {
+                "type": "text",
                 "text": "Take a screenshot and tell me what you see"
             },
             {

--- a/docs/completion/document_understanding.md
+++ b/docs/completion/document_understanding.md
@@ -400,7 +400,7 @@ Expected Response
       "max_output_tokens": 16384,
       "mode": "chat",
       ...,
-      "supports_pdf_input": true, # 👈 supports_pdf_input is true
+      "supports_pdf_input": true # 👈 supports_pdf_input is true
     }
   ]
 }

--- a/docs/completion/drop_params.md
+++ b/docs/completion/drop_params.md
@@ -184,7 +184,7 @@ await litellm.acompletion(
     api_key="xxxxx",
     api_base=api_base,
     messages=[{"role": "user", "content": "Hello! return a json object"}],
-    tools=[{"type": "function", "function": {"name": "get_current_time", "description": "Get the current time in a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The city name, e.g. San Francisco"}}, "required": ["location"]}}}]
+    tools=[{"type": "function", "function": {"name": "get_current_time", "description": "Get the current time in a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The city name, e.g. San Francisco"}}, "required": ["location"]}}}],
     allowed_openai_params=["tools"],
 )
 ```

--- a/docs/completion/function_call.md
+++ b/docs/completion/function_call.md
@@ -190,7 +190,7 @@ tool_calls = response.choices[0].message.tool_calls
 
 ##### Expected output
 In the output you can see the model calls the function multiple times - for San Francisco, Tokyo, Paris
-```json
+```python
 ModelResponse(
   id='chatcmpl-8MHBKZ9t6bXuhBvUMzoKsfmmlv7xq', 
   choices=[
@@ -262,7 +262,7 @@ print("Second Response\n", second_response)
 ```
 
 #### Expected output
-```json
+```python
 ModelResponse(
   id='chatcmpl-8MHBLh1ldADBP71OrifKap6YfAd4w', 
   choices=[
@@ -453,7 +453,7 @@ print(function_json)
 ```
 
 #### Output from function_to_dict
-```json
+```python
 {
     'name': 'get_current_weather', 
     'description': 'Get the current weather in a given location', 

--- a/docs/completion/image_generation_chat.md
+++ b/docs/completion/image_generation_chat.md
@@ -17,7 +17,7 @@ Supported Providers:
 
 LiteLLM will standardize the `images` response in the assistant message for models that support image generation during chat completions.
 
-```python title="Example response from litellm"
+```text title="Example response from litellm"
 "message": {
     ...
     "content": "Here's the image you requested:",
@@ -231,7 +231,7 @@ asyncio.run(generate_image())
 
 The `images` field in the response follows this structure:
 
-```python
+```text
 "images": [
     {
         "image_url": {

--- a/docs/completion/image_generation_chat.md
+++ b/docs/completion/image_generation_chat.md
@@ -17,7 +17,7 @@ Supported Providers:
 
 LiteLLM will standardize the `images` response in the assistant message for models that support image generation during chat completions.
 
-```text title="Example response from litellm"
+```json title="Example response from litellm"
 "message": {
     ...
     "content": "Here's the image you requested:",
@@ -231,7 +231,7 @@ asyncio.run(generate_image())
 
 The `images` field in the response follows this structure:
 
-```text
+```json
 "images": [
     {
         "image_url": {

--- a/docs/completion/input.md
+++ b/docs/completion/input.md
@@ -120,7 +120,7 @@ def completion(
     # Optional liteLLM function params
     **kwargs,
 
-) -> ModelResponse:
+) -> ModelResponse: ...
 ```
 ### Required Fields
 

--- a/docs/completion/model_alias.md
+++ b/docs/completion/model_alias.md
@@ -4,7 +4,7 @@ The model name you show an end-user might be different from the one you pass to 
 
 LiteLLM simplifies this by letting you pass in a model alias mapping. 
 
-# expected format
+## expected format
 
 ```python
 litellm.model_alias_map = {
@@ -13,7 +13,7 @@ litellm.model_alias_map = {
 }
 ```
 
-# usage 
+## usage 
 
 ### Relevant Code
 ```python

--- a/docs/completion/prefix.md
+++ b/docs/completion/prefix.md
@@ -8,11 +8,11 @@ Supported by:
 - Mistral
 - Anthropic
 
-```python
+```json
 {
   "role": "assistant", 
   "content": "..", 
-  ...
+  ...,
   "prefix": true # 👈 KEY CHANGE
 }
 ```

--- a/docs/completion/prompt_formatting.md
+++ b/docs/completion/prompt_formatting.md
@@ -31,7 +31,7 @@ import litellm
 # Create your own custom prompt template 
 litellm.register_prompt_template(
 	    model="togethercomputer/LLaMA-2-7B-32K",
-        initial_prompt_value="You are a good assistant" # [OPTIONAL]
+        initial_prompt_value="You are a good assistant", # [OPTIONAL]
 	    roles={
             "system": {
                 "pre_message": "[INST] <<SYS>>\n", # [OPTIONAL]
@@ -42,10 +42,10 @@ litellm.register_prompt_template(
                 "post_message": " [/INST]" # [OPTIONAL]
             }, 
             "assistant": {
-                "pre_message": "\n" # [OPTIONAL]
+                "pre_message": "\n", # [OPTIONAL]
                 "post_message": "\n" # [OPTIONAL]
             }
-        }
+        },
         final_prompt_value="Now answer as best you can:" # [OPTIONAL]
 )
 

--- a/docs/completion/reliable_completions.md
+++ b/docs/completion/reliable_completions.md
@@ -123,11 +123,14 @@ Allow `45seconds` for each request. In the 45s this function tries calling the p
 ```python
 while response == None and time.time() - start_time < 45:
         for model in fallbacks:
+            ...
 ```
 
 #### Cool-Downs for rate-limited models
 If a model API call leads to an error - allow it to cooldown for `60s`
 ```python
+try:
+  ...
 except Exception as e:
   print(f"got exception {e} for model {model}")
   rate_limited_models.add(model)

--- a/docs/completion/usage.md
+++ b/docs/completion/usage.md
@@ -96,5 +96,3 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 ```
 
 Will automatically receive usage information in the response, without needing to explicitly include `stream_options`.
-
-```

--- a/docs/completion/vision.md
+++ b/docs/completion/vision.md
@@ -196,7 +196,7 @@ Expected Response
 
 If you have images without a mime-type, or if litellm is incorrectly inferring the mime type of your image (e.g. calling `gs://` url's with vertex ai), you can set this explicitly via the `format` param. 
 
-```python
+```text
 "image_url": {
   "url": "gs://my-gs-image",
   "format": "image/jpeg"

--- a/docs/completion/vision.md
+++ b/docs/completion/vision.md
@@ -196,7 +196,7 @@ Expected Response
 
 If you have images without a mime-type, or if litellm is incorrectly inferring the mime type of your image (e.g. calling `gs://` url's with vertex ai), you can set this explicitly via the `format` param. 
 
-```text
+```json
 "image_url": {
   "url": "gs://my-gs-image",
   "format": "image/jpeg"

--- a/docs/embedding/supported_embedding.md
+++ b/docs/embedding/supported_embedding.md
@@ -210,8 +210,6 @@ input=["good morning from litellm"]
         -0.0022326677571982145,
         0.010749882087111473,
         ...
-        ...
-        ...
    
       ]
     }
@@ -255,7 +253,7 @@ Use this for calling `/embedding` endpoints on OpenAI Compatible Servers, exampl
 from litellm import embedding
 response = embedding(
   model = "openai/<your-llm-name>",     # add `openai/` prefix to model so litellm knows to route to OpenAI
-  api_base="http://0.0.0.0:4000/"       # set API Base of your Custom OpenAI Endpoint
+  api_base="http://0.0.0.0:4000/",      # set API Base of your Custom OpenAI Endpoint
   input=["good morning from litellm"]
 )
 ```
@@ -284,11 +282,11 @@ print(response)
 | Model Name           | Function Call                               |
 |----------------------|---------------------------------------------|
 | Amazon Nova Multimodal Embeddings | `embedding(model="bedrock/amazon.nova-2-multimodal-embeddings-v1:0", input=input)` | [Nova Docs](../providers/bedrock_embedding#amazon-nova-multimodal-embeddings) |
-| Amazon Nova (Async) | `embedding(model="bedrock/async_invoke/amazon.nova-2-multimodal-embeddings-v1:0", input=input, input_type="text", output_s3_uri="s3://bucket/")` | [Nova Async Docs](../providers/bedrock_embedding#asynchronous-embeddings-with-segmentation) |
+| Amazon Nova (Async) | `embedding(model="bedrock/async_invoke/amazon.nova-2-multimodal-embeddings-v1:0", input=input, input_type="text", output_s3_uri="s3://bucket/")` | [Nova Async Docs](../providers/bedrock_embedding#async-invoke-support) |
 | Titan Embeddings - G1 | `embedding(model="amazon.titan-embed-text-v1", input=input)` |
 | Cohere Embeddings - English | `embedding(model="cohere.embed-english-v3", input=input)` |
 | Cohere Embeddings - Multilingual | `embedding(model="cohere.embed-multilingual-v3", input=input)` |
-| TwelveLabs Marengo (Async) | `embedding(model="bedrock/async_invoke/us.twelvelabs.marengo-embed-2-7-v1:0", input=input, input_type="text")` | [Async Invoke Docs](../providers/bedrock_embedding#async-invoke-embedding) |
+| TwelveLabs Marengo (Async) | `embedding(model="bedrock/async_invoke/us.twelvelabs.marengo-embed-2-7-v1:0", input=input, input_type="text")` | [Async Invoke Docs](../providers/bedrock_embedding#async-invoke-support) |
 
 ## TwelveLabs Bedrock Embedding Models
 

--- a/docs/exception_mapping.md
+++ b/docs/exception_mapping.md
@@ -192,6 +192,7 @@ When calling the LiteLLM proxy, content policy violations will return detailed f
     }
   }
 }
+```
 
 ## Details 
 

--- a/docs/extras/gemini_img_migration.md
+++ b/docs/extras/gemini_img_migration.md
@@ -205,7 +205,7 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
         "images": [{
           "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
           "detail": "auto"
-        }
+        }]
       },
       "finish_reason": "stop"
     }

--- a/docs/files_endpoints.md
+++ b/docs/files_endpoints.md
@@ -252,7 +252,7 @@ print("content=", content)
 
 **Upload a File**
 ```python
-from litellm
+import litellm
 import os 
 
 os.environ["OPENAI_API_KEY"] = "sk-.."

--- a/docs/image_generation.md
+++ b/docs/image_generation.md
@@ -150,7 +150,7 @@ Any non-openai params, will be treated as provider-specific params, and sent in 
 
 ### Output from `litellm.image_generation()`
 
-```json
+```python
 
 {
     "created": 1703658209,
@@ -185,9 +185,9 @@ response = image_generation(model='gpt-image-1', prompt="cute baby otter")
 This can be set as env variables or passed as **params to litellm.image_generation()**
 ```python showLineNumbers
 import os
-os.environ['AZURE_API_KEY'] = 
-os.environ['AZURE_API_BASE'] = 
-os.environ['AZURE_API_VERSION'] = 
+os.environ['AZURE_API_KEY'] = ""
+os.environ['AZURE_API_BASE'] = ""
+os.environ['AZURE_API_VERSION'] = ""
 ```
 
 ### Usage
@@ -269,7 +269,7 @@ Use this for calling `/image_generation` endpoints on OpenAI Compatible Servers,
 from litellm import image_generation
 response = image_generation(
   model = "openai/<your-llm-name>",     # add `openai/` prefix to model so litellm knows to route to OpenAI
-  api_base="http://0.0.0.0:8000/"       # set API Base of your Custom OpenAI Endpoint
+  api_base="http://0.0.0.0:8000/",      # set API Base of your Custom OpenAI Endpoint
   prompt="cute baby otter"
 )
 ```

--- a/docs/langchain/langchain.md
+++ b/docs/langchain/langchain.md
@@ -150,7 +150,8 @@ litellm.failure_callback = ["lunary"]
 
 chat = ChatLiteLLM(
   model="gpt-4o"
-  messages = [
+)
+messages = [
     HumanMessage(
         content="what model are you"
     )

--- a/docs/learn/gateway_quickstart.md
+++ b/docs/learn/gateway_quickstart.md
@@ -64,7 +64,7 @@ If the request succeeds, the proxy returns `200 OK` with an OpenAI-style respons
 
 The assistant text will be in:
 
-```json
+```text
 choices[0].message.content
 ```
 

--- a/docs/mcp_zero_trust.md
+++ b/docs/mcp_zero_trust.md
@@ -150,7 +150,7 @@ guardrails:
 ```
 
 **What the client sees when blocked:**
-```json
+```text
 HTTP 403
 { "error": "MCPJWTSigner: incoming token is missing required claims: ['employee_id']. Configure the IdP to include these claims." }
 ```

--- a/docs/observability/azure_sentinel.md
+++ b/docs/observability/azure_sentinel.md
@@ -23,7 +23,7 @@ We will use the `--config` to set `litellm.callbacks = ["azure_sentinel"]` this 
 
 ```yaml showLineNumbers title="config.yaml"
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:

--- a/docs/observability/custom_callback.md
+++ b/docs/observability/custom_callback.md
@@ -48,7 +48,7 @@ for chunk in response:
 ## async
 import asyncio 
 
-def async completion():
+async def completion():
     response = await acompletion(model="gpt-3.5-turbo", messages=[{ "role": "user", "content": "Hi 👋 - i'm openai"}],
                               stream=True)
     async for chunk in response: 
@@ -191,7 +191,7 @@ customHandler = MyCustomHandler()
 
 litellm.callbacks = [customHandler]
 
-def async completion():
+async def completion():
     response = await acompletion(model="gpt-3.5-turbo", messages=[{ "role": "user", "content": "Hi 👋 - i'm openai"}],
                               stream=True)
     async for chunk in response: 

--- a/docs/observability/datadog.md
+++ b/docs/observability/datadog.md
@@ -26,7 +26,7 @@ We will use the `--config` to set `litellm.callbacks = ["datadog"]` this will lo
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -47,7 +47,7 @@ litellm_settings:
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -86,8 +86,11 @@ When `LITELLM_DD_AGENT_HOST` is set, logs are sent to the agent instead of direc
 
 **Note:** We use `LITELLM_DD_AGENT_HOST` instead of `DD_AGENT_HOST` to avoid conflicts with `ddtrace` which automatically sets `DD_AGENT_HOST` for APM tracing.
 
-> [!IMPORTANT]
-> **Datadog LLM Observability**: `DD_API_KEY` is **REQUIRED** even when using the Datadog Agent (`LITELLM_DD_AGENT_HOST`). The agent acts as a proxy but the API key header is mandatory for the LLM Observability endpoint.
+:::info
+
+**Datadog LLM Observability**: `DD_API_KEY` is **REQUIRED** even when using the Datadog Agent (`LITELLM_DD_AGENT_HOST`). The agent acts as a proxy but the API key header is mandatory for the LLM Observability endpoint.
+
+:::
 
 **Step 3**: Start the proxy, make a test request
 
@@ -131,7 +134,7 @@ When redaction is enabled, the actual message content and response text will be 
 
 ```yaml showLineNumbers title="config.yaml"
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -242,7 +245,7 @@ We will use the `--config` to set `litellm.callbacks = ["datadog_cost_management
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:

--- a/docs/observability/greenscale_integration.md
+++ b/docs/observability/greenscale_integration.md
@@ -43,7 +43,7 @@ litellm.success_callback = ["greenscale"]
 #openai call
 response = completion(
   model="gpt-3.5-turbo",
-  messages=[{"role": "user", "content": "Hi 👋 - i'm openai"}]
+  messages=[{"role": "user", "content": "Hi 👋 - i'm openai"}],
   metadata={
     "greenscale_project": "acme-project",
     "greenscale_application": "acme-application"

--- a/docs/observability/humanloop.md
+++ b/docs/observability/humanloop.md
@@ -138,7 +138,7 @@ You can do `humanloop/<litellm_model_name>`
 ```python
 litellm.completion(
     model="humanloop/gpt-3.5-turbo", # or `humanloop/anthropic/claude-3-5-sonnet`
-    ...
+    # ...
 )
 ```
 

--- a/docs/observability/langfuse_integration.md
+++ b/docs/observability/langfuse_integration.md
@@ -146,12 +146,12 @@ response = completion(
   metadata={
       "generation_name": "ishaan-test-generation",  # set langfuse Generation Name
       "generation_id": "gen-id22",                  # set langfuse Generation ID 
-      "parent_observation_id": "obs-id9"            # set langfuse Parent Observation ID
-      "version":  "test-generation-version"         # set langfuse Generation Version
+      "parent_observation_id": "obs-id9",           # set langfuse Parent Observation ID
+      "version":  "test-generation-version",        # set langfuse Generation Version
       "trace_user_id": "user-id2",                  # set langfuse Trace User ID
       "session_id": "session-1",                    # set langfuse Session ID
       "tags": ["tag1", "tag2"],                     # set langfuse Tags
-      "trace_name": "new-trace-name"                # set langfuse Trace Name
+      "trace_name": "new-trace-name",               # set langfuse Trace Name
       "trace_id": "trace-id22",                     # set langfuse Trace ID
       "trace_metadata": {"key": "value"},           # set langfuse Trace Metadata
       "trace_version": "test-trace-version",        # set langfuse Trace Version (if not set, defaults to Generation Version)
@@ -307,7 +307,7 @@ os.environ['OPENAI_API_KEY']="sk-..."
 litellm.success_callback = ["langfuse"] 
 
 chat = ChatLiteLLM(
-  model="gpt-3.5-turbo"
+  model="gpt-3.5-turbo",
   model_kwargs={
       "metadata": {
         "trace_user_id": "user-id2", # set langfuse Trace User ID

--- a/docs/observability/lunary_integration.md
+++ b/docs/observability/lunary_integration.md
@@ -61,7 +61,8 @@ litellm.failure_callback = ["lunary"]
 
 chat = ChatLiteLLM(
   model="gpt-4o"
-  messages = [
+)
+messages = [
     HumanMessage(
         content="what model are you"
     )
@@ -76,7 +77,7 @@ You can use Lunary to manage [prompt templates](https://lunary.ai/docs/features/
 
 ```python
 from litellm import completion
-from lunary
+import lunary
 
 template = lunary.render_template("template-slug", {
   "name": "John", # Inject variables

--- a/docs/observability/scrub_data.md
+++ b/docs/observability/scrub_data.md
@@ -25,7 +25,7 @@ class MyCustomHandler(CustomLogger):
 
             kwargs["messages"] = [{"role": "user", "content": "MASK_THIS_ASYNC_VALUE"}]
 
-        return kwargs, responses
+        return kwargs, result
 
     def logging_hook(
         self, kwargs: dict, result: Any, call_type: str
@@ -42,7 +42,7 @@ class MyCustomHandler(CustomLogger):
 
             kwargs["messages"] = [{"role": "user", "content": "MASK_THIS_SYNC_VALUE"}]
 
-        return kwargs, responses
+        return kwargs, result
 
 
 customHandler = MyCustomHandler()
@@ -88,7 +88,7 @@ for chunk in response:
 ## async
 import asyncio 
 
-def async completion():
+async def completion():
     response = await acompletion(model="gpt-3.5-turbo", messages=[{ "role": "user", "content": "Hi 👋 - i'm openai"}],
                               stream=True)
     async for chunk in response: 

--- a/docs/old_guardrails.md
+++ b/docs/old_guardrails.md
@@ -27,7 +27,7 @@ litellm_settings:
     - hide_secrets_guard:
         callbacks: [hide_secrets]
         default_on: false
-    - your-custom-guardrail
+    - your-custom-guardrail:
         callbacks: [hide_secrets]
         default_on: false
 ```
@@ -139,7 +139,7 @@ response = client.chat.completions.create(
         }
     ],
     extra_body={
-        "metadata": {"guardrails": {"prompt_injection": False, "hide_secrets_guard": True}}}
+        "metadata": {"guardrails": {"prompt_injection": False, "hide_secrets_guard": True}}
     }
 )
 
@@ -165,7 +165,7 @@ chat = ChatOpenAI(
     openai_api_base="http://0.0.0.0:4000",
     model = "llama3",
     extra_body={
-        "metadata": {"guardrails": {"prompt_injection": False, "hide_secrets_guard": True}}}
+        "metadata": {"guardrails": {"prompt_injection": False, "hide_secrets_guard": True}}
     }
 )
 
@@ -348,7 +348,7 @@ litellm_settings:
         callback: ["presidio"]
         default_on: true
         logging_only: true
-    - your-custom-guardrail
+    - your-custom-guardrail:
         callbacks: [hide_secrets]
         default_on: false
 ```

--- a/docs/projects/Softgen.md
+++ b/docs/projects/Softgen.md
@@ -4,4 +4,4 @@
 LiteLLM helps `Softgen` users to choose and use different LLMs.
 
 - [Softgen](https://softgen.ai)
-- [Academy](hhttps://academy.softgen.ai)
+- [Academy](https://academy.softgen.ai)

--- a/docs/provider_registration/index.md
+++ b/docs/provider_registration/index.md
@@ -109,7 +109,7 @@ bytez_transformation = BytezChatConfig()
 
 Then much lower in the code
 
-```py
+```py nolint
 elif custom_llm_provider == "bytez":
     api_key = (
         api_key
@@ -153,6 +153,8 @@ LITELLM_CHAT_PROVIDERS = [
     "xai",
     "custom_openai",
     "text-completion-openai",
+    # ...
+]
 ```
 
 Add yourself to the if statement chain of providers here
@@ -160,7 +162,7 @@ Add yourself to the if statement chain of providers here
 #### `litellm/litellm_core_utils/get_llm_provider_logic.py`
 
 ```py
-elif model == "*":
+if model == "*":
     custom_llm_provider = "openai"
 # bytez models
 elif model.startswith("bytez/"):
@@ -262,7 +264,7 @@ The debugger is your friend.
 Setup headers, validate key/model:
 
 ```python
-def validate_environment(...):
+def validate_environment(*args, **kwargs):
     headers.update({
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
@@ -275,7 +277,7 @@ def validate_environment(...):
 Return the final request URL:
 
 ```python
-def get_complete_url(...):
+def get_complete_url(*args, **kwargs):
     return f"{api_base}/{model}"
 ```
 
@@ -284,7 +286,7 @@ def get_complete_url(...):
 Adapt OpenAI-style input into provider-specific format:
 
 ```python
-def transform_request(...):
+def transform_request(*args, **kwargs):
     data = {"messages": messages, "params": optional_params}
     return data
 ```
@@ -294,7 +296,7 @@ def transform_request(...):
 Process and map the raw provider response:
 
 ```python
-def transform_response(...):
+def transform_response(*args, **kwargs):
     json = raw_response.json()
     model_response.model = model
     model_response.choices[0].message.content = json.get("output")

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -580,7 +580,7 @@ import litellm
 
 response = await litellm.acompletion(
     model="anthropic/claude-3-5-sonnet-20240620",
-    messages = [{"role": "user", "content": "What's the weather like in Boston today?"}]
+    messages = [{"role": "user", "content": "What's the weather like in Boston today?"}],
     tools = [
         {
             "type": "function",
@@ -626,7 +626,7 @@ client = openai.AsyncOpenAI(
 
 response = await client.chat.completions.create(
     model="anthropic/claude-3-5-sonnet-20240620",
-    messages = [{"role": "user", "content": "What's the weather like in Boston today?"}]
+    messages = [{"role": "user", "content": "What's the weather like in Boston today?"}],
     tools = [
         {
             "type": "function",
@@ -1398,7 +1398,7 @@ print(response)
 ```yaml
 model_list:
     - model_name: claude-memory-model
-    litellm_params:
+      litellm_params:
         model: anthropic/claude-sonnet-4-5-20250929
         api_key: os.environ/ANTHROPIC_API_KEY
 ```
@@ -1732,8 +1732,11 @@ response = completion(
 
 You can "put words in Claude's mouth" by including an `assistant` role message as the last item in the `messages` array.
 
-> [!IMPORTANT]
-> The returned completion will _not_ include your "pre-fill" text, since it is part of the prompt itself. Make sure to prefix Claude's completion with your pre-fill.
+:::info
+
+The returned completion will _not_ include your "pre-fill" text, since it is part of the prompt itself. Make sure to prefix Claude's completion with your pre-fill.
+
+:::
 
 ```python
 import os
@@ -2164,7 +2167,7 @@ response = completion(
 ```yaml
 model_list:
     - model_name: claude-sonnet-4-5-20250929
-        litellm_params:
+      litellm_params:
         model: anthropic/claude-sonnet-4-5-20250929
         api_key: os.environ/ANTHROPIC_API_KEY
 ```

--- a/docs/providers/anthropic_effort.md
+++ b/docs/providers/anthropic_effort.md
@@ -309,10 +309,10 @@ output_config={"effort": "very_low"}
 output_config={"effort": "low"}
 
 # ❌ This will raise an error (max only works on Opus 4.6)
-litellm.completion(model="anthropic/claude-sonnet-4-6", reasoning_effort="max", ...)
+litellm.completion(model="anthropic/claude-sonnet-4-6", messages=messages, reasoning_effort="max")
 
 # ✅ max is only for Opus 4.6
-litellm.completion(model="anthropic/claude-opus-4-6", reasoning_effort="max", ...)
+litellm.completion(model="anthropic/claude-opus-4-6", messages=messages, reasoning_effort="max")
 ```
 
 ### Model not supported

--- a/docs/providers/anthropic_tool_input_examples.md
+++ b/docs/providers/anthropic_tool_input_examples.md
@@ -262,7 +262,7 @@ On Google Cloud's Vertex AI and Amazon Bedrock, only Claude Opus 4.5 supports to
 
 Include examples that demonstrate different use cases:
 
-```python
+```python nolint
 "input_examples": [
     {"location": "San Francisco, CA", "unit": "fahrenheit"},  # US city
     {"location": "Tokyo, Japan", "unit": "celsius"},          # International
@@ -274,7 +274,7 @@ Include examples that demonstrate different use cases:
 
 Show when optional parameters should and shouldn't be included:
 
-```python
+```python nolint
 "input_examples": [
     {
         "query": "machine learning",
@@ -290,7 +290,7 @@ Show when optional parameters should and shouldn't be included:
 
 Make format expectations clear through examples:
 
-```python
+```python nolint
 "input_examples": [
     {
         "phone": "+1-555-123-4567",  # Shows expected phone format
@@ -304,7 +304,7 @@ Make format expectations clear through examples:
 
 Use realistic, production-like examples rather than placeholder data:
 
-```python
+```python nolint
 # ✅ Good - realistic examples
 "input_examples": [
     {"email": "alice@company.com", "role": "admin"},

--- a/docs/providers/aws_sagemaker.md
+++ b/docs/providers/aws_sagemaker.md
@@ -344,7 +344,7 @@ response = client.chat.completions.create(model="jumpstart-model", messages = [
 ],
 temperature=0.7,
 extra_body={
-    top_k=1 # 👈 PROVIDER-SPECIFIC PARAM
+    "top_k": 1 # 👈 PROVIDER-SPECIFIC PARAM
 }
 )
 

--- a/docs/providers/azure/azure.md
+++ b/docs/providers/azure/azure.md
@@ -273,7 +273,7 @@ Note: **Azure requires the `base_url` to be set with `/extensions`**
 
 Example 
 ```python
-base_url=https://gpt-4-vision-resource.openai.azure.com/openai/deployments/gpt-4-vision/extensions
+base_url="https://gpt-4-vision-resource.openai.azure.com/openai/deployments/gpt-4-vision/extensions"
 # base_url="{azure_endpoint}/openai/deployments/{azure_deployment}/extensions"
 ```
 
@@ -971,7 +971,7 @@ curl http://localhost:4000/v1/batches?limit=2 \
 **1. Create File for Batch Completion**
 
 ```python
-from litellm
+import litellm
 import os 
 
 os.environ["AZURE_API_KEY"] = ""
@@ -1142,7 +1142,7 @@ In production, [Router connects to a Redis Cache](#redis-queue) to track usage a
 
 #### Quick Start
 
-```python
+```bash
 uv add litellm
 ```
 
@@ -1183,7 +1183,7 @@ router = Router(model_list=model_list)
 
 # openai.chat.completions.create replacement
 response = router.completion(model="gpt-3.5-turbo", 
-				messages=[{"role": "user", "content": "Hey, how's it going?"}]
+				messages=[{"role": "user", "content": "Hey, how's it going?"}])
 
 print(response)
 ```

--- a/docs/providers/azure/azure_embedding.md
+++ b/docs/providers/azure/azure_embedding.md
@@ -8,9 +8,9 @@ import TabItem from '@theme/TabItem';
 This can be set as env variables or passed as **params to litellm.embedding()**
 ```python
 import os
-os.environ['AZURE_API_KEY'] = 
-os.environ['AZURE_API_BASE'] = 
-os.environ['AZURE_API_VERSION'] = 
+os.environ['AZURE_API_KEY'] = ""
+os.environ['AZURE_API_BASE'] = ""
+os.environ['AZURE_API_VERSION'] = ""
 ```
 
 ### Usage

--- a/docs/providers/azure/azure_speech.md
+++ b/docs/providers/azure/azure_speech.md
@@ -37,7 +37,7 @@ response.stream_to_file(speech_file_path)
 
 ```yaml showLineNumbers title="proxy_config.yaml"
 model_list:
- - model_name: azure/tts-1
+  - model_name: azure/tts-1
     litellm_params:
       model: azure/tts-1
       api_base: "os.environ/AZURE_API_BASE_TTS"

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -310,7 +310,7 @@ response = client.chat.completions.create(model="bedrock-claude-v1", messages = 
 ],
 temperature=0.7,
 extra_body={
-    top_k=1 # 👈 PROVIDER-SPECIFIC PARAM
+    "top_k": 1 # 👈 PROVIDER-SPECIFIC PARAM
 }
 )
 
@@ -1283,8 +1283,11 @@ print(response_guard)
 
 If you're using Anthropic's Claude with Bedrock, you can "put words in Claude's mouth" by including an `assistant` role message as the last item in the `messages` array.
 
-> [!IMPORTANT]
-> The returned completion will _**not**_ include your "pre-fill" text, since it is part of the prompt itself. Make sure to prefix Claude's completion with your pre-fill.
+:::info
+
+The returned completion will _**not**_ include your "pre-fill" text, since it is part of the prompt itself. Make sure to prefix Claude's completion with your pre-fill.
+
+:::
 
 ```python
 import os
@@ -2238,10 +2241,10 @@ model_list:
     - model_name: bedrock-model
       litellm_params:
         model: bedrock/anthropic.claude-instant-v1
-        aws_access_key_id: "",
-        aws_secret_access_key: "",
-        aws_region_name: "",
-        aws_bedrock_runtime_endpoint: "https://my-fake-endpoint.com",
+        aws_access_key_id: ""
+        aws_secret_access_key: ""
+        aws_region_name: ""
+        aws_bedrock_runtime_endpoint: "https://my-fake-endpoint.com"
         extra_headers: {"key": "value"}
 ```
 

--- a/docs/providers/clarifai.md
+++ b/docs/providers/clarifai.md
@@ -79,7 +79,6 @@ tools = [{
             "additionalProperties": False
         },
     }
-  }
 }]
 
 response = litellm.completion(

--- a/docs/providers/codestral.md
+++ b/docs/providers/codestral.md
@@ -111,7 +111,7 @@ async for chunk in response:
       "finish_reason": null
     }
   ],
-  "model": "codestral-2405", 
+  "model": "codestral-2405"
 }
 
 ```
@@ -172,12 +172,12 @@ response = await litellm.acompletion(
   "object": "chat.completion",
   "created": 1677652288,
   "model": "codestral/codestral-latest",
-  "system_fingerprint": None,
+  "system_fingerprint": null,
   "choices": [{
     "index": 0,
     "message": {
       "role": "assistant",
-      "content": "\n\nHello there, how may I assist you today?",
+      "content": "\n\nHello there, how may I assist you today?"
     },
     "logprobs": null,
     "finish_reason": "stop"
@@ -231,7 +231,7 @@ async for chunk in response:
     "object":"chat.completion.chunk",
     "created":1694268190,
     "model": "codestral/codestral-latest",
-    "system_fingerprint": None, 
+    "system_fingerprint": null, 
     "choices":[
         {
             "index":0,

--- a/docs/providers/dashscope.md
+++ b/docs/providers/dashscope.md
@@ -86,4 +86,3 @@ for chunk in response:
 | qwen3-235b-a22b | `completion(model="dashscope/qwen3-235b-a22b", messages)` |  
 | qwen3-32b | `completion(model="dashscope/qwen3-32b", messages)` |  
 | qwen3-30b-a3b | `completion(model="dashscope/qwen3-30b-a3b", messages)` |
-```

--- a/docs/providers/datarobot.md
+++ b/docs/providers/datarobot.md
@@ -17,6 +17,7 @@ response = completion(
             model="datarobot/openai/gpt-4o-mini",
             messages=messages,
         )
+```
 
 
 ### Completion

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -1772,7 +1772,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 </TabItem>
 </Tabs>
-# Gemini-Pro-Vision
+## Gemini-Pro-Vision
 LiteLLM Supports the following image types passed in `url`
 - Images with direct links - https://storage.googleapis.com/github-repo/img/gemini/intro/landmark3.jpg
 - Image in local storage - ./localimage.jpeg
@@ -2126,7 +2126,7 @@ LiteLLM follows the OpenAI format and accepts sending inline data as an encoded 
 
 The format to follow is 
 
-```python
+```text
 data:<mime_type>;base64,<encoded_data>
 ```
 

--- a/docs/providers/google_ai_studio/image_gen.md
+++ b/docs/providers/google_ai_studio/image_gen.md
@@ -114,8 +114,8 @@ model_list:
     litellm_params:
       model: gemini/imagen-4.0-generate-001
       api_key: os.environ/GEMINI_API_KEY
-  model_info:
-    mode: image_generation
+    model_info:
+      mode: image_generation
 
 general_settings:
   master_key: sk-1234

--- a/docs/providers/huggingface.md
+++ b/docs/providers/huggingface.md
@@ -53,13 +53,13 @@ Examples:
 
 ```python
 # Run DeepSeek-R1 inference through Together AI
-completion(model="huggingface/together/deepseek-ai/DeepSeek-R1",...)
+completion(model="huggingface/together/deepseek-ai/DeepSeek-R1", messages=messages)
 
 # Run Qwen2.5-72B-Instruct inference through Sambanova
-completion(model="huggingface/sambanova/Qwen/Qwen2.5-72B-Instruct",...)
+completion(model="huggingface/sambanova/Qwen/Qwen2.5-72B-Instruct", messages=messages)
 
 # Run Llama-3.3-70B-Instruct inference through HF Inference API
-completion(model="huggingface/meta-llama/Llama-3.3-70B-Instruct",...)
+completion(model="huggingface/meta-llama/Llama-3.3-70B-Instruct", messages=messages)
 ```
 
 
@@ -259,7 +259,7 @@ messages=[
 response = completion(
     model="huggingface/tgi",
     messages=messages,
-    api_base="https://my-endpoint.endpoints.huggingface.cloud/v1/""
+    api_base="https://my-endpoint.endpoints.huggingface.cloud/v1/"
 )
 print(response.choices[0])
 ```
@@ -376,7 +376,7 @@ response = embedding(
 )
 ```
 
-# FAQ
+## FAQ
 
 **How does billing work with Hugging Face Inference Providers?**
 

--- a/docs/providers/litellm_proxy.md
+++ b/docs/providers/litellm_proxy.md
@@ -38,7 +38,7 @@ litellm.api_base = "your-openai-proxy-url"
 messages = [{ "content": "Hello, how are you?","role": "user"}]
 
 # litellm proxy call
-response = completion(model="litellm_proxy/your-model-name", messages)
+response = completion(model="litellm_proxy/your-model-name", messages=messages)
 ```
 
 ## Usage - passing `api_base`, `api_key` per request

--- a/docs/providers/llamafile.md
+++ b/docs/providers/llamafile.md
@@ -13,7 +13,7 @@ LiteLLM supports all models on Llamafile.
 | Supported Endpoints       | `/chat/completions`, `/embeddings`, `/completions`                                                                                   |
 
 
-# Quick Start
+## Quick Start
 
 ## Usage - litellm.completion (calling OpenAI compatible endpoint)
 llamafile Provides an OpenAI compatible endpoint for chat completions - here's how to call it with LiteLLM

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -3,13 +3,13 @@ import TabItem from '@theme/TabItem';
 
 # MiniMax  
 
-# MiniMax - v1/messages
+## MiniMax - v1/messages
 
-## Overview
+### Overview
 
 Litellm provides anthropic specs compatible support for minmax
 
-## Supported Models
+### Supported Models
 
 MiniMax offers three models through their Anthropic-compatible API:
 
@@ -20,9 +20,9 @@ MiniMax offers three models through their Anthropic-compatible API:
 | **MiniMax-M2** | Agentic capabilities, Advanced reasoning | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
 
 
-## Usage Examples
+### Usage Examples
 
-### Basic Chat Completion
+#### Basic Chat Completion
 
 ```python
 import litellm
@@ -38,7 +38,7 @@ response = litellm.anthropic.messages.acreate(
 print(response.choices[0].message.content)
 ```
 
-### Using Environment Variables
+#### Using Environment Variables
 
 ```bash
 export MINIMAX_API_KEY="your-minimax-api-key"
@@ -55,7 +55,7 @@ response = litellm.anthropic.messages.acreate(
 )
 ```
 
-### With Thinking (M2.1 Feature)
+#### With Thinking (M2.1 Feature)
 
 ```python
 response = litellm.anthropic.messages.acreate(
@@ -71,7 +71,7 @@ for block in response.choices[0].message.content:
         print(f"Thinking: {block.thinking}")
 ```
 
-### With Tool Calling
+#### With Tool Calling
 
 ```python
 tools = [
@@ -102,7 +102,7 @@ response = litellm.anthropic.messages.acreate(
 
 
 
-## Usage with LiteLLM Proxy 
+### Usage with LiteLLM Proxy 
 
 You can use MiniMax models with the Anthropic SDK by routing through LiteLLM Proxy:
 
@@ -112,7 +112,7 @@ You can use MiniMax models with the Anthropic SDK by routing through LiteLLM Pro
 | **2. Set Environment Variables** | Point Anthropic SDK to proxy endpoint |
 | **3. Use Anthropic SDK** | Call MiniMax models using native Anthropic SDK |
 
-### Step 1: Configure LiteLLM Proxy
+#### Step 1: Configure LiteLLM Proxy
 
 Create a `config.yaml`:
 
@@ -131,7 +131,7 @@ Start the proxy:
 litellm --config config.yaml
 ```
 
-### Step 2: Use with Anthropic SDK
+#### Step 2: Use with Anthropic SDK
 
 ```python
 import os
@@ -166,13 +166,13 @@ for block in message.content:
         print(f"Text:\n{block.text}\n")
 ```
 
-# MiniMax - v1/chat/completions
+## MiniMax - v1/chat/completions
 
-## Usage with LiteLLM SDK
+### Usage with LiteLLM SDK
 
 You can use MiniMax's OpenAI-compatible API directly with LiteLLM:
 
-### Basic Chat Completion
+#### Basic Chat Completion
 
 ```python
 import litellm
@@ -190,7 +190,7 @@ response = litellm.completion(
 print(response.choices[0].message.content)
 ```
 
-### Using Environment Variables
+#### Using Environment Variables
 
 ```bash
 export MINIMAX_API_KEY="your-minimax-api-key"
@@ -206,7 +206,7 @@ response = litellm.completion(
 )
 ```
 
-### With Reasoning Split
+#### With Reasoning Split
 
 ```python
 response = litellm.completion(
@@ -226,7 +226,7 @@ if hasattr(response.choices[0].message, 'reasoning_details'):
 print(f"Response: {response.choices[0].message.content}")
 ```
 
-### With Tool Calling
+#### With Tool Calling
 
 ```python
 tools = [
@@ -255,7 +255,7 @@ response = litellm.completion(
 )
 ```
 
-### Streaming
+#### Streaming
 
 ```python
 response = litellm.completion(
@@ -272,7 +272,7 @@ for chunk in response:
 ```
 
 
-## Usage with OpenAI SDK via LiteLLM Proxy
+### Usage with OpenAI SDK via LiteLLM Proxy
 
 You can also use MiniMax models with the OpenAI SDK by routing through LiteLLM Proxy:
 
@@ -282,7 +282,7 @@ You can also use MiniMax models with the OpenAI SDK by routing through LiteLLM P
 | **2. Set Environment Variables** | Point OpenAI SDK to proxy endpoint |
 | **3. Use OpenAI SDK** | Call MiniMax models using native OpenAI SDK |
 
-### Step 1: Configure LiteLLM Proxy
+#### Step 1: Configure LiteLLM Proxy
 
 Create a `config.yaml`:
 
@@ -301,7 +301,7 @@ Start the proxy:
 litellm --config config.yaml
 ```
 
-### Step 2: Use with OpenAI SDK
+#### Step 2: Use with OpenAI SDK
 
 ```python
 import os
@@ -328,7 +328,7 @@ if hasattr(response.choices[0].message, 'reasoning_details'):
 print(f"Text:\n{response.choices[0].message.content}\n")
 ```
 
-### Streaming with OpenAI SDK
+#### Streaming with OpenAI SDK
 
 ```python
 from openai import OpenAI
@@ -366,7 +366,7 @@ for chunk in stream:
             text_buffer = content_text
 ```
 
-## Cost Calculation
+### Cost Calculation
 
 Cost calculation works automatically using the pricing information in `model_prices_and_context_window.json`.
 
@@ -382,13 +382,13 @@ response = litellm.completion(
 print(f"Cost: ${response._hidden_params.get('response_cost', 0)}")
 ```
 
-# MiniMax - Text-to-Speech
+## MiniMax - Text-to-Speech
 
-## Quick Start
+### Quick Start
 
-## **LiteLLM Python SDK Usage**
+### **LiteLLM Python SDK Usage**
 
-### Basic Usage
+#### Basic Usage
 
 ```python
 from pathlib import Path
@@ -406,7 +406,7 @@ response = speech(
 response.stream_to_file(speech_file_path)
 ```
 
-### Async Usage
+#### Async Usage
 
 ```python
 from litellm import aspeech
@@ -427,7 +427,7 @@ async def test_async_speech():
 asyncio.run(test_async_speech())
 ```
 
-### Voice Selection
+#### Voice Selection
 
 MiniMax supports many voices. LiteLLM provides OpenAI-compatible voice names that map to MiniMax voices:
 
@@ -456,7 +456,7 @@ response = speech(
 )
 ```
 
-### Custom Parameters
+#### Custom Parameters
 
 MiniMax TTS supports additional parameters for fine-tuning audio output:
 
@@ -480,7 +480,7 @@ response = speech(
 response.stream_to_file("custom_speech.mp3")
 ```
 
-### Response Formats
+#### Response Formats
 
 ```python
 from litellm import speech
@@ -518,11 +518,11 @@ response = speech(
 )
 ```
 
-## **LiteLLM Proxy Usage**
+### **LiteLLM Proxy Usage**
 
 LiteLLM provides an OpenAI-compatible `/audio/speech` endpoint for MiniMax TTS.
 
-### Setup
+#### Setup
 
 Add MiniMax to your proxy configuration:
 
@@ -547,7 +547,7 @@ litellm --config /path/to/config.yaml
 # RUNNING on http://0.0.0.0:4000
 ```
 
-### Making Requests
+#### Making Requests
 
 ```bash
 curl http://0.0.0.0:4000/v1/audio/speech \
@@ -582,7 +582,7 @@ curl http://0.0.0.0:4000/v1/audio/speech \
   --output custom_speech.mp3
 ```
 
-## Voice Mappings
+### Voice Mappings
 
 LiteLLM maps OpenAI-compatible voice names to MiniMax voice IDs:
 
@@ -598,13 +598,13 @@ LiteLLM maps OpenAI-compatible voice names to MiniMax voice IDs:
 You can also use any MiniMax-native voice ID directly by passing it as the `voice` parameter.
 
 
-### Streaming (WebSocket)
+#### Streaming (WebSocket)
 
 :::note
 The current implementation uses MiniMax's HTTP endpoint. For WebSocket streaming support, please refer to MiniMax's official documentation at [https://platform.minimax.io/docs](https://platform.minimax.io/docs).
 :::
 
-## Error Handling
+### Error Handling
 
 ```python
 from litellm import speech
@@ -625,7 +625,7 @@ except Exception as e:
     print(f"Error: {e}")
 ```
 
-### Extra Body Parameters
+#### Extra Body Parameters
 
 Pass these via `extra_body`:
 

--- a/docs/providers/oci.md
+++ b/docs/providers/oci.md
@@ -120,17 +120,17 @@ messages = [{"role": "user", "content": "Hey! how's it going?"}]
 response = completion(
     model="oci/xai.grok-4",
     messages=messages,
-    oci_region=<your_oci_region>,
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
+    oci_region="<your_oci_region>",
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
     oci_serving_mode="ON_DEMAND",  # Optional, default is "ON_DEMAND". Other option is "DEDICATED"
     # Provide either the private key string OR the path to the key file:
     # Option 1: pass the private key as a string
-    oci_key=<string_with_content_of_oci_key>,
+    oci_key="<string_with_content_of_oci_key>",
     # Option 2: pass the private key file path
     # oci_key_file="<path/to/oci_key.pem>",
-    oci_compartment_id=<oci_compartment_id>,
+    oci_compartment_id="<oci_compartment_id>",
 )
 print(response)
 ```
@@ -341,17 +341,17 @@ response = completion(
     model="oci/xai.grok-4",
     messages=messages,
     stream=True,
-    oci_region=<your_oci_region>,
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
+    oci_region="<your_oci_region>",
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
     oci_serving_mode="ON_DEMAND",  # Optional, default is "ON_DEMAND". Other option is "DEDICATED"
     # Provide either the private key string OR the path to the key file:
     # Option 1: pass the private key as a string
-    oci_key=<string_with_content_of_oci_key>,
+    oci_key="<string_with_content_of_oci_key>",
     # Option 2: pass the private key file path
     # oci_key_file="<path/to/oci_key.pem>",
-    oci_compartment_id=<oci_compartment_id>,
+    oci_compartment_id="<oci_compartment_id>",
 )
 for chunk in response:
     print(chunk["choices"][0]["delta"]["content"])  # same as openai format
@@ -402,11 +402,11 @@ response = completion(
     model="oci/cohere.command-latest",
     messages=messages,
     oci_region="us-chicago-1",
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
-    oci_key=<string_with_content_of_oci_key>,
-    oci_compartment_id=<oci_compartment_id>,
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
+    oci_key="<string_with_content_of_oci_key>",
+    oci_compartment_id="<oci_compartment_id>",
 )
 print(response)
 ```
@@ -453,14 +453,14 @@ messages = [{"role": "user", "content": "Hey! how's it going?"}]
 response = completion(
     model="oci/xai.grok-4",  # Must match the model type hosted on the endpoint
     messages=messages,
-    oci_region=<your_oci_region>,
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
+    oci_region="<your_oci_region>",
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
     oci_serving_mode="DEDICATED",
     oci_endpoint_id="ocid1.generativeaiendpoint.oc1...",  # Your dedicated endpoint OCID
-    oci_key=<string_with_content_of_oci_key>,
-    oci_compartment_id=<oci_compartment_id>,
+    oci_key="<string_with_content_of_oci_key>",
+    oci_compartment_id="<oci_compartment_id>",
 )
 print(response)
 ```
@@ -508,13 +508,13 @@ response = completion(
     model="oci/cohere.command-latest",  # Use Cohere model name to get Cohere API format
     messages=messages,
     oci_region="us-chicago-1",
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
     oci_serving_mode="DEDICATED",
     oci_endpoint_id="ocid1.generativeaiendpoint.oc1...",  # Your Cohere endpoint OCID
-    oci_key=<string_with_content_of_oci_key>,
-    oci_compartment_id=<oci_compartment_id>,
+    oci_key="<string_with_content_of_oci_key>",
+    oci_compartment_id="<oci_compartment_id>",
 )
 ```
 
@@ -729,11 +729,11 @@ response = embedding(
     model="oci/cohere.embed-english-v3.0",
     input=["Hello world", "Goodbye world"],
     oci_region="us-ashburn-1",
-    oci_user=<your_oci_user>,
-    oci_fingerprint=<your_oci_fingerprint>,
-    oci_tenancy=<your_oci_tenancy>,
-    oci_key=<string_with_content_of_oci_key>,
-    oci_compartment_id=<oci_compartment_id>,
+    oci_user="<your_oci_user>",
+    oci_fingerprint="<your_oci_fingerprint>",
+    oci_tenancy="<your_oci_tenancy>",
+    oci_key="<string_with_content_of_oci_key>",
+    oci_compartment_id="<oci_compartment_id>",
 )
 print(response)
 ```

--- a/docs/providers/openai_compatible.md
+++ b/docs/providers/openai_compatible.md
@@ -145,7 +145,7 @@ Some VLLM models (e.g. gemma) don't support system messages. To map those reques
 ```yaml
 model_list:
 - model_name: my-custom-model
-   litellm_params:
+  litellm_params:
       model: openai/google/gemma
       api_base: http://my-custom-base
       api_key: "" 

--- a/docs/providers/ovhcloud.md
+++ b/docs/providers/ovhcloud.md
@@ -64,7 +64,7 @@ response = completion(
     temperature = 0.2,
     top_p = 0.9,
     user = "user",
-    api_key = "your-api-key" # Optional if set through the enviromnent variable,
+    api_key = "your-api-key", # Optional if set through the enviromnent variable
     stream = True
 )
 

--- a/docs/providers/predibase.md
+++ b/docs/providers/predibase.md
@@ -134,7 +134,7 @@ os.environ["PREDIBASE_API_KEY"] = ""
 # Create your own custom prompt template 
 litellm.register_prompt_template(
 	    model="togethercomputer/LLaMA-2-7B-32K",
-        initial_prompt_value="You are a good assistant" # [OPTIONAL]
+        initial_prompt_value="You are a good assistant", # [OPTIONAL]
 	    roles={
             "system": {
                 "pre_message": "[INST] <<SYS>>\n", # [OPTIONAL]
@@ -145,10 +145,10 @@ litellm.register_prompt_template(
                 "post_message": " [/INST]" # [OPTIONAL]
             }, 
             "assistant": {
-                "pre_message": "\n" # [OPTIONAL]
+                "pre_message": "\n", # [OPTIONAL]
                 "post_message": "\n" # [OPTIONAL]
             }
-        }
+        },
         final_prompt_value="Now answer as best you can:" # [OPTIONAL]
 )
 

--- a/docs/providers/recraft.md
+++ b/docs/providers/recraft.md
@@ -47,8 +47,8 @@ model_list:
     litellm_params:
       model: recraft/recraftv3
       api_key: os.environ/RECRAFT_API_KEY
-  model_info:
-    mode: image_generation
+    model_info:
+      mode: image_generation
 
 general_settings:
   master_key: sk-1234
@@ -183,8 +183,8 @@ model_list:
     litellm_params:
       model: recraft/recraftv3
       api_key: os.environ/RECRAFT_API_KEY
-  model_info:
-    mode: image_edit
+    model_info:
+      mode: image_edit
 
 general_settings:
   master_key: sk-1234

--- a/docs/providers/replicate.md
+++ b/docs/providers/replicate.md
@@ -145,7 +145,7 @@ os.environ["REPLICATE_API_KEY"] = ""
 # Create your own custom prompt template 
 litellm.register_prompt_template(
 	    model="togethercomputer/LLaMA-2-7B-32K",
-        initial_prompt_value="You are a good assistant" # [OPTIONAL]
+        initial_prompt_value="You are a good assistant", # [OPTIONAL]
 	    roles={
             "system": {
                 "pre_message": "[INST] <<SYS>>\n", # [OPTIONAL]
@@ -156,10 +156,10 @@ litellm.register_prompt_template(
                 "post_message": " [/INST]" # [OPTIONAL]
             }, 
             "assistant": {
-                "pre_message": "\n" # [OPTIONAL]
+                "pre_message": "\n", # [OPTIONAL]
                 "post_message": "\n" # [OPTIONAL]
             }
-        }
+        },
         final_prompt_value="Now answer as best you can:" # [OPTIONAL]
 )
 

--- a/docs/providers/sambanova.md
+++ b/docs/providers/sambanova.md
@@ -145,7 +145,7 @@ import litellm
 # Example dummy function
 
 def get_current_weather(location, unit="fahrenheit"):
-    if unit == "fahrenheit"
+    if unit == "fahrenheit":
         return{"location": location, "temperature": "72", "unit": "fahrenheit"}
     else:
         return{"location": location, "temperature": "22", "unit": "celsius"}
@@ -184,8 +184,7 @@ print("\nFirst LLM Response:\n", response)
 response_message = response.choices[0].message
 tool_calls = response_message.tool_calls
 
-if tool_calls:
-    # Step 2: check if the model wanted to call a function
+# Step 2: check if the model wanted to call a function
 if tool_calls:
     # Step 3: call the function
     # Note: the JSON response may not always be valid; be sure to handle errors
@@ -305,7 +304,7 @@ response = litellm.completion(
     stream=False
 )
 
-print(response.choices[0].message.content))
+print(response.choices[0].message.content)
 ```
 
 ## SambaNova - Embeddings

--- a/docs/providers/stability.md
+++ b/docs/providers/stability.md
@@ -360,6 +360,7 @@ response = image_edit(
 )
 
 print(response)
+```
 
 ### Supported Image Edit Models
 
@@ -445,7 +446,7 @@ response = image_edit(
     prompt="Add flowers in the masked area",
 )
 print(response)
-```
+
 # Fast upscale without prompt
 response = image_edit(
     model="bedrock/stability.stable-fast-upscale-v1:0",
@@ -463,6 +464,7 @@ response = image_edit(
 )
 
 print(response)
+```
 
 ### Supported Bedrock Stability Models
 

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -138,7 +138,7 @@ tools = [
 ]
 
 data = {
-    "model": "vertex_ai/gemini-1.5-pro-preview-0514"),
+    "model": "vertex_ai/gemini-1.5-pro-preview-0514",
     "messages": messages,
     "tools": tools,
     "tool_choice": "required",
@@ -210,7 +210,7 @@ model_list:
 or
 ```yaml
 model_list:
- - model_name: gemini-pro
+  - model_name: gemini-pro
     litellm_params:
       model: vertex_ai/gemini-1.5-pro
       litellm_credential_name: vertex-global
@@ -1392,7 +1392,7 @@ model_list:
         model: gemini-1.5-pro
         vertex_credentials: os.environ/VERTEX_FILE_PATH_ENV_VAR # os.environ["VERTEX_FILE_PATH_ENV_VAR"] = "/path/to/service_account.json" 
         vertex_project: "my-special-project"
-        vertex_location: "my-special-location:
+        vertex_location: "my-special-location"
 ```
 
 </TabItem>
@@ -1586,7 +1586,7 @@ In certain use-cases you may need to make calls to the models and pass [safety s
 ```python
 response = completion(
     model="vertex_ai/gemini-2.5-pro", 
-    messages=[{"role": "user", "content": "write code for saying hi from LiteLLM"}]
+    messages=[{"role": "user", "content": "write code for saying hi from LiteLLM"}],
     safety_settings=[
         {
             "category": "HARM_CATEGORY_HARASSMENT",
@@ -1678,7 +1678,7 @@ response = client.chat.completions.create(
 ```python
 import litellm 
 
-litellm.set_verbose = True 👈 See RAW REQUEST/RESPONSE 
+litellm.set_verbose = True # 👈 See RAW REQUEST/RESPONSE 
 
 litellm.vertex_ai_safety_settings = [
         {
@@ -1747,12 +1747,12 @@ litellm.vertex_project = "hardy-device-38811" # Your Project ID`
 import os, litellm 
 
 # set via env var
-os.environ["VERTEXAI_LOCATION"] = "us-central1 # Your Location
+os.environ["VERTEXAI_LOCATION"] = "us-central1" # Your Location
 
 ### OR ###
 
 # set directly on module 
-litellm.vertex_location = "us-central1 # Your Location
+litellm.vertex_location = "us-central1" # Your Location
 ```
 
 ## Gemini Pro
@@ -2376,7 +2376,7 @@ response = completion(
                 },
                 {
                     "type": "audio_input",
-                    "audio_input {
+                    "audio_input": {
                         "audio_input": f"data:audio/mp3;base64,{encoded_file}", # 👈 AUDIO File ('file' message works as too)
                     }  
                 },
@@ -2602,7 +2602,7 @@ All models listed [here](https://github.com/BerriAI/litellm/blob/57f37f743886a02
 ```python
 response = litellm.embedding(
     model="vertex_ai/text-embedding-004",
-    input=["good morning from litellm", "gm"]
+    input=["good morning from litellm", "gm"],
     input_type = "RETRIEVAL_DOCUMENT",
     dimensions=1,
 )
@@ -2651,7 +2651,7 @@ You can pass any vertex specific params to the embedding model. Just pass them t
 ```python
 response = litellm.embedding(
     model="vertex_ai/text-embedding-004",
-    input=["good morning from litellm", "gm"]
+    input=["good morning from litellm", "gm"],
     task_type = "RETRIEVAL_DOCUMENT",
     title = "test",
     dimensions=1,

--- a/docs/providers/vertex_embedding.md
+++ b/docs/providers/vertex_embedding.md
@@ -100,7 +100,7 @@ All models listed [here](https://github.com/BerriAI/litellm/blob/57f37f743886a02
 ```python
 response = litellm.embedding(
     model="vertex_ai/text-embedding-004",
-    input=["good morning from litellm", "gm"]
+    input=["good morning from litellm", "gm"],
     input_type = "RETRIEVAL_DOCUMENT",
     dimensions=1,
 )
@@ -149,7 +149,7 @@ You can pass any vertex specific params to the embedding model. Just pass them t
 ```python
 response = litellm.embedding(
     model="vertex_ai/text-embedding-004",
-    input=["good morning from litellm", "gm"]
+    input=["good morning from litellm", "gm"],
     task_type = "RETRIEVAL_DOCUMENT",
     title = "test",
     dimensions=1,

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -13,7 +13,7 @@ LiteLLM supports all models on VLLM.
 | Supported Endpoints | `/chat/completions`, `/embeddings`, `/completions`, `/rerank`, `/audio/transcriptions` |
 
 
-# Quick Start
+## Quick Start
 
 ## Usage - litellm.completion (calling OpenAI compatible endpoint)
 vLLM Provides an OpenAI compatible endpoints - here's how to call it with LiteLLM 

--- a/docs/providers/wandb_inference.md
+++ b/docs/providers/wandb_inference.md
@@ -188,7 +188,8 @@ Once done, add the `openai-project` header to your request as shown below:
 response = completion(
     model="...",
     extra_headers={"openai-project": "team_name/project_name"},
-    ...
+    # ...
+)
 ```
 
 For more information, see [Personal entities unsupported](https://docs.wandb.ai/guides/inference/usage-limits/#personal-entities-unsupported).

--- a/docs/providers/xinference.md
+++ b/docs/providers/xinference.md
@@ -73,8 +73,8 @@ model_list:
       model: xinference/stabilityai/stable-diffusion-3.5-large
       api_base: http://127.0.0.1:9997/v1
       api_key: anything
-  model_info:
-    mode: image_generation
+    model_info:
+      mode: image_generation
 
 general_settings:
   master_key: sk-1234

--- a/docs/proxy/access_control.md
+++ b/docs/proxy/access_control.md
@@ -433,7 +433,7 @@ Expected Response
   "models": [],
   "user_id": "ishaan@berri.ai",
   "key": "sk-7shH8TGMAofR4zQpAAo6kQ",
-  "key_name": "sk-...o6kQ",
+  "key_name": "sk-...o6kQ"
 }
 ```
 
@@ -459,7 +459,7 @@ Expected Response
 {
   "team_alias": "engineering_team",
   "team_id": "01044ee8-441b-45f4-be7d-c70e002722d8",
-  "organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23",
+  "organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23"
 }
 ```
 

--- a/docs/proxy/auto_routing_semantic.md
+++ b/docs/proxy/auto_routing_semantic.md
@@ -163,10 +163,12 @@ Configure each route with:
 - **Utterances** - Example phrases that will trigger this route. Use placeholders in brackets for variables:
 
 ```json
+[
 "how to code a program in [language]",
 "can you explain this [language] code",
 "can you explain this [language] script",
 "can you convert this [language] code to [target_language]"
+]
 ```
 
 - **Description** - A human-readable description of what this route handles

--- a/docs/proxy/billing.md
+++ b/docs/proxy/billing.md
@@ -76,9 +76,10 @@ Response Object:
 <TabItem value="curl" label="Curl">
 
 ```bash
+# Authorization: 👈 Team's Key
 curl --location 'http://0.0.0.0:4000/chat/completions' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer sk-tXL0wt5-lOOVK9sfY2UacA' \ # 👈 Team's Key
+--header 'Authorization: Bearer sk-tXL0wt5-lOOVK9sfY2UacA' \
 --data ' {
       "model": "fake-openai-endpoint",
       "messages": [

--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -1184,7 +1184,7 @@ curl -i --location 'http://0.0.0.0:4000/chat/completions' \
 
 Response from litellm proxy
 
-```json
+```text
 date: Thu, 04 Apr 2024 17:37:21 GMT
 content-type: application/json
 x-litellm-cache-key: 586bf3f3c1bf5aecb55bd9996494d3bbc69eb58397163add6d49537762a7548d
@@ -1235,7 +1235,7 @@ litellm_settings:
 import os
 from openai import OpenAI
 
-client = OpenAI(api_key=<litellm-api-key>, base_url="http://0.0.0.0:4000")
+client = OpenAI(api_key="<litellm-api-key>", base_url="http://0.0.0.0:4000")
 
 chat_completion = client.chat.completions.create(
     messages=[

--- a/docs/proxy/clientside_auth.md
+++ b/docs/proxy/clientside_auth.md
@@ -166,7 +166,7 @@ model_list:
       model: "fireworks_ai/*"
       configurable_clientside_auth_params: ["api_base"]
       # OR 
-      configurable_clientside_auth_params: [{"api_base": "^https://litellm.*direct\.fireworks\.ai/v1$"}] # 👈 regex
+      configurable_clientside_auth_params: [{"api_base": '^https://litellm.*direct\.fireworks\.ai/v1$'}] # 👈 regex
 ```
 
 Specify any/all auth params you want the user to be able to configure:

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -197,8 +197,8 @@ router_settings:
     "ContentPolicyViolationErrorAllowedFails": 15, # int 
     "InternalServerErrorAllowedFails": 20, # int 
   }
-  content_policy_fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for content policy violations
-  fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for all errors
+  content_policy_fallbacks: [{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for content policy violations
+  fallbacks: [{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for all errors
 
 ```
 
@@ -440,8 +440,8 @@ router_settings:
     "ContentPolicyViolationErrorAllowedFails": 15, # int
     "InternalServerErrorAllowedFails": 20, # int
   }
-  content_policy_fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for content policy violations
-  fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for all errors
+  content_policy_fallbacks: [{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for content policy violations
+  fallbacks: [{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for all errors
 ```
 
 | Name | Type | Description |

--- a/docs/proxy/configs.md
+++ b/docs/proxy/configs.md
@@ -343,7 +343,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 Add all openai models across all OpenAI organizations with just 1 model definition 
 
 ```yaml
-  - model_name: *
+  - model_name: "*"
     litellm_params:
       model: openai/*
       api_key: os.environ/OPENAI_API_KEY
@@ -376,7 +376,7 @@ For optimal performance:
 - Select your optimal routing strategy in `router_settings:routing_strategy`.
 
 LiteLLM supports
-```python
+```text
 ["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"`
 ```
 
@@ -541,7 +541,7 @@ model_list:
       roles: {"system":{"pre_message":"<|im_start|>system\n", "post_message":"<|im_end|>"}, "assistant":{"pre_message":"<|im_start|>assistant\n","post_message":"<|im_end|>"}, "user":{"pre_message":"<|im_start|>user\n","post_message":"<|im_end|>"}}
       final_prompt_value: "\n"
       bos_token: " "
-      eos_token: " "
+      eos_token: " "
       max_tokens: 4096
 ```
 

--- a/docs/proxy/cost_tracking.md
+++ b/docs/proxy/cost_tracking.md
@@ -153,7 +153,7 @@ The following spend gets tracked in Table `LiteLLM_SpendLogs`
   "metadata": {
     "attempted_fallbacks": 0,                                                    # 0 = requested model group served the request
     "original_model_group": "llama3"                                             # Model group originally requested
-  },
+  }
 
 }
 ```
@@ -371,6 +371,7 @@ curl -L -X GET 'http://localhost:4000/user/daily/activity?start_date=2025-03-20&
                         "completion_tokens": 9,
                         "total_tokens": 46,
                         "api_requests": 1
+                    }
                 },
                 "providers": { "openai": { ... }, "azure_ai": { ... } },
                 "api_keys": { "3126b6eaf1...": { ... } }
@@ -1214,7 +1215,8 @@ print(response)
 #### `/spend/logs` Request Format 
 
 ```bash
-curl -X GET "http://0.0.0.0:4000/spend/logs?request_id=<your-call-id" \ # e.g.: chatcmpl-9ZKMURhVYSi9D6r6PJ9vLcayIK0Vm
+# request_id: e.g.: chatcmpl-9ZKMURhVYSi9D6r6PJ9vLcayIK0Vm
+curl -X GET "http://0.0.0.0:4000/spend/logs?request_id=<your-call-id" \
 -H "Authorization: Bearer sk-1234"
 ```
 

--- a/docs/proxy/custom_auth.md
+++ b/docs/proxy/custom_auth.md
@@ -82,7 +82,7 @@ These fields are read straight off the returned object and enforced with no flag
 Who the request belongs to. The `*_id` fields also tell LiteLLM which DB records to load when `custom_auth_run_common_checks: true`.
 
 ```python
-UserAPIKeyAuth(
+def UserAPIKeyAuth(
     api_key: Optional[str] = None,                    # The API key (will be hashed automatically)
     token: Optional[str] = None,                      # Hashed token for internal use
     key_alias: Optional[str] = None,                  # Key alias for identification
@@ -92,7 +92,7 @@ UserAPIKeyAuth(
     team_id: Optional[str] = None,                    # Team identifier (also used to load the team record)
     org_id: Optional[str] = None,                     # Organization identifier (also used to load the org record)
     end_user_id: Optional[str] = None,                # End-user identifier (also used to load the end-user record)
-)
+): ...
 ```
 
 ### Rate limits
@@ -100,7 +100,7 @@ UserAPIKeyAuth(
 All scopes below are enforced directly off the returned object, with no flag.
 
 ```python
-UserAPIKeyAuth(
+def UserAPIKeyAuth(
     # Key
     tpm_limit: Optional[int] = None,
     rpm_limit: Optional[int] = None,
@@ -119,7 +119,7 @@ UserAPIKeyAuth(
     # Per-model (key / team scoped)
     metadata: Dict = {},          # e.g. {"model_tpm_limit": {...}, "model_rpm_limit": {...}}
     team_metadata: Optional[Dict] = None,  # same keys, team scoped
-)
+): ...
 ```
 
 :::note
@@ -133,12 +133,12 @@ Per-model rate limits are read from `metadata` (key) and `team_metadata` (team),
 ### Advanced
 
 ```python
-UserAPIKeyAuth(
+def UserAPIKeyAuth(
     max_parallel_requests: Optional[int] = None,      # Concurrent request limit
     allowed_model_region: Optional[AllowedModelRegion] = None,  # Geographic restrictions
     blocked: Optional[bool] = None,                   # Whether the key is blocked
     config: Dict = {},                                # Configuration settings
-)
+): ...
 ```
 
 ### Object permission (MCP, agents, etc.)

--- a/docs/proxy/customers.md
+++ b/docs/proxy/customers.md
@@ -115,8 +115,10 @@ If the customer_id already exists, spend will be incremented.
 Call `/customer/info` to get a customer's all up spend
 
 ```bash showLineNumbers title="Get customer spend"
-curl -X GET 'http://0.0.0.0:4000/customer/info?end_user_id=ishaan3' \ # 👈 CUSTOMER ID
-        -H 'Authorization: Bearer sk-1234' \ # 👈 YOUR PROXY KEY
+# end_user_id: 👈 CUSTOMER ID
+# Authorization: 👈 YOUR PROXY KEY
+curl -X GET 'http://0.0.0.0:4000/customer/info?end_user_id=ishaan3' \
+        -H 'Authorization: Bearer sk-1234'
 ```
 
 Expected Response:

--- a/docs/proxy/email.md
+++ b/docs/proxy/email.md
@@ -148,7 +148,7 @@ litellm_settings:
 
 Customize budget alert behavior using these environment variables:
 
-```yaml showLineNumbers title=".env"
+```bash showLineNumbers title=".env"
 # Percentage of max budget that triggers alerts (as decimal: 0.8 = 80%)
 # Only applies to keys without max_budget_alert_emails configured
 EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE=0.8

--- a/docs/proxy/endpoint_activity.md
+++ b/docs/proxy/endpoint_activity.md
@@ -28,9 +28,11 @@ Endpoint activity is **automatically tracked** whenever you make API calls throu
 When you make a request to any endpoint, activity is automatically recorded:
 
 ```bash showLineNumbers title="Endpoint activity is automatically tracked"
-curl -X POST 'http://0.0.0.0:4000/chat/completions' \ # 👈 ENDPOINT AUTOMATICALLY TRACKED
+# /chat/completions: 👈 ENDPOINT AUTOMATICALLY TRACKED
+# Authorization: 👈 YOUR PROXY KEY
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer sk-1234' \ # 👈 YOUR PROXY KEY
+  --header 'Authorization: Bearer sk-1234' \
   --data '{
     "model": "gpt-3.5-turbo",
     "messages": [

--- a/docs/proxy/forward_client_headers.md
+++ b/docs/proxy/forward_client_headers.md
@@ -116,9 +116,11 @@ For **Claude Code** with `/login` and your own Anthropic key, see [Claude Code B
 
 Client request:
 ```bash
+# Authorization: Proxy authentication (stripped)
+# x-api-key: Client's Anthropic key (forwarded!)
 curl -X POST "http://localhost:4000/v1/messages" \
-  -H "Authorization: Bearer sk-proxy-auth-123" \     # Proxy authentication (stripped)
-  -H "x-api-key: sk-ant-api03-YOUR-KEY..." \        # Client's Anthropic key (forwarded!)
+  -H "Authorization: Bearer sk-proxy-auth-123" \
+  -H "x-api-key: sk-ant-api03-YOUR-KEY..." \
   -H "Content-Type: application/json" \
   -d '{
     "model": "claude-sonnet-4",

--- a/docs/proxy/guardrails/bedrock.md
+++ b/docs/proxy/guardrails/bedrock.md
@@ -358,7 +358,7 @@ curl -i http://localhost:4000/v1/chat/completions \
       "error": "Violated guardrail policy",
       "bedrock_guardrail_response": {
         "action": "GUARDRAIL_INTERVENED",
-        "blockedResponse": "I can't provide information on creating explosives.",
+        "blockedResponse": "I can't provide information on creating explosives."
         // ... additional details
       }
     },

--- a/docs/proxy/guardrails/crowdstrike_aidr.md
+++ b/docs/proxy/guardrails/crowdstrike_aidr.md
@@ -172,7 +172,7 @@ curl -sSLX POST 'http://localhost:4000/v1/chat/completions' \
 
 When the guardrail detects PII, it redacts the sensitive content before returning the response to the user:
 
-```json
+```text
 {
   "choices": [
     {
@@ -207,7 +207,7 @@ curl -sSLX POST http://localhost:4000/v1/chat/completions \
 
 The above request should not be blocked, and you should receive a regular LLM response (simplified for brevity):
 
-```json
+```text
 {
   "choices": [
     {

--- a/docs/proxy/guardrails/crowdstrike_aidr.md
+++ b/docs/proxy/guardrails/crowdstrike_aidr.md
@@ -172,7 +172,7 @@ curl -sSLX POST 'http://localhost:4000/v1/chat/completions' \
 
 When the guardrail detects PII, it redacts the sensitive content before returning the response to the user:
 
-```text
+```json
 {
   "choices": [
     {
@@ -186,7 +186,7 @@ When the guardrail detects PII, it redacts the sensitive content before returnin
   ],
   ...
 }
-200
+// 200 (HTTP status code printed by -w "%{http_code}")
 ```
 
 </TabItem>
@@ -207,7 +207,7 @@ curl -sSLX POST http://localhost:4000/v1/chat/completions \
 
 The above request should not be blocked, and you should receive a regular LLM response (simplified for brevity):
 
-```text
+```json
 {
   "choices": [
     {
@@ -221,7 +221,7 @@ The above request should not be blocked, and you should receive a regular LLM re
   ],
   ...
 }
-200
+// 200 (HTTP status code printed by -w "%{http_code}")
 ```
 
 </TabItem>

--- a/docs/proxy/guardrails/custom_code_guardrail.md
+++ b/docs/proxy/guardrails/custom_code_guardrail.md
@@ -12,13 +12,13 @@ Write custom guardrail logic using Python-like code that runs in a sandboxed env
 ```yaml
 model_list:
     - model_name: gpt-4
-        litellm_params:
+      litellm_params:
         model: gpt-4
         api_key: os.environ/OPENAI_API_KEY
 
 guardrails:
     - guardrail_name: block-ssn
-        litellm_params:
+      litellm_params:
         guardrail: custom_code
         mode: pre_call
         custom_code: |

--- a/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/proxy/guardrails/custom_guardrail.md
@@ -526,13 +526,13 @@ response = client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "Write a short poem"}],
     extra_body={
-        "guardrails": [
+        "guardrails": {
             "custom-pre-guard": {
                 "extra_body": {
                     "success_threshold": 0.9
                 }
             }
-        ]
+        }
     }
 )
 ```

--- a/docs/proxy/guardrails/pangea.md
+++ b/docs/proxy/guardrails/pangea.md
@@ -129,7 +129,7 @@ curl -sSLX POST http://localhost:4000/v1/chat/completions \
 
 The above request should not be blocked, and you should receive a regular LLM response (simplified for brevity):
 
-```json
+```text
 {
   "choices": [
     {
@@ -178,7 +178,7 @@ curl -sSLX POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 When the recipe configured in the `pangea-ai-guard-response` plugin detects PII, it redacts the sensitive content before returning the response to the user:
 
-```json
+```text
 {
   "choices": [
     {

--- a/docs/proxy/guardrails/pangea.md
+++ b/docs/proxy/guardrails/pangea.md
@@ -129,7 +129,7 @@ curl -sSLX POST http://localhost:4000/v1/chat/completions \
 
 The above request should not be blocked, and you should receive a regular LLM response (simplified for brevity):
 
-```text
+```json
 {
   "choices": [
     {
@@ -146,7 +146,7 @@ The above request should not be blocked, and you should receive a regular LLM re
   ],
   ...
 }
-200
+// 200 (HTTP status code printed by -w "%{http_code}")
 ```
 
 </TabItem>
@@ -178,7 +178,7 @@ curl -sSLX POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 When the recipe configured in the `pangea-ai-guard-response` plugin detects PII, it redacts the sensitive content before returning the response to the user:
 
-```text
+```json
 {
   "choices": [
     {
@@ -195,7 +195,7 @@ When the recipe configured in the `pangea-ai-guard-response` plugin detects PII,
   ],
   ...
 }
-200
+// 200 (HTTP status code printed by -w "%{http_code}")
 ```
 
 </TabItem>

--- a/docs/proxy/guardrails/pii_masking_v2.md
+++ b/docs/proxy/guardrails/pii_masking_v2.md
@@ -328,7 +328,7 @@ Example response with masked entities:
       "index": 0,
       "finish_reason": "stop"
     }
-  ],
+  ]
   // ... other response fields
 }
 ```

--- a/docs/proxy/guardrails/prompt_injection.md
+++ b/docs/proxy/guardrails/prompt_injection.md
@@ -36,14 +36,14 @@ curl --location 'http://0.0.0.0:4000/v1/chat/completions' \
 
 3. Expected response
 
-```python
+```json
 {
     "error": {
         "message": {
             "error": "Rejected message. This is a prompt injection attack."
         },
-        "type": None, 
-        "param": None, 
+        "type": null,
+        "param": null,
         "code": 400
     }
 }

--- a/docs/proxy/guardrails/prompt_injection.md
+++ b/docs/proxy/guardrails/prompt_injection.md
@@ -36,7 +36,7 @@ curl --location 'http://0.0.0.0:4000/v1/chat/completions' \
 
 3. Expected response
 
-```json
+```python
 {
     "error": {
         "message": {

--- a/docs/proxy/guardrails/quick_start.md
+++ b/docs/proxy/guardrails/quick_start.md
@@ -324,12 +324,12 @@ This config will return the `/guardrails/list` response above. The `guardrail_in
 
 ```yaml
 - guardrail_name: "aporia-post-guard"
-    litellm_params:
+  litellm_params:
       guardrail: aporia  # supported values: "aporia", "lakera"
       mode: "post_call"
       api_key: os.environ/APORIA_API_KEY_2
       api_base: os.environ/APORIA_API_BASE_2
-    guardrail_info: # Optional field, info is returned on GET /guardrails/list
+  guardrail_info: # Optional field, info is returned on GET /guardrails/list
       # you can enter any fields under info for consumers of your guardrail
       params:
         - name: "toxicity_score"
@@ -755,10 +755,10 @@ The `guardrails` parameter can be passed to any LiteLLM Proxy endpoint (`/chat/c
 1. Simple List Format:
 
 ```python
-"guardrails": [
+{"guardrails": [
     "aporia-pre-guard",
     "aporia-post-guard"
-]
+]}
 ```
 
 1. Advanced Dictionary Format:
@@ -766,14 +766,14 @@ The `guardrails` parameter can be passed to any LiteLLM Proxy endpoint (`/chat/c
 In this format the dictionary key is `guardrail_name` you want to run
 
 ```python
-"guardrails": {
+{"guardrails": {
     "aporia-pre-guard": {
         "extra_body": {
             "success_threshold": 0.9,
             "other_param": "value"
         }
     }
-}
+}}
 ```
 
 #### Type Definition

--- a/docs/proxy/guardrails/secret_detection.md
+++ b/docs/proxy/guardrails/secret_detection.md
@@ -10,7 +10,7 @@ Example if you want to redact the value of `OPENAI_API_KEY` in the following req
     "messages": [
         {
             "role": "user",
-            "content": "Hey, how's it going, API_KEY = 'sk_1234567890abcdef'",
+            "content": "Hey, how's it going, API_KEY = 'sk_1234567890abcdef'"
         }
     ]
 }
@@ -23,7 +23,7 @@ Example if you want to redact the value of `OPENAI_API_KEY` in the following req
     "messages": [
         {
             "role": "user",
-            "content": "Hey, how's it going, API_KEY = '[REDACTED]'",
+            "content": "Hey, how's it going, API_KEY = '[REDACTED]'"
         }
     ]
 }
@@ -75,7 +75,7 @@ LiteLLM Proxy:WARNING: secret_detection.py:88 - Detected and redacted secrets in
 
 
 You can also see the raw request sent from litellm to the API Provider with (`--detailed_debug`).
-```json
+```text
 POST Request Sent from LiteLLM:
 curl -X POST \
 https://api.groq.com/openai/v1/ \

--- a/docs/proxy/guardrails/tool_permission.md
+++ b/docs/proxy/guardrails/tool_permission.md
@@ -214,8 +214,8 @@ curl -X POST "http://localhost:4000/v1/chat/completions" \
 		"prompt_tokens": 112,
 		"total_tokens": 735,
 		"completion_tokens_details": {
-			"reasoning_tokens": 384,
-		},
+			"reasoning_tokens": 384
+		}
 	},
 	"service_tier": "default"
 }

--- a/docs/proxy/litellm_managed_files.md
+++ b/docs/proxy/litellm_managed_files.md
@@ -335,7 +335,6 @@ print(file) # File retrieved successfully
 <TabItem value="no_access" label="User did not create file">
 
 ```python
-```python
 from openai import OpenAI
 
 ... # User created file (3b)

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -70,7 +70,7 @@ Set `litellm.turn_off_message_logging=True` This will prevent the messages and r
 **1. Setup config.yaml**
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -116,7 +116,7 @@ Example config.yaml
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 ```
@@ -358,7 +358,7 @@ uv add langfuse>=2.0.0
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -1332,7 +1332,7 @@ AWS_REGION_NAME = ""
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -2011,7 +2011,7 @@ class MyCustomHandler(CustomLogger):
 
 **Expected Output**
 
-```json
+```python
 {'mode': 'embedding', 'input_cost_per_token': 0.002}
 ```
 
@@ -2031,7 +2031,7 @@ class MyCustomHandler(CustomLogger):
 
 **Expected Output /chat/completion [for both `stream` and `non-stream` responses]**
 
-```json
+```python
 ModelResponse(
     id='chatcmpl-8Tfu8GoMElwOZuj2JlHBhNHG01PPo',
     choices=[
@@ -2058,7 +2058,7 @@ ModelResponse(
 
 **Expected Output /embeddings**
 
-```json
+```python
 {
     'model': 'ada',
     'data': [
@@ -2448,7 +2448,7 @@ AWS_REGION_NAME = ""
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:
@@ -2548,7 +2548,7 @@ Your logs should be available on DynamoDB
     "S": "{'user': 'ishaan-2'}"
   },
   "response": {
-    "S": "EmbeddingResponse(model='text-embedding-ada-002-v2', data=[{'embedding': [-0.03503197431564331, -0.020601635798811913, -0.015375726856291294,
+    "S": "EmbeddingResponse(model='text-embedding-ada-002-v2', data=[{'embedding': [-0.03503197431564331, -0.020601635798811913, -0.015375726856291294,"
   }
 }
 ```
@@ -2575,7 +2575,7 @@ export SENTRY_ENVIRONMENT="development" # Controls the Sentry Environment (defau
 
 ```yaml 
 model_list:
- - model_name: gpt-3.5-turbo
+  - model_name: gpt-3.5-turbo
     litellm_params:
       model: gpt-3.5-turbo
 litellm_settings:

--- a/docs/proxy/metrics.md
+++ b/docs/proxy/metrics.md
@@ -7,8 +7,8 @@ curl -X GET "http://0.0.0.0:4000/daily_metrics" -H "Authorization: Bearer sk-123
 
 ## Response format 
 ```json
-[
-    daily_spend = [
+{
+    "daily_spend": [
         {
             "daily_spend": 7.9261938052047e+16,
             "day": "2024-02-01T00:00:00",
@@ -35,10 +35,10 @@ curl -X GET "http://0.0.0.0:4000/daily_metrics" -H "Authorization: Bearer sk-123
         }
 
     ],
-    total_spend = 200,
-    top_models = {"gpt4": 0.2, "vertexai/gemini-pro":10},
-    top_api_keys = {"899922": 0.9, "838hcjd999seerr88": 20}
+    "total_spend": 200,
+    "top_models": {"gpt4": 0.2, "vertexai/gemini-pro":10},
+    "top_api_keys": {"899922": 0.9, "838hcjd999seerr88": 20}
 
-]
+}
 
 ```

--- a/docs/proxy/native_litellm_prompt.md
+++ b/docs/proxy/native_litellm_prompt.md
@@ -20,7 +20,7 @@ Store prompts as `.prompt` files in your repository and use them directly with L
 
 Create `prompts/hello.prompt`:
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4
 temperature: 0.7
@@ -52,7 +52,7 @@ response = litellm.completion(
 
 Create `prompts/hello.prompt` in your BitBucket repository:
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4
 temperature: 0.7
@@ -96,7 +96,7 @@ response = litellm.completion(
 
 Create `prompts/hello.prompt` in your gitlab repository:
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4
 temperature: 0.7
@@ -141,7 +141,7 @@ response = litellm.completion(
 
 Create `prompts/hello.prompt`:
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4
 temperature: 0.7
@@ -205,7 +205,7 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 `.prompt` files use YAML frontmatter for metadata and support Jinja2 templating:
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4                    # Model to use
 temperature: 0.7                # Optional parameters
@@ -223,7 +223,7 @@ User: {{user_message}}
 
 **Multi-role conversations:**
 
-```yaml
+```yaml nolint
 ---
 model: gpt-4
 temperature: 0.3
@@ -235,7 +235,7 @@ User: {{user_question}}
 
 **Dynamic model selection:**
 
-```yaml
+```yaml nolint
 ---
 model: "{{preferred_model}}"  # Model can be a variable
 temperature: 0.7

--- a/docs/proxy/prometheus.md
+++ b/docs/proxy/prometheus.md
@@ -633,7 +633,7 @@ Configure which metrics to emit by specifying them in `prometheus_metrics_config
 
 ```yaml
 model_list:
- - model_name: gpt-4o
+  - model_name: gpt-4o
     litellm_params:
       model: gpt-4o
 
@@ -756,7 +756,7 @@ To monitor the health of litellm adjacent services (redis / postgres), do:
 
 ```yaml
 model_list:
- - model_name: gpt-4o
+  - model_name: gpt-4o
     litellm_params:
       model: gpt-4o
 litellm_settings:

--- a/docs/proxy/prompt_management.md
+++ b/docs/proxy/prompt_management.md
@@ -108,7 +108,7 @@ prompts:
 
 Create `.prompt` files in your prompt directory:
 
-```yaml
+```yaml nolint
 # prompts/hello.prompt
 ---
 model: gpt-4
@@ -163,7 +163,7 @@ litellm_settings:
 
 Your BitBucket repository should contain `.prompt` files:
 
-```yaml
+```yaml nolint
 # prompts/my_bitbucket_prompt.prompt
 ---
 model: gpt-4
@@ -198,7 +198,7 @@ litellm_settings:
 
 Your GitLab repository should contain `.prompt` files:
 
-```yaml
+```yaml nolint
 # prompts/my_gitlab_prompt.prompt
 ---
 model: gpt-4
@@ -497,7 +497,7 @@ You can do `langfuse/<litellm_model_name>`
 ```python
 litellm.completion(
     model="langfuse/gpt-3.5-turbo", # or `langfuse/anthropic/claude-3-5-sonnet`
-    ...
+    # ...
 )
 ```
 

--- a/docs/proxy/rate_limit_tiers.md
+++ b/docs/proxy/rate_limit_tiers.md
@@ -54,9 +54,10 @@ Expected Response:
 ## 3. Check if budget is enforced on key 
 
 ```bash
+# Authorization: 👈 KEY from step 2.
 curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer sk-...' \ # 👈 KEY from step 2.
+-H 'Authorization: Bearer sk-...' \
 -d '{
     "model": "<REPLACE_WITH_MODEL_NAME_FROM_CONFIG.YAML>",
     "messages": [

--- a/docs/proxy/reliability.md
+++ b/docs/proxy/reliability.md
@@ -121,7 +121,7 @@ For direct `Router` tests, pass `mock_testing_fallbacks=True` to trigger fallbac
 
 from litellm import Router
 
-model_list = [{..}, {..}] # defined in Step 1.
+model_list = [{...}, {...}] # defined in Step 1.
 
 router = Router(model_list=model_list, fallbacks=[{"bad-model": ["my-good-model"]}])
 
@@ -172,7 +172,7 @@ In this request the following will occur:
 ```python
 from litellm import Router
 
-router = Router(model_list=[..]) # defined in Step 1.
+router = Router(model_list=[...]) # defined in Step 1.
 
 resp = router.completion(
     model="gpt-3.5-turbo",
@@ -300,7 +300,7 @@ fallbacks = [
 ```python
 from litellm import Router
 
-router = Router(model_list=[..]) # defined in Step 1.
+router = Router(model_list=[...]) # defined in Step 1.
 
 resp = router.completion(
     model="gpt-3.5-turbo",
@@ -472,7 +472,7 @@ In your proxy config.yaml just add this line 👇
 
 ```yaml
 router_settings:
-  content_policy_fallbacks=[{"claude-2": ["my-fallback-model"]}]
+  content_policy_fallbacks: [{"claude-2": ["my-fallback-model"]}]
 ```
 
 Start proxy 
@@ -536,7 +536,7 @@ In your proxy config.yaml just add this line 👇
 
 ```yaml
 router_settings:
-  context_window_fallbacks=[{"claude-2": ["my-fallback-model"]}]
+  context_window_fallbacks: [{"claude-2": ["my-fallback-model"]}]
 ```
 
 Start proxy 
@@ -797,11 +797,11 @@ router_settings:
 model_list:
   - model_name: gpt-3.5-turbo-small
     litellm_params:
-    model: azure/chatgpt-v-2
+      model: azure/chatgpt-v-2
       api_base: os.environ/AZURE_API_BASE
       api_key: os.environ/AZURE_API_KEY
       api_version: "2023-07-01-preview"
-      model_info:
+    model_info:
       base_model: azure/gpt-4-1106-preview # 2. 👈 (azure-only) SET BASE MODEL
 
   - model_name: gpt-3.5-turbo-large
@@ -859,9 +859,9 @@ Fallback across providers (e.g. from Azure OpenAI to Anthropic) if you hit conte
 
 ```yaml
 model_list:
-  - model_name: gpt-3.5-turbo-small
-    litellm_params:
-    model: azure/chatgpt-v-2
+    - model_name: gpt-3.5-turbo-small
+      litellm_params:
+        model: azure/chatgpt-v-2
         api_base: os.environ/AZURE_API_BASE
         api_key: os.environ/AZURE_API_KEY
         api_version: "2023-07-01-preview"
@@ -884,9 +884,9 @@ You can also set default_fallbacks, in case a specific model group is misconfigu
 
 ```yaml
 model_list:
-  - model_name: gpt-3.5-turbo-small
-    litellm_params:
-    model: azure/chatgpt-v-2
+    - model_name: gpt-3.5-turbo-small
+      litellm_params:
+        model: azure/chatgpt-v-2
         api_base: os.environ/AZURE_API_BASE
         api_key: os.environ/AZURE_API_KEY
         api_version: "2023-07-01-preview"

--- a/docs/proxy/rules.md
+++ b/docs/proxy/rules.md
@@ -18,7 +18,7 @@ def my_custom_rule(input): # receives the model response
 
 ### Step 2. Point it to your proxy
 
-```python
+```yaml
 litellm_settings:
   post_call_rules: post_call_rules.my_custom_rule
 ```

--- a/docs/proxy/team_based_routing.md
+++ b/docs/proxy/team_based_routing.md
@@ -43,8 +43,9 @@ litellm --config /path/to/config.yaml
 ### Create Team with Model Alias
 
 ```bash
+# Authorization: 👈 Master Key
 curl --location 'http://0.0.0.0:4000/team/new' \
---header 'Authorization: Bearer sk-1234' \ # 👈 Master Key
+--header 'Authorization: Bearer sk-1234' \
 --header 'Content-Type: application/json' \
 --data '{
   "team_alias": "my-new-team_4",

--- a/docs/proxy/team_budgets.md
+++ b/docs/proxy/team_budgets.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 # Setting Team Budgets
 
 
-# Pre-Requisites
+## Pre-Requisites
 
 - You must set up a Postgres database (e.g. Supabase, Neon, etc.)
 

--- a/docs/proxy/team_logging.md
+++ b/docs/proxy/team_logging.md
@@ -505,7 +505,7 @@ Use this to enable prompt logging for specific keys when you have globally disab
 Example config.yaml with globally disabled prompt logging (message redaction)
 ```yaml
 model_list:
- - model_name: gpt-4o
+  - model_name: gpt-4o
     litellm_params:
       model: gpt-4o
 litellm_settings:

--- a/docs/proxy/team_model_add.md
+++ b/docs/proxy/team_model_add.md
@@ -17,8 +17,9 @@ Useful for teams that want to call their own finetuned models.
 
 
 ```bash
+# Authorization: 👈 Team API Key (has same 'team_id' as below)
 curl -L -X POST 'http://0.0.0.0:4000/model/new' \
--H 'Authorization: Bearer sk-******2ql3-sm28WU0tTAmA' \ # 👈 Team API Key (has same 'team_id' as below)
+-H 'Authorization: Bearer sk-******2ql3-sm28WU0tTAmA' \
 -H 'Content-Type: application/json' \
 -d '{
   "model_name": "my-team-model", # 👈 Call LiteLLM with this model name
@@ -39,9 +40,10 @@ curl -L -X POST 'http://0.0.0.0:4000/model/new' \
 ## Test it! 
 
 ```bash
+# Authorization: 👈 Team API Key
 curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Bearer sk-******2ql3-sm28WU0tTAmA' \ # 👈 Team API Key
+-H 'Authorization: Bearer sk-******2ql3-sm28WU0tTAmA' \
 -d '{
   "model": "my-team-model", # 👈 team model name
   "messages": [
@@ -69,18 +71,18 @@ curl -L -X GET 'http://localhost:4000/team/info?team_id=e59e2671-a064-436a-a0fa-
 
 ```json
 {
-    {
     "team_id": "e59e2671-a064-436a-a0fa-16ae96e5a0a1",
     "team_info": {
         ...,
         "litellm_model_table": {
             "model_aliases": {
-                "my-team-model": # 👈 public model name "model_name_e59e2671-a064-436a-a0fa-16ae96e5a0a1_e81c9286-2195-4bd9-81e1-cf393788a1a0" 👈 internally generated model name (used to ensure uniqueness)
+                "my-team-model": # 👈 public model name
+                    "model_name_e59e2671-a064-436a-a0fa-16ae96e5a0a1_e81c9286-2195-4bd9-81e1-cf393788a1a0" # 👈 internally generated model name (used to ensure uniqueness)
             },
             "created_by": "default_user_id",
             "updated_by": "default_user_id"
         }
-    },
+    }
 }
 ```
 

--- a/docs/proxy/timeout.md
+++ b/docs/proxy/timeout.md
@@ -61,8 +61,8 @@ model_list = [{
         "api_key": os.getenv("AZURE_API_KEY"),
         "api_version": os.getenv("AZURE_API_VERSION"),
         "api_base": os.getenv("AZURE_API_BASE"),
-        "timeout": 300 # sets a 5 minute timeout
-        "stream_timeout": 30 # sets a 30s timeout for streaming calls
+        "timeout": 300, # sets a 5 minute timeout
+        "stream_timeout": 30, # sets a 30s timeout for streaming calls
     }
 }]
 

--- a/docs/proxy/token_auth.md
+++ b/docs/proxy/token_auth.md
@@ -74,9 +74,10 @@ curl --location ' 'https://demo.duendesoftware.com/connect/token'' \
 Create a JWT for your project on your OpenID provider (e.g. Keycloak).
 
 ```bash
+# client_id: 👈 project id
 curl --location ' 'https://demo.duendesoftware.com/connect/token'' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
---data-urlencode 'client_id={CLIENT_ID}' \ # 👈 project id
+--data-urlencode 'client_id={CLIENT_ID}' \
 --data-urlencode 'client_secret={CLIENT_SECRET}' \
 --data-urlencode 'grant_type=client_credential' \
 ```
@@ -300,7 +301,7 @@ general_settings:
   enable_jwt_auth: True
   litellm_jwtauth:  
     # Use namespace as team identifier (resolves via team_alias in DB)
-    team_alias_jwt_field: "kubernetes\.io.namespace"
+    team_alias_jwt_field: 'kubernetes\.io.namespace'
 ```
 
 #### Step 3: Create ServiceAccount and Configure Pod
@@ -413,7 +414,7 @@ general_settings:
   litellm_jwtauth:
     user_id_jwt_field: "sub"
     # Map the namespace to team_alias in the database
-    team_alias_jwt_field: "kubernetes\.io.namespace"
+    team_alias_jwt_field: 'kubernetes\.io.namespace'
     user_id_upsert: true
 ```
 
@@ -744,7 +745,7 @@ general_settings:
   master_key: sk-1234
   enable_jwt_auth: True
   litellm_jwtauth:
-    ...
+    # ...
     team_id_jwt_field: "litellm-team" # 👈 Set field in the JWT token that stores the team ID
     team_allowed_routes: ["/v1/chat/completions"] # 👈 Set accepted routes
 ```

--- a/docs/proxy/user_keys.md
+++ b/docs/proxy/user_keys.md
@@ -707,8 +707,8 @@ print(query_result[:5])
       "embedding": [
         0.0023064255,
         -0.009327292,
-        .... 
-        -0.0028842222,
+        ...,
+        -0.0028842222
       ],
       "index": 0
     }
@@ -888,7 +888,7 @@ $ aider --openai-api-base http://0.0.0.0:4000 --openai-api-key fake-key
 </TabItem>
 <TabItem value="autogen" label="AutoGen">
 
-```python
+```bash
 uv add pyautogen
 ```
 

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -1019,7 +1019,7 @@ curl --location 'http://0.0.0.0:4000/team/new' \
 {
     "key": "sk-sA7VDkyhlQ7m8Gt77Mbt3Q",
     "expires": "2024-01-19T01:21:12.816168",
-    "team_id": "my-prod-team",
+    "team_id": "my-prod-team"
 }
 ```
 
@@ -1100,7 +1100,7 @@ curl --location 'http://0.0.0.0:4000/user/new' \
 {
     "key": "sk-sA7VDkyhlQ7m8Gt77Mbt3Q",
     "expires": "2024-01-19T01:21:12.816168",
-    "user_id": "krrish@berri.ai",
+    "user_id": "krrish@berri.ai"
 }
 ```
 
@@ -1147,7 +1147,7 @@ curl --location 'http://0.0.0.0:4000/key/generate' \
 ```json
 {
     "key": "sk-ulGNRXWtv7M0lFnnsQk0wQ",
-    "expires": "2024-01-18T20:48:44.297973",
+    "expires": "2024-01-18T20:48:44.297973"
 }
 ```
 

--- a/docs/proxy_auth.md
+++ b/docs/proxy_auth.md
@@ -164,7 +164,7 @@ The main handler that manages the token lifecycle.
 from litellm.proxy_auth import ProxyAuthHandler
 
 handler = ProxyAuthHandler(
-    credential=<TokenCredential>,  # required - credential provider
+    credential="<TokenCredential>",  # required - credential provider
     scope="<oauth2-scope>"         # required - OAuth2 scope to request
 )
 ```

--- a/docs/proxy_server.md
+++ b/docs/proxy_server.md
@@ -212,7 +212,7 @@ docker compose up -d
 </TabItem>
 <TabItem value="autogen" label="AutoGen">
 
-```python
+```bash
 uv add pyautogen
 ```
 
@@ -345,7 +345,7 @@ python3 run.py --task "a script that says hello world" --name "hello world"
 </TabItem>
 <TabItem value="langroid" label="Langroid">
 
-```python
+```bash
 uv add langroid
 ```
 
@@ -447,7 +447,7 @@ $ aider --openai-api-base http://0.0.0.0:8000 --openai-api-key fake-key
 </TabItem>
 <TabItem value="autogen" label="AutoGen">
 
-```python
+```bash
 uv add pyautogen
 ```
 
@@ -580,7 +580,7 @@ python3 run.py --task "a script that says hello world" --name "hello world"
 </TabItem>
 <TabItem value="langroid" label="Langroid">
 
-```python
+```bash
 uv add langroid
 ```
 

--- a/docs/reasoning_content.md
+++ b/docs/reasoning_content.md
@@ -25,7 +25,7 @@ Supported Providers:
 
 LiteLLM will standardize the `reasoning_content` in the response and `thinking_blocks` in the assistant message.
 
-```python title="Example response from litellm"
+```python nolint title="Example response from litellm"
 "message": {
     ...
     "reasoning_content": "The capital of France is Paris.",
@@ -646,17 +646,17 @@ Expected Response
       "model_group": "claude-3-sonnet-reasoning",
       "providers": ["anthropic"],
       "mode": "chat",
-      "supports_reasoning": true,
+      "supports_reasoning": true
     },
     {
       "model_group": "deepseek-reasoning",
       "providers": ["deepseek"],
-      "supports_reasoning": true,
+      "supports_reasoning": true
     },
     {
       "model_group": "my-custom-reasoning-model",
       "providers": ["openai"],
-      "supports_reasoning": true,
+      "supports_reasoning": true
     }
   ]
 }
@@ -676,7 +676,7 @@ You can also route explicitly via `openai/responses/gpt-5.4` or `azure/responses
 
 **SDK:**
 ```python
-litellm.completion(model="azure/responses/my-reasoning-model", ...)
+litellm.completion(model="azure/responses/my-reasoning-model")  # ...
 ```
 
 **Proxy config:**

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -190,20 +190,20 @@ You can also set a `weight` param, to specify which model should get picked when
 
 ```yaml
 model_list:
-	- model_name: gpt-3.5-turbo
-	  litellm_params:
-	  	model: azure/chatgpt-v-2
-		api_key: os.environ/AZURE_API_KEY
-		api_version: os.environ/AZURE_API_VERSION
-		api_base: os.environ/AZURE_API_BASE
-		rpm: 900 
-	- model_name: gpt-3.5-turbo
-	  litellm_params:
-	  	model: azure/chatgpt-functioncalling
-		api_key: os.environ/AZURE_API_KEY
-		api_version: os.environ/AZURE_API_VERSION
-		api_base: os.environ/AZURE_API_BASE
-		rpm: 10 
+    - model_name: gpt-3.5-turbo
+      litellm_params:
+        model: azure/chatgpt-v-2
+        api_key: os.environ/AZURE_API_KEY
+        api_version: os.environ/AZURE_API_VERSION
+        api_base: os.environ/AZURE_API_BASE
+        rpm: 900 
+    - model_name: gpt-3.5-turbo
+      litellm_params:
+        model: azure/chatgpt-functioncalling
+        api_key: os.environ/AZURE_API_KEY
+        api_version: os.environ/AZURE_API_VERSION
+        api_base: os.environ/AZURE_API_BASE
+        rpm: 10 
 ```
 
 ##### **Python SDK**
@@ -252,20 +252,20 @@ asyncio.run(router_acompletion())
 
 ```yaml
 model_list:
-	- model_name: gpt-3.5-turbo
-	  litellm_params:
-	  	model: azure/chatgpt-v-2
-		api_key: os.environ/AZURE_API_KEY
-		api_version: os.environ/AZURE_API_VERSION
-		api_base: os.environ/AZURE_API_BASE
-		weight: 9
-	- model_name: gpt-3.5-turbo
-	  litellm_params:
-	  	model: azure/chatgpt-functioncalling
-		api_key: os.environ/AZURE_API_KEY
-		api_version: os.environ/AZURE_API_VERSION
-		api_base: os.environ/AZURE_API_BASE
-		weight: 1 
+    - model_name: gpt-3.5-turbo
+      litellm_params:
+        model: azure/chatgpt-v-2
+        api_key: os.environ/AZURE_API_KEY
+        api_version: os.environ/AZURE_API_VERSION
+        api_base: os.environ/AZURE_API_BASE
+        weight: 9
+    - model_name: gpt-3.5-turbo
+      litellm_params:
+        model: azure/chatgpt-functioncalling
+        api_key: os.environ/AZURE_API_KEY
+        api_version: os.environ/AZURE_API_VERSION
+        api_base: os.environ/AZURE_API_BASE
+        weight: 1 
 ```
 
 ##### **Python SDK**
@@ -313,8 +313,11 @@ asyncio.run(router_acompletion())
 </TabItem>
 <TabItem value="usage-based-v2" label="Rate-Limit Aware v2 (ASYNC)">
 
-> [!WARNING]  
+:::warning
+
 **Usage-based routing is not recommended for production due to performance impacts.** Use `simple-shuffle` (default) for optimal performance in high-traffic scenarios. Usage-based routing adds significant latency due to Redis operations for tracking usage across deployments.
+
+:::
 
 
 **🎉 NEW** This is an async implementation of usage-based-routing.
@@ -340,7 +343,7 @@ model_list = [{ # list of model deployments
 		"model": "azure/chatgpt-v-2", # actual model name
 		"api_key": os.getenv("AZURE_API_KEY"),
 		"api_version": os.getenv("AZURE_API_VERSION"),
-		"api_base": os.getenv("AZURE_API_BASE")
+		"api_base": os.getenv("AZURE_API_BASE"),
 		"tpm": 100000,
 		"rpm": 10000,
 	}, 
@@ -350,7 +353,7 @@ model_list = [{ # list of model deployments
 		"model": "azure/chatgpt-functioncalling", 
 		"api_key": os.getenv("AZURE_API_KEY"),
 		"api_version": os.getenv("AZURE_API_VERSION"),
-		"api_base": os.getenv("AZURE_API_BASE")
+		"api_base": os.getenv("AZURE_API_BASE"),
 		"tpm": 100000,
 		"rpm": 1000,
 	},
@@ -367,12 +370,12 @@ router = Router(model_list=model_list,
                 redis_host=os.environ["REDIS_HOST"], 
 				redis_password=os.environ["REDIS_PASSWORD"], 
 				redis_port=os.environ["REDIS_PORT"], 
-                routing_strategy="simple-shuffle" # 👈 RECOMMENDED - best performance
+                routing_strategy="simple-shuffle", # 👈 RECOMMENDED - best performance
 				enable_pre_call_checks=True, # enables router rate limits for concurrent calls
 				)
 
 response = await router.acompletion(model="gpt-3.5-turbo", 
-				messages=[{"role": "user", "content": "Hey, how's it going?"}]
+				messages=[{"role": "user", "content": "Hey, how's it going?"}])
 
 print(response)
 ```
@@ -383,20 +386,20 @@ print(response)
 
 ```yaml
 model_list:
-	- model_name: gpt-3.5-turbo # model alias 
-	  litellm_params: # params for litellm completion/embedding call 
-		model: azure/chatgpt-v-2 # actual model name
-		api_key: os.environ/AZURE_API_KEY
-		api_version: os.environ/AZURE_API_VERSION
-		api_base: os.environ/AZURE_API_BASE
+    - model_name: gpt-3.5-turbo # model alias 
+      litellm_params: # params for litellm completion/embedding call 
+        model: azure/chatgpt-v-2 # actual model name
+        api_key: os.environ/AZURE_API_KEY
+        api_version: os.environ/AZURE_API_VERSION
+        api_base: os.environ/AZURE_API_BASE
       tpm: 100000
-	  rpm: 10000
-	- model_name: gpt-3.5-turbo 
-	  litellm_params: # params for litellm completion/embedding call 
-		model: gpt-3.5-turbo 
-		api_key: os.getenv(OPENAI_API_KEY)
+      rpm: 10000
+    - model_name: gpt-3.5-turbo 
+      litellm_params: # params for litellm completion/embedding call 
+        model: gpt-3.5-turbo 
+        api_key: os.getenv(OPENAI_API_KEY)
       tpm: 100000
-	  rpm: 1000
+      rpm: 1000
 
 router_settings:
   routing_strategy: simple-shuffle # 👈 RECOMMENDED - best performance
@@ -489,7 +492,7 @@ router = Router(..., routing_strategy_args={"ttl": 10})
 
 ```yaml
 router_settings:
-	routing_strategy_args: {"ttl": 10}
+  routing_strategy_args: {"ttl": 10}
 ```
 
 #### Set Lowest Latency Buffer
@@ -519,7 +522,7 @@ router = Router(..., routing_strategy_args={"lowest_latency_buffer": 0.5})
 
 ```yaml
 router_settings:
-	routing_strategy_args: {"lowest_latency_buffer": 0.5}
+  routing_strategy_args: {"lowest_latency_buffer": 0.5}
 ```
 
 </TabItem>
@@ -572,12 +575,12 @@ router = Router(model_list=model_list,
                 redis_host=os.environ["REDIS_HOST"], 
 				redis_password=os.environ["REDIS_PASSWORD"], 
 				redis_port=os.environ["REDIS_PORT"], 
-                routing_strategy="usage-based-routing"
+                routing_strategy="usage-based-routing",
 				enable_pre_call_check=True, # enables router rate limits for concurrent calls
 				)
 
 response = await router.acompletion(model="gpt-3.5-turbo", 
-				messages=[{"role": "user", "content": "Hey, how's it going?"}]
+				messages=[{"role": "user", "content": "Hey, how's it going?"}])
 
 print(response)
 ```
@@ -1164,15 +1167,15 @@ print(response)
 ```yaml
 model_list:
   - model_name: o1
-  	litellm_params:
-		model: o1
-		api_key: os.environ/OPENAI_API_KEY
-		weight: 1	
+    litellm_params:
+      model: o1
+      api_key: os.environ/OPENAI_API_KEY
+      weight: 1
   - model_name: o1
     litellm_params:
-		model: o1-preview
-		api_key: os.environ/OPENAI_API_KEY
-		weight: 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN o1-preview
+      model: o1-preview
+      api_key: os.environ/OPENAI_API_KEY
+      weight: 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN o1-preview
 ```
 
 </TabItem>
@@ -1291,7 +1294,7 @@ model_list = [{
 	"model_name": "gpt-4",
 	"litellm_params": {
 		"model": "azure/gpt-4",
-		...
+		# ...
 		"max_parallel_requests": 10 # 👈 SET PER DEPLOYMENT
 	}
 }]
@@ -1339,8 +1342,8 @@ print(f"response: {response}")
 
 ```yaml
 router_settings:
-	allowed_fails: 3 # cooldown model if it fails > 1 call in a minute. 
-  	cooldown_time: 30 # (in seconds) how long to cooldown model if fails/min > allowed_fails
+  allowed_fails: 3 # cooldown model if it fails > 1 call in a minute. 
+  cooldown_time: 30 # (in seconds) how long to cooldown model if fails/min > allowed_fails
 ```
 
 Defaults:
@@ -1392,7 +1395,7 @@ router = Router(..., disable_cooldowns=True)
 
 ```yaml
 router_settings:
-	disable_cooldowns: True
+  disable_cooldowns: True
 ```
 
 </TabItem>
@@ -1644,8 +1647,8 @@ router_settings:
     "ContentPolicyViolationErrorRetries": 4
   }
   allowed_fails_policy: {
-	"ContentPolicyViolationErrorAllowedFails": 1000, # Allow 1000 ContentPolicyViolationError before cooling down a deployment
-	"RateLimitErrorAllowedFails": 100 # Allow 100 RateLimitErrors before cooling down a deployment
+    "ContentPolicyViolationErrorAllowedFails": 1000, # Allow 1000 ContentPolicyViolationError before cooling down a deployment
+    "RateLimitErrorAllowedFails": 100 # Allow 100 RateLimitErrors before cooling down a deployment
   }
 ```
 
@@ -1696,9 +1699,9 @@ print(response)
 
 **Pass in Redis URL, additional kwargs** 
 ```python 
-router = Router(model_list: Optional[list] = None,
+router = Router(model_list=model_list,
                  ## CACHING ## 
-                 redis_url=os.getenv("REDIS_URL")",
+                 redis_url=os.getenv("REDIS_URL"),
 				 cache_kwargs= {}, # additional kwargs to pass to RedisCache (see caching.py)
 				 cache_responses=True)
 ```
@@ -1744,7 +1747,7 @@ model_list = [
                     "api_key": os.getenv("AZURE_API_KEY"),
                     "api_version": os.getenv("AZURE_API_VERSION"),
                     "api_base": os.getenv("AZURE_API_BASE"),
-					"region_name": "eu" # 👈 SET 'EU' REGION NAME
+					"region_name": "eu", # 👈 SET 'EU' REGION NAME
 					"base_model": "azure/gpt-35-turbo", # 👈 (Azure-only) SET BASE MODEL
                 },
             },
@@ -1757,7 +1760,7 @@ model_list = [
             },
 			{
 				"model_name": "gemini-pro",
-				"litellm_params: {
+				"litellm_params": {
 					"model": "vertex_ai/gemini-pro-1.5", 
 					"vertex_project": "adroit-crow-1234",
 					"vertex_location": "us-east1" # 👈 AUTOMATICALLY INFERS 'region_name'

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -97,7 +97,7 @@ response = client.chat.completions.create(
         }
     ],
     extra_body={ 
-        "priority": 0 👈 SET VALUE HERE
+        "priority": 0 # 👈 SET VALUE HERE
     }
 )
 
@@ -156,7 +156,7 @@ litellm_settings:
     request_timeout: 600 # 👈 Will keep retrying until timeout occurs
 
 router_settings:
-    redis_host; os.environ/REDIS_HOST
+    redis_host: os.environ/REDIS_HOST
     redis_password: os.environ/REDIS_PASSWORD
     redis_port: os.environ/REDIS_PORT
 ```

--- a/docs/sdk_custom_pricing.md
+++ b/docs/sdk_custom_pricing.md
@@ -50,7 +50,7 @@ def test_completion_azure_model():
         # azure call
         response = completion(
           model = "azure/<your_deployment_name>", 
-          messages = [{ "content": "Hello, how are you?","role": "user"}]
+          messages = [{ "content": "Hello, how are you?","role": "user"}],
           input_cost_per_token=0.005,
           output_cost_per_token=1,
         )

--- a/docs/secret_managers/azure_key_vault.md
+++ b/docs/secret_managers/azure_key_vault.md
@@ -29,7 +29,7 @@ export["AZURE_KEY_VAULT_URI"]="your-azure-key-vault-uri"
 ```yaml
 model_list: 
     - model_name: "my-azure-models" # model alias 
-        litellm_params:
+      litellm_params:
             model: "azure/<your-deployment-name>"
             api_key: "os.environ/AZURE-API-KEY" # reads from key vault - get_secret("AZURE_API_KEY")
             api_base: "os.environ/AZURE-API-BASE" # reads from key vault - get_secret("AZURE_API_BASE")

--- a/docs/text_completion.md
+++ b/docs/text_completion.md
@@ -167,7 +167,7 @@ Here's the exact JSON output format you can expect from completion calls:
       "finish_reason": null
     }
   ],
-  "model": "gpt-3.5-turbo-instruct"
+  "model": "gpt-3.5-turbo-instruct",
   "system_fingerprint": "fp_44709d6fcb",
 }
 

--- a/docs/tutorials/TogetherAI_liteLLM.md
+++ b/docs/tutorials/TogetherAI_liteLLM.md
@@ -3,8 +3,8 @@ https://together.ai/
 
 
 
-```python
-!uv add litellm
+```bash
+uv add litellm
 ```
 
 

--- a/docs/tutorials/compare_llms.md
+++ b/docs/tutorials/compare_llms.md
@@ -87,8 +87,8 @@ Benchmark Results for 'When will BerriAI IPO?':
 
 <!-- 
 ## Pre-requisites:
-``` python
-!uv add litellm
+```bash
+uv add litellm
 ```
 
 ## Example Use Case 1 - Code Generator

--- a/docs/tutorials/compare_llms_2.md
+++ b/docs/tutorials/compare_llms_2.md
@@ -19,8 +19,8 @@ given test set using litellm
 
 <div class="cell code" id="fBkbl4Qo9pvz">
 
-``` python
-!uv add litellm
+```bash
+uv add litellm
 ```
 
 </div>

--- a/docs/tutorials/fallbacks.md
+++ b/docs/tutorials/fallbacks.md
@@ -64,11 +64,14 @@ Allow `45seconds` for each request. In the 45s this function tries calling the p
 ```python
 while response == None and time.time() - start_time < 45:
         for model in fallbacks:
+            ...
 ```
 
 #### Cool-Downs for rate-limited models
 If a model API call leads to an error - allow it to cooldown for `60s`
 ```python
+try:
+  ...
 except Exception as e:
   print(f"got exception {e} for model {model}")
   rate_limited_models.add(model)

--- a/docs/tutorials/first_playground.md
+++ b/docs/tutorials/first_playground.md
@@ -23,7 +23,7 @@ Let's make sure our keys are working. Run this script in any environment of your
 
 🚨 Don't forget to replace the placeholder key values with your keys!
 
-```python 
+```bash
 uv add litellm
 ```
 
@@ -121,7 +121,7 @@ if __name__ == '__main__':
 
 ### Let's test it
 Start the server:
-```python 
+```bash
 python main.py
 ```
 
@@ -179,7 +179,7 @@ This is what you should see:
 <Image img={require('../../img/litellm_streamlit_playground.png')} alt="streamlit_playground" />
 
 
-# Congratulations 🚀 
+## Congratulations 🚀 
 
 You've created your first LLM Playground - with the ability to call 50+ LLM APIs. 
 

--- a/docs/tutorials/gradio_integration.md
+++ b/docs/tutorials/gradio_integration.md
@@ -2,8 +2,11 @@
 Simple tutorial for integrating LiteLLM completion calls with streaming Gradio chatbot demos
 
 ### Install & Import Dependencies
+```bash
+uv add gradio litellm
+```
+
 ```python
-!uv add gradio litellm
 import gradio
 import litellm
 ```

--- a/docs/tutorials/huggingface_codellama.md
+++ b/docs/tutorials/huggingface_codellama.md
@@ -6,7 +6,7 @@ This is a specialized task particular to code models. The model is trained to ge
 
 This task is available in the base and instruction variants of the **7B** and **13B** CodeLlama models. It is not available for any of the 34B models or the Python versions.
 
-# usage
+## usage
 
 ```python 
 import os
@@ -26,7 +26,7 @@ model = "huggingface/codellama/CodeLlama-34b-Instruct-hf" # specify huggingface 
 response = completion(model=model, messages=messages, max_tokens=500)
 ```
 
-# output 
+## output 
 ```python
 def remove_non_ascii(s: str) -> str:
     """ Remove non-ASCII characters from a string.

--- a/docs/tutorials/litellm_Test_Multiple_Providers.md
+++ b/docs/tutorials/litellm_Test_Multiple_Providers.md
@@ -9,8 +9,8 @@
 
 
 
-```python
-!uv add litellm python-dotenv
+```bash
+uv add litellm python-dotenv
 ```
 
 
@@ -26,9 +26,9 @@ from dotenv import load_dotenv
 load_dotenv()
 ```
 
-# Quality Test endpoint
+## Quality Test endpoint
 
-## Test the same prompt across multiple LLM providers
+### Test the same prompt across multiple LLM providers
 
 In this example, let's ask some questions about Paul Graham
 
@@ -42,7 +42,7 @@ result = testing_batch_completion(models=models, messages=messages)
 ```
 
 
-# Load Test endpoint
+## Load Test endpoint
 
 Run 100+ simultaneous queries across multiple providers to see when they fail + impact on latency
 
@@ -55,7 +55,7 @@ final_prompt = context + prompt
 result = load_test_model(models=models, prompt=final_prompt, num_calls=5)
 ```
 
-## Visualize the data
+### Visualize the data
 
 
 ```python
@@ -89,7 +89,7 @@ plt.show()
     
 
 
-# Duration Test endpoint
+## Duration Test endpoint
 
 Run load testing for 2 mins. Hitting endpoints with 100+ queries every 15 seconds.
 

--- a/docs/tutorials/lm_evaluation_harness.md
+++ b/docs/tutorials/lm_evaluation_harness.md
@@ -96,7 +96,7 @@ cd FastEval
 On FastEval make the following **2 line code change** to set `OPENAI_BASE_URL`
 
 https://github.com/FastEval/FastEval/pull/90/files
-```python
+```python nolint
 try:
     api_base = os.environ["OPENAI_BASE_URL"] #changed: read api base from .env
     if api_base == None:

--- a/docs/tutorials/model_fallbacks.md
+++ b/docs/tutorials/model_fallbacks.md
@@ -8,8 +8,8 @@ keywords: [fallbacks, failover, provider failover, model failover, OpenAI, Anthr
 Here's how you can implement model fallbacks (provider failover) across 3 LLM providers (OpenAI, Anthropic, Azure) using LiteLLM. 
 
 ## 1. Install LiteLLM
-```python 
-!uv add litellm
+```bash
+uv add litellm
 ```
 
 ## 2. Basic Fallbacks Code 
@@ -66,13 +66,13 @@ try:
 except ContextWindowExceededError as e:
     model_max_tokens = get_max_tokens(model)
     for model in context_window_fallback_list:
-        if model_max_tokens < model["max_tokens"]
-        try:
-            response = completion(model=model["model"], messages=messages)
-            return response
-        except ContextWindowExceededError as e:
-            model_max_tokens = get_max_tokens(model["model"])
-            continue
+        if model_max_tokens < model["max_tokens"]:
+            try:
+                response = completion(model=model["model"], messages=messages)
+                return response
+            except ContextWindowExceededError as e:
+                model_max_tokens = get_max_tokens(model["model"])
+                continue
 
 print(response)
 ```

--- a/docs/tutorials/oobabooga.md
+++ b/docs/tutorials/oobabooga.md
@@ -1,8 +1,11 @@
 # Oobabooga Text Web API Tutorial
 
 ### Install + Import LiteLLM 
-```python 
-!uv add litellm
+```bash
+uv add litellm
+```
+
+```python
 from litellm import completion 
 import os
 ```

--- a/docs/tutorials/opencode_integration.md
+++ b/docs/tutorials/opencode_integration.md
@@ -382,7 +382,7 @@ model_list:
 - OpenCode defaults custom OpenAI-compatible provider models to text-only input and strips image
   attachments before sending, so the request reaching LiteLLM contains no image. Declare
   `modalities` on the model in your OpenCode config:
-  ```text
+  ```json
   "claude-3-5-sonnet-20241022": {
     "name": "Claude 3.5 Sonnet",
     "modalities": { "input": ["text", "image"], "output": ["text"] }

--- a/docs/tutorials/opencode_integration.md
+++ b/docs/tutorials/opencode_integration.md
@@ -382,7 +382,7 @@ model_list:
 - OpenCode defaults custom OpenAI-compatible provider models to text-only input and strips image
   attachments before sending, so the request reaching LiteLLM contains no image. Declare
   `modalities` on the model in your OpenCode config:
-  ```json
+  ```text
   "claude-3-5-sonnet-20241022": {
     "name": "Claude 3.5 Sonnet",
     "modalities": { "input": ["text", "image"], "output": ["text"] }

--- a/docs/tutorials/prompt_caching.md
+++ b/docs/tutorials/prompt_caching.md
@@ -105,7 +105,7 @@ You need to specify `cache_control_injection_points` in your model configuration
 
 LiteLLM will then automatically add a `cache_control` directive to the specified messages in your requests:
 
-```json showLineNumbers title="cache_control_directive.json"
+```text showLineNumbers title="cache_control_directive.json"
 "cache_control": {
     "type": "ephemeral"
 }

--- a/docs/tutorials/prompt_caching.md
+++ b/docs/tutorials/prompt_caching.md
@@ -105,7 +105,7 @@ You need to specify `cache_control_injection_points` in your model configuration
 
 LiteLLM will then automatically add a `cache_control` directive to the specified messages in your requests:
 
-```text showLineNumbers title="cache_control_directive.json"
+```json showLineNumbers title="cache_control_directive.json"
 "cache_control": {
     "type": "ephemeral"
 }


### PR DESCRIPTION
Cleanup pass over `docs/` fixing everything a new structural check flags. The check itself lands in a stacked follow-up PR so this diff stays docs-only; the two are meant to merge in order, this one first.

What was wrong, by category: fenced `yaml`, `json` and `python` blocks that did not parse (missing commas, `def async`, unquoted `<placeholders>`, trailing commas, `model_list` entries with `litellm_params` at the wrong indent, tab-indented YAML in routing.md, an unterminated string, a stray BEL byte in configs.md, `from litellm` instead of `import litellm`); three pages that rendered half their content as one giant code block because a fence was never closed (exception_mapping.md, completion/usage.md, providers/dashscope.md); two fences in a2a.md with the first line of code on the ``` line, where it is silently dropped; comments placed after or between `\` line continuations in curl examples, which cut the pasted command in half (moved above the command); four GitHub-style `> [!NOTE]` alerts that Docusaurus renders as plain blockquotes (now admonitions); eleven pages with more than one H1 (later ones demoted); and a handful of links to anchors or URLs that did not exist.

Blocks labeled with the wrong language were relabeled rather than rewritten: shell commands in `python` fences are now `bash`, HTTP dumps and console output are `text`, Python reprs are `python`, `.env` contents are `bash`. Pseudo-signatures like `enable_cache(type: Optional[...] = "local", ...)` became valid `def` stubs. Blocks that are deliberately fragments carry a `nolint` marker on the fence instead: the dotprompt files in prompt_management.md and native_litellm_prompt.md, dict fragments in anthropic_tool_input_examples.md, claude_code_context_management.md and reasoning_content.md, a partial upstream diff in tutorials/lm_evaluation_harness.md, and `elif` branches meant to be pasted into an existing chain in new_rerank_provider.md and provider_registration/index.md.

Judgment calls worth a look: reliability.md moved a `model_info` block out from under `litellm_params`, where it had been silently nested; routing.md's tab-indented YAML now uses spaces with `tpm`/`rpm` at deployment level (the untouched `tpm` lines were already there); metrics.md's `[ key = value ]` pseudo-JSON is now a JSON object with the same values; custom_auth.md's `UserAPIKeyAuth(` field listing is now a `def` stub; configs.md:544 lost the BEL byte so `eos_token` is now a plain space. No prose was changed, no models or ports were renamed, and no content was added.

Verified locally: the structural check reports zero findings for all 784 pages, `node scripts/check-writing-style.js docs` passes, and `npm run build` succeeds with `onBrokenLinks` and `onBrokenAnchors` set to throw.

https://claude.ai/code/session_01BC8ryFjdJAW2iMYeEZFwHR
