### PR TITLE
docs(tutorials): rewrite the Claude Desktop (Cowork) guide around SSO JWT auth and the MCP gateway

### DIFF
--- a/docs/tutorials/claude_desktop_cowork.md
+++ b/docs/tutorials/claude_desktop_cowork.md
@@ -125,10 +125,10 @@ model_list:
 </TabItem>
 </Tabs>
 
-`jwks_url` is optional: without it LiteLLM reads `jwks_uri` from `{issuer}/.well-known/openid-configuration`. `user_id_upsert: true` creates the LiteLLM user on first request, so spend accrues per person under **Internal Users** and the `oid` or `sub` value lands on every spend log row; `user_allowed_email_domain: yourcompany.com` refuses tokens from any other email domain. `team_ids_jwt_field: groups` turns the token's group memberships into LiteLLM team memberships: create a team whose `team_id` equals the group's id (an Entra group object id, an Okta group name) and that team's `models`, `max_budget`, rate limits, and MCP server permissions apply to everyone in the group. A token whose groups match no team is still accepted as the user, with no team budget and no MCP servers, so drop the line if you do not need teams. A token whose `iss` matches no entry falls back to the `JWT_PUBLIC_KEY_URL`, `JWT_AUDIENCE`, and `JWT_ISSUER` environment variables, which is the single-provider setup [JWT auth](../proxy/token_auth.md) describes and works here too.
+`jwks_url` is optional: without it LiteLLM reads `jwks_uri` from `{issuer}/.well-known/openid-configuration`. `user_id_upsert: true` creates the LiteLLM user on first request, so spend accrues per person under **Internal Users** and the `oid` or `sub` value lands on every spend log row; `user_allowed_email_domain: yourcompany.com` refuses tokens from any other email domain. `team_ids_jwt_field: groups` turns the token's group memberships into LiteLLM team memberships: create a team whose `team_id` equals the group's id (an Entra group object id, an Okta group name) and that team's `models`, `max_budget`, rate limits, and MCP server permissions apply to everyone in the group. LiteLLM adds the user to the team the first time a token carries that group, so they also show up under the team's members, and a user who belongs to exactly one team keeps resolving to it even when a later token omits the claim. A token whose groups match no team is still accepted as the user, with no team budget and no MCP servers, so drop the line if you do not need teams. A token whose `iss` matches no entry falls back to the `JWT_PUBLIC_KEY_URL`, `JWT_AUDIENCE`, and `JWT_ISSUER` environment variables, which is the single-provider setup [JWT auth](../proxy/token_auth.md) describes and works here too.
 
 :::warning `public_key_url` and `audience` are not `litellm_jwtauth` keys
-Anthropic's gateway guide shows `litellm_jwtauth` with `public_key_url` and `audience` directly under it. LiteLLM has no such keys and refuses to start with `Invalid arguments provided: audience, public_key_url`. Put them in an `issuers` entry as above, or set `JWT_PUBLIC_KEY_URL` and `JWT_AUDIENCE` as environment variables.
+Anthropic's gateway guide shows `litellm_jwtauth` with `public_key_url` and `audience` directly under it. LiteLLM has no such keys and refuses to start with `Invalid arguments provided: public_key_url, audience`. Put them in an `issuers` entry as above, or set `JWT_PUBLIC_KEY_URL` and `JWT_AUDIENCE` as environment variables.
 :::
 
 ### 3. Configure Claude Desktop
@@ -256,7 +256,7 @@ Under single sign-on every request is attributed to the LiteLLM user upserted fr
 
 **`Authentication Error, Missing JWT Public Key URL from environment.` on every request.** The token's `iss` matched no `issuers` entry (compare the `iss` claim in the token with the `issuer` value; Entra tokens carry `/v2.0` at the end) and no `JWT_PUBLIC_KEY_URL` fallback is set.
 
-**`Invalid arguments provided: audience, public_key_url` at startup.** The config followed Anthropic's snippet. Move those values into an `issuers` entry.
+**`Invalid arguments provided: public_key_url, audience` at startup.** The config followed Anthropic's snippet. Move those values into an `issuers` entry.
 
 **`Authentication Error, Validation fails: Audience doesn't match`.** The token was issued to a different client id; `audience` must be the client id of the Claude Desktop app registration, and `bearerTokenType` must be left at `id_token`, since an access token's audience is the API it was requested for.
 

--- a/docs/tutorials/claude_desktop_cowork.md
+++ b/docs/tutorials/claude_desktop_cowork.md
@@ -128,7 +128,7 @@ model_list:
 `jwks_url` is optional: without it LiteLLM reads `jwks_uri` from `{issuer}/.well-known/openid-configuration`. `user_id_upsert: true` creates the LiteLLM user on first request, so spend accrues per person under **Internal Users** and the `oid` or `sub` value lands on every spend log row; `user_allowed_email_domain: yourcompany.com` refuses tokens from any other email domain. `team_ids_jwt_field: groups` turns the token's group memberships into LiteLLM team memberships: create a team whose `team_id` equals the group's id (an Entra group object id, an Okta group name) and that team's `models`, `max_budget`, rate limits, and MCP server permissions apply to everyone in the group. LiteLLM adds the user to the team the first time a token carries that group, so they also show up under the team's members, and a user who belongs to exactly one team keeps resolving to it even when a later token omits the claim. A token whose groups match no team is still accepted as the user, with no team budget and no MCP servers, so drop the line if you do not need teams. A token whose `iss` matches no entry falls back to the `JWT_PUBLIC_KEY_URL`, `JWT_AUDIENCE`, and `JWT_ISSUER` environment variables, which is the single-provider setup [JWT auth](../proxy/token_auth.md) describes and works here too.
 
 :::warning `public_key_url` and `audience` are not `litellm_jwtauth` keys
