### PR TITLE
docs: fill the Python version from docs-models.json and lint hardcoded versions

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install pyyaml
       - run: python3 scripts/check-docs.py docs

--- a/docs-models.json
+++ b/docs-models.json
@@ -4,5 +4,7 @@
   "anthropic": "claude-sonnet-5",
   "anthropic_large": "claude-opus-5",
   "gemini_pro": "gemini-3.1-pro-preview",
-  "gemini_flash": "gemini-3.8-flash"
+  "gemini_flash": "gemini-3.8-flash",
+  "python_version": "3.13",
+  "python_min_version": "3.10"
 }

--- a/docs/extras/contributing_code.md
+++ b/docs/extras/contributing_code.md
@@ -55,7 +55,7 @@ Enforcement happens in two places: opt-in local git hooks in `.githooks/`, and a
 
 Examples:
 
-```
+```text keep-python-version
 feat(router): add weighted round-robin strategy
 fix(bedrock): decouple STS region from aws_region_name
 chore(deps): bump black to 26.3.1

--- a/docs/providers/langgraph.md
+++ b/docs/providers/langgraph.md
@@ -181,7 +181,7 @@ Before using LiteLLM with LangGraph, you need a running LangGraph server.
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.11+ (required by the LangGraph CLI's in-memory server) {/* keep-python-version */}
 - An LLM API key (OpenAI or Google Gemini)
 
 ### 1. Install the LangGraph CLI

--- a/docs/proxy/cli.md
+++ b/docs/proxy/cli.md
@@ -150,7 +150,7 @@ This page documents all command-line interface (CLI) arguments available for the
    - **Status:** Beta. Opt in when you want higher gateway throughput; uvicorn remains the default.
    - Starts the proxy via [Granian](https://github.com/emmett-framework/granian) (Rust-backed ASGI server) instead of uvicorn. Supports HTTP/1 and HTTP/2.
    - **Why use it:** Granian moves the HTTP layer off Python into a Rust runtime, which tends to handle concurrent proxy traffic more predictably than uvicorn alone. In LiteLLM load tests, Granian showed a **10–20 RPS improvement** over an equivalent uvicorn multi-worker setup, with **better stability under sustained load and fewer request failures**.
-   - **Requirements:** Python 3.9+ and the `granian` package (included in `litellm[proxy]`).
+   - **Requirements:** Python {{python_min_version}}+ and the `granian` package (included in `litellm[proxy]`).
    - **Limitations when using Granian:**
      - `--max_requests_before_restart` is not supported (Granian uses `workers_lifetime` in seconds, not a per-request limit).
      - `--ciphers` is not applied.

--- a/docs/proxy/guardrails/litellm_content_filter.md
+++ b/docs/proxy/guardrails/litellm_content_filter.md
@@ -641,7 +641,7 @@ Mount the file at `<site-packages>/litellm/proxy/guardrails/guardrail_hooks/lite
 ```yaml title="values.yaml (Helm)"
 extraVolumeMounts:
   - name: content-filter-categories
-    mountPath: /usr/local/lib/python3.13/site-packages/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/categories/<your-category-name>.yaml
+    mountPath: /usr/local/lib/python{{python_version}}/site-packages/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/categories/<your-category-name>.yaml
     subPath: <your-category-name>.yaml
     readOnly: true
 

--- a/docs/proxy/headroom.md
+++ b/docs/proxy/headroom.md
@@ -204,7 +204,7 @@ In the Admin UI, open any request in **Logs**, scroll to the **Guardrails & Poli
 Here is the dockerfile for deploying the headroom proxy
 
 ```Dockerfile
-FROM python:3.12-slim
+FROM python:{{python_version}}-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/docs/proxy/quick_start.md
+++ b/docs/proxy/quick_start.md
@@ -16,8 +16,8 @@ LiteLLM Server (LLM Gateway) manages:
 $ uv tool install 'litellm[proxy]'
 ```
 
-:::warning Requires Python 3.10+
-LiteLLM 1.84.0 and newer require Python 3.10 or higher (`requires-python >=3.10`). `uv tool install` handles this for you by provisioning a compatible Python automatically. A bare `pip install 'litellm[proxy]'` does not; on Python 3.9 pip silently resolves down to the last release that still allowed 3.9, which is 1.83.9, with no error. If you pinned to an old version unexpectedly, check `python --version` and upgrade to 3.10+ (or use uv), then reinstall
+:::warning Minimum Python version
+LiteLLM 1.84.0 and newer require Python {{python_min_version}} or higher (`requires-python >={{python_min_version}}`). `uv tool install` handles this for you by provisioning a compatible Python automatically. A bare `pip install 'litellm[proxy]'` does not; on an older interpreter pip silently resolves down to the last release whose `requires-python` still allowed it (1.83.9 for the previous floor), with no error. If you pinned to an old version unexpectedly, check `python --version` and upgrade to {{python_min_version}}+ (or use uv), then reinstall
 :::
 
 ## Quick Start - LiteLLM Proxy CLI

--- a/docs/troubleshoot/pip_venv_upgrade.md
+++ b/docs/troubleshoot/pip_venv_upgrade.md
@@ -39,7 +39,7 @@ uv add 'litellm[proxy]==<version>'
 prisma generate --schema <venv>/lib/python<version>/site-packages/litellm_proxy_extras/schema.prisma
 ```
 
-Replace `<venv>` with your virtual environment path and `<version>` with your Python version (e.g., `python3.11`, `python3.12`, `python3.13`).
+Replace `<venv>` with your virtual environment path and `<version>` with your interpreter's version (for example `python{{python_version}}`).
 
 ### 5. Apply DB migrations
 
@@ -75,7 +75,7 @@ Then run the migration with the explicit schema path:
 prisma migrate deploy --schema <venv>/lib/python<version>/site-packages/litellm_proxy_extras/schema.prisma
 ```
 
-Replace `<venv>` with your virtual environment path and `<version>` with your Python version (e.g., `python3.11`, `python3.12`, `python3.13`).
+Replace `<venv>` with your virtual environment path and `<version>` with your interpreter's version (for example `python{{python_version}}`).
 
 ### 6. Start the proxy
 

--- a/docs/troubleshoot/prisma_migrations.md
+++ b/docs/troubleshoot/prisma_migrations.md
@@ -124,10 +124,10 @@ DATABASE_URL="<your_database_url>" prisma db push
 
 ```
 PermissionError: [Errno 13] Permission denied:
-'/usr/local/lib/python3.11/site-packages/prisma/binaries/prisma-query-engine-debian-openssl-3.0.x'
+'/usr/local/lib/python{{python_version}}/site-packages/prisma/binaries/prisma-query-engine-debian-openssl-3.0.x'
 ```
 
-**Cause:** before Prisma can talk to your database it has to decide which query engine binary to run, and it does that by walking the engine paths the Prisma CLI recorded when the client was generated. A generated client carries five of them, one per supported platform, so the walk always runs. It tests each candidate with `Path.exists()`, which reports a missing file as `False` but re-raises `PermissionError` when a directory on the way to the candidate denies the running uid; it only swallows `ENOENT`, `ENOTDIR`, `EBADF` and `ELOOP`. An image that generates the client as one uid and runs as another, or that installs the client somewhere the runtime uid cannot traverse, therefore dies at startup rather than moving on to the next candidate. Python 3.14 returns `False` here and is unaffected; every other interpreter LiteLLM supports, 3.10 through 3.13, raises.
+**Cause:** before Prisma can talk to your database it has to decide which query engine binary to run, and it does that by walking the engine paths the Prisma CLI recorded when the client was generated. A generated client carries five of them, one per supported platform, so the walk always runs. It tests each candidate with `Path.exists()`, which reports a missing file as `False` but re-raises `PermissionError` when a directory on the way to the candidate denies the running uid; it only swallows `ENOENT`, `ENOTDIR`, `EBADF` and `ELOOP`. An image that generates the client as one uid and runs as another, or that installs the client somewhere the runtime uid cannot traverse, therefore dies at startup rather than moving on to the next candidate. Python 3.14 returns `False` here and is unaffected; every older interpreter LiteLLM supports raises. {/* keep-python-version */}
 
 **How to fix:** point Prisma at an engine the runtime uid can read, setting both variables together. `PRISMA_QUERY_ENGINE_BINARY` on its own does not clear this, because the walk that raises runs before Prisma reads that variable. `PRISMA_BINARY_PLATFORM` is the one that short-circuits the walk, before any candidate is tested, so neither variable substitutes for the other:
 

--- a/docs/tutorials/openclaw_integration.md
+++ b/docs/tutorials/openclaw_integration.md
@@ -17,7 +17,7 @@ Chat apps → OpenClaw Gateway → LiteLLM Proxy → LLM Providers (OpenAI, Anth
 | Requirement | How to get it |
 |---|---|
 | **Node.js 22+** | `node --version` — install from [nodejs.org](https://nodejs.org) if needed |
-| **Python 3.8+** | `python --version` |
+| **Python {{python_min_version}}+** | `python --version` |
 | **At least one LLM API key** | OpenAI, Anthropic, Gemini, etc. |
 
 ## Step 1: Install LiteLLM Proxy

--- a/docs/tutorials/scalekit_agentkit.md
+++ b/docs/tutorials/scalekit_agentkit.md
@@ -10,7 +10,7 @@ Add authenticated tool calls to your LiteLLM-powered agents. [Scalekit](https://
 
 ## Prerequisites
 
-- Python 3.9+
+- Python {{python_min_version}}+
 - A [Scalekit account](https://app.scalekit.com) with a connection configured (this tutorial uses Gmail)
 - API keys for at least one LLM provider, or a running LiteLLM proxy
 - Scalekit API credentials (`SCALEKIT_CLIENT_ID`, `SCALEKIT_CLIENT_SECRET`, `SCALEKIT_ENV_URL`) from Dashboard → **Developers** → **API Credentials**

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -16,6 +16,7 @@ Every check here is deterministic and fails the build:
   github-alert        a GitHub-style "> [!NOTE]" alert, which Docusaurus renders as a plain quote
   multiple-h1         more than one H1 in a page
   model-literal       a fenced block hardcodes a model id from docs-models.json instead of its {{role}} placeholder
+  python-literal      a Python version is written out (python3.12, python:3.12-slim, Python 3.12+) instead of {{python_version}} or {{python_min_version}}
   model-role-unknown  a {{placeholder}} that looks like a docs-models.json role but is not one, which the build would print literally
 
 Usage:
@@ -30,6 +31,14 @@ substitution before parsing a block, and the model-literal rule fails a block
 that writes the current id itself, because that block would not follow the
 next bump. Add `keep-model-ids` to the fence line when the exact id is the
 point of the block (a price map key, a cache key, a printed log).
+
+The Python version examples use ({{python_version}}, the interpreter in the
+official Docker image) and the lowest version LiteLLM supports
+({{python_min_version}}, the pyproject floor) come from the same file, and the
+python-literal rule fails a fence or prose line that spells a version out.
+Add `keep-python-version` to the fence line, or a `{/* keep-python-version */}`
+comment on the prose line, when one specific version is the point (a bug in
+one interpreter, a third-party requirement, a historical commit message).
 A placeholder that looks like a role but is not one (a typo, or a role removed
 from docs-models.json) fails model-role-unknown, since the build would print it
 as written.
@@ -312,6 +321,11 @@ def check_page(page, site, page_cache):
                         continue
                     seen_ids.add(m.group(0))
                     err("model-literal", start + offset + 1, f"hardcoded model id `{m.group(0)}`; write `{{{{{MODEL_ROLES[m.group(0)]}}}}}` so docs-models.json controls it, or add keep-model-ids if the exact id is the point")
+        if "keep-python-version" not in meta_tokens:
+            for offset, l in enumerate(buf):
+                m = PYTHON_LITERAL_RE.search(l)
+                if m:
+                    err("python-literal", start + offset + 1, python_literal_message(m.group(0)))
         content = textwrap.dedent(substitute_models("\n".join(buf)))
         if lang in YAML_LANGS:
             try:
@@ -348,6 +362,10 @@ def check_page(page, site, page_cache):
     for line_no, raw in page.prose:
         if GITHUB_ALERT_RE.match(raw):
             err("github-alert", line_no, "GitHub-style alert does not render in Docusaurus; use :::note / :::warning")
+        if "keep-python-version" not in raw:
+            m = PYTHON_LITERAL_RE.search(raw)
+            if m:
+                err("python-literal", line_no, python_literal_message(m.group(0)))
         text = strip_inline_code(raw)
         targets = [m.group(1) for m in MD_LINK_RE.finditer(text)] + [m.group(1) for m in HREF_RE.finditer(text)]
         for target in targets:
@@ -404,17 +422,19 @@ def check_page(page, site, page_cache):
     return errors
 
 
-KNOWN_META_RE = re.compile(r"^(showLineNumbers|nolint|keep-model-ids|live|noInline|title=\S+|mode=\S+|\{[\d,\s-]+\})$")
+KNOWN_META_RE = re.compile(r"^(showLineNumbers|nolint|keep-model-ids|keep-python-version|live|noInline|title=\S+|mode=\S+|\{[\d,\s-]+\})$")
 
 
-def load_model_roles():
-    """{model id: role} from docs-models.json, the file src/remark/docs-models.js reads."""
+def load_roles():
+    """{role: value} from docs-models.json, the file src/remark/docs-models.js reads."""
     with open(os.path.join(REPO_ROOT, "docs-models.json"), encoding="utf-8") as f:
-        roles = json.load(f)
-    return {model_id: role for role, model_id in roles.items()}
+        return json.load(f)
 
 
-MODEL_ROLES = load_model_roles()
+ROLE_TO_ID = load_roles()
+PYTHON_ROLES = {"python_version", "python_min_version"}
+# {model id: role}. The Python roles hold bare version numbers, which get their own rule below.
+MODEL_ROLES = {model_id: role for role, model_id in ROLE_TO_ID.items() if role not in PYTHON_ROLES}
 MODEL_TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z0-9_]+)\s*\}\}")
 # A hardcoded id counts only as a whole token: `.` and `/` before it are boundaries
 # (azure/gpt-5.6-luna, us.anthropic.claude-sonnet-5) but `-` and `:` are not, so an
@@ -422,7 +442,16 @@ MODEL_TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z0-9_]+)\s*\}\}")
 MODEL_LITERAL_RE = re.compile(
     r"(?<![A-Za-z0-9:@-])(?:" + "|".join(re.escape(i) for i in sorted(MODEL_ROLES, key=len, reverse=True)) + r")(?![A-Za-z0-9@-]|[.:][0-9])"
 ) if MODEL_ROLES else re.compile(r"(?!x)x")
