### PR TITLE
docs: add Cohere Parse OCR on Cohere and Azure AI Foundry

### DIFF
--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -5,7 +5,7 @@
 | Cost Tracking | ✅ |
 | Logging | ✅ (Basic Logging not supported) |
 | Load Balancing | ✅ |
-| Supported Providers | `mistral`, `azure_ai`, `vertex_ai` |
+| Supported Providers | `mistral`, `azure_ai`, `vertex_ai`, `cohere` |
 
 :::tip
 
@@ -345,6 +345,7 @@ The response follows Mistral's OCR format with the following structure:
 | Provider    | Link to Usage      |
 |-------------|--------------------|
 | Mistral AI  |   [Usage](#quick-start)                 |
-| Azure AI    |   [Usage](../docs/providers/azure_ocr)                 |
+| Azure AI (Mistral, Cohere Parse) |   [Usage](../docs/providers/azure_ocr)                 |
 | Vertex AI   |   [Usage](../docs/providers/vertex_ocr)                 |
+| Cohere Parse |   [Usage](../docs/providers/cohere#parse-ocr)                 |
 

--- a/docs/providers/azure_ocr.md
+++ b/docs/providers/azure_ocr.md
@@ -201,6 +201,10 @@ curl http://0.0.0.0:4000/v1/ocr \
 
 `output_format` accepts `markdown` (default) or `blocks`, and `req_format: native` returns Cohere's own response body instead of the LiteLLM OCR shape. Cost tracking bills `usage_info.pages_processed` at the per-page price in the model cost map.
 
+The model cost map prices `azure_ai/Cohere-parse-v5` at Cohere's published rate of $1.50 per 1,000 pages, the price the Foundry catalog links to for this model.
+
+Health checks (`/health` and the Admin UI's Test Connection button) send Parse a small PNG instead of the PDF used for Mistral OCR. The `ocr` probe is picked from the model cost map for `Cohere-parse-v5`; a deployment under any other name needs `model_info: {mode: ocr}` in its `model_list` entry, like every other non-chat model.
+
 ## Supported Models
 
 - `mistral-document-ai-2505` - Latest Mistral OCR model on Azure AI

--- a/docs/providers/azure_ocr.md
+++ b/docs/providers/azure_ocr.md
@@ -1,15 +1,15 @@
-# Azure AI OCR (Mistral)
+# Azure AI OCR (Mistral, Cohere Parse)
 
 ## Overview
 
 | Property | Details |
 |-------|-------|
-| Description | Azure AI OCR provides document intelligence capabilities powered by Mistral, enabling text extraction from PDFs and images |
+| Description | Azure AI OCR provides document intelligence capabilities powered by Mistral and Cohere Parse, enabling text extraction from PDFs and images |
 | Provider Route on LiteLLM | `azure_ai/` |
 | Supported Operations | `/ocr` |
 | Link to Provider Doc | [Azure AI ↗](https://ai.azure.com/)
 
-Extract text from documents and images using Azure AI's OCR models, powered by Mistral.
+Extract text from documents and images using Azure AI's OCR models, powered by Mistral. Cohere Parse deployments are covered [below](#cohere-parse).
 
 ## Quick Start
 
@@ -146,9 +146,65 @@ response = await litellm.aocr(
 Azure AI OCR endpoints don't have internet access. LiteLLM automatically converts public URLs to base64 data URIs before sending requests to Azure AI.
 :::
 
+## Cohere Parse
+
+Azure AI Foundry also serves [Cohere Parse](https://ai.azure.com/catalog/models/Cohere-parse-v5) through the same `/ocr` endpoint. Use `azure_ai/<deployment name>`: any deployment whose name contains `parse` is sent to the Cohere Parse API on your Foundry resource, at `{api_base}/providers/cohere/v2/parse`.
+
+Parse accepts `image_url` documents only, an image URL or a base64 `data:image/...` URI. PDFs and `document_url` inputs are rejected with a 400 before anything is sent to Azure. Foundry cannot fetch external URLs, so LiteLLM downloads a remote image and sends it inline as a data URI, the same conversion it applies for the Mistral models above.
+
+### **LiteLLM SDK**
+
+```python showLineNumbers title="Cohere Parse on Azure AI"
+import litellm
+import os
+
+os.environ["AZURE_AI_API_KEY"] = ""
+os.environ["AZURE_AI_API_BASE"] = "https://<resource>.services.ai.azure.com"
+
+response = litellm.ocr(
+    model="azure_ai/Cohere-parse-v5",
+    document={
+        "type": "image_url",
+        "image_url": "https://raw.githubusercontent.com/mistralai/cookbook/refs/heads/main/mistral/ocr/receipt.png",
+    },
+    output_format="markdown",
+)
+
+for page in response.pages:
+    print(page.markdown)
+print(response.usage_info.pages_processed)
+```
+
+### **LiteLLM PROXY**
+
+```yaml showLineNumbers title="proxy_config.yaml"
+model_list:
+  - model_name: azure-cohere-parse
+    litellm_params:
+      model: azure_ai/Cohere-parse-v5
+      api_key: "os.environ/AZURE_AI_API_KEY"
+      api_base: "os.environ/AZURE_AI_API_BASE"
+```
+
+```bash showLineNumbers title="Test request"
+curl http://0.0.0.0:4000/v1/ocr \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "azure-cohere-parse",
+    "document": {
+      "type": "image_url",
+      "image_url": "https://raw.githubusercontent.com/mistralai/cookbook/refs/heads/main/mistral/ocr/receipt.png"
+    }
+  }'
+```
+
+`output_format` accepts `markdown` (default) or `blocks`, and `req_format: native` returns Cohere's own response body instead of the LiteLLM OCR shape. Cost tracking bills `usage_info.pages_processed` at the per-page price in the model cost map.
+
 ## Supported Models
 
 - `mistral-document-ai-2505` - Latest Mistral OCR model on Azure AI
+- `Cohere-parse-v5` - Cohere Parse, image documents only
 
 Use the Azure AI provider prefix: `azure_ai/<model-name>`
 

--- a/docs/providers/azure_ocr.md
+++ b/docs/providers/azure_ocr.md
@@ -203,7 +203,7 @@ curl http://0.0.0.0:4000/v1/ocr \
 
 The model cost map prices `azure_ai/Cohere-parse-v5` at Cohere's published rate of $1.50 per 1,000 pages, the price the Foundry catalog links to for this model.
 
-Health checks (`/health` and the Admin UI's Test Connection button) send Parse a small PNG instead of the PDF used for Mistral OCR. The `ocr` probe is picked from the model cost map for `Cohere-parse-v5`; a deployment under any other name needs `model_info: {mode: ocr}` in its `model_list` entry, like every other non-chat model.
+Health checks (`/health` and the Admin UI's Test Connection button) send Parse a small PNG instead of the PDF used for Mistral OCR. Each probe is a real one-page Parse call, so it bills one page per deployment per check. The `ocr` probe mode and the per-page price are both looked up in the model cost map under `Cohere-parse-v5`; a deployment under any other name needs `model_info: {mode: ocr, base_model: azure_ai/Cohere-parse-v5}` in its `model_list` entry, the same `mode` and `base_model` convention every other Azure model uses, so health checks probe it as OCR and spend tracking finds the Parse price instead of recording $0.
 
 ## Supported Models
 

--- a/docs/providers/azure_ocr.md
+++ b/docs/providers/azure_ocr.md
@@ -148,7 +148,7 @@ Azure AI OCR endpoints don't have internet access. LiteLLM automatically convert
 
 ## Cohere Parse
 
-Azure AI Foundry also serves [Cohere Parse](https://ai.azure.com/catalog/models/Cohere-parse-v5) through the same `/ocr` endpoint. Use `azure_ai/<deployment name>`: any deployment whose name contains `parse` is sent to the Cohere Parse API on your Foundry resource, at `{api_base}/providers/cohere/v2/parse`.
+Azure AI Foundry also serves [Cohere Parse](https://ai.azure.com/catalog/models/Cohere-parse-v5) through the same `/ocr` endpoint. Use `azure_ai/<deployment name>`: a deployment whose name contains both `cohere` and `parse` (the catalog's default name `Cohere-parse-v5` does) is sent to the Cohere Parse API on your Foundry resource, at `{api_base}/providers/cohere/v2/parse`. Other names keep routing to Mistral OCR, so keep `cohere` and `parse` in the deployment name if you rename it.
 
 Parse accepts `image_url` documents only, an image URL or a base64 `data:image/...` URI. PDFs and `document_url` inputs are rejected with a 400 before anything is sent to Azure. Foundry cannot fetch external URLs, so LiteLLM downloads a remote image and sends it inline as a data URI, the same conversion it applies for the Mistral models above.
 

--- a/docs/providers/cohere.md
+++ b/docs/providers/cohere.md
@@ -349,3 +349,80 @@ curl http://0.0.0.0:4000/rerank \
 
 </TabItem>
 </Tabs>
+
+## Parse (OCR)
+
+[Cohere Parse](https://docs.cohere.com/reference/parse) turns a document image into markdown. LiteLLM serves it through the [`/ocr` endpoint](../ocr), so requests and responses use the same shape as every other OCR provider and each call is cost tracked per billed page.
+
+Parse accepts `image_url` documents only: an image URL or a base64 `data:image/...` URI. PDFs and `document_url` inputs are rejected with a 400 before anything is sent to Cohere.
+
+<Tabs>
+<TabItem value="sdk" label="LiteLLM SDK Usage">
+
+```python showLineNumbers
+import os
+from litellm import ocr
+
+os.environ["COHERE_API_KEY"] = ""
+
+response = ocr(
+    model="cohere/parse-v5.0",
+    document={
+        "type": "image_url",
+        "image_url": "https://raw.githubusercontent.com/mistralai/cookbook/refs/heads/main/mistral/ocr/receipt.png",
+    },
+)
+
+for page in response.pages:
+    print(page.markdown)
+print(response.usage_info.pages_processed)
+```
+</TabItem>
+
+<TabItem value="proxy" label="LiteLLM Proxy Usage">
+
+**Setup**
+
+Add this to your litellm proxy config.yaml
+
+```yaml
+model_list:
+  - model_name: cohere-parse
+    litellm_params:
+      model: cohere/parse-v5.0
+      api_key: os.environ/COHERE_API_KEY
+```
+
+Start litellm
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+Test request
+
+```bash
+curl http://0.0.0.0:4000/v1/ocr \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "cohere-parse",
+    "document": {
+      "type": "image_url",
+      "image_url": "https://raw.githubusercontent.com/mistralai/cookbook/refs/heads/main/mistral/ocr/receipt.png"
+    }
+  }'
+```
+</TabItem>
+</Tabs>
+
+### Supported Parameters
+
+| Parameter | Values | Description |
+|-----------|--------|-------------|
+| `output_format` | `markdown` (default), `blocks` | Cohere's output layout. With `blocks`, each page carries Cohere's `blocks` array and `markdown` is empty |
+| `req_format` | `litellm` (default), `native` | `native` returns Cohere's own response body instead of the LiteLLM OCR shape |
+
+Cohere Parse deployed on Azure AI Foundry is covered in [Azure AI OCR](./azure_ocr#cohere-parse).


### PR DESCRIPTION
## TLDR

- Documents Cohere Parse OCR on `/v1/ocr` for `cohere/parse-v5.0` and Azure AI Foundry deployments
- Adds the `output_format` and `req_format` parameter table plus proxy and SDK examples
- Pairs with the code change in https://github.com/BerriAI/litellm/pull/39862

## Relevant issues

Docs side of BerriAI/litellm PR 39862 (https://github.com/BerriAI/litellm/pull/39862)

## Linear ticket

Resolves LIT-6992

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to markdown documentation with no runtime or configuration behavior in this diff.
> 
> **Overview**
> Documentation-only follow-up for Cohere Parse on LiteLLM’s **`/ocr`** API (companion to the implementation PR).
> 
> **`docs/ocr.md`** now lists **`cohere`** as a supported OCR provider and links to the new Cohere Parse and updated Azure AI sections.
> 
> **`docs/providers/cohere.md`** adds a **Parse (OCR)** section for **`cohere/parse-v5.0`**: image-only inputs, SDK and proxy **`/v1/ocr`** examples, and tables for **`output_format`** (`markdown` / `blocks`) and **`req_format`** (`litellm` / `native`).
> 
> **`docs/providers/azure_ocr.md`** is retitled and expanded for **Cohere Parse on Azure AI Foundry** (`azure_ai/Cohere-parse-v5`): deployment-name routing (`cohere` + `parse`), image-only constraints and URL-to-base64 behavior, SDK/proxy examples, pricing and cost tracking, and health-check / **`model_info`** notes for non-default deployment names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad526f4b408f01617a416275c5f751c812b4feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