-Anthropic's gateway guide shows `litellm_jwtauth` with `public_key_url` and `audience` directly under it. LiteLLM has no such keys and refuses to start with `Invalid arguments provided: public_key_url, audience`. Put them in an `issuers` entry as above, or set `JWT_PUBLIC_KEY_URL` and `JWT_AUDIENCE` as environment variables.
+Anthropic's gateway guide shows `litellm_jwtauth` with `public_key_url` and `audience` directly under it. LiteLLM has no such keys and refuses to start with `ValueError: Invalid arguments provided: ...` naming `public_key_url` and `audience`. Put them in an `issuers` entry as above, or set `JWT_PUBLIC_KEY_URL` and `JWT_AUDIENCE` as environment variables.
 :::
 
 ### 3. Configure Claude Desktop
@@ -256,7 +256,7 @@ Under single sign-on every request is attributed to the LiteLLM user upserted fr
 
 **`Authentication Error, Missing JWT Public Key URL from environment.` on every request.** The token's `iss` matched no `issuers` entry (compare the `iss` claim in the token with the `issuer` value; Entra tokens carry `/v2.0` at the end) and no `JWT_PUBLIC_KEY_URL` fallback is set.
 
-**`Invalid arguments provided: public_key_url, audience` at startup.** The config followed Anthropic's snippet. Move those values into an `issuers` entry.
+**`ValueError: Invalid arguments provided` naming `public_key_url` and `audience` at startup.** The config followed Anthropic's snippet. Move those values into an `issuers` entry.
 
 **`Authentication Error, Validation fails: Audience doesn't match`.** The token was issued to a different client id; `audience` must be the client id of the Claude Desktop app registration, and `bearerTokenType` must be left at `id_token`, since an access token's audience is the API it was requested for.
 

--- a/docs/tutorials/claude_desktop_cowork.md
+++ b/docs/tutorials/claude_desktop_cowork.md
@@ -1,77 +1,284 @@
+---
+title: Claude Desktop (Cowork)
+sidebar_label: Claude Desktop (Cowork)
+description: Point Claude Desktop (Cowork, Chat, and Code sessions) at LiteLLM as its inference gateway, with single sign-on through LiteLLM JWT auth or a static virtual key, MCP servers through the LiteLLM MCP gateway under the same identity, fleet rollout, and the failures people actually hit.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Claude Desktop (Cowork) Integration
 
-Route Claude Desktop requests through LiteLLM Proxy to get unified logging, budget controls, and access to any model.
+Claude Desktop on third-party inference sends every model call from Cowork, Chat, and Code sessions to a gateway you name, and LiteLLM is that gateway: unified logging, per-user and per-team budgets, model access control, and any Claude deployment behind it (Anthropic, Bedrock, Vertex AI, Foundry) without touching the client again. This page covers the two ways a device authenticates to LiteLLM, single sign-on through your identity provider (nothing to hand out or rotate, spend attributed to the person) and a static virtual key (the quickest way to try it), then what shows up in the model picker, how the same identity reaches MCP servers through the LiteLLM MCP gateway, how to ship the configuration to a fleet, and what to check when something does not work.
 
-<iframe width="840" height="500" src="https://www.loom.com/embed/adb864c1f7c74de3bfc9584ca6d32080" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe
+  src="https://www.loom.com/embed/adb864c1f7c74de3bfc9584ca6d32080"
+  frameBorder="0"
+  allowFullScreen
+  style={{ width: '100%', aspectRatio: '16/9', maxWidth: '900px', marginBottom: '20px' }}
+></iframe>
 
----
+## How it fits together
 
-## Quick Reference
+Claude Desktop treats LiteLLM the way it treats Anthropic's own API: it discovers models with `GET /v1/models` at launch and sends chat traffic to `POST /v1/messages` with streaming and tool use, carrying `Authorization: Bearer <credential>` on every request. The credential is either a LiteLLM virtual key or, with single sign-on, the ID token your identity provider issued to the signed-in user, which LiteLLM validates with [JWT auth](../proxy/token_auth.md) on every request and maps to a LiteLLM user and teams.
 
 | Setting | Value |
-|---------|-------|
-| Gateway URL | `<LITELLM_PROXY_BASE_URL>` |
-| API Key | Your LiteLLM Virtual Key |
+|---|---|
+| Gateway base URL | `https://your-litellm-proxy.com`, no `/v1` suffix |
+| Credential, single sign-on | the user's ID token, validated by LiteLLM JWT auth |
+| Credential, static key | a LiteLLM virtual key |
+| Endpoints used | `GET /v1/models`, `POST /v1/messages`, and `POST /mcp` for MCP servers |
+| LiteLLM version | v1.98.0 or later for model discovery, v1.89.0 or later for the `issuers` JWT config |
+| Claude Desktop version | 1.6889.0 or later for single sign-on |
 
----
+## Option A: Single sign-on with your identity provider
 
-## Step 1: Enable Developer Mode
+With `inferenceCredentialKind: interactive`, Claude Desktop runs an OpenID Connect sign-in (authorization code with PKCE) in the system browser against your identity provider, keeps the refresh token in OS secure storage, and sends the ID token to LiteLLM as the bearer credential. LiteLLM checks the signature against the provider's signing keys, the issuer, and the audience, then maps the token's claims to a LiteLLM user and, through a groups claim, to LiteLLM teams. Nobody provisions or rotates keys, a user removed from the identity provider loses access when the token expires, MFA and conditional access apply, and the only thing the user sees is a **Sign in to your organization** button. This path needs a database behind LiteLLM, because users and spend are written to it.
 
-In Claude Desktop, go to **Help → Claude → Help** and click **Enable Developer Mode**.
+### 1. Register Claude Desktop in your identity provider
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/64274593-33e6-4a7b-a7f3-a08f8aea8209/ascreenshot_8a9c909a978544888dafb6e0c7e3f468_text_export.jpeg)
+Claude Desktop is a native app, so it registers as a public client (PKCE, no client secret) with a loopback redirect URI.
 
----
+<Tabs>
+<TabItem value="entra" label="Microsoft Entra ID">
 
