### PR TITLE
docs(pass_through): OpenAI WebSocket passthrough is opt-in

### DIFF
--- a/docs/pass_through/openai_passthrough.md
+++ b/docs/pass_through/openai_passthrough.md
@@ -34,7 +34,7 @@ general_settings:
   enable_openai_websocket_passthrough: true
 ```
 
-While it is off, a WebSocket client receives one `error` event that names this setting and the connection closes with code `1008`. Keys with model restrictions are refused on these routes even when it is on. If you only need the Realtime API for models in your `model_list`, use the proxy's own `/v1/realtime` route instead, which needs no opt-in and enforces the key's model access
+While it is off, a WebSocket client receives one `error` event that names this setting and the connection closes with code `1008`. Even when it is on, a request is refused the same way if any model restriction applies to it, whether that restriction sits on the key, its team, the caller's team membership, the internal user, or the project. The setting can also be stored in the database with `store_model_in_db: true`, through `POST /config/field/update` or the Admin UI settings page, and each proxy instance picks it up on its next config reload; a value set in the YAML wins over the stored one. If you only need the Realtime API for models in your `model_list`, use the proxy's own `/v1/realtime` route instead, which needs no opt-in and enforces the key's model access
 
 ## When to use this?
 

--- a/docs/pass_through/openai_passthrough.md
+++ b/docs/pass_through/openai_passthrough.md
@@ -34,7 +34,7 @@ general_settings:
   enable_openai_websocket_passthrough: true
 ```
 
-While it is off, a WebSocket client receives one `error` event that names this setting and the connection closes with code `1008`. Even when it is on, a request is refused the same way if any model restriction applies to it, whether that restriction sits on the key, its team, the caller's team membership, the internal user, or the project. The setting can also be stored in the database with `store_model_in_db: true`, through `POST /config/field/update` or the Admin UI settings page, and each proxy instance picks it up on its next config reload; a value set in the YAML wins over the stored one. If you only need the Realtime API for models in your `model_list`, use the proxy's own `/v1/realtime` route instead, which needs no opt-in and enforces the key's model access
+While it is off, a WebSocket client receives one `error` event that names this setting and the connection closes with code `1008`. Even when it is on, a request is refused the same way if any model restriction applies to it, whether that restriction sits on the key, its team, the caller's team membership, the internal user, or the project. The setting can also be stored in the database with `store_model_in_db: true`, through `POST /config/field/update`, and each proxy instance picks it up on its next config reload; a value set in the YAML wins over the stored one. If you only need the Realtime API for models in your `model_list`, use the proxy's own `/v1/realtime` route instead, which needs no opt-in and enforces the key's model access
 
 ## When to use this?
 

--- a/docs/pass_through/openai_passthrough.md
+++ b/docs/pass_through/openai_passthrough.md
@@ -25,6 +25,17 @@ Standard passthrough endpoint that may conflict with LiteLLM's native implementa
 
 **Note:** Some endpoints like `/openai/v1/responses` will be routed to LiteLLM's native implementation instead of OpenAI.
 
+## WebSocket endpoints are off by default
+
+Both prefixes can also relay WebSocket connections (for example `/openai_passthrough/v1/realtime` and `/openai/v1/responses`) to OpenAI. The relay forwards frames without reading them, so it cannot check which model a session asks for, and it is served under the proxy's own OpenAI credential. Because of that it is disabled unless a proxy admin opts in:
+
+```yaml
+general_settings:
+  enable_openai_websocket_passthrough: true
+```
+
+While it is off, a WebSocket client receives one `error` event that names this setting and the connection closes with code `1008`. Keys with model restrictions are refused on these routes even when it is on. If you only need the Realtime API for models in your `model_list`, use the proxy's own `/v1/realtime` route instead, which needs no opt-in and enforces the key's model access
+
 ## When to use this?
 
 - For 90% of your use cases, you should use the [native LiteLLM OpenAI Integration](https://docs.litellm.ai/docs/providers/openai) (`/chat/completions`, `/embeddings`, `/completions`, `/images`, `/batches`, etc.)


### PR DESCRIPTION
## TLDR

Documents that the OpenAI pass-through WebSocket routes (`/openai_passthrough/<ws path>` and `/openai/<ws path>`) are off by default from https://github.com/BerriAI/litellm/pull/39841 onward and how an admin turns them on

## What changed

A new section in `docs/pass_through/openai_passthrough.md`, "WebSocket endpoints are off by default", explains that the route relays frames to OpenAI under the proxy's own credential without reading them, shows the `general_settings.enable_openai_websocket_passthrough: true` opt-in, describes the `error` event plus close code 1008 a client sees while it is off, notes that keys with a model list are refused even when it is on, and points realtime users at the proxy's own `/v1/realtime` route

## Related

Code change: https://github.com/BerriAI/litellm/pull/39841

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or config behavior changes in this PR.
> 
> **Overview**
> Adds a **WebSocket endpoints are off by default** section to the OpenAI passthrough docs so admins know pass-through WebSocket routes on `/openai_passthrough` and `/openai` are disabled unless opted in (behavior from PR #39841).
> 
> The new text explains why (blind frame relay under the proxy credential), how to enable via `general_settings.enable_openai_websocket_passthrough`, what clients see when disabled (`error` + close `1008`), that model restrictions still block access when enabled, DB/YAML config precedence, and when to use native `/v1/realtime` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddb67a32862526d2337d0be97a2ad02eabd7fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->