### PR TITLE
docs: point proxy examples at port 4000

### DIFF
--- a/docs/audio_transcription.md
+++ b/docs/audio_transcription.md
@@ -84,7 +84,7 @@ general_settings:
 ```bash showLineNumbers title="Start Proxy Server"
 litellm --config /path/to/config.yaml 
 
-# RUNNING on http://0.0.0.0:8000
+# RUNNING on http://0.0.0.0:4000
 ```
 
 ### Test 
@@ -93,7 +93,7 @@ litellm --config /path/to/config.yaml
 <TabItem value="curl" label="Curl">
 
 ```bash showLineNumbers title="Test with cURL"
-curl --location 'http://0.0.0.0:8000/v1/audio/transcriptions' \
+curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
 --header 'Authorization: Bearer sk-1234' \
 --form 'file=@"/Users/krrishdholakia/Downloads/gettysburg.wav"' \
 --form 'model="whisper"'
@@ -106,7 +106,7 @@ curl --location 'http://0.0.0.0:8000/v1/audio/transcriptions' \
 from openai import OpenAI
 client = openai.OpenAI(
     api_key="sk-1234",
-    base_url="http://0.0.0.0:8000"
+    base_url="http://0.0.0.0:4000"
 )
 
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1451,7 +1451,7 @@ async with stdio_client(server_params) as (read, write):
         # Use OpenAI SDK pointed to LiteLLM proxy
         client = OpenAI(
             api_key="your-api-key",  # Your LiteLLM proxy API key
-            base_url="http://localhost:8000"  # Your LiteLLM proxy URL
+            base_url="http://localhost:4000"  # Your LiteLLM proxy URL
         )
 
         messages = [{"role": "user", "content": "what's (3 + 5)"}]

--- a/docs/providers/google_ai_studio/realtime.md
+++ b/docs/providers/google_ai_studio/realtime.md
@@ -24,7 +24,7 @@ model_list:
 ```bash
 litellm --config /path/to/config.yaml 
 
-# RUNNING on http://0.0.0.0:8000
+# RUNNING on http://0.0.0.0:4000
 ```
 
 ### Test 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1024,7 +1024,7 @@ litellm --config config.yaml
 3. Test it!
 
 ```bash
-curl --location 'http://0.0.0.0:8000/v1/audio/transcriptions' \
+curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
 --header 'Authorization: Bearer sk-1234' \
 --form 'file=@"/Users/krrishdholakia/Downloads/gettysburg.wav"' \
 --form 'model="gpt-4o-transcribe"'

--- a/docs/proxy_server.md
+++ b/docs/proxy_server.md
@@ -18,7 +18,7 @@ uv tool install 'litellm[proxy]'
 ```shell 
 $ litellm --model ollama/codellama 
 
-#INFO: Ollama running on http://0.0.0.0:8000
+#INFO: Ollama running on http://0.0.0.0:4000
 ```
 
 ### Test
@@ -32,7 +32,7 @@ $ litellm --test
 ```python
 import openai 
 
-openai.api_base = "http://0.0.0.0:8000"
+openai.api_base = "http://0.0.0.0:4000"
 
 print(openai.ChatCompletion.create(model="test", messages=[{"role":"user", "content":"Hey!"}]))
 ```
@@ -145,7 +145,7 @@ Replace openai base:
 import openai 
 
 openai.api_key = "any-string-here"
-openai.api_base = "http://0.0.0.0:8080" # your proxy url
+openai.api_base = "http://0.0.0.0:4000" # your proxy url
 
 # call openai
 response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hey"}])
@@ -169,7 +169,7 @@ git clone https://github.com/danny-avila/LibreChat.git
 
 #### 2. Modify `docker-compose.yml`
 ```yaml
-OPENAI_REVERSE_PROXY=http://host.docker.internal:8000/v1/chat/completions
+OPENAI_REVERSE_PROXY=http://host.docker.internal:4000/v1/chat/completions
 ```
 
 #### 3. Save fake OpenAI key in `.env`