-## Step 2: Open Configure Third-Party Inference
+In the Entra admin center create an app registration for accounts in your directory only, then under **Authentication** add a **Mobile and desktop applications** platform with the custom redirect URI `http://127.0.0.1/callback`. Use `127.0.0.1` rather than `localhost`, keep the `/callback` path, and add it under that platform specifically: it is the only one Entra lets use any local port, which the app needs because it picks a free port at sign-in time. No client secret or API permissions are needed. Copy the **Application (client) ID** and **Directory (tenant) ID**.
 
-Click the **menu bar** icon to open the Claude menu.
+The issuer is `https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0` and the signing keys are at `https://login.microsoftonline.com/YOUR_TENANT_ID/discovery/v2.0/keys`. The stable user id claim is `oid`. To map users to LiteLLM teams by group, add a **groups** claim to the ID token under **Token configuration**; it carries group object ids.
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/66110720-1f11-4a1f-8a0a-a59498bc3290/ascreenshot_c674301e5a4a4ecf8cf000bbbef55aa6_text_export.jpeg)
+</TabItem>
+<TabItem value="okta" label="Okta">
 
-Click **Developer**.
+In the Okta admin console create an app integration of type **OIDC, Native Application** with the **Authorization Code** and **Refresh Token** grant types. Okta matches the redirect URI exactly, port included, so pick a fixed port such as `53180`, register `http://127.0.0.1:53180/callback`, and set the same port in Claude Desktop below. Assign the users or groups who should get access.
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/2fcad657-4f8c-4dc2-b9ff-597de4e98030/ascreenshot_241063b192ae4c75996aaefdab991f13_text_export.jpeg)
+The issuer is `https://YOUR_ORG.okta.com`, the plain org URL rather than the metadata URI ending in `/.well-known/openid-configuration` (a custom authorization server's issuer is `https://YOUR_ORG.okta.com/oauth2/AUTH_SERVER_ID`), and the signing keys are at `https://YOUR_ORG.okta.com/oauth2/v1/keys`. The stable user id claim is `sub`. Add a `groups` claim to the ID token for team mapping.
 
-Click **Configure Third-Party Inference…**
+</TabItem>
+</Tabs>
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/dbb36dff-bbbe-4ddd-b30e-25b2c41bff47/ascreenshot_a7516b203052432f9a1d08cbe92cd214_text_export.jpeg)
+### 2. Configure LiteLLM to validate the token
 
----
+Describe the identity provider to LiteLLM with an `issuers` entry (LiteLLM v1.89.0 or later). Each entry binds one `iss` value to its signing keys and audience and carries that provider's claim names, so several providers can sit side by side. The audience is the client id you registered: an ID token's `aud` is the client it was issued to, and checking it is what stops a token minted for some other app in the same tenant from reaching your gateway.
 
-## Step 3: Enter Your LiteLLM Gateway URL and API Key
+<Tabs>
+<TabItem value="entra" label="Microsoft Entra ID">
 
-The inference settings dialog opens. Enter your LiteLLM Proxy URL in the **Gateway URL** field.
+```yaml title="config.yaml"
+general_settings:
+  enable_jwt_auth: true
+  litellm_jwtauth:
+    user_id_upsert: true
+    issuers:
+      - issuer: https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
+        jwks_url: https://login.microsoftonline.com/YOUR_TENANT_ID/discovery/v2.0/keys
+        audience: YOUR_CLIENT_ID
+        user_id_jwt_field: oid
+        user_email_jwt_field: email
+        team_ids_jwt_field: groups
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/2d0daa12-d874-42ca-bc3e-f38c27c701e4/ascreenshot_8c8be28828974c10ab53124fa13e67c3_text_export.jpeg)
-
+model_list:
+  - model_name: claude-sonnet-5
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-5
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-haiku-4-5
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
 ```
