### PR TITLE
docs(milvus): document the gRPC transport for Milvus vector stores

### DIFF
--- a/docs/providers/milvus_vector_stores.md
+++ b/docs/providers/milvus_vector_stores.md
@@ -123,6 +123,29 @@ vector_store_registry:
         limit: 10
 ```
 
+### gRPC transport
+
+Milvus deployments that only expose the gRPC port (19530 by default) can be searched over gRPC instead of the REST API. Set `milvus_transport: grpc` and point `api_base` at the gRPC endpoint:
+
+```yaml
+vector_store_registry:
+  - vector_store_name: "milvus-grpc-knowledgebase"
+    litellm_params:
+        vector_store_id: "my-collection-name"
+        custom_llm_provider: "milvus"
+        milvus_transport: grpc
+        api_key: os.environ/MILVUS_API_KEY
+        api_base: https://your-milvus-host:19530
+        litellm_embedding_model: "azure/text-embedding-3-large"
+        milvus_text_field: "book_intro"
+        milvus_db_name: "default"
+        milvus_partition_names: ["books"]
+```
+
+The gRPC transport uses the `pymilvus` client, which ships with the `milvus` extra (`pip install 'litellm[milvus]'`). It covers vector store search, including the search that runs when a chat completions, responses, or messages request names the store. Create, retrieve, update, delete, and file routes on `/v1/vector_stores` still use the REST API. Over gRPC the `filters`, `ranking_options`, and `rewrite_query` search options return a 400 instead of being ignored, and `max_num_results` must be between 1 and 50
+
+Only a proxy admin can save a gRPC connection through `/vector_store/new` or `/vector_store/update`, and changing any store's provider, credential name, or `litellm_params` through `/vector_store/update` needs a proxy admin as well. A gRPC store saved before this check existed returns a 403 asking for an admin re-save until a proxy admin saves it again
+
 ### Start Proxy
 
 ```bash
@@ -159,6 +182,9 @@ curl -X POST 'http://0.0.0.0:4000/v1/vector_stores/my-collection-name/search' \
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `milvus_transport` | string | `"grpc"` to search over the Milvus gRPC port with PyMilvus; omit to use the REST API |
+| `milvus_db_name` | string | Database name for either transport (default: "default") |
+| `milvus_partition_names` | list | Partition names to search, for either transport |
 | `dbName` | string | Database name (default: "default") |
 | `annsField` | string | Vector field name to search (default: "book_intro_vector") |
 | `limit` | integer | Maximum number of results to return |


### PR DESCRIPTION
## TLDR

Documents the Milvus gRPC transport that BerriAI/litellm#39039 adds to Milvus vector stores: how to turn it on with `milvus_transport: grpc`, the `pymilvus` extra it needs, which routes it covers, the search options it rejects, and the proxy admin gate on saving or changing a gRPC connection

## What changed

A new "gRPC transport" subsection under Setup Config in `docs/providers/milvus_vector_stores.md` with a registry example, plus three new rows in the Optional Parameters table for `milvus_transport`, `milvus_db_name`, and `milvus_partition_names`

## Checks

`npm run lint:writing` and `npm run lint:docs` both pass on the branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or configuration behavior in this PR.
> 
> **Overview**
> **Documentation-only** update to `milvus_vector_stores.md` describing Milvus vector store search over **gRPC** (companion to the feature in BerriAI/litellm#39039).
> 
> Adds a **gRPC transport** subsection under proxy setup with a `vector_store_registry` example using `milvus_transport: grpc`, gRPC `api_base`, `milvus_db_name`, and `milvus_partition_names`. It explains the **`litellm[milvus]`** / PyMilvus dependency, that **search** (including RAG-triggered search) uses gRPC while **`/v1/vector_stores` CRUD/file routes stay REST**, stricter search behavior (**400** for `filters`, `ranking_options`, `rewrite_query`; **`max_num_results` 1–50**), and **proxy-admin-only** save/update rules for gRPC connections (including **403** until an admin re-saves legacy gRPC stores).
> 
> The **Optional Parameters** table gains rows for `milvus_transport`, `milvus_db_name`, and `milvus_partition_names`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e1d41b13ecd0b5d8673c3b9207f2d26c325435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->