### PR TITLE
docs(bedrock_mantle): correct gpt-oss-20b and safeguard-20b prices

### DIFF
--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -245,9 +245,9 @@ os.environ['BEDROCK_MANTLE_REGION'] = "us-east-1"  # or use AWS_REGION
 | `openai.gpt-5.5` | `/responses` | 1.05M | $5.50 | $33.00 |
 | `openai.gpt-5.4` | `/responses` | 1.05M | $2.75 | $16.50 |
 | `openai.gpt-oss-120b` | `/chat/completions` | 131K | $0.15 | $0.60 |
-| `openai.gpt-oss-20b` | `/chat/completions` | 131K | $0.075 | $0.30 |
+| `openai.gpt-oss-20b` | `/chat/completions` | 131K | $0.07 | $0.30 |
 | `openai.gpt-oss-safeguard-120b` | `/chat/completions` | 131K | $0.15 | $0.60 |
-| `openai.gpt-oss-safeguard-20b` | `/chat/completions` | 131K | $0.075 | $0.30 |
+| `openai.gpt-oss-safeguard-20b` | `/chat/completions` | 131K | $0.07 | $0.20 |
 
 ## Sample Usage
 


### PR DESCRIPTION
## TLDR

The Bedrock Mantle supported-models table listed `openai.gpt-oss-20b` at $0.075 per 1M input tokens and `openai.gpt-oss-safeguard-20b` at $0.075 input / $0.30 output. The AWS us-east-1 Bedrock offer file (standard-tier Mantle SKUs, publication 2026-09-01) bills gpt-oss-20b at $0.07 / $0.30 and safeguard-20b at $0.07 / $0.20, which is also what the matching Bedrock Converse rows already said

This updates the two table rows to match. The gateway's own price map is corrected in BerriAI/litellm#39866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only pricing table edits with no code, auth, or data-path changes.
> 
> **Overview**
> Updates the **Supported Models** pricing table in the Bedrock Mantle docs so two GPT-OSS 20B rows match AWS Bedrock Mantle billing.
> 
> For **`openai.gpt-oss-20b`**, input is corrected from **$0.075** to **$0.07** per 1M tokens (output stays **$0.30**). For **`openai.gpt-oss-safeguard-20b`**, input is **$0.07** (was **$0.075**) and output is **$0.20** (was **$0.30**). No runtime or gateway behavior changes in this PR—documentation only; the LiteLLM price map is handled separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51727faee56aad7410c05bb766a8581a19441669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->