-https://your-litellm-proxy.com
+
+</TabItem>
+<TabItem value="okta" label="Okta">
+
+```yaml title="config.yaml"
+general_settings:
+  enable_jwt_auth: true
+  litellm_jwtauth:
+    user_id_upsert: true
+    issuers:
+      - issuer: https://YOUR_ORG.okta.com
+        jwks_url: https://YOUR_ORG.okta.com/oauth2/v1/keys
+        audience: YOUR_CLIENT_ID
+        user_id_jwt_field: sub
+        user_email_jwt_field: email
+        team_ids_jwt_field: groups
+
+model_list:
+  - model_name: claude-sonnet-5
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-5
+    litellm_params:
+      model: anthropic/claude-opus-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-haiku-4-5
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
-Next, get your virtual API key from the LiteLLM Dashboard. Go to **Virtual Keys → + Create New Key**, copy the key, then paste it into the **API Key** field.
+</TabItem>
+</Tabs>
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/6a5b1233-de81-48be-8a17-e026d3dd9b49/ascreenshot_23dbd432db6d4f90ab5b0d598edd5a40_text_export.jpeg)
+`jwks_url` is optional: without it LiteLLM reads `jwks_uri` from `{issuer}/.well-known/openid-configuration`. `user_id_upsert: true` creates the LiteLLM user on first request, so spend accrues per person under **Internal Users** and the `oid` or `sub` value lands on every spend log row; `user_allowed_email_domain: yourcompany.com` refuses tokens from any other email domain. `team_ids_jwt_field: groups` turns the token's group memberships into LiteLLM team memberships: create a team whose `team_id` equals the group's id (an Entra group object id, an Okta group name) and that team's `models`, `max_budget`, rate limits, and MCP server permissions apply to everyone in the group. A token whose groups match no team is still accepted as the user, with no team budget and no MCP servers, so drop the line if you do not need teams. A token whose `iss` matches no entry falls back to the `JWT_PUBLIC_KEY_URL`, `JWT_AUDIENCE`, and `JWT_ISSUER` environment variables, which is the single-provider setup [JWT auth](../proxy/token_auth.md) describes and works here too.
 
-Save the settings.
+:::warning `public_key_url` and `audience` are not `litellm_jwtauth` keys
+Anthropic's gateway guide shows `litellm_jwtauth` with `public_key_url` and `audience` directly under it. LiteLLM has no such keys and refuses to start with `Invalid arguments provided: audience, public_key_url`. Put them in an `issuers` entry as above, or set `JWT_PUBLIC_KEY_URL` and `JWT_AUDIENCE` as environment variables.
+:::
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/70e429ad-9e42-4936-a691-725701e802bc/ascreenshot_ffc156c61ed44cb7989f417dc38233b6_text_export.jpeg)
+### 3. Configure Claude Desktop
 
----
+Open the configuration window: **Help > Troubleshooting > Enable Developer Mode**, then **Developer > Configure Third-Party Inference…**. In the **Connection** section set **Inference provider** to **Gateway**, **Gateway base URL** to your proxy URL, and **Credential kind** to **Interactive sign-in**, which hides the API key field and reveals **Gateway SSO IdP (OIDC)**: enter the **Client ID** and **Issuer URL** from step 1, leave **Scopes** empty for the default `openid profile email offline_access`, and fill **Redirect port** only for Okta (`53180`). **Apply locally** writes the configuration for this device, which is enough to try it out; **Export** produces the managed configuration for a fleet (see [Rolling out to a fleet](#rolling-out-to-a-fleet)).
 
-## Step 4: Verify Your Setup
+The exported keys, in a macOS `.mobileconfig` payload:
 
-Restart Claude Desktop. Open a new conversation and send a message. All requests now route through your LiteLLM Proxy.
+```xml
+<key>inferenceProvider</key>
+<string>gateway</string>
+<key>inferenceGatewayBaseUrl</key>
+<string>https://your-litellm-proxy.com</string>
+<key>inferenceCredentialKind</key>
+<string>interactive</string>
+<key>inferenceGatewayOidc</key>
+<string>{"issuer":"https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0","clientId":"YOUR_CLIENT_ID"}</string>
+```
 
-![](https://colony-recorder.s3.amazonaws.com/files/2026-04-22/9e72faf1-0b5e-49d5-8ac4-b64dcd2b2f94/ascreenshot_813a1b584a1f4523ab7f7702f5985be0_text_export.jpeg)
+For Okta the JSON is `{"issuer":"https://YOUR_ORG.okta.com","clientId":"YOUR_CLIENT_ID","redirectPort":53180}`. `inferenceGatewayOidc` is one key whose value is a JSON string (a `REG_SZ` on Windows, a native object in Linux's `managed-settings.json`); dotted keys such as `inferenceGatewayOidc.clientId` are never read. Leave `bearerTokenType` at its default `id_token`, which is what the `issuers` entry validates; Google Workspace needs `access_token` there, because it issues no fresh ID token on refresh and re-prompts users about hourly otherwise.
 
-You can verify traffic is flowing by checking the LiteLLM Dashboard under **Usage**, where you should see requests attributed to your virtual key.
+### 4. Verify
 
----
+On the next launch the user sees **Sign in to your organization**, signs in through the browser, and lands back in the app with the model picker filled from your proxy. In the LiteLLM UI, **Logs** shows each request under the user's id, and **Internal Users** shows the upserted user with spend. The same endpoints can be exercised from a shell with any ID token your provider issues for that client id:
+
+```bash
+curl https://your-litellm-proxy.com/v1/models \
+  -H "Authorization: Bearer $ID_TOKEN" -H "anthropic-version: 2023-06-01"
+
+curl -N https://your-litellm-proxy.com/v1/messages \
+  -H "Authorization: Bearer $ID_TOKEN" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-5","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"hello"}]}'
+```
+
+The first returns the Anthropic-shaped model list the picker is built from; the second streams a reply. A `401` with `Audience doesn't match` means the token was issued to a different client id than the one in `audience`; `Missing JWT Public Key URL from environment.` means the token's `iss` matched no `issuers` entry; `Token Expired` is the state the app resolves on its own by refreshing the token, or by prompting **Sign in again** when the refresh fails.
+
+## Option B: Static virtual key
+
+A [virtual key](../proxy/virtual_keys.md) is the right credential for a proof of concept, a shared workstation, or a gateway that already hands out per-team keys. Everyone on the same managed profile shares that key and its budget, and rotating it means pushing a new profile, which is why fleets end up on single sign-on.
+
+Create the key in the LiteLLM UI under **Virtual Keys > + Create New Key**, scoped to the Claude models with a `max_budget`, and copy it. In Claude Desktop, enable Developer Mode under **Help > Troubleshooting**, open **Developer > Configure Third-Party Inference…**, set **Inference provider** to **Gateway**, enter the **Gateway base URL** and the key as the **Gateway API key**, keep **Credential kind** at **Static API key** and **Gateway auth scheme** at **Bearer** (LiteLLM also accepts `x-api-key`), and apply.
+
+<img src="https://colony-recorder.s3.amazonaws.com/files/2026-04-22/64274593-33e6-4a7b-a7f3-a08f8aea8209/ascreenshot_8a9c909a978544888dafb6e0c7e3f468_text_export.jpeg" alt="Enable Developer Mode under Help > Troubleshooting" style={{ maxWidth: '700px', marginBottom: '20px' }} />
+
+<img src="https://colony-recorder.s3.amazonaws.com/files/2026-04-22/dbb36dff-bbbe-4ddd-b30e-25b2c41bff47/ascreenshot_a7516b203052432f9a1d08cbe92cd214_text_export.jpeg" alt="Developer > Configure Third-Party Inference" style={{ maxWidth: '700px', marginBottom: '20px' }} />
+
+<img src="https://colony-recorder.s3.amazonaws.com/files/2026-04-22/2d0daa12-d874-42ca-bc3e-f38c27c701e4/ascreenshot_8c8be28828974c10ab53124fa13e67c3_text_export.jpeg" alt="Gateway URL and API key fields" style={{ maxWidth: '700px', marginBottom: '20px' }} />
+
+<img src="https://colony-recorder.s3.amazonaws.com/files/2026-04-22/6a5b1233-de81-48be-8a17-e026d3dd9b49/ascreenshot_23dbd432db6d4f90ab5b0d598edd5a40_text_export.jpeg" alt="Create a virtual key in the LiteLLM UI" style={{ maxWidth: '700px', marginBottom: '20px' }} />
+
+<img src="https://colony-recorder.s3.amazonaws.com/files/2026-04-22/9e72faf1-0b5e-49d5-8ac4-b64dcd2b2f94/ascreenshot_813a1b584a1f4523ab7f7702f5985be0_text_export.jpeg" alt="Claude Desktop connected through LiteLLM" style={{ maxWidth: '700px', marginBottom: '20px' }} />
+
+The exported form is `inferenceProvider: gateway`, `inferenceGatewayBaseUrl`, and `inferenceGatewayApiKey`, with `inferenceGatewayAuthScheme: x-api-key` only if you chose that scheme. Requests then show up under that key in **Logs** and **Usage**.
+
+## Models in the picker
+
+Claude Desktop builds the picker from `GET /v1/models` and keeps only ids that contain `claude` or `anthropic`, case-insensitively, so the `model_name` values in your `model_list` are what matter, not the upstream ids behind them: `claude-sonnet-5` served from Bedrock or Vertex AI passes, `smart-router` does not. LiteLLM does not return the `anthropic_family_tier` field that would let an opaque alias through the filter, so either put `claude` in the name or list the model in `inferenceModels`, which replaces discovery with exactly the entries you give (the first is the default):
+
+```json
+[
+  {"name": "claude-sonnet-5", "supports1m": true},
+  {"name": "claude-opus-5", "labelOverride": "Opus 5 via LiteLLM"},
+  {"name": "claude-haiku-4-5"}
+]
+```
+
+`supports1m` adds a second, 1M-context picker entry for that model (the string shorthand `"claude-sonnet-5[1m]"` means the same); set it only on a `name` that exactly matches the id your proxy returns and only for deployments that accept 1M-token requests. `anthropicFamilyTier` (`sonnet`, `opus`, `haiku`, `fable`, `mythos`) with `isFamilyDefault: true` tells the app which entry a bare tier alias resolves to. Organizations on Claude for Teams or Enterprise also need each gateway model name on their `availableModels` allowlist, or it shows greyed out; [Auto Router with Claude Code and Claude Desktop](./claude_code_autorouter.md) covers the allowlist rules and how to put an auto router behind a name the picker accepts. Non-Claude models behind LiteLLM work the same way once their `model_name` contains `claude`; add `drop_params: true` to those entries so the Anthropic-specific request fields Cowork and Code sessions send are dropped where the provider has no equivalent instead of failing the request.
+
+## MCP servers through the LiteLLM MCP gateway
+
+Managed MCP servers on Claude Desktop are `managedMcpServers` entries, and pointing them at LiteLLM's [MCP gateway](../mcp.md) instead of at each upstream server keeps MCP traffic under the same logging, access control, and identity as inference. LiteLLM exposes every configured server on one streamable HTTP endpoint, `https://your-litellm-proxy.com/mcp`, authenticated with the same bearer credential; the `x-mcp-servers` header narrows one entry to specific servers (the per-server path `/mcp/<server_name>` does the same), and tools appear as `<server>-<tool>`.
+
+```yaml title="config.yaml"
+mcp_servers:
+  deepwiki:
+    url: https://mcp.deepwiki.com/mcp
+    transport: http
+  github:
+    url: https://api.githubcopilot.com/mcp
+    transport: http
+    auth_type: bearer_token
+    auth_value: os.environ/GITHUB_TOKEN
+```
+
+Access to a server is granted rather than assumed: a signed-in user sees only the servers their team, key, or organization is permitted to use, and every other server is simply absent from `tools/list`. With single sign-on the grant lives on the team the token's groups map to, so create that team with the servers in its `object_permission` (the same call sets the models and budget the group gets):
+
+```bash
+curl -X POST https://your-litellm-proxy.com/team/new \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" \
+  -d '{"team_id": "GROUP_ID_FROM_THE_TOKEN", "team_alias": "Claude Desktop users",
+       "models": ["claude-sonnet-5", "claude-opus-5", "claude-haiku-4-5"], "max_budget": 500,
+       "object_permission": {"mcp_servers": ["deepwiki", "github"]}}'
+```
+
+A low-risk server can instead be opened to everyone with `allow_all_keys: true` ([Public MCP servers](../mcp_control.md#public-mcp-servers-allow_all_keys)), and [MCP access control](../mcp_control.md) covers access groups and per-tool permissions. On the Claude Desktop side, a static virtual key goes in the entry's headers:
+
+```json
+[
+  {
+    "name": "litellm",
+    "transport": "http",
+    "url": "https://your-litellm-proxy.com/mcp",
+    "headers": {"Authorization": "Bearer sk-...", "x-mcp-servers": "deepwiki,github"}
+  }
+]
+```
+
+Static headers cannot carry a signed-in user's own token, so single sign-on fleets use `headersHelper` instead: an executable Claude Desktop runs that prints the headers as a flat JSON object, re-run on the `headersHelperTtlSec` schedule and again when the server answers 401 or 403 (Claude Desktop 1.46388.1 or later). A helper that obtains an ID token for the same app registration keeps chat and MCP spend on the same LiteLLM user. `toolPolicy`, a map of tool name to `allow`, `ask`, or `blocked`, sets the confirmation policy per tool. Servers that need the user's own upstream login (GitHub, Atlassian, and the like) take `"oauth": true` against the per-server URL `https://your-litellm-proxy.com/mcp/<server_name>` with LiteLLM's [MCP OAuth passthrough](../mcp_oauth_passthrough.md) or the [gateway-hosted DCR bridge](../mcp_oauth_passthrough.md#gateway-hosted-sign-in-dcr-bridge); Claude Desktop starts that sign-in only when the server answers an unauthenticated request with HTTP 401, on the loopback callback `http://127.0.0.1:53280/callback`. A server marked `available_on_public_internet: false` is hidden from callers outside the private ranges (or the `mcp_internal_ip_ranges` you set), so a laptop on the public internet sees only the rest ([MCP servers on the public internet](../mcp_public_internet.md)).
+
+Claude Desktop's built-in connectors (`"server": "microsoft365"`, `"github"`, `"websearch"`) run inside the app against those vendors' own APIs and never pass through LiteLLM; only `url` entries do. To keep GitHub or Microsoft 365 traffic under LiteLLM, configure the vendor's MCP server as an `mcp_servers` entry on the proxy and point a `url` entry at it.
+
+## Rolling out to a fleet
+
+**Export** in the configuration window turns what you applied into the template your MDM expects: a `.mobileconfig` (macOS), a `.reg` file or ADMX (Windows), or Intune OMA-URI JSON. Managed configuration is read from `/Library/Managed Preferences/<user>/com.anthropic.claudefordesktop.plist` on macOS, `HKLM\SOFTWARE\Policies\Claude` (or `HKCU`) on Windows, and `/etc/claude-desktop/managed-settings.json` on Linux, while **Apply locally** writes to `~/Library/Application Support/Claude-3p/configLibrary/`, `%LOCALAPPDATA%\Claude-3p\configLibrary\`, and `~/.config/Claude-3p/configLibrary/`. `bootstrapUrl` lets devices fetch the same configuration from a server you host instead of an MDM profile; LiteLLM does not serve a bootstrap endpoint today.
+
+Two more keys matter behind LiteLLM. `inferenceCustomHeaders`, a JSON object of extra headers sent on every inference and discovery request (routing and tenant headers only, never credentials), is how a profile stamps `x-litellm-tags` on every request, which [tag budgets](../proxy/tag_budgets.md), [tag routing](../proxy/tag_routing.md), and the Usage page all group by; `{"x-litellm-tags": "claude-desktop,finance"}` gives a department its own budget without a separate key or team. `inferenceStreamIdleTimeoutSec` (300 to 1800) extends how long a Cowork or Code session waits for model output on a streaming response, but only when LiteLLM writes SSE keep-alive pings while the upstream model is silent; a response with nothing on it still times out at the default.
+
+## Usage attribution
+
+Under single sign-on every request is attributed to the LiteLLM user upserted from the token, and to the team when a groups claim maps to one, so **Usage** breaks spend down by person and by team and budgets apply at both levels. Under a static key the key is the unit, and one key per team or per purpose with its own `max_budget` is the practical granularity. Either way, `x-litellm-tags` from `inferenceCustomHeaders` adds a third axis, such as a department or cost center, without changing who authenticates.
+
+## Troubleshooting
+
+**The model picker is empty, or the connection test passes but no Claude model appears.** Discovery keeps only ids containing `claude` or `anthropic`; rename the `model_name` or set `inferenceModels`. LiteLLM older than v1.98.0 answers `/v1/models` in OpenAI shape only, which the app cannot parse; upgrade, or set `inferenceModels` so the app skips discovery.
+
+**`Authentication Error, Missing JWT Public Key URL from environment.` on every request.** The token's `iss` matched no `issuers` entry (compare the `iss` claim in the token with the `issuer` value; Entra tokens carry `/v2.0` at the end) and no `JWT_PUBLIC_KEY_URL` fallback is set.
+
+**`Invalid arguments provided: audience, public_key_url` at startup.** The config followed Anthropic's snippet. Move those values into an `issuers` entry.
+
+**`Authentication Error, Validation fails: Audience doesn't match`.** The token was issued to a different client id; `audience` must be the client id of the Claude Desktop app registration, and `bearerTokenType` must be left at `id_token`, since an access token's audience is the API it was requested for.
+
+**`Token Expired`, or users are asked to sign in every hour.** Refresh needs the `offline_access` scope, which the default scopes include; a custom `scopes` value in `id_token` mode must list it explicitly. Google Workspace re-prompts hourly in `id_token` mode regardless; use `bearerTokenType: access_token` there.
+
+**`gateway SSO: server does not advertise device_authorization_endpoint`.** The app could not read `inferenceGatewayOidc`, usually because it was pushed as dotted keys or invalid JSON. Re-export from the configuration window.
+
+**`OIDC discovery failed (HTTP 404)` or `(HTTP 405)`.** The `issuer` value is the metadata URI instead of the issuer base URL; remove the `/.well-known/openid-configuration` suffix.
+
+**The browser shows Connected but the app reports `Token exchange failed (HTTP 401)`.** The identity provider registration is a confidential (Web) client expecting a secret. Register a Native application (Okta) or a Mobile and desktop applications platform (Entra) instead; the type cannot be changed after creation.
+
+**`tools/list` on the LiteLLM MCP endpoint comes back empty.** The signed-in user has no grant on any server: the token's groups match no team, or the team's `object_permission` lists no `mcp_servers`. Add the servers to the team or set `allow_all_keys: true` on the server.
+
+**Requests to a non-Claude model fail with 400.** Cowork and Code sessions send Anthropic-specific fields; set `drop_params: true` on that `model_list` entry.
+
+**The 1M context window entry is missing.** `supports1m` sits on an `inferenceModels` entry whose `name` does not match the discovered id exactly.
 
 ## Related
 
-- [Auto Router with Claude Code and Claude Desktop](claude_code_autorouter.md)
-- [LiteLLM Virtual Keys](../proxy/virtual_keys.md)
-- [Cursor Integration](cursor_integration.md)
-- [Claude Code Integration](claude_responses_api.md)
+- [JWT auth](../proxy/token_auth.md) for every `litellm_jwtauth` option, including role mappings and JWT-to-virtual-key mapping
+- [Virtual keys](../proxy/virtual_keys.md)
+- [MCP gateway](../mcp.md), [MCP access control](../mcp_control.md), and [MCP OAuth passthrough](../mcp_oauth_passthrough.md)
+- [Auto Router with Claude Code and Claude Desktop](./claude_code_autorouter.md)
+- [Claude Code with LiteLLM](./claude_responses_api.md)
+- Anthropic's [gateway guide](https://claude.com/docs/third-party/claude-desktop/gateway), [configuration reference](https://claude.com/docs/third-party/claude-desktop/configuration), and [MCP servers and extensions](https://claude.com/docs/third-party/claude-desktop/extensions) for Claude Desktop on third-party inference


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Cowork page only covered pasting a static virtual key
- The 99% case is SSO: JWT auth for chat and MCP with Claude Desktop
- Anthropic's gateway guide shows a `litellm_jwtauth` shape LiteLLM rejects at startup
- Nothing said how Claude Desktop reaches MCP servers through LiteLLM

How it solves it:

- Rewrites the tutorial around the SSO path with Entra and Okta tabs
- Documents the `issuers` JWT config, group-to-team mapping, and the startup error
- Adds MCP gateway, model picker, fleet rollout, attribution, and troubleshooting sections
- Keeps the static-key path as the quick-start option with the existing screenshots

## User Flow

Before: an admin rolling Claude Desktop out with single sign-on follows Anthropic's LiteLLM snippet and the proxy refuses to start, and the page they land on from docs.litellm.ai only shows a pasted virtual key

1. They open https://docs.litellm.ai/docs/tutorials/claude_desktop_cowork and find one path: create a virtual key, paste it into **Configure Third-Party Inference**
2. They go to Anthropic's gateway guide instead and copy its LiteLLM snippet, `litellm_jwtauth` with `public_key_url` and `audience`, into `config.yaml`
3. They start the proxy and it exits with `ValueError: Invalid arguments provided` naming `public_key_url` and `audience`, then `Application startup failed`
4. They fall back to the virtual key; every user on the managed profile shares one key and one budget, and `GET https://litellm-domain/user/info` never shows a per-person spend row
5. They add an MCP server to the managed configuration, point it straight at the upstream server, and nothing about it shows up in https://litellm-domain/ui/?page=logs

After: the same admin follows the rewritten page, users sign in with the identity provider, and every request and MCP call lands under that user in LiteLLM

1. They open https://docs.litellm.ai/docs/tutorials/claude_desktop_cowork and follow **Option A**: register a public client in Entra or Okta with the `http://127.0.0.1/callback` (or `:53180`) redirect
2. They put the `issuers` entry from the page into `config.yaml` (issuer, `jwks_url`, `audience`, `user_id_jwt_field`, `user_email_jwt_field`, `team_ids_jwt_field`) with `user_id_upsert: true`, and the proxy starts
3. They create the team the groups claim maps to with `POST https://litellm-domain/team/new` carrying `models`, `max_budget`, and `object_permission.mcp_servers`
4. They set **Credential kind** to **Interactive sign-in** with the client id and issuer, export the `.mobileconfig`, and users see **Sign in to your organization** on launch
5. `GET https://litellm-domain/v1/models` with the user's ID token returns the Anthropic-shaped list the picker is built from, and `POST https://litellm-domain/v1/messages` streams a reply
6. `POST https://litellm-domain/mcp` with the same token lists `deepwiki-ask_question` and the other tools the team was granted, and a user whose token matches no team sees `"tools": []`
7. `GET https://litellm-domain/user/info?user_id=<oid>` shows the upserted user with spend, and the team's members list carries them
8. A token for another client id gets `401 Audience doesn't match`, one from an unlisted issuer gets `401 Missing JWT Public Key URL from environment.`, and an expired one gets `401 Token Expired`, each matched to a fix in the Troubleshooting section

## Relevant issues

Overlaps litellm-docs #624 (LIT-4690), which plans to delete this tutorial in favor of `docs/proxy/client_setup/claude_desktop.md`; whichever lands second carries the SSO, MCP, and troubleshooting content across

## Linear ticket

Resolves LIT-5669

## Screenshots / Proof of Fix

Everything below ran against a live proxy from the `litellm` main checkout on a random port (22267) with a Postgres database, real Anthropic calls, and the MCP server deepwiki.com. The identity provider is a local JWKS server standing in for Entra (RS256 keys on port 20018), so the tokens are real signed ID tokens with Entra's claim shape; the issuer and audience values are the placeholders the page uses.

Shared setup: `config.yaml` is the page's Option A config with the local JWKS URL, and the team is created the way the MCP section shows.

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

mcp_servers:
  deepwiki:
    url: https://mcp.deepwiki.com/mcp
    transport: http

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  enable_jwt_auth: true
  litellm_jwtauth:
    user_id_upsert: true
    issuers:
      - issuer: https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0
        jwks_url: http://127.0.0.1:20018/keys
        audience: 8f3c2a10-lit5669-claude-desktop
        user_id_jwt_field: oid
        user_email_jwt_field: email
        team_ids_jwt_field: groups
```

```bash
curl -X POST http://127.0.0.1:22267/team/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" \
  -d '{"team_id": "claude-desktop-users", "team_alias": "Claude Desktop users", "models": ["claude-haiku-4-5", "claude-sonnet-5"], "max_budget": 50, "object_permission": {"mcp_servers": ["deepwiki"]}}'
```

### Before (774ffc39)

Following the page as it stands on `main` plus Anthropic's gateway guide: the guide's `litellm_jwtauth` snippet (`public_key_url` and `audience` directly under it) is what an admin ends up with, and the proxy refuses to start.

```
### 9. Anthropic's snippet (public_key_url + audience directly under litellm_jwtauth) is rejected at startup
python litellm/proxy/proxy_cli.py --config config_bad.yaml --port 27106
ValueError: Invalid arguments provided: audience, public_key_url. Allowed arguments are: admin_jwt_scope, admin_allowed_routes, team_id_jwt_field, team_id_upsert, team_ids_jwt_field, upsert_sso_user_to_team, team_allowed_routes, team_id_default, team_alias_jwt_field, org_id_jwt_field, org_alias_jwt_field, user_id_jwt_field, user_email_jwt_field, user_allowed_email_domain, user_roles_jwt_field, user_allowed_roles, user_id_upsert, end_user_id_jwt_field, public_key_ttl, public_key_stale_ttl, public_allowed_routes, enforce_rbac, roles_jwt_field, role_mappings, object_id_jwt_field, scope_mappings, enforce_scope_based_access, enforce_team_based_model_access, custom_validate, jwt_litellm_role_map, sync_user_role_and_teams, oidc_userinfo_endpoint, oidc_userinfo_enabled, oidc_userinfo_cache_ttl, virtual_key_claim_field, virtual_key_mapping_cache_ttl, unregistered_jwt_client_behavior, routing_overrides, team_claim_fallback, fallback_to_db_teams, issuers.
ERROR:    Application startup failed. Exiting.
exit code: 3
```

### After (9d1973c8)

Following the rewritten page. Later commit bca57a5d only rewords the error text the page quotes and cannot change proxy behavior, so the run below stands at its hash.

```
### 1. Model discovery, what Claude Desktop calls at launch (ID token, groups claim = [claude-desktop-users])
curl -s http://127.0.0.1:22267/v1/models -H 'Authorization: Bearer $ID_TOKEN' -H 'anthropic-version: 2023-06-01'
{"data":[{"type":"model","id":"claude-sonnet-5","display_name":"claude-sonnet-5","created_at":"2023-02-28T18:56:42Z","max_input_tokens":1000000,"max_tokens":128000},{"type":"model","id":"claude-haiku-4-5","display_name":"claude-haiku-4-5","created_at":"2023-02-28T18:56:42Z","max_input_tokens":200000,"max_tokens":64000}],"has_more":false,"first_id":"claude-sonnet-5","last_id":"claude-haiku-4-5"}

### 2. Streaming /v1/messages with the same ID token (real Anthropic call)
curl -sN http://127.0.0.1:22267/v1/messages -H 'Authorization: Bearer $ID_TOKEN' -H 'anthropic-version: 2023-06-01' -d '{"model":"claude-haiku-4-5","max_tokens":40,"stream":true,"messages":[{"role":"user","content":"Say hello from LiteLLM in five words."}]}'
event: message_start
data: {"type":"message_start","message":{"model":"claude-haiku-4-5","id":"msg_011CejKdbpuxx7FvmcJ5tYu2","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":2,"service_tier":"standard","inference_geo":"not_available"}}}
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from"}         }
event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" LiteLLM today."}   }
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}              }


