### PR TITLE
docs(pricing): document the batch and long-context batch pricing keys

### DIFF
--- a/docs/provider_registration/add_model_pricing.md
+++ b/docs/provider_registration/add_model_pricing.md
@@ -56,6 +56,23 @@ Here's the full specification with all available fields:
 }
 ```
 
+### Batch pricing keys
+
+Batch API lines bill from the `*_batches` keys when the entry carries them. An entry without them bills half its standard rate
+
+| Key | Bills |
+| --- | --- |
+| `input_cost_per_token_batches` | prompt tokens |
+| `output_cost_per_token_batches` | completion tokens |
+| `cache_read_input_token_cost_batches` | cached prompt tokens |
+| `cache_creation_input_token_cost_batches` | cache write tokens |
+| `input_cost_per_token_above_272k_tokens_batches` | prompt tokens, prompt over 272K |
+| `output_cost_per_token_above_272k_tokens_batches` | completion tokens, prompt over 272K |
+| `cache_read_input_token_cost_above_272k_tokens_batches` | cached prompt tokens, prompt over 272K |
+| `cache_creation_input_token_cost_above_272k_tokens_batches` | cache write tokens, prompt over 272K |
+
+The `above_272k` keys apply to a batch line whose prompt exceeds 272K tokens, the long-context threshold OpenAI prices from. Any tier key the entry leaves out falls back to that entry's flat `*_batches` rate for the same tokens
+
 ### Examples
 
 #### Anthropic Claude


### PR DESCRIPTION
## TLDR

Adds a "Batch pricing keys" section to the Add Model Pricing page listing the eight `*_batches` cost-map keys, including the `above_272k_tokens_batches` tier keys that BerriAI/litellm#39861 ships, and says how a batch line that crosses 272K prompt tokens bills

## Linear ticket

Relates to LIT-6903

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to provider registration guidance; no runtime or billing code is modified.
> 
> **Overview**
> Adds a **Batch pricing keys** section to the Add Model Pricing guide so contributors know how to set batch billing fields in `model_prices_and_context_window.json`.
> 
> The new text states that batch lines use the `*_batches` cost-map keys when present, and otherwise bill at half the standard rate. It lists eight keys (input/output, cache read/create, plus `above_272k_tokens_batches` tiers) and explains that long-context batch tiers apply when the prompt exceeds 272K tokens, with missing tier keys falling back to the flat `*_batches` rate for those tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a61b7aea59b08fde9c4dd2a52c8f533be479886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->