### PR TITLE
docs(guardrails): document embedding inspection toggle

### DIFF
--- a/docs/proxy/guardrails/aim_security.md
+++ b/docs/proxy/guardrails/aim_security.md
@@ -47,6 +47,7 @@ guardrails:
       api_key: os.environ/AIM_API_KEY
       api_base: os.environ/AIM_API_BASE # Optional, use only when using a self-hosted Aim Outpost
       ssl_verify: False # Optional, set to False to disable SSL verification or a string path to a custom CA bundle
+      inspect_embeddings: false # Optional, set to true to inspect /embeddings input
 ```
 
 Under the `api_key`, insert the API key you were issued. The key can be found in the guard's page.

--- a/docs/proxy/guardrails/cato_networks.md
+++ b/docs/proxy/guardrails/cato_networks.md
@@ -40,6 +40,7 @@ guardrails:
       api_key: os.environ/CATO_API_KEY
       api_base: os.environ/CATO_API_BASE
       ssl_verify: False # Optional, set to False to disable SSL verification or a string path to a custom CA bundle
+      inspect_embeddings: false # Optional, set to true to inspect /embeddings input
 ```
 
 Under the `api_key`, insert the API key you were issued. The key can be found in the guard's page.


### PR DESCRIPTION
## Summary

Document the optional inspect_embeddings setting for AIM and Cato guardrails

## Validation

Documentation-only change

Resolves LIT-6624
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm-docs/pull/1224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->