### 3. MCP gateway with the same ID token: initialize, then tools/list (team claude-desktop-users grants mcp_servers: [deepwiki])
curl -s http://127.0.0.1:22267/mcp -H 'Authorization: Bearer $ID_TOKEN' -H 'mcp-session-id: ...' -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
HTTP/1.1 200 OK
"name":"deepwiki-ask_question"
"name":"deepwiki-read_wiki_contents"
"name":"deepwiki-read_wiki_structure"

### 4. Team membership comes from the groups claim, and MCP access is granted, never assumed
# fresh user fresh-user-1788567015, first request carries groups=[claude-desktop-users]
GET /v1/models -> 200
curl -s 'http://127.0.0.1:22267/team/info?team_id=claude-desktop-users' -H 'Authorization: Bearer $LITELLM_MASTER_KEY'  # members_with_roles
['default_user_id', '3f2b9a44-lit5669-qa-user', 'fresh-user-1788566940', 'fresh-user-1788567015']
# fresh user never-grouped-1788567016 whose token carries no groups claim: models answer, MCP tools/list is empty
GET /v1/models -> 200
HTTP/1.1 200 OK
"tools": []
# fresh user unknown-grouped-1788567016 with groups=[unknown-group] (matches no team): same result
GET /v1/models -> 200
HTTP/1.1 200 OK
"tools": []

