### PR TITLE
docs(auto-router): document per-hop compression

### DIFF
--- a/docs/auto_router/feature_history.md
+++ b/docs/auto_router/feature_history.md
@@ -19,6 +19,7 @@ Merged after the v1.100.0 release candidate was cut. Available in `v1.101.0-dev`
 - **1M context preset.** [#39490](https://github.com/BerriAI/litellm/pull/39490).
 - **Mid-task stall escalation.** `stall_escalation_enabled: true` reads the assistant's own recent tool calls and bumps a request one tier when it's stuck in a retry loop, the same ladder `escalation_keywords` uses. Off by default. [#39809](https://github.com/BerriAI/litellm/pull/39809). [Post](/blog/auto-router-stall-escalation).
 - **One-click Auto Router setup.** Configure automatically checks the chat model groups your proxy already serves and fills all four tiers, mixing providers when needed, without picking a template first. [#39693](https://github.com/BerriAI/litellm/pull/39693).
+- **Per-hop compression.** `auto_router_routing_compression` and `auto_router_model_compression` name a compression guardrail for the routing decision and for the model call separately, or `none` for either hop. Naming the same guardrail on both compresses once. [#39823](https://github.com/BerriAI/litellm/pull/39823).
 
 Posts: [Route on Context Size and Modality](/blog/auto-router-more-routing-configurations), [Mid-Task Stall Escalation](/blog/auto-router-stall-escalation).
 

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -165,6 +165,12 @@ Every knob v2 exposes. All fields on `complexity_router_config` are optional exc
         questionComplexity: 0.02
 
     complexity_router_default_model: {{anthropic}}
+
+    # Compression guardrail per hop; a guardrail name, or `none`. Both unset (the
+    # default) keeps whatever compression the key, team, or request already applies
+    # on both hops
+    # auto_router_routing_compression: headroom-compression
+    # auto_router_model_compression: none
 ```
 
 ## Classification
@@ -539,6 +545,25 @@ writes = 0 if warm else cache_creation
     complexity_router_config: {...}
 ```
 
+## Compression
+
+From v1.101.0 an auto router can name a compression guardrail for each of the two hops a routed request makes: the classifier call that decides the tier, and the call to the model it routes to. Both fields sit on the marker's `litellm_params` next to `complexity_router_default_model`, take the name of a [Headroom](./headroom.md) or [Compresr](./guardrails/compresr.md) guardrail, and accept `none`, case-insensitive, for a hop that should not be compressed at all.
+
+```yaml title="config.yaml"
+- model_name: smart-router
+  litellm_params:
+    model: auto_router/complexity_router
+    complexity_router_config: {...}
+    auto_router_routing_compression: headroom-compression
+    auto_router_model_compression: none
+```
+
+Leaving both unset preserves what every existing router does today: a single compression pass, whichever one the key, team, or request already selected, feeding both hops. Setting either field makes the router authoritative for the requests it serves instead, and every other compression guardrail is suppressed for them, including one marked `default_on` and one the caller named in the request body. Ordinary deployments on the same proxy are untouched. Naming the same guardrail on both hops runs it once and reuses the result rather than compressing the same text twice.
+
+A name that does not resolve to an active compression guardrail costs a warning in the proxy logs and an uncompressed hop rather than a failed request. Errors from a guardrail that does resolve still behave as that guardrail is configured to behave, so a compression service that is unreachable and set to fail closed still fails the request before any provider call.
+
+Two things are worth knowing before rolling this out. Compressing the routing hop only saves tokens when the LLM classifier is what runs, since that is the only classifier that sends the text to a model; the heuristic scorers read it locally for free, and the deprecated semantic router embeds only the last user message, which compression leaves alone. And when the two hops name different guardrails, the model hop compresses first, so the classifier reads the model-compressed text rather than the original. Routing deliberately reads the live messages: the only uncompressed copy available is the one taken before the pre-call guardrails run, and handing that to a compression service would ship a masking guardrail's own input to a third party.
+
 ## Context window
 
 An auto router entry is a marker rather than a callable model, so it carries no provider metadata of its own and advertises no context window until you declare one. The number is not derived from the tier models: not the minimum across them, not the maximum, and not the window of `complexity_router_default_model`. Tiers hold model names the proxy resolves at request time, and nothing in the model-info path walks that list. Until you declare a window, `GET /v1/models` omits `max_input_tokens` and `max_output_tokens` for the router entirely, and `/model_group/info` reports `null` for both.
@@ -699,6 +724,8 @@ Tier and classifier dropdowns exclude embedding-mode models; the semantic embedd
 Selecting **LLM Classifier** reveals, alongside the classifier model and timeout, a **Classifier Prompt** editor (`classifier_llm_config.system_prompt`, prefilled with the built-in rubric for the router's context window size and tier names, and sent only once you edit it), an **If the classifier fails** choice between scoring with the heuristic and routing to the default model (`classifier_fallback`, the second option available only once the router has a default model), and the classifier context settings: **Context Window Size** (`classifier_context_window_size`), **Context Per-Turn Character Limit** (`classifier_context_per_turn_chars`), and an **Include Assistant Turns** toggle (`classifier_context_include_assistant_turns`). They are written only when the classifier type is LLM, and a value left at the default is omitted from the saved config so the backend default applies.
 
 **Advanced > Session Affinity** holds the session pin, off to match the config default. Both the create tab and the edit modal write the value explicitly, so a router built in the UI records what it does rather than inheriting whatever the default happens to be.
+
+**Advanced > Compression** picks the compression guardrail for the routing decision, then either reuses it for the model call or takes a different one, `None` included. Editing a router back to *not configured* does not clear a policy that was already saved, because a model update merges the fields it is given and never deletes a key, so picking **None** for both hops is how you turn compression off from the modal. Legacy semantic auto routers (`auto_router/<name>`) accept both fields through `config.yaml` and the model-management API but have no control for them in the UI yet.
 
 ## Claude Code and Claude Desktop
 

--- a/docs/proxy/guardrails/compresr.md
+++ b/docs/proxy/guardrails/compresr.md
@@ -181,6 +181,10 @@ curl -i http://0.0.0.0:4000/v1/messages \
 
 The response includes an `x-litellm-applied-guardrails: compresr-compression` header so the caller can confirm that compression actually ran.
 
+## Compression behind an auto router
+
+A request an [auto router](../auto_routing.md) serves makes two calls, one to classify the request and one to the model it routes to. By default both see the same compressed text. From v1.101.0 the router can name a compression guardrail per hop, or `none` for either, with `auto_router_routing_compression` and `auto_router_model_compression`. Setting either field puts the router in charge of compression for its own requests and suppresses the guardrails this page attaches at the key, team, or request level for them. See [Compression](../auto_routing.md#compression).
+
 ## Rolling out to a team
 
 A platform admin can turn on compression for a whole team without any client changes. The best fit is agent and RAG workloads whose volume is dominated by non-code tool output, such as search results, retrieved documents, ticket threads, CRM records, and transcripts.

--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -153,6 +153,10 @@ curl -i http://0.0.0.0:4000/v1/messages \
 
 The response includes an `x-litellm-applied-guardrails: headroom-compression` header so the caller can confirm compression actually ran.
 
+## Compression behind an auto router
+
+A request an [auto router](./auto_routing.md) serves makes two calls, one to classify the request and one to the model it routes to. By default both see the same compressed text. From v1.101.0 the router can name a compression guardrail per hop, or `none` for either, with `auto_router_routing_compression` and `auto_router_model_compression`. Setting either field puts the router in charge of compression for its own requests and suppresses the guardrails above for them, whether they were attached to a key, a team, or the request body. See [Compression](./auto_routing.md#compression).
+
 ## Claude Code usage
 
 This is the most common rollout: a platform admin wants to cut input token spend for a team that drives heavy traffic through Claude Code without asking each developer to change their setup.


### PR DESCRIPTION
## What

Documents [BerriAI/litellm#39823](https://github.com/BerriAI/litellm/pull/39823): the two new `auto_router_routing_compression` / `auto_router_model_compression` fields that let an auto router pick a compression guardrail for the routing decision and the model call independently, or `none` for either.

## Where

- `docs/auto_router/feature_history.md`: bullet under **Coming in Next Release**, which is where the request to add this originated.
- `docs/proxy/auto_routing.md`: neither field appeared anywhere in the docs yet, so this is the real home. Adds the fields (commented out, matching the other opt-in knobs) to the **Full config** block, a new **Compression** section covering the suppression semantics and the rollout caveats called out in the PR description, and a paragraph under **UI** for the new Advanced > Compression control.
- `docs/proxy/headroom.md`, `docs/proxy/guardrails/compresr.md`: one cross-link section each, since both are compression guardrails an auto router can now name per hop.

## Checked

- `npm run build` passes (`onBrokenLinks`/`onBrokenAnchors: throw`, so the new cross-links and the `#compression` anchor resolve).
- `python3 scripts/check-docs.py docs` and `node scripts/check-writing-style.js` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)