### PR TITLE
docs(blog): fuzzy full-width post search, Heuristic v2 post, Fusion benchmark retitle

### DIFF
--- a/src/theme/BlogListPage/index.js
+++ b/src/theme/BlogListPage/index.js
@@ -51,8 +51,60 @@ function queryTokens(query) {
   return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
 }
 
-function matchesQuery(text, tokens) {
-  return tokens.every(token => text.includes(token));
+function maxEditDistance(token) {
+  if (token.length <= 3) return 0;
+  if (token.length <= 5) return 1;
+  return 2;
+}
+
+function levenshteinDistance(first, second, maxDistance) {
+  if (Math.abs(first.length - second.length) > maxDistance) return maxDistance + 1;
+
+  let previous = Array.from({length: second.length + 1}, (_, index) => index);
+  for (let firstIndex = 1; firstIndex <= first.length; firstIndex++) {
+    const current = [firstIndex];
+    for (let secondIndex = 1; secondIndex <= second.length; secondIndex++) {
+      current[secondIndex] = Math.min(
+        current[secondIndex - 1] + 1,
+        previous[secondIndex] + 1,
+        previous[secondIndex - 1] + (first[firstIndex - 1] === second[secondIndex - 1] ? 0 : 1)
+      );
+    }
+    previous = current;
+  }
+
+  return previous[second.length];
+}
+
+function isSubsequence(token, word) {
+  let tokenIndex = 0;
+  for (const character of word) {
+    if (character === token[tokenIndex]) tokenIndex++;
+  }
+  return tokenIndex === token.length;
+}
+
+function tokenScore(word, token) {
+  if (word === token) return 4;
+  if (word.startsWith(token)) return 3;
+  if (word.includes(token)) return 2;
+  if (levenshteinDistance(word, token, maxEditDistance(token)) <= maxEditDistance(token)) return 1;
+  if (token.length >= 4 && isSubsequence(token, word)) return 0.5;
+  return null;
+}
+
+function itemScore(item, tokens) {
+  if (tokens.length === 0) return 0;
+
+  const words = searchableText(item).match(/[\p{L}\p{N}]+/gu) || [];
+  return tokens.reduce((score, token) => {
+    const bestTokenScore = words.reduce((best, word) => {
+      const current = tokenScore(word, token);
+      return current !== null && current > best ? current : best;
+    }, null);
+
+    return score === null || bestTokenScore === null ? null : score + bestTokenScore;
+  }, 0);
 }
 
 // ── Provider marquee ──────────────────────────────────────────────────────
@@ -156,9 +208,11 @@ export default function BlogListPage(props) {
   const [activeTab, setActiveTab] = useState('all');
   const [query, setQuery] = useState('');
   const tokens = queryTokens(query);
-  const filtered = filterItems(items, activeTab).filter(item =>
-    matchesQuery(searchableText(item), tokens)
-  );
+  const filtered = filterItems(items, activeTab)
+    .map((item, index) => ({item, index, score: itemScore(item, tokens)}))
+    .filter(({score}) => score !== null)
+    .sort((first, second) => second.score - first.score || first.index - second.index)
+    .map(({item}) => item);
 
   return (
     <Layout

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -151,7 +151,6 @@
 /* ── Search ───────────────────────────────────────────────────────────── */
 .searchRow {
   margin-top: 2rem;
-  max-width: 420px;
 }
 
 .searchInput {
@@ -367,10 +366,6 @@
   .pagination {
     padding: 1rem 0 3rem;
     gap: 1rem;
-  }
-
-  .searchRow {
-    max-width: none;
   }
 
   .searchInput {


### PR DESCRIPTION
## Blog search
- Search bar on the blog list page is now full width (dropped the 420px cap and its mobile override).
- Matching is fuzzy: per-token scoring on exact / prefix / substring / Levenshtein (edit distance scaled by token length) / subsequence, results sorted by score with stable date order as the tiebreaker.

## Posts
- New draft: **Introducing Auto Router Heuristic v2: Better Quality with 45% Lower Cost** (`blog/heuristic_v2/`).
- Fusion terminal-bench benchmark post: retitled, new hero image.

## Verification
- `npm run build` passes (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)