-ROLE_TO_ID = {role: model_id for model_id, role in MODEL_ROLES.items()}
+# python3.12, python-3.12, python:3.12-slim and Python 3.12+; `python3 -m venv` and wheel tags such as cp312 are not versions.
+PYTHON_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9.])[Pp]ython[-:_ ]?3\.\d{1,2}(?![0-9])")
+
+
+def python_literal_message(literal):
+    return (
+        f"hardcoded Python version `{literal}`; write `{{{{python_version}}}}` (the version examples use) or "
+        f"`{{{{python_min_version}}}}` (the lowest version LiteLLM supports) so docs-models.json controls it, "
+        "or add keep-python-version if this exact version is the point"
+    )
 
 
 def substitute_models(text):

--- a/src/remark/docs-models.js
+++ b/src/remark/docs-models.js
@@ -1,9 +1,10 @@
-// Fills in {{role}} model-id placeholders from docs-models.json at build time.
+// Fills in {{role}} placeholders from docs-models.json at build time.
 //
-// docs-models.json maps a role (openai_small, anthropic, gemini_flash, ...) to
-// the model id examples use today. Pages write `{{openai_small}}` inside code
-// blocks and inline code (and, if needed, in prose) and the rendered site shows
-// the real id, so moving the docs to a new model is one edit to that file.
+// docs-models.json maps a role (openai_small, anthropic, gemini_flash,
+// python_version, ...) to the value examples use today: a model id, or the
+// Python version. Pages write `{{openai_small}}` inside code blocks and inline
+// code (and, if needed, in prose) and the rendered site shows the real value,
+// so moving the docs to a new model or Python version is one edit to that file.
 // scripts/check-docs.py applies the same substitution before it parses YAML,
 // JSON and Python blocks.
 


