### PR TITLE
docs(auto-router): add API setup path

### DIFF
--- a/docs/auto_router/index.md
+++ b/docs/auto_router/index.md
@@ -90,7 +90,7 @@ items={[
   },
   {
     title: "Recommended Configurations",
-    description: "Anthropic, OpenAI, Gemini, and Lite ladders as config.yaml, plus the benchmark and production configs.",
+    description: "1M Context, Anthropic, OpenAI, Gemini, and Lite ladders as config.yaml, plus the benchmark and production configs.",
     to: "/docs/auto_router/recommended_configurations",
   },
   {

--- a/docs/auto_router/recommended_configurations.md
+++ b/docs/auto_router/recommended_configurations.md
@@ -1,13 +1,14 @@
 ---
 title: Recommended Configurations
 sidebar_label: Recommended Configurations
-description: The bundled Anthropic, OpenAI, Gemini, and Lite presets as config.yaml, the configs the public benchmarks were run on, and how to choose between them.
+description: The bundled 1M Context, Anthropic, OpenAI, Gemini, and Lite presets as config.yaml, the configs the public benchmarks were run on, and how to choose between them.
 ---
 
-Recommended ladders per model family, matching the dashboard's Auto Router templates. Every tier must exist as a `model_name` in the same file; swap the provider prefix or credentials for your own deployments and the router entry stays the same.
+Recommended ladders, matching the dashboard's Auto Router templates. Every tier must exist as a `model_name` in the same file; swap the provider prefix or credentials for your own deployments and the router entry stays the same.
 
 | Ladder | SIMPLE | MEDIUM | COMPLEX | REASONING | Classifier |
 | --- | --- | --- | --- | --- | --- |
+| [1M Context](#1m-context) | gpt-5.6-luna | gpt-5.6-terra | gpt-5.6-sol | claude-opus-5, high effort | heuristic v2 |
 | [Anthropic Family](#anthropic-family) | claude-haiku-4-5 | claude-sonnet-5 | claude-opus-5 | claude-opus-5, high effort | heuristic |
 | [OpenAI Family](#openai-family) | gpt-5.6-luna | gpt-5.6-terra | gpt-5.6-sol | gpt-5.6-sol, xhigh effort | heuristic |
 | [Gemini Family](#gemini-family) | gemini-2.5-flash-lite | gemini-3.1-flash-lite | gemini-3.7-flash | gemini-3.1-pro-preview | heuristic |
@@ -19,6 +20,7 @@ Recommended ladders per model family, matching the dashboard's Auto Router templ
 
 - **One family** when clients depend on provider-specific behavior (Anthropic cache control, OpenAI reasoning params). Every tier stays on one API surface.
 - **Lite** when cost beats provider consistency and traffic is agentic. Mixed providers, LLM classifier with the `agentic` rubric.
+- **1M Context** for long prompts. Luna, Terra, Sol, then Opus 5 at high effort, with the heuristic v2 classifier.
 - **Same model, more effort** for the top rung. Costs more output tokens, not a higher per-token rate. Pattern: [effort ladders](/docs/proxy/auto_routing#effort-ladders).
 - All ladders leave `session_affinity` off (the default; see [prompt caching](/docs/auto_router/prompt_caching)) and set `escalation_keywords: ["LITELLM ESCALATE"]`, which bumps a request one tier when the exact phrase appears. Matching is case-sensitive.
 
@@ -183,6 +185,47 @@ model_list:
         escalation_keywords: ["LITELLM ESCALATE"]
         session_affinity: false
       complexity_router_default_model: muse-spark-1.2-xhigh
+```
+
+## 1M Context
+
+Luna, Terra, Sol, then Opus 5 at high reasoning effort. Uses the heuristic v2 classifier, so classification adds no LLM call.
+
+The GPT tiers accept up to 922K input tokens and Opus 5 accepts 1M. The router moves oversized prompts to the lowest higher tier with capacity. See [context-window escalation](/docs/proxy/auto_routing#context-window).
+
+```yaml title="config.yaml"
+model_list:
+  - model_name: gpt-5.6-luna
+    litellm_params:
+      model: openai/gpt-5.6-luna
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-5.6-terra
+    litellm_params:
+      model: openai/gpt-5.6-terra
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-5.6-sol
+    litellm_params:
+      model: openai/gpt-5.6-sol
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: claude-opus-5-high
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+      reasoning_effort: high
+
+  - model_name: 1m-auto
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE:    gpt-5.6-luna
+          MEDIUM:    gpt-5.6-terra
+          COMPLEX:   gpt-5.6-sol
+          REASONING: claude-opus-5-high
+        classifier_type: heuristic_v2
+        escalation_keywords: ["LITELLM ESCALATE"]
+        session_affinity: false
+      complexity_router_default_model: gpt-5.6-terra
 ```
 
 ## The benchmark configuration

--- a/docs/auto_router/setup.md
+++ b/docs/auto_router/setup.md
@@ -6,14 +6,15 @@ description: Every way to stand up an Auto Router, from a one-click preset in th
 
 import NavigationCards from '@site/src/components/NavigationCards';
 
-Four ways in. All of them create the same `auto_router/complexity_router` deployment.
+Five ways in. All of them create the same `auto_router/complexity_router` deployment.
 
 <NavigationCards
-columns={4}
+columns={5}
 items={[
   { title: "Dashboard presets", description: "Pick a template, Test Routing, save.", to: "#dashboard-presets" },
   { title: "Agent skill", description: "One line to your coding agent.", to: "#agent-skill" },
   { title: "config.yaml", description: "One router entry in model_list.", to: "#configyaml" },
+  { title: "Model-management API", description: "POST /model/new, for CI/CD.", to: "#model-management-api" },
   { title: "Autorouter CLI", description: "Try it locally without touching the proxy.", to: "#autorouter-cli" },
 ]}
 />
@@ -71,6 +72,33 @@ model_list:
 - No `classifier_type` means the heuristic scorer: free, no added latency.
 - `classifier_type: llm` with a small model raises accuracy on agent traffic for a fraction of a cent per request. See [benchmarks](/docs/auto_router/benchmarks).
 - Everything else (keyword rules, tier pools, session affinity, scorer tuning): [configuration reference](/docs/proxy/auto_routing).
+
+## Model-management API
+
+For CI/CD or scripts, create the same deployment with `POST /model/new`. Enable `store_model_in_db` first; Auto Routers are model deployments, so there is no separate `/auto_router/new` endpoint.
+
+```bash
+curl -X POST "http://localhost:4000/model/new" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "smart-router",
+    "litellm_params": {
+      "model": "auto_router/complexity_router",
+      "complexity_router_config": {
+        "tiers": {
+          "SIMPLE": "gpt-4o-mini",
+          "MEDIUM": "gpt-4o",
+          "COMPLEX": "claude-sonnet-5",
+          "REASONING": "gpt-5.5"
+        }
+      },
+      "complexity_router_default_model": "gpt-4o"
+    }
+  }'
+```
+
+The response includes `model_id`. Use it with `PATCH /model/{model_id}/update` for partial changes, and call the router by its `model_name`. Validate a complexity configuration before saving with `POST /auto_router/validate_complexity_router_config`. See [Model Management](/docs/proxy/model_management) for deployment CRUD and [Configuration Reference](/docs/proxy/auto_routing) for the full router payload.
 
 ## Autorouter CLI
 

--- a/docs/auto_router/setup.md
+++ b/docs/auto_router/setup.md
@@ -75,25 +75,28 @@ model_list:
 
 ## Model-management API
 
-For CI/CD or scripts, create the same deployment with `POST /model/new`. Enable `store_model_in_db` first; Auto Routers are model deployments, so there is no separate `/auto_router/new` endpoint.
+For CI/CD or scripts, create the same deployment with `POST /model/new`. Enable `store_model_in_db` first; Auto Routers are model deployments, so there is no separate `/auto_router/new` endpoint. This example uses the [Anthropic Family preset](/docs/auto_router/recommended_configurations#anthropic-family); create the referenced model deployments first.
 
 ```bash
 curl -X POST "http://localhost:4000/model/new" \
   -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "smart-router",
+    "model_name": "claude-auto",
     "litellm_params": {
       "model": "auto_router/complexity_router",
       "complexity_router_config": {
         "tiers": {
-          "SIMPLE": "gpt-4o-mini",
-          "MEDIUM": "gpt-4o",
-          "COMPLEX": "claude-sonnet-5",
-          "REASONING": "gpt-5.5"
-        }
+          "SIMPLE": "claude-haiku-4-5",
+          "MEDIUM": "claude-sonnet-5",
+          "COMPLEX": "claude-opus-5",
+          "REASONING": "claude-opus-5-high"
+        },
+        "classifier_type": "heuristic",
+        "escalation_keywords": ["LITELLM ESCALATE"],
+        "session_affinity": false
       },
-      "complexity_router_default_model": "gpt-4o"
+      "complexity_router_default_model": "claude-sonnet-5"
     }
   }'
 ```

--- a/docs/auto_router/setup.md
+++ b/docs/auto_router/setup.md
@@ -23,7 +23,7 @@ items={[
 ![Auto Router templates in the Add Model form](../../blog/autorouter_setup_and_testing/presets.png)
 
 - Models + Endpoints, Add Model, Auto Router tab.
-- Templates: Anthropic Family, OpenAI Family, Gemini Family, Lite. Each fills all four tiers from models your proxy already serves.
+- Templates: 1M Context, Anthropic Family, OpenAI Family, Gemini Family, Lite. Each fills all four tiers from models your proxy already serves.
 - A template whose models are not deployed is greyed out with the missing names listed.
 - **Test Routing** sends one prompt through the classifier and shows the model it would pick. Nothing is created and the picked model is not called.
 - **Test Connection** runs a minimal request per tier model group. Green means reachable with your credentials.


### PR DESCRIPTION
## Summary

Document the model-management API as a fifth Auto Router setup path.

Adds a `POST /model/new` example, the database-storage prerequisite, and links to validation, updates, and the detailed configuration reference.

## Validation

- `git diff --check`
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)