### 5. Attribution: the user LiteLLM upserted from the token, and the team the groups claim mapped to
curl -s 'http://127.0.0.1:22267/user/info?user_id=3f2b9a44-lit5669-qa-user' -H 'Authorization: Bearer $LITELLM_MASTER_KEY'
{"user_id": "3f2b9a44-lit5669-qa-user", "user_email": "qa.user@example.com", "spend": 0.000158}
curl -s 'http://127.0.0.1:22267/team/info?team_id=claude-desktop-users' -H 'Authorization: Bearer $LITELLM_MASTER_KEY'
{"team_id": "claude-desktop-users", "team_alias": "Claude Desktop users", "models": ["claude-haiku-4-5", "claude-sonnet-5"], "max_budget": 50.0, "spend": 7.900000000000001e-05} object_permission.mcp_servers: ['deepwiki']

### 6. Negative: token minted for another app in the tenant (wrong aud)
{"error":{"message":"Authentication Error, Validation fails: Audience doesn't match","type":"auth_error","param":"None","code":"401"}}

### 7. Negative: token whose iss matches no issuers entry
{"error":{"message":"Authentication Error, Missing JWT Public Key URL from environment.","type":"auth_error","param":"None","code":"401"}}

### 8. Negative: expired token (what the app sees before it refreshes or prompts Sign in again)
{"error":{"message":"Token Expired","type":"expired_key","param":null,"code":"401"}}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no application or proxy code modifications.
> 
> **Overview**
> **Rewrites** `claude_desktop_cowork.md` from a short virtual-key walkthrough into an end-to-end Claude Desktop + LiteLLM guide.
> 
> The page now centers **Option A (SSO)**: Entra/Okta app registration, `litellm_jwtauth` **`issuers`** YAML (with group-to-team mapping and `user_id_upsert`), Claude Desktop **interactive sign-in** / managed-config keys, and curl-based verification. It adds a prominent warning that Anthropic’s `public_key_url` / `audience` under `litellm_jwtauth` **breaks proxy startup** and documents the correct shape.
> 
> **Option B** keeps the static virtual-key path with the existing screenshots. New material covers **model picker** behavior (`inferenceModels`, naming, `drop_params`), **MCP via `/mcp`** (team `object_permission`, `headersHelper`, OAuth passthrough), **MDM fleet rollout** (`inferenceCustomHeaders`, stream idle timeout), **usage attribution**, and a **troubleshooting** section for common JWT/OIDC/MCP failures. Front matter, Docusaurus tabs, and updated related links are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca57a5d10df6d3853aee32e06a1b7a0ada095fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->