### PR TITLE
docs(proxy): correct tag_routing_prefix's unprefixed-tag behavior

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -181,7 +181,7 @@ router_settings:
   disable_cooldowns: True                  # bool - Disable cooldowns for all models 
   enable_tag_filtering: True                # bool - Use tag based routing for requests
   tag_filtering_match_any: True             # bool - Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags
-  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive, skipping the known-tag-vocabulary heuristic. Unprefixed tags keep matching as today.
+  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive. Once set, an unprefixed tag is a no-op (except inherited key/team/project tags, which keep applying).
   retry_policy: {                          # Dict[str, int]: retry policy for different types of exceptions
     "AuthenticationErrorRetries": 3,
     "TimeoutErrorRetries": 3,
@@ -426,7 +426,7 @@ router_settings:
   disable_cooldowns: True                  # bool - Disable cooldowns for all models
   enable_tag_filtering: True                # bool - Use tag based routing for requests
   tag_filtering_match_any: True             # bool - Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags
-  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive, skipping the known-tag-vocabulary heuristic. Unprefixed tags keep matching as today.
+  tag_routing_prefix: "route:"              # string - Opt-in marker prefix (default ""). A request tag starting with this exact string is stripped and matched as an explicit routing directive. Once set, an unprefixed tag is a no-op (except inherited key/team/project tags, which keep applying).
   retry_policy: {                          # Dict[str, int]: retry policy for different types of exceptions
     "AuthenticationErrorRetries": 3,
     "TimeoutErrorRetries": 3,
@@ -460,7 +460,7 @@ router_settings:
 | enable_weighted_failover | boolean | If true and `routing_strategy` is `simple-shuffle`, a retryable failure on one deployment re-picks (weighted) across other deployments in the same model group before cross-group fallbacks. Default: false. |
 | fallback_access_check | Optional[FallbackAccessCheck] | SDK only. An async predicate `(model, request_kwargs, llm_router) -> bool` the router consults before each cross-model fallback attempt; targets it rejects are skipped. The proxy injects its own check and exposes it through `general_settings.enforce_fallback_model_access`. [More information here](reliability#enforce-key-model-access-on-fallbacks) |
 | tag_filtering_match_any | boolean | Tag matching behavior (only when enable_tag_filtering=true). `true`: match if deployment has ANY requested tag; `false`: match only if deployment has ALL requested tags |
-| tag_routing_prefix | string | Default `""` (no-op). A request tag starting with this exact string is stripped and matched as an explicit, trusted routing directive, exempt from the heuristic that otherwise infers routing intent from deployment tag vocabulary. Unprefixed tags keep matching as today. [Tag Based Routing](tag_routing) |
+| tag_routing_prefix | string | Default `""` (no-op). A request tag starting with this exact string is stripped and matched as an explicit, trusted routing directive. Once set, an unprefixed tag is a no-op, except inherited key/team/project tags, which keep applying. [Tag Based Routing](tag_routing) |
 | cooldown_time | integer | The duration (in seconds) to cooldown a model if it exceeds the allowed failures. |
 | disable_cooldowns | boolean | If true, disables cooldowns for all models. [More information here](reliability) |
 | retry_policy | object | Specifies the number of retries for different types of exceptions. [More information here](reliability) |

--- a/docs/proxy/tag_routing.md
+++ b/docs/proxy/tag_routing.md
@@ -445,7 +445,13 @@ This protection requires the proxy layer. A direct SDK `Router` call that bypass
 
 Tag-based routing infers "is this tag meant for routing" by checking whether some deployment's literal tag string happens to match. That heuristic is usually right, but a caller-invented `&`/`!` tag that matches nothing is treated as suspicious noise and can block `allow_fail_open`'s fallback (see above) even when the caller genuinely wanted an honest, if unsatisfiable, request. Configure `router_settings.tag_routing_prefix` to let a caller mark specific tags as trusted, unambiguous routing directives, removing that ambiguity entirely for the tags that use it.
 
-Any request tag starting with the configured prefix is stripped of the prefix and matched using the usual `!`/`&`/plain-tag logic, with no vocabulary check needed since the caller already declared routing intent explicitly. An unprefixed tag keeps going through today's existing handling unchanged, so adopting the prefix requires no migration.
+Any request tag starting with the configured prefix is stripped of the prefix and matched using the usual `!`/`&`/plain-tag logic, with no vocabulary check needed since the caller already declared routing intent explicitly. Once the prefix is configured, an unprefixed tag is a complete no-op: it is never matched, required, or excluded, and can never cause `no_deployments_with_tag_routing`. Key/team/project policy tags (`metadata.inherited_tags`) are the one exception; they are not caller-controlled, so they keep applying regardless of prefix (see [Fail-Open Fallback](#fail-open-fallback-allow_fail_open)).
+
+:::caution
+
+Configuring `tag_routing_prefix` on a model group that already relies on plain, unprefixed tags for routing stops that routing immediately. Migrate every caller to prefix their routing tags at the same time you turn this on, or their requests fall through to the default-tagged pool (or the full unfiltered set, if there is no default pool) instead of the deployment their tag used to select.
+
+:::
 
 ### Quick example
 
@@ -517,7 +523,7 @@ curl http://localhost:4000/v1/chat/completions \
 | Default | `""`. `str.startswith("")` matches every string, so the mechanism is a full no-op until configured |
 | Matching | Exact literal prefix, no delimiter auto-appended. Configure a trailing delimiter yourself (e.g. `"route:"`, not `"route"`) — a prefix with no delimiter can coincidentally match an unrelated tag that happens to start with the same characters |
 | Stripping order | The prefix is stripped first, before `!`/`&` parsing, so `route:!provider:x` and `route:&provider:x` both work |
-| Unprefixed tags | Keep going through today's existing handling unchanged: the known-tag-vocabulary heuristic for plain tags, and the unknown-tag fail-open guard for `!`/`&` tags |
+| Unprefixed tags | A complete no-op once the prefix is configured: never matched, required, or excluded, and never a cause of `no_deployments_with_tag_routing`. `metadata.inherited_tags` (key/team/project policy) is exempt and keeps applying regardless of prefix |
 | Interaction with fail-open | A prefixed `&`/`!` tag counts as known to `allow_fail_open`'s unknown-tag guard regardless of deployment tag vocabulary |
 
 ## Per-Model-Group Tag Filtering (`enable_tag_filtering`)


### PR DESCRIPTION
Documents the corrected behavior from https://github.com/BerriAI/litellm/pull/39903, fixing https://github.com/BerriAI/litellm/issues/39901.

Adds to docs/proxy/tag_routing.md and docs/proxy/config_settings.md:
- Once tag_routing_prefix is configured, an unprefixed request tag is a complete no-op: never matched, required, or excluded, and never a cause of no_deployments_with_tag_routing. The prior text ("keeps going through today's existing handling unchanged") described the bug this PR fixes, not the actual corrected behavior.
- Key/team/project policy tags in metadata.inherited_tags are exempt from this scoping and keep applying regardless of prefix, since they are not caller-controlled.
- A migration caution for operators already routing on plain unprefixed tags, since configuring tag_routing_prefix now stops that routing immediately for any caller not yet migrated to the prefix.

Verified with npm run build locally; no new broken links or anchors on the edited pages.