@@ -202,7 +202,7 @@ cp .env.local.example .env.local
 #### 4. Set the API Key and Base
 ```env
 OPENAI_API_KEY="my-fake-key"
-OPENAI_API_HOST="http://0.0.0.0:8000
+OPENAI_API_HOST="http://0.0.0.0:4000
 ```
 
 #### 5. Run with docker compose
@@ -221,7 +221,7 @@ from autogen import AssistantAgent, UserProxyAgent, oai
 config_list=[
     {
         "model": "my-fake-model",
-        "api_base": "http://0.0.0.0:8000",  #litellm compatible endpoint
+        "api_base": "http://0.0.0.0:4000",  #litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL", # just a placeholder
     }
@@ -250,7 +250,7 @@ from autogen.agentchat import GroupChat
 config_list = [
     {
         "model": "ollama/mistralorca",
-        "api_base": "http://0.0.0.0:8000",  # litellm compatible endpoint
+        "api_base": "http://0.0.0.0:4000",  # litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL",  # just a placeholder
     }
@@ -260,7 +260,7 @@ llm_config = {"config_list": config_list, "seed": 42}
 code_config_list = [
     {
         "model": "ollama/phind-code",
-        "api_base": "http://0.0.0.0:8000",  # litellm compatible endpoint
+        "api_base": "http://0.0.0.0:4000",  # litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL",  # just a placeholder
     }
@@ -337,7 +337,7 @@ export OPENAI_API_KEY="sk-1234"
 ```
 
 ```shell 
-export OPENAI_BASE_URL="http://0.0.0.0:8000"
+export OPENAI_BASE_URL="http://0.0.0.0:4000"
 ```
 ```shell
 python3 run.py --task "a script that says hello world" --name "hello world"
@@ -355,7 +355,7 @@ from langroid.language_models.openai_gpt import OpenAIGPTConfig, OpenAIGPT
 # configure the LLM
 my_llm_config = OpenAIGPTConfig(
     # where proxy server is listening 
-    api_base="http://0.0.0.0:8000", 
+    api_base="http://0.0.0.0:4000", 
 )
 
 # create llm, one-off interaction
@@ -399,7 +399,7 @@ $ litellm --model ollama/codellama --temperature 0.3 --max_tokens 2048
 ```shell 
 $ litellm
 
-#INFO: litellm proxy running on http://0.0.0.0:8000
+#INFO: litellm proxy running on http://0.0.0.0:4000
 ```
 
 #### Send a request to your proxy
@@ -407,7 +407,7 @@ $ litellm
 import openai 
 
 openai.api_key = "any-string-here"
-openai.api_base = "http://0.0.0.0:8080" # your proxy url
+openai.api_base = "http://0.0.0.0:4000" # your proxy url
 
 # call gpt-3.5-turbo
 response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hey"}])
@@ -431,7 +431,7 @@ In the [config.py](https://continue.dev/docs/reference/Models/openai) set this a
       api_key="IGNORED",
       model="fake-model-name",
       context_length=2048, # customize if needed for your model
-      api_base="http://localhost:8000" # your proxy server url
+      api_base="http://localhost:4000" # your proxy server url
   ),
 ```
 
@@ -442,7 +442,7 @@ Credits [@vividfog](https://github.com/ollama/ollama/issues/305#issuecomment-175
 ```shell
 $ uv add aider 
 
-$ aider --openai-api-base http://0.0.0.0:8000 --openai-api-key fake-key
+$ aider --openai-api-base http://0.0.0.0:4000 --openai-api-key fake-key
 ```
 </TabItem>
 <TabItem value="autogen" label="AutoGen">
@@ -456,7 +456,7 @@ from autogen import AssistantAgent, UserProxyAgent, oai
 config_list=[
     {
         "model": "my-fake-model",
-        "api_base": "http://localhost:8000",  #litellm compatible endpoint
+        "api_base": "http://localhost:4000",  #litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL", # just a placeholder
     }
@@ -485,7 +485,7 @@ from autogen.agentchat import GroupChat
 config_list = [
     {
         "model": "ollama/mistralorca",
-        "api_base": "http://localhost:8000",  # litellm compatible endpoint
+        "api_base": "http://localhost:4000",  # litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL",  # just a placeholder
     }
@@ -495,7 +495,7 @@ llm_config = {"config_list": config_list, "seed": 42}
 code_config_list = [
     {
         "model": "ollama/phind-code",
-        "api_base": "http://localhost:8000",  # litellm compatible endpoint
+        "api_base": "http://localhost:4000",  # litellm compatible endpoint
         "api_type": "open_ai",
         "api_key": "NULL",  # just a placeholder
     }
@@ -572,7 +572,7 @@ export OPENAI_API_KEY="sk-1234"
 ```
 
 ```shell 
-export OPENAI_BASE_URL="http://0.0.0.0:8000"
+export OPENAI_BASE_URL="http://0.0.0.0:4000"
 ```
 ```shell
 python3 run.py --task "a script that says hello world" --name "hello world"
@@ -590,7 +590,7 @@ from langroid.language_models.openai_gpt import OpenAIGPTConfig, OpenAIGPT
 # configure the LLM
 my_llm_config = OpenAIGPTConfig(
     #format: "local/[URL where LiteLLM proxy is listening]
-    chat_model="local/localhost:8000", 
+    chat_model="local/localhost:4000", 
     chat_context_length=2048,  # adjust based on model
 )
 
@@ -618,7 +618,7 @@ GPT-Pilot helps you build apps with AI Agents. [For more](https://github.com/Pyt
 In your .env set the openai endpoint to your local server. 
 
 ```
-OPENAI_ENDPOINT=http://0.0.0.0:8000
+OPENAI_ENDPOINT=http://0.0.0.0:4000
 OPENAI_API_KEY=my-fake-key
 ```
 </TabItem>
@@ -639,7 +639,7 @@ import guidance
 
 # set api_base to your proxy
 # set api_key to anything
-gpt4 = guidance.llms.OpenAI("gpt-4", api_base="http://0.0.0.0:8000", api_key="anything")
+gpt4 = guidance.llms.OpenAI("gpt-4", api_base="http://0.0.0.0:4000", api_key="anything")
 
 experts = guidance('''
 {{#system~}}
@@ -791,7 +791,7 @@ litellm --model ollama/llama2 \
   --max_tokens 250 \
   --temperature 0.5
 
-# OpenAI-compatible server running on http://0.0.0.0:8000
+# OpenAI-compatible server running on http://0.0.0.0:4000
 ```
 
 ### Performance

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -70,7 +70,7 @@ model_list:
 ```bash
 litellm --config /path/to/config.yaml 
 
-# RUNNING on http://0.0.0.0:8000
+# RUNNING on http://0.0.0.0:4000
 ```
 
 ### Test 

--- a/docs/tutorials/eval_suites.md
+++ b/docs/tutorials/eval_suites.md
@@ -22,7 +22,7 @@ LiteLLM allows you to create an OpenAI compatible server for all supported LLMs.
 ```shell
 $ litellm --model huggingface/bigcode/starcoder
 
-#INFO: Proxy running on http://0.0.0.0:8000
+#INFO: Proxy running on http://0.0.0.0:4000
 ```
 
 **Here's how you can create the proxy for other supported llms**
@@ -157,14 +157,14 @@ $ litellm --model command-nightly
 Before running the eval we will set `openai.api_base` to the litellm proxy from Step 1
 
 ```python
-openai.api_base = "http://0.0.0.0:8000"
+openai.api_base = "http://0.0.0.0:4000"
 ```
 
 ```python
 import openai
 import pandas as pd
 openai.api_key = "anything"             # this can be anything, we set the key on the proxy
-openai.api_base = "http://0.0.0.0:8000" # set api base to the proxy from step 1
+openai.api_base = "http://0.0.0.0:4000" # set api base to the proxy from step 1
 
 
 import mlflow

--- a/docs/tutorials/lm_evaluation_harness.md
+++ b/docs/tutorials/lm_evaluation_harness.md
@@ -22,7 +22,7 @@ Using a custom api base
 $ export HUGGINGFACE_API_KEY=my-api-key #[OPTIONAL]
 $ litellm --model huggingface/tinyllama --api_base https://k58ory32yinf1ly0.us-east-1.aws.endpoints.huggingface.cloud
 ```
-OpenAI Compatible Endpoint at http://0.0.0.0:8000
+OpenAI Compatible Endpoint at http://0.0.0.0:4000
 
 **Step 2: Create a Virtual Env for LM Harness + Use OpenAI 0.28.1**
 We will now run lm harness with a new virtual env with openai==0.28.1
@@ -39,7 +39,7 @@ uv add openai==0.28.01
 
 **Step 3: Set OpenAI API Base & Key**
 ```shell
-$ export OPENAI_BASE_URL=http://0.0.0.0:8000
+$ export OPENAI_BASE_URL=http://0.0.0.0:4000
 ```
 
 LM Harness requires you to set an OpenAI API key `OPENAI_API_SECRET_KEY` for running benchmarks
@@ -74,7 +74,7 @@ $ litellm --model huggingface/bigcode/starcoder
 
 **Step 2: Set OpenAI API Base & Key**
 ```shell
-$ export OPENAI_BASE_URL=http://0.0.0.0:8000
+$ export OPENAI_BASE_URL=http://0.0.0.0:4000
 ```
 
 Set this to anything since the proxy has the credentials
@@ -130,7 +130,7 @@ $ litellm --model huggingface/bigcode/starcoder
 
 **Step 2: Set OpenAI API Base & Key**
 ```shell
-$ export OPENAI_BASE_URL=http://0.0.0.0:8000
+$ export OPENAI_BASE_URL=http://0.0.0.0:4000
 ```
 
 **Step 3 Run with FLASK** 


### PR DESCRIPTION
The LiteLLM proxy listens on port 4000 and 1355 lines of docs already say so, but eight pages still pointed OpenAI SDK, curl, and third-party tool configs at `0.0.0.0:8000` or `localhost:8000`. Anyone copying those snippets gets a connection refused. This PR changes each such URL to 4000.

The rule applied: a port is changed only when the URL is the LiteLLM proxy itself, judged by reading each occurrence in context (a preceding `litellm --config` or `litellm --model` command, an "your proxy url" comment, or a client `base_url` described as pointing at LiteLLM). Two `0.0.0.0:8080 # your proxy url` lines in `proxy_server.md` are included because they sit directly under a banner announcing the proxy on port 8000, and leaving them on 8080 would have made the page internally inconsistent after the rest was changed.

Files touched: `docs/proxy_server.md`, `docs/audio_transcription.md`, `docs/realtime.md`, `docs/mcp.md`, `docs/providers/openai.md`, `docs/providers/google_ai_studio/realtime.md`, `docs/tutorials/eval_suites.md`, `docs/tutorials/lm_evaluation_harness.md`. 36 lines changed, all inside code blocks, no prose or table edits.

Deliberately left on 8000 because the URL is a different server: `docs/providers/vllm.md` (hosted vLLM), `docs/providers/triton-inference-server.md`, `docs/providers/lm_studio.md`, `docs/providers/lemonade.md`, `docs/proxy/guardrails/guardrails_ai.md` and `docs/proxy/guardrails/quick_start.md` (Guardrails AI server default), `docs/image_generation.md`, `docs/reasoning_content.md`, `docs/completion/audio.md` and `docs/completion/vision.md` (a custom OpenAI-compatible model's `api_base` inside a model_list), `docs/mcp_zero_trust.md` (the MCP server, not the proxy).

Checks run: `python scripts/check-docs.py docs` (no structural problems) and `node scripts/check-writing-style.js docs blog release_notes` (no prose em dashes; the 9 vocabulary warnings pre-exist on main).

https://claude.ai/code/session_01BC8ryFjdJAW2iMYeEZFwHR
