### PR TITLE
docs(fireworks_ai): note that developer input items reach the Responses API as system messages

### DIFF
--- a/docs/providers/fireworks_ai.md
+++ b/docs/providers/fireworks_ai.md
@@ -284,6 +284,8 @@ curl http://0.0.0.0:4000/v1/responses \
 
 Multi-turn tool calling works the same way it does against Fireworks directly: send back the `function_call_output` items together with the `previous_response_id` Fireworks returned, and Fireworks continues the conversation server-side
 
+`developer` input items are sent to Fireworks as `system` messages, since Fireworks' Responses API has no developer role on models such as kimi-k3 and qwen3.8. A model whose chat template needs the system message first (qwen3.8) still rejects a developer item placed after the first input item, the same way it does when called directly
+
 ## Document Inlining 
 
 LiteLLM supports document inlining for Fireworks AI models. This is useful for models that are not vision models, but still need to parse documents/images/etc.


### PR DESCRIPTION
## TLDR

BerriAI/litellm#39826 (native Fireworks Responses API, in review) now sends `developer` input items to Fireworks as `system` messages, because Fireworks' Responses API has no developer role on models such as kimi-k3 and qwen3.8. This adds one paragraph to the Responses API section of the Fireworks AI provider page saying so, and noting that a model whose chat template needs the system message first (qwen3.8) still rejects a developer item placed after the first input item, the same way it does when called directly

Code PR: BerriAI/litellm#39826

## Merge timing

Same as #1205: the page lands ahead of the Sep 12 RC that ships the path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a short note in the **Responses API** section of the Fireworks AI provider page documenting how LiteLLM handles `developer` input items when calling Fireworks natively (related implementation in BerriAI/litellm#39826).
> 
> **`developer` items are forwarded as `system` messages** because Fireworks’ Responses API has no `developer` role on models like kimi-k3 and qwen3.8. The doc also warns that models whose chat template requires the system message first (e.g. qwen3.8) will still error if a `developer` item appears after the first input item—matching direct Fireworks behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a313d280417cfb91a03442625756dd36587c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->