### PR DESCRIPTION
Pages disagreed on which Python version to show: prerequisites said 3.8+, 3.9+ or 3.11+, venv paths used 3.11, the Headroom Dockerfile used 3.12 and the Helm mount path used 3.13, while the real floor (`requires-python >=3.10` in litellm's pyproject) was typed out by hand in the quick start.

This applies the docs-models.json approach from #1201 to the Python version. `docs-models.json` gains two roles: `python_version` (3.13, the interpreter the official Docker image ships, so paths like `/usr/local/lib/python3.13/site-packages` match what users actually see) and `python_min_version` (3.10, the pyproject floor). The remark plugin fills `{{python_version}}` and `{{python_min_version}}` at build time like it does for model ids, and every page that mentioned a version now uses one of the two placeholders. Moving the docs to a new Python, or raising the floor, is a one-line edit.

`scripts/check-docs.py` gains a `python-literal` rule that fails any fenced block or prose line that spells a version out (`python3.12`, `python:3.12-slim`, `Python 3.12+`). `keep-python-version` on the fence line, or a `{/* keep-python-version */}` comment on a prose line, keeps a version that is genuinely the point: the LangGraph in-memory server's own 3.11 floor, the Python 3.14 `Path.exists` behaviour in the Prisma runbook, and the example breaking-change commit message in the contributing guide. The model-literal rule skips the Python roles so bare `3.13` is never mistaken for a model id. The docs CI job now runs the checker on 3.13.

Blog posts and release notes are dated content, are not processed by the plugin, and are left alone.

https://claude.ai/code/session_01L1LFGx3wvva2d8ARV7jFKp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs CI only; no runtime proxy or library behavior changes.
> 
> **Overview**
> Docs previously mixed Python **3.8+**, **3.9+**, **3.11**, **3.12**, and **3.13** across prerequisites, Docker paths, and install notes. This PR adds **`python_version`** (3.13, official image / `site-packages` paths) and **`python_min_version`** (3.10, `requires-python` floor) to **`docs-models.json`**, fills **`{{python_version}}`** / **`{{python_min_version}}`** at build time via the existing remark plugin, and updates affected pages (proxy quick start, CLI, Helm mounts, Headroom Dockerfile, venv/Prisma guides, tutorials).
> 
> **`scripts/check-docs.py`** gains a **`python-literal`** rule (with **`keep-python-version`** / MDX comment escapes for intentional literals like LangGraph’s 3.11 requirement). Docs structure CI runs on **Python 3.13**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed19aaeefd788362ebc1ea0373eaa0381da3381c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->