### PR TITLE
docs: replace hand-written Enterprise admonitions with an EnterpriseFeature component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ Custom standalone pages live in `src/pages/`.
 
 If you add, remove, or move docs pages, check whether `sidebars.js` needs to be updated.
 
+To mark a page or section as Enterprise-gated, put `<EnterpriseFeature />` on its own line with a blank line before and after it, instead of writing the admonition by hand. It is registered globally in `src/theme/MDXComponents.js`, so no import is needed. Pass `feature="SSO"` to name the feature in the first sentence, use `<EnterpriseFeature free />` for features that ship in `litellm[proxy]` without a license, and put a one-line note between `<EnterpriseFeature>` and `</EnterpriseFeature>` when the page needs an extra sentence, such as a user limit. The component lives in `src/components/EnterpriseFeature/`.
+
 ## 5. Verify your changes
 
 Before opening a PR, run:

--- a/docs/fine_tuning.md
+++ b/docs/fine_tuning.md
@@ -3,12 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # /fine_tuning
 
-
-:::info
-
-This is an Enterprise only endpoint [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 | Feature | Supported | Notes | 
 |-------|-------|-------|

--- a/docs/observability/gcs_bucket_integration.md
+++ b/docs/observability/gcs_bucket_integration.md
@@ -4,12 +4,7 @@ import Image from '@theme/IdealImage';
 
 Log LLM Logs to [Google Cloud Storage Buckets](https://cloud.google.com/storage?hl=en)
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature />
 
 ### Usage
 

--- a/docs/proxy/access_control.md
+++ b/docs/proxy/access_control.md
@@ -157,9 +157,7 @@ An internal user viewer can view their own information but cannot create or dele
 
 ## Organization/Team Specific Roles
 
-:::info 
-Organization/Team specific roles are premium features. You need to be a LiteLLM Enterprise user to use them. [Get a 30 day trial here](https://www.litellm.ai/#trial).
-:::
+<EnterpriseFeature />
 
 These roles are scoped to specific organizations or teams. Users with these roles can only manage resources within their assigned organization or team.
 

--- a/docs/proxy/admin_ui_sso.md
+++ b/docs/proxy/admin_ui_sso.md
@@ -4,19 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # ✨ SSO for Admin UI
 
-:::info
-From v1.76.0, SSO is now Free for up to 5 users.
-:::
-
-:::info
-
-✨ SSO is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature feature="SSO">From v1.76.0, SSO is free for up to 5 users. Beyond that, an enterprise license is required.</EnterpriseFeature>
 
 ### Usage (Google, Microsoft, Okta, etc.)
 

--- a/docs/proxy/cost_tracking.md
+++ b/docs/proxy/cost_tracking.md
@@ -936,11 +936,7 @@ curl -X GET "http://localhost:4000/spend/logs?start_date=2024-01-01&end_date=202
 
 Log specific key,value pairs as part of the metadata for a spend log
 
-:::info
-
-Logging specific key,value pairs in spend logs metadata is an enterprise feature.
-
-:::
+<EnterpriseFeature feature="Logging specific key,value pairs in spend logs metadata" />
 
 Requirements: 
 

--- a/docs/proxy/custom_auth.md
+++ b/docs/proxy/custom_auth.md
@@ -250,14 +250,7 @@ This path also enforces end-user budgets and per-model end-user budgets when `en
 
 Supported from v1.72.2+
 
-:::info 
-
-✨ Supporting Custom Auth + LiteLLM Virtual Keys is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-:::
+<EnterpriseFeature feature="Using Custom Auth with LiteLLM Virtual Keys" />
 
 ### Usage
 

--- a/docs/proxy/custom_sso.md
+++ b/docs/proxy/custom_sso.md
@@ -1,8 +1,6 @@
 # ✨ Event Hooks for SSO Login
 
-:::info
-✨ SSO is free for up to 5 users. After that, an enterprise license is required. [Get Started with Enterprise here](https://www.litellm.ai/enterprise)
-:::
+<EnterpriseFeature feature="SSO">SSO is free for up to 5 users. Beyond that, an enterprise license is required.</EnterpriseFeature>
 
 ## Overview
 

--- a/docs/proxy/dynamic_logging.md
+++ b/docs/proxy/dynamic_logging.md
@@ -5,13 +5,7 @@ import TabItem from '@theme/TabItem';
 
 # Dynamic Callback Management
 
-:::info
-
-✨ This is an enterprise feature.
-
-[Get started with LiteLLM Enterprise](https://www.litellm.ai/enterprise)
-
-:::
+<EnterpriseFeature />
 
 LiteLLM's dynamic callback management enables teams to control logging behavior on a per-request basis without requiring central infrastructure changes. This is essential for organizations managing large-scale service ecosystems where:
 

--- a/docs/proxy/dynamic_rate_limit.md
+++ b/docs/proxy/dynamic_rate_limit.md
@@ -113,10 +113,7 @@ Reserve TPM/RPM capacity for different environments or use cases. This ensures c
 - Real-time applications vs batch processing
 - Critical services vs experimental features
 
-:::tip
-
-Reserving TPM/RPM on keys based on priority is a premium feature. Please [get an enterprise license](/docs/enterprise) for it.
-:::
+<EnterpriseFeature feature="Reserving TPM/RPM on keys based on priority" />
 
 ### How Priority Reservation Works
 

--- a/docs/proxy/email.md
+++ b/docs/proxy/email.md
@@ -235,11 +235,7 @@ After regenerating the key, the user will receive an email notification with:
 
 ## Email Customization
 
-:::info
-
-Customizing Email Branding is an Enterprise Feature [Get in touch with us for a Free Trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature feature="Customizing Email Branding" />
 
 LiteLLM allows you to customize various aspects of your email notifications. Below is a complete reference of all customizable fields:
 

--- a/docs/proxy/global_control_plane.md
+++ b/docs/proxy/global_control_plane.md
@@ -4,15 +4,7 @@ import { ControlPlaneArchitecture } from '@site/src/components/ControlPlaneArchi
 
 Deploy a single LiteLLM UI that manages multiple independent LiteLLM proxy instances, each with its own database, Redis, and master key.
 
-:::info
-
-This is an Enterprise feature.
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 ## When to use this
 

--- a/docs/proxy/guardrails/aporia_api.md
+++ b/docs/proxy/guardrails/aporia_api.md
@@ -137,11 +137,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 ## 5. ✨ Control Guardrails per Project (API Key)
 
-:::info
-
-✨ This is an Enterprise only feature [Contact us to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Use this to control what guardrails run per project. In this tutorial we only want the following guardrails to run for 1 project (API Key)
 - `guardrails`: ["aporia-pre-guard", "aporia-post-guard"]

--- a/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/proxy/guardrails/custom_guardrail.md
@@ -460,12 +460,7 @@ curl -i  -X POST http://localhost:4000/v1/chat/completions \
 
 ## ✨ Pass additional parameters to guardrail
 
-:::info
-
-✨ This is an Enterprise only feature [Contact us to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature />
 
 Use this to pass additional parameters to the guardrail API call. e.g. things like success threshold
 

--- a/docs/proxy/guardrails/guardrail_policies.md
+++ b/docs/proxy/guardrails/guardrail_policies.md
@@ -79,9 +79,7 @@ x-litellm-applied-guardrails: pii_masking,prompt_injection
 
 ## Add guardrails for a specific team
 
-:::info
-✨ Enterprise only feature for team/key-based policy attachments. [Get a free trial](https://www.litellm.ai/enterprise#trial)
-:::
+<EnterpriseFeature feature="Team/key-based policy attachment" />
 
 You have a global baseline, but want to add extra guardrails for a specific team.
 
@@ -139,9 +137,7 @@ Now the `finance` team gets `pii_masking` + `strict_compliance_check` + `audit_l
 
 ## Remove guardrails for a specific team
 
-:::info
-✨ Enterprise only feature for team/key-based policy attachments. [Get a free trial](https://www.litellm.ai/enterprise#trial)
-:::
+<EnterpriseFeature feature="Team/key-based policy attachment" />
 
 You have guardrails running globally, but want to disable some for a specific team (e.g., internal testing).
 

--- a/docs/proxy/guardrails/guardrails_ai.md
+++ b/docs/proxy/guardrails/guardrails_ai.md
@@ -57,11 +57,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 ## ✨ Control Guardrails per Project (API Key)
 
-:::info
-
-✨ This is an Enterprise only feature [Contact us to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Use this to control what guardrails run per project. In this tutorial we only want the following guardrails to run for 1 project (API Key)
 - `guardrails`: ["aporia-pre-guard", "aporia-post-guard"]

--- a/docs/proxy/guardrails/quick_start.md
+++ b/docs/proxy/guardrails/quick_start.md
@@ -373,11 +373,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 ### 4. ✨ Pass Dynamic Parameters to Guardrail
 
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 Use this to pass additional parameters to the guardrail API call. e.g. things like success threshold. **[See `guardrails` spec for more details](/docs/proxy/guardrails/quick_start#guardrails-request-parameter)**
 
@@ -472,11 +468,7 @@ Monitor which guardrails were executed and whether they passed or failed. e.g. g
 
 ### ✨ Control Guardrails per API Key
 
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 Use this to control what guardrails run per API Key. In this tutorial we only want the following guardrails to run for 1 API Key
 
@@ -528,11 +520,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 ### ✨ Tag-based Guardrail Modes
 
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 Run guardrails based on the user-agent header. This is useful for running pre-call checks on OpenWebUI but only masking in logs for Claude CLI.
 
@@ -608,11 +596,7 @@ guardrails:
 
 ### ✨ Model-level Guardrails
 
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 This is great for cases when you have an on-prem and hosted model, and just want to run prevent sending PII to the hosted model.
 
@@ -646,11 +630,7 @@ guardrails:
 
 ### ✨ Disable team from turning on/off guardrails
 
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature />
 
 #### 1. Disable team from modifying guardrails
 

--- a/docs/proxy/ip_address.md
+++ b/docs/proxy/ip_address.md
@@ -1,11 +1,7 @@
 
 # ✨ IP Address Filtering
 
-:::info
-
-You need a LiteLLM License to use this feature. [Grab time](https://enterprise.litellm.ai/demo), to get one today!
-
-:::
+<EnterpriseFeature />
 
 Restrict which IP's can call the proxy endpoints.
 

--- a/docs/proxy/jwt_auth_arch.md
+++ b/docs/proxy/jwt_auth_arch.md
@@ -4,15 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # Control Model Access with OIDC (Azure AD/Keycloak/etc.)
 
-:::info
-
-✨ JWT Auth is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature feature="JWT Auth" />
 
 <Image img={require('../../img/control_model_access_jwt.png')} style={{ width: '100%', maxWidth: '4000px' }} />
 

--- a/docs/proxy/jwt_key_mapping.md
+++ b/docs/proxy/jwt_key_mapping.md
@@ -1,12 +1,6 @@
 # JWT → Virtual Key Mapping
 
-:::info Enterprise
-
-JWT → Virtual Key Mapping is an Enterprise feature.
-
-[Get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature feature="JWT → Virtual Key Mapping" />
 
 Map JWT tokens to LiteLLM virtual keys, so every JWT client gets the same granular controls as a virtual key: model restrictions, spend limits, rate limits, guardrails, and full spend tracking.
 

--- a/docs/proxy/litellm_managed_files.md
+++ b/docs/proxy/litellm_managed_files.md
@@ -7,14 +7,7 @@ import Image from '@theme/IdealImage';
 - Reuse the same file across different providers.
 - Prevent users from seeing files they don't have access to on `list` and `retrieve` calls. 
 
-:::info
-
-This is a free LiteLLM Enterprise feature.
-
-Available via the `litellm` docker image. If you are using the pip package, you must install [`litellm-enterprise`](https://pypi.org/project/litellm-enterprise/).
-
-:::
-
+<EnterpriseFeature free />
 
 | Property | Value | Comments |
 | --- | --- | --- |

--- a/docs/proxy/logging.md
+++ b/docs/proxy/logging.md
@@ -264,13 +264,7 @@ LiteLLM.Info: "no-log request, skipping logging"
 
 ### ✨ Dynamically Disable specific callbacks
 
-:::info
-
-This is an enterprise feature.
-
-[Proceed with LiteLLM Enterprise](https://www.litellm.ai/enterprise)
-
-:::
+<EnterpriseFeature />
 
 For some use cases, you may want to disable specific callbacks for a request. You can do this by passing `x-litellm-disable-callbacks: <callback_name>` in the request headers.
 
@@ -1113,12 +1107,7 @@ litellm_settings:
 
 Log LLM Logs to [Google Cloud Storage Buckets](https://cloud.google.com/storage?hl=en)
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature />
 
 | Property                     | Details                                                        |
 | ---------------------------- | -------------------------------------------------------------- |
@@ -1198,12 +1187,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 Log LLM Logs/SpendLogs to [Google Cloud Storage PubSub Topic](https://cloud.google.com/pubsub/docs/reference/rest)
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature />
 
 | Property    | Details                                                            |
 | ----------- | ------------------------------------------------------------------ |
@@ -1503,12 +1487,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 Log LLM Logs to [Azure Data Lake Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction)
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature />
 
 | Property                        | Details                                                                                                         |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
@@ -2087,11 +2066,7 @@ ModelResponse(
   Send LiteLLM logs to a custom API endpoint
 </p>
 
-:::info
-
-This is an Enterprise only feature [Get Started with Enterprise here](https://github.com/BerriAI/litellm/tree/main/enterprise)
-
-:::
+<EnterpriseFeature />
 
 | Property       | Details                                                                                                                                                    |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/proxy/managed_batches.md
+++ b/docs/proxy/managed_batches.md
@@ -1,10 +1,6 @@
 # [BETA] LiteLLM Managed Files with Batches
 
-:::info
-
-Available with the `litellm[proxy]` package or any `litellm` docker image. No Enterprise license is required.
-
-:::
+<EnterpriseFeature free />
 
 | Feature | Supported | Comments |
 | --- | --- | --- |

--- a/docs/proxy/managed_finetuning.md
+++ b/docs/proxy/managed_finetuning.md
@@ -1,14 +1,6 @@
 # ✨ [BETA] LiteLLM Managed Files with Finetuning
 
-
-:::info
-
-This is a free LiteLLM Enterprise feature.
-
-Available via the `litellm[proxy]` package or any `litellm` docker image.
-
-:::
-
+<EnterpriseFeature free />
 
 | Property | Value | Comments |
 | --- | --- | --- |

--- a/docs/proxy/model_access_groups.md
+++ b/docs/proxy/model_access_groups.md
@@ -190,15 +190,7 @@ Control access to all models with a specific prefix (e.g. `openai/*`).
 
 Use this to also give users access to all models, except for a few that you don't want them to use (e.g. `openai/o1-*`). 
 
-:::info
-
-Setting model access groups on wildcard models is an Enterprise feature. 
-
-See pricing [here](https://litellm.ai/#pricing)
-
-Get a trial key [here](https://litellm.ai/#trial)
-:::
-
+<EnterpriseFeature feature="Setting model access groups on wildcard models" />
 
 1. Setup config.yaml
 

--- a/docs/proxy/multi_region.md
+++ b/docs/proxy/multi_region.md
@@ -133,11 +133,11 @@ Health-check each region against `/health/liveliness`, not `/health/readiness`. 
 
 By default every instance serves both LLM traffic and admin traffic (UI and management APIs). In a multi-region deployment you can designate one instance as admin-only and strip admin surfaces from the regional instances. This keeps management access behind one hostname and reduces the attack surface of the instances serving LLM traffic.
 
-:::info
+<EnterpriseFeature>
 
-`DISABLE_ADMIN_ENDPOINTS` and `DISABLE_LLM_API_ENDPOINTS` are Enterprise features. [Enterprise Pricing](https://www.litellm.ai/#pricing)
+`DISABLE_ADMIN_ENDPOINTS` and `DISABLE_LLM_API_ENDPOINTS` are Enterprise features.
 
-:::
+</EnterpriseFeature>
 
 <Tabs>
 <TabItem value="admin" label="Admin instance">

--- a/docs/proxy/multiple_admins.md
+++ b/docs/proxy/multiple_admins.md
@@ -18,11 +18,7 @@ LiteLLM tracks changes to the following entities and actions:
 - **Entities:** Keys, Teams, Users, Models
 - **Actions:** Create, Update, Delete, Regenerate
 
-:::tip
-
-Requires Enterprise License, Get in touch with us [here](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 ## Usage
 

--- a/docs/proxy/oauth2.md
+++ b/docs/proxy/oauth2.md
@@ -2,11 +2,7 @@
 
 Use this if you want to use an Oauth2.0 token to make `/chat`, `/embeddings` requests to the LiteLLM Proxy
 
-:::info
-
-This is an Enterprise Feature - [get in touch with us if you want a free trial to test if this feature meets your needs](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 ## Usage 
 

--- a/docs/proxy/pagerduty.md
+++ b/docs/proxy/pagerduty.md
@@ -2,15 +2,7 @@ import Image from '@theme/IdealImage';
 
 # PagerDuty Alerting
 
-:::info
-
-✨ PagerDuty Alerting is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature feature="PagerDuty Alerting" />
 
 Handles two types of alerts:
 - High LLM API Failure Rate. Configure X fails in Y seconds to trigger an alert.

--- a/docs/proxy/project_management.md
+++ b/docs/proxy/project_management.md
@@ -1,13 +1,6 @@
 # ✨ [Beta] Project Management
 
-:::info
-
-This is an Enterprise feature.
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Projects in LiteLLM sit between teams and keys in the organizational hierarchy, enabling fine-grained access control and budget management for specific use cases or applications.
 

--- a/docs/proxy/provider_budget_routing.md
+++ b/docs/proxy/provider_budget_routing.md
@@ -272,11 +272,7 @@ Expected response on failure
 
 ## ✨ Tag Budgets
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://www.litellm.ai/#pricing)
-
-:::
+<EnterpriseFeature />
 
 Use this to set budgets for tags - example $10/day for tag=`product:chat-bot`, $100/day for tag=`product:chat-bot-2`
 

--- a/docs/proxy/public_routes.md
+++ b/docs/proxy/public_routes.md
@@ -3,11 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # Control Public & Private Routes
 
-:::info
-
-Requires a LiteLLM Enterprise License. [Get a free trial](https://enterprise.litellm.ai/demo).
-
-:::
+<EnterpriseFeature />
 
 Control which routes require authentication and which routes are publicly accessible.
 

--- a/docs/proxy/rate_limit_tiers.md
+++ b/docs/proxy/rate_limit_tiers.md
@@ -4,16 +4,7 @@ Define tiers with rate limits. Assign them to keys.
 
 Use this to control access and budgets across a lot of keys.
 
-:::info 
-
-This is a LiteLLM Enterprise feature.
-
-Get a 30 day free trial + get in touch [here](https://litellm.ai/#trial).
-
-See pricing [here](https://litellm.ai/#pricing).
-
-:::
-
+<EnterpriseFeature />
 
 ## 1. Create a budget 
 

--- a/docs/proxy/saml_sso.md
+++ b/docs/proxy/saml_sso.md
@@ -4,9 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # SAML 2.0 SSO
 
-:::info
-SSO is free for up to 5 users. After that, an enterprise license is required. [Get Started with Enterprise here](https://www.litellm.ai/enterprise).
-:::
+<EnterpriseFeature feature="SSO">SSO is free for up to 5 users. Beyond that, an enterprise license is required.</EnterpriseFeature>
 
 LiteLLM supports SAML 2.0 single sign-on for the admin UI alongside its existing OIDC providers (Google, Microsoft, Generic OAuth). SAML can be configured from the admin UI (**Admin Settings -> SSO Settings**) or through environment variables; no changes to `config.yaml` are needed. When SAML is configured and no OIDC provider is set, the existing **SSO** login button on the admin UI automatically redirects to the SAML Identity Provider.
 

--- a/docs/proxy/team_logging.md
+++ b/docs/proxy/team_logging.md
@@ -24,11 +24,7 @@ Team 3 -> Disabled Logging (for GDPR compliance)
 
 ## [BETA] Team Logging
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 ### UI Usage
 
@@ -260,11 +256,7 @@ All requests made with these keys will log data to their team-specific logging.
 
 Use the `/key/generate` or `/key/update` endpoints to add logging callbacks to a specific key.
 
-:::info
-
-✨ This is an Enterprise only feature [Get Started with Enterprise here](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 **How key based logging works:**
 

--- a/docs/proxy/team_model_add.md
+++ b/docs/proxy/team_model_add.md
@@ -1,13 +1,6 @@
 # ✨ Allow Teams to Add Models
 
-:::info
-
-This is an Enterprise feature.
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Allow team to add a their own models/key for that project - so any OpenAI call they make uses their OpenAI key.
 

--- a/docs/proxy/temporary_budget_increase.md
+++ b/docs/proxy/temporary_budget_increase.md
@@ -10,16 +10,7 @@ Set temporary budget increase for a LiteLLM Virtual Key. Use this if you get ask
 | Team | ❌ |
 | Organization | ❌ |
 
-:::note
-
-✨ Temporary Budget Increase is a LiteLLM Enterprise feature.
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
-
+<EnterpriseFeature feature="Temporary Budget Increase" />
 
 1. Create a LiteLLM Virtual Key with budget
 

--- a/docs/proxy/token_auth.md
+++ b/docs/proxy/token_auth.md
@@ -5,16 +5,7 @@ import TabItem from '@theme/TabItem';
 
 Use JWT's to auth admins / users / projects into the proxy.
 
-:::info
-
-✨ JWT-based Auth  is on LiteLLM Enterprise
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
-
+<EnterpriseFeature feature="JWT-based Auth" />
 
 :::tip JWT → Virtual Key Mapping
 

--- a/docs/proxy/ui_project_management.md
+++ b/docs/proxy/ui_project_management.md
@@ -4,14 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # ✨ [Beta] Project Management UI
 
-:::info
-
-This is an Enterprise feature.
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Manage projects directly from the LiteLLM Admin UI. Projects sit between teams and keys in your organizational hierarchy, enabling fine-grained access control and budget management for specific use cases or applications.
 

--- a/docs/proxy/ui_team_soft_budget_alerts.md
+++ b/docs/proxy/ui_team_soft_budget_alerts.md
@@ -2,15 +2,7 @@ import Image from '@theme/IdealImage';
 
 # Team Soft Budget Alerts
 
-:::info
-
-✨ This is an Enterprise feature. Email budget alerts require an enterprise license.
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-:::
+<EnterpriseFeature>Email budget alerts require an enterprise license.</EnterpriseFeature>
 
 Set a soft budget on a team and get email alerts when spending crosses the threshold, without blocking any requests.
 

--- a/docs/proxy/unmanaged_vertex_batches.md
+++ b/docs/proxy/unmanaged_vertex_batches.md
@@ -1,10 +1,6 @@
 # Unmanaged Vertex AI Batches
 
-:::info
-
-This is a LiteLLM Enterprise feature.
-
-:::
+<EnterpriseFeature />
 
 LiteLLM supports two paths for Vertex AI batch jobs. The managed path handles file upload and format conversion automatically. The unmanaged path lets you upload batch files directly to GCS in Vertex AI's native format; LiteLLM skips transformation but tracks cost when enabled.
 

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -438,11 +438,7 @@ Set a separate budget for each model available to a virtual key. For example, on
 - A $0.0000001 daily budget for `gpt-4o`
 - A $10 budget every 30 days for `gpt-4o-mini`
 
-:::info
-
-✨ This feature is available with LiteLLM Enterprise. [Get started with Enterprise](https://www.litellm.ai/#pricing).
-
-:::
+<EnterpriseFeature />
 
 `model_max_budget` uses the **[`Dict[str, GenericBudgetInfo]`](#genericbudgetinfo)** schema.
 
@@ -566,11 +562,7 @@ By default, LiteLLM returns a `budget_exceeded` error when a per-model budget is
 
 Use an internal-user per-model budget to apply one limit across all keys owned by that user. This prevents a user from bypassing the limit by creating another key. For example, use this scope to give each engineer a $200 monthly Opus budget when engineers have multiple keys.
 
-:::info
-
-✨ This feature is available with LiteLLM Enterprise. [Get started with Enterprise](https://www.litellm.ai/#pricing).
-
-:::
+<EnterpriseFeature />
 
 `model_max_budget` uses the same **[`Dict[str, GenericBudgetInfo]`](#genericbudgetinfo)** schema as the key-level setting. You can configure it with either `/user/new` or `/user/update`.
 

--- a/docs/proxy/virtual_keys.md
+++ b/docs/proxy/virtual_keys.md
@@ -623,16 +623,7 @@ litellm_settings:
 
 ### ✨ Key Rotations 
 
-:::info
-
-This is an Enterprise feature.
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Get free 30-day trial key](https://www.litellm.ai/enterprise#trial)
-
-
-:::
+<EnterpriseFeature />
 
 Rotate an existing API Key, while optionally updating its parameters.
 

--- a/docs/secret.md
+++ b/docs/secret.md
@@ -1,14 +1,6 @@
 # Secret Managers Overview
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 LiteLLM supports **reading secrets (eg. `OPENAI_API_KEY`)** and **writing secrets (eg. Virtual Keys)** from Azure Key Vault, Google Secret Manager, Hashicorp Vault, CyberArk Conjur, and AWS Secret Manager.
 

--- a/docs/secret_managers/aws_kms.md
+++ b/docs/secret_managers/aws_kms.md
@@ -1,14 +1,6 @@
 # AWS Key Management V1
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 :::tip
 

--- a/docs/secret_managers/aws_secret_manager.md
+++ b/docs/secret_managers/aws_secret_manager.md
@@ -3,15 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # AWS Secret Manager
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Store your proxy keys in AWS Secret Manager.
 

--- a/docs/secret_managers/azure_key_vault.md
+++ b/docs/secret_managers/azure_key_vault.md
@@ -1,14 +1,6 @@
 # Azure Key Vault
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 ## Usage with LiteLLM Proxy Server
 

--- a/docs/secret_managers/cyberark.md
+++ b/docs/secret_managers/cyberark.md
@@ -2,15 +2,7 @@
 
 import Image from '@theme/IdealImage';
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 | Feature | Support | Description |
 |---------|----------|-------------|

--- a/docs/secret_managers/google_kms.md
+++ b/docs/secret_managers/google_kms.md
@@ -1,14 +1,6 @@
 # Google Key Management Service
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Use encrypted keys from Google KMS on the proxy
 

--- a/docs/secret_managers/google_secret_manager.md
+++ b/docs/secret_managers/google_secret_manager.md
@@ -1,14 +1,6 @@
 # Google Secret Manager
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 Support for [Google Secret Manager](https://cloud.google.com/security/products/secret-manager)
 

--- a/docs/secret_managers/hashicorp_vault.md
+++ b/docs/secret_managers/hashicorp_vault.md
@@ -2,15 +2,7 @@ import Image from '@theme/IdealImage';
 
 # Hashicorp Vault
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 | Feature | Support | Description |
 |---------|----------|-------------|

--- a/docs/secret_managers/overview.md
+++ b/docs/secret_managers/overview.md
@@ -2,15 +2,7 @@ import Image from '@theme/IdealImage';
 
 # Secret Managers Overview
 
-:::info
-
-✨ **This is an Enterprise Feature**
-
-[Enterprise Pricing](https://www.litellm.ai/#pricing)
-
-[Contact us here to get a free trial](https://enterprise.litellm.ai/demo)
-
-:::
+<EnterpriseFeature />
 
 LiteLLM supports **reading secrets (eg. `OPENAI_API_KEY`)** and **writing secrets (eg. Virtual Keys)** from Azure Key Vault, Google Secret Manager, Hashicorp Vault, CyberArk Conjur, and AWS Secret Manager.
 

--- a/docs/tutorials/claude_code_okta_sso.md
+++ b/docs/tutorials/claude_code_okta_sso.md
@@ -2,11 +2,7 @@
 
 Route Claude Code through LiteLLM using each developer's Okta identity. Claude Code sends the developer's own Okta access token with every request, LiteLLM validates it against your Okta authorization server and creates the user automatically on first request, and usage, spend, and logs are attributed to that user. There are no per-user API keys to issue and no manual provisioning, so the setup works the same for 10 developers or 10,000.
 
-:::info
-
-JWT authentication is a LiteLLM Enterprise feature. [Get in touch](https://www.litellm.ai/enterprise) for a license key.
-
-:::
+<EnterpriseFeature feature="JWT authentication" />
 
 This guide uses Okta, but any OIDC provider that issues JWT access tokens (Azure AD, Keycloak, Auth0, etc.) works the same way; only the issuer URLs and app setup differ.
 

--- a/src/components/EnterpriseFeature/index.js
+++ b/src/components/EnterpriseFeature/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import Admonition from '@theme/Admonition';
+import Link from '@docusaurus/Link';
+
+const TRIAL_URL = 'https://www.litellm.ai/enterprise#trial';
+const DEMO_URL = 'https://enterprise.litellm.ai/demo';
+
+// A one-line note written inline (<EnterpriseFeature>text</EnterpriseFeature>)
+// arrives as a plain string; block content separated by blank lines arrives
+// already wrapped in <p> elements by MDX.
+function Note({ children }) {
+  if (children == null) return null;
+  if (typeof children === 'string') return <p>{children}</p>;
+  return children;
+}
+
+export default function EnterpriseFeature({ feature, free = false, children }) {
+  if (free) {
+    return (
+      <Admonition type="info" title="Free Enterprise feature">
+        <p>
+          Available with the <code>litellm[proxy]</code> package or any{' '}
+          <code>litellm</code> docker image. No Enterprise license is required.
+        </p>
+        <Note>{children}</Note>
+      </Admonition>
+    );
+  }
+
+  return (
+    <Admonition type="info" title="Enterprise feature">
+      <p>
+        {feature ? `${feature} requires` : 'This feature requires'} a LiteLLM
+        Enterprise license. Start a{' '}
+        <a href={TRIAL_URL}>free 30-day trial</a> or{' '}
+        <a href={DEMO_URL}>book a demo</a>.{' '}
+        <Link to="/docs/enterprise">See what Enterprise includes</Link>.
+      </p>
+      <Note>{children}</Note>
+    </Admonition>
+  );
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,8 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
+
+// Components listed here are available in every .md/.mdx page without an import.
+export default {
+  ...MDXComponents,
+  EnterpriseFeature,
+};


### PR DESCRIPTION
Seventy-five admonitions in docs/ mention Enterprise, written in eight or so different wordings and pointing at six different trial, pricing, or contact URLs. This PR adds one MDX component for the gate and swaps the hand-written admonitions for it, so every gated page reads the same and the trial and demo links live in one place.

## The component

`src/components/EnterpriseFeature/index.js` renders a Docusaurus info admonition titled "Enterprise feature" whose body reads "{feature} requires a LiteLLM Enterprise license." (or "This feature requires a LiteLLM Enterprise license." when no `feature` prop is given), followed by "Start a free 30-day trial or book a demo. See what Enterprise includes." The trial link is https://www.litellm.ai/enterprise#trial and the demo link is https://enterprise.litellm.ai/demo, matching the banner on docs/enterprise.md; the last sentence links to /docs/enterprise. Passing `free` changes the title to "Free Enterprise feature" and the body to "Available with the `litellm[proxy]` package or any `litellm` docker image. No Enterprise license is required." Children render as an extra paragraph after the default text, which is how the SSO five-user note and the email budget alert note are kept.

The component is registered in a new `src/theme/MDXComponents.js` that spreads `@theme-original/MDXComponents` and adds `EnterpriseFeature`, so pages use `<EnterpriseFeature />` without an import. CONTRIBUTING.md gets a short paragraph explaining when to reach for it.

## The sweep

63 admonitions across 52 pages are replaced. Only admonitions whose whole purpose was the gate (a sentence saying the feature is Enterprise, Enterprise-only, premium, or needs a license, plus pricing, trial, or contact links) were swapped. Feature names from the originals are carried into the `feature` prop (SSO, JWT Auth, JWT-based Auth, JWT authentication, JWT to Virtual Key Mapping, PagerDuty Alerting, Temporary Budget Increase, Customizing Email Branding, Logging specific key,value pairs in spend logs metadata, Setting model access groups on wildcard models, Reserving TPM/RPM on keys based on priority, Team/key-based policy attachment, Using Custom Auth with LiteLLM Virtual Keys). The managed files, managed batches, and managed finetuning pages use the `free` variant. On admin_ui_sso.md the separate "From v1.76.0, SSO is now Free for up to 5 users" admonition directly above the Enterprise one was folded into the component's note so the page does not show two stacked banners. The multi_region.md note keeps the `DISABLE_ADMIN_ENDPOINTS` and `DISABLE_LLM_API_ENDPOINTS` names as children.

Twelve admonitions were intentionally left alone because they carry content beyond the gate:

| File | Why it stays |
|------|--------------|
| docs/enterprise.md | The canonical Enterprise banner (quickstart link, trial, demo, SSO note) |
| docs/learn/enterprise_quickstart.md | Same banner plus a link to the full feature catalog |
| docs/migration_policy.md | A beta note saying a feature might move to Enterprise, not a gate |
| docs/proxy/billing_metrics.md | Explains the license plus metering credentials needed from onboarding |
| docs/proxy/docker_image_security.md | Says enterprise images are signed the same way and who to contact |
| docs/proxy/multi_tenant_architecture.md | Compares open source and Enterprise tenancy layers |
| docs/proxy/multiple_admins.md (line 94) | Explains when `audit_log_callbacks` fires and the non-license fallback |
| docs/proxy/prod.md (line 620) | A dedicated support pointer, not a feature gate |
| docs/proxy/self_serve.md (line 117) | A pointer to the SSO login page |
| docs/secret_managers/aws_kms.md (tip) | Points to the v2 docs; the info gate above it was replaced |
| docs/proxy/access_control.md (line 211) | A "how to create a team admin" how-to with a curl example inside it |
| docs/proxy/cost_tracking.md (line 172) | A "schedule a meeting" pointer under the non-admin `/spend` section; the `get_spend_routes` permission itself is not license-gated in litellm, only the `/global/spend/report` endpoint in the example is, so turning it into an explicit gate would overstate it |

No H1s, headings, or prose outside admonitions were changed, and release_notes/ and blog/ were not touched.

## Verification

`python3 scripts/check-docs.py docs` reports no structural problems across 784 files. `node scripts/check-writing-style.js docs blog release_notes` finds no prose em dashes. `npm run build` exits 0 with the site's broken-link check enabled; the only warnings are the HTML minifier diagnostics Docusaurus already emits for ten pages. Two of those pages, docs/proxy/email and docs/proxy/logging, are touched by this PR, but the diagnostics point at a code block inside a tab and at an image next to a heading, 15 to 30 KB away from the banner, and the diff on both pages only swaps the admonition lines. In the built HTML, the pagerduty, custom_sso, and managed_batches pages render the three variants with the expected text and the three expected hrefs, and 52 built pages contain the banner.

https://claude.ai/code/session_01BC8ryFjdJAW2iMYeEZFwHR

