### PR TITLE
docs: sweep retired model ids left in plain fences after #1201

### DIFF
--- a/docs/anthropic_unified/structured_output.md
+++ b/docs/anthropic_unified/structured_output.md
@@ -27,7 +27,7 @@ Use LiteLLM to call Anthropic's structured output feature via the `/v1/messages`
 model_list:
   - model_name: claude-sonnet
     litellm_params:
-      model: anthropic/claude-sonnet-4-5-20250514
+      model: anthropic/{{anthropic}}
       api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
@@ -80,7 +80,7 @@ curl http://localhost:4000/v1/messages \
 model_list:
   - model_name: azure-claude-sonnet
     litellm_params:
-      model: azure_ai/claude-sonnet-4-5-20250514
+      model: azure_ai/{{anthropic}}
       api_key: os.environ/AZURE_AI_API_KEY
       api_base: https://your-endpoint.inference.ai.azure.com
 ```
@@ -251,7 +251,7 @@ curl http://localhost:4000/v1/messages \
       "text": "{\"name\":\"John Smith\",\"email\":\"john@example.com\",\"plan_interest\":\"Enterprise\",\"demo_requested\":true}"
     }
   ],
-  "model": "claude-sonnet-4-5-20250514",
+  "model": "{{anthropic}}",
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {

--- a/docs/claude_code_context_management.md
+++ b/docs/claude_code_context_management.md
@@ -124,7 +124,7 @@ curl -X POST http://localhost:4000/v1/messages \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
   -d '{
-    "model": "gpt-5.4-mini",
+    "model": "{{openai_small}}",
     "max_tokens": 1024,
     "messages": [...],
     "tools": [...],
@@ -164,7 +164,7 @@ Without this setting, the polyfill is a no-op and `applied_edits[0].error: "summ
 import litellm
 
 response = await litellm.anthropic.messages.acreate(
-    model="gpt-5.4-mini",          # any non-Anthropic provider
+    model="{{openai_small}}",          # any non-Anthropic provider
     max_tokens=1024,
     messages=[...],                # multi-turn history
     context_management={
@@ -188,7 +188,7 @@ curl -X POST http://localhost:4000/v1/messages \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
   -d '{
-    "model": "gpt-5.4-mini",
+    "model": "{{openai_small}}",
     "max_tokens": 1024,
     "messages": [...],
     "context_management": {
@@ -261,7 +261,7 @@ When compaction fires, the response includes `context_management.applied_edits` 
     },
     {"type": "text", "text": "Sure, here's the output formatter..."}
   ],
-  "model": "gpt-5.4-mini",
+  "model": "{{openai_small}}",
   "stop_reason": "end_turn",
   "usage": {"input_tokens": 420, "output_tokens": 120},
   "context_management": {
@@ -320,7 +320,7 @@ When at least one edit fires, the response includes a `context_management` field
   "type": "message",
   "role": "assistant",
   "content": [{"type": "text", "text": "Based on the latest weather data..."}],
-  "model": "gpt-5.4-mini",
+  "model": "{{openai_small}}",
   "stop_reason": "end_turn",
   "usage": {
     "input_tokens": 620,
@@ -346,7 +346,7 @@ The `context_management.applied_edits` field is included in the final `message_d
 
 ```
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_01...","type":"message","role":"assistant","content":[],"model":"gpt-5.4-mini","stop_reason":null,"usage":{"input_tokens":620,"output_tokens":0}}}
+data: {"type":"message_start","message":{"id":"msg_01...","type":"message","role":"assistant","content":[],"model":"{{openai_small}}","stop_reason":null,"usage":{"input_tokens":620,"output_tokens":0}}}
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

--- a/docs/completion/anthropic_advisor_tool.md
+++ b/docs/completion/anthropic_advisor_tool.md
@@ -38,7 +38,7 @@ flowchart TD
 
     D -->|"yes — tool_use\nname=advisor"| E{"max_uses\nexceeded?"}
 
-    E -->|no| F["ADVISOR SUB-CALL\nclaude-opus-4-6\nfull transcript forwarded\nno tools"]
+    E -->|no| F["ADVISOR SUB-CALL\n{{anthropic_large}}\nfull transcript forwarded\nno tools"]
 
     F --> G["Inject advice as\ntool_result into history"]
 
@@ -59,13 +59,13 @@ flowchart TD
 
 ## Model Compatibility
 
-The executor and advisor models must form a valid pair. Currently the only supported advisor model is `claude-opus-4-6`.
+The executor and advisor models must form a valid pair. The advisor is an Opus model (`{{anthropic_large}}`), and the executor can be Opus 4.6 or later, Sonnet 4.6 or later, or Haiku 4.5.
 
 | Executor | Advisor |
 |----------|---------|
-| `claude-haiku-4-5-20251001` | `claude-opus-4-6` |
-| `claude-sonnet-4-6` | `claude-opus-4-6` |
-| `claude-opus-4-6` | `claude-opus-4-6` |
+| `claude-haiku-4-5-20251001` | `{{anthropic_large}}` |
+| `{{anthropic}}` | `{{anthropic_large}}` |
+| `{{anthropic_large}}` | `{{anthropic_large}}` |
 
 ---
 
@@ -79,7 +79,7 @@ The executor and advisor models must form a valid pair. Currently the only suppo
 import litellm
 
 response = litellm.completion(
-    model="anthropic/claude-sonnet-4-6",
+    model="anthropic/{{anthropic}}",
     messages=[
         {"role": "user", "content": "Build a concurrent worker pool in Go with graceful shutdown."}
     ],
@@ -87,7 +87,7 @@ response = litellm.completion(
         {
             "type": "advisor_20260301",
             "name": "advisor",
-            "model": "claude-opus-4-6",
+            "model": "{{anthropic_large}}",
         }
     ],
     max_tokens=4096,
@@ -102,7 +102,7 @@ print(response.choices[0].message.content)
 import litellm
 
 response = litellm.completion(
-    model="anthropic/claude-sonnet-4-6",
+    model="anthropic/{{anthropic}}",
     messages=[
         {"role": "user", "content": "Build a REST API with authentication in Python."}
     ],
@@ -110,7 +110,7 @@ response = litellm.completion(
         {
             "type": "advisor_20260301",
             "name": "advisor",
-            "model": "claude-opus-4-6",
+            "model": "{{anthropic_large}}",
             "max_uses": 3,                             # cap advisor calls per request
             "caching": {"type": "ephemeral", "ttl": "5m"},  # enable for 3+ calls per conversation
         }
@@ -125,7 +125,7 @@ response = litellm.completion(
 import litellm
 
 response = litellm.completion(
-    model="anthropic/claude-sonnet-4-6",
+    model="anthropic/{{anthropic}}",
     messages=[
         {"role": "user", "content": "Implement a distributed rate limiter."}
     ],
@@ -133,7 +133,7 @@ response = litellm.completion(
         {
             "type": "advisor_20260301",
             "name": "advisor",
-            "model": "claude-opus-4-6",
+            "model": "{{anthropic_large}}",
         }
     ],
     max_tokens=4096,
@@ -160,7 +160,7 @@ tools = [
     {
         "type": "advisor_20260301",
         "name": "advisor",
-        "model": "claude-opus-4-6",
+        "model": "{{anthropic_large}}",
     }
 ]
 
@@ -169,7 +169,7 @@ messages = [
 ]
 
 response = litellm.completion(
-    model="anthropic/claude-sonnet-4-6",
+    model="anthropic/{{anthropic}}",
     messages=messages,
     tools=tools,
     max_tokens=4096,
@@ -182,7 +182,7 @@ messages.append({"role": "assistant", "content": response.choices[0].message.con
 messages.append({"role": "user", "content": "Now add a max-in-flight limit of 10."})
 
 response2 = litellm.completion(
-    model="anthropic/claude-sonnet-4-6",
+    model="anthropic/{{anthropic}}",
     messages=messages,
     tools=tools,
     max_tokens=4096,
@@ -203,7 +203,7 @@ LiteLLM automatically strips `advisor_tool_result` blocks from message history w
 model_list:
   - model_name: claude-sonnet
     litellm_params:
-      model: anthropic/claude-sonnet-4-6
+      model: anthropic/{{anthropic}}
       api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
@@ -226,7 +226,7 @@ response = client.chat.completions.create(
         {
             "type": "advisor_20260301",
             "name": "advisor",
-            "model": "claude-opus-4-6",
+            "model": "{{anthropic_large}}",
         }
     ],
     max_tokens=4096,
@@ -247,7 +247,7 @@ import litellm
 
 async def main():
     response = await litellm.anthropic.messages.acreate(
-        model="anthropic/claude-sonnet-4-6",
+        model="anthropic/{{anthropic}}",
         messages=[
             {"role": "user", "content": "Build a concurrent worker pool in Go with graceful shutdown."}
         ],
@@ -255,7 +255,7 @@ async def main():
             {
                 "type": "advisor_20260301",
                 "name": "advisor",
-                "model": "claude-opus-4-6",
+                "model": "{{anthropic_large}}",
             }
         ],
         max_tokens=4096,
@@ -274,7 +274,7 @@ import litellm
 
 async def main():
     response = await litellm.anthropic.messages.acreate(
-        model="anthropic/claude-sonnet-4-6",
+        model="anthropic/{{anthropic}}",
         messages=[
             {"role": "user", "content": "Implement a distributed rate limiter."}
         ],
@@ -282,7 +282,7 @@ async def main():
             {
                 "type": "advisor_20260301",
                 "name": "advisor",
-                "model": "claude-opus-4-6",
+                "model": "{{anthropic_large}}",
             }
         ],
         max_tokens=4096,
@@ -309,7 +309,7 @@ asyncio.run(main())
 model_list:
   - model_name: claude-sonnet
     litellm_params:
-      model: anthropic/claude-sonnet-4-6
+      model: anthropic/{{anthropic}}
       api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
@@ -334,7 +334,7 @@ response = client.beta.messages.create(
         {
             "type": "advisor_20260301",
             "name": "advisor",
-            "model": "claude-opus-4-6",
+            "model": "{{anthropic_large}}",
         }
     ],
 )
@@ -348,7 +348,7 @@ import asyncio
 import litellm
 
 async def main():
-    # executor: openai/gpt-5.6-luna  |  advisor: claude-opus-4-6
+    # executor: openai/gpt-5.6-luna  |  advisor: {{anthropic_large}}
     # LiteLLM runs the orchestration loop automatically
     response = await litellm.anthropic.messages.acreate(
         model="openai/gpt-5.6-luna",
@@ -359,7 +359,7 @@ async def main():
             {
                 "type": "advisor_20260301",
                 "name": "advisor",
-                "model": "claude-opus-4-6",
+                "model": "{{anthropic_large}}",
                 "max_uses": 3,
             }
         ],
@@ -429,7 +429,7 @@ Advisor calls run as a separate sub-inference billed at the advisor model's rate
       },
       {
         "type": "advisor_message",
-        "model": "claude-opus-4-6",
+        "model": "{{anthropic_large}}",
         "input_tokens": 823,
         "output_tokens": 1612
       },

--- a/docs/completion/computer_use.md
+++ b/docs/completion/computer_use.md
@@ -23,7 +23,7 @@ LiteLLM will standardize the computer use tools across all supported providers.
 <Tabs>
 <TabItem value="sdk" label="LiteLLM Python SDK">
 
-```python
+```python keep-model-ids
 import os 
 from litellm import completion
 
@@ -72,7 +72,7 @@ print(response)
 
 1. Define computer use models on config.yaml
 
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: claude-3-5-sonnet-latest # Anthropic claude-3-5-sonnet-latest
     litellm_params:
@@ -96,7 +96,7 @@ litellm --config config.yaml
 
 3. Test it using the OpenAI Python SDK
 
-```python
+```python keep-model-ids
 import os 
 from openai import OpenAI
 
@@ -163,7 +163,7 @@ assert litellm.supports_computer_use(model="openai/{{openai_large}}") == False
 
 1. Define computer use models on config.yaml
 
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: claude-3-5-sonnet-latest # Anthropic claude-3-5-sonnet-latest
     litellm_params:
@@ -196,7 +196,7 @@ curl -X 'GET' \
 
 Expected Response 
 
-```json
+```json keep-model-ids
 {
   "data": [
     {
@@ -235,7 +235,7 @@ Computer use supports several different tool types for various interaction modes
 
 The `computer_20241022` tool provides direct screen interaction capabilities.
 
-```python
+```python keep-model-ids
 import os 
 from litellm import completion
 
@@ -283,7 +283,7 @@ print(response)
 
 The `bash_20241022` tool provides command line interface access.
 
-```python
+```python keep-model-ids
 import os 
 from litellm import completion
 
@@ -317,7 +317,7 @@ print(response)
 
 The `text_editor_20250124` tool provides text file editing capabilities.
 
-```python
+```python keep-model-ids
 import os 
 from litellm import completion
 
@@ -353,7 +353,7 @@ print(response)
 
 You can combine different computer use tools in a single request:
 
-```python
+```python keep-model-ids
 import os 
 from litellm import completion
 

--- a/docs/completion/function_call.md
+++ b/docs/completion/function_call.md
@@ -84,7 +84,7 @@ def test_parallel_function_call():
             }
         ]
         response = litellm.completion(
-            model="gpt-3.5-turbo-1106",
+            model="{{openai_small}}",
             messages=messages,
             tools=tools,
             tool_choice="auto",  # auto is default, but we'll be explicit
@@ -122,7 +122,7 @@ def test_parallel_function_call():
                     }
                 )  # extend conversation with function response
             second_response = litellm.completion(
-                model="gpt-3.5-turbo-1106",
+                model="{{openai_small}}",
                 messages=messages,
             )  # get a new response from the model where it can see the function response
             print("\nSecond LLM response:\n", second_response)
@@ -178,7 +178,7 @@ tools = [
 ]
 
 response = litellm.completion(
-    model="gpt-3.5-turbo-1106",
+    model="{{openai_small}}",
     messages=messages,
     tools=tools,
     tool_choice="auto",  # auto is default, but we'll be explicit
@@ -206,7 +206,7 @@ ModelResponse(
         ]))
     ], 
     created=1700319953, 
-    model='gpt-3.5-turbo-1106', 
+    model='{{openai_small}}', 
     object='chat.completion', 
     system_fingerprint='fp_eeff13170a',
     usage={'completion_tokens': 77, 'prompt_tokens': 88, 'total_tokens': 165}, 
@@ -255,7 +255,7 @@ if tool_calls:
 Once the functions are executed, send the model the information for each function call and its response. This allows the model to generate a new response considering the effects of the function calls.
 ```python
 second_response = litellm.completion(
-    model="gpt-3.5-turbo-1106",
+    model="{{openai_small}}",
     messages=messages,
 )
 print("Second Response\n", second_response)
@@ -270,7 +270,7 @@ ModelResponse(
     message=Message(content="The current weather in San Francisco is 72°F, in Tokyo it's 10°C, and in Paris it's 22°C.", role='assistant'))
   ], 
   created=1700319955, 
-  model='gpt-3.5-turbo-1106', 
+  model='{{openai_small}}', 
   object='chat.completion', 
   system_fingerprint='fp_eeff13170a', 
   usage={'completion_tokens': 28, 'prompt_tokens': 169, 'total_tokens': 197}, 
@@ -509,7 +509,7 @@ print(response)
 For Models/providers without function calling support, LiteLLM allows you to add the function to the prompt set: `litellm.add_function_to_prompt = True`
 
 #### Usage
-```python
+```python keep-model-ids
 import os, litellm
 from litellm import completion
 

--- a/docs/completion/input.md
+++ b/docs/completion/input.md
@@ -30,7 +30,7 @@ Use this function to get an up-to-date list of supported openai params for any m
 ```python
 from litellm import get_supported_openai_params
 
-response = get_supported_openai_params(model="anthropic.claude-3", custom_llm_provider="bedrock")
+response = get_supported_openai_params(model="anthropic.{{anthropic}}", custom_llm_provider="bedrock")
 
 print(response) # ["max_tokens", "tools", "tool_choice", "stream"]
 ```

--- a/docs/completion/json_mode.md
+++ b/docs/completion/json_mode.md
@@ -59,7 +59,7 @@ Call `litellm.get_supported_openai_params` to check if a model/provider supports
 ```python
 from litellm import get_supported_openai_params
 
-params = get_supported_openai_params(model="anthropic.claude-3", custom_llm_provider="bedrock")
+params = get_supported_openai_params(model="anthropic.{{anthropic}}", custom_llm_provider="bedrock")
 
 assert "response_format" in params
 ```

--- a/docs/completion/reliable_completions.md
+++ b/docs/completion/reliable_completions.md
@@ -43,7 +43,7 @@ response = completion(
 
 The ids below are illustrative and kept for their context window sizes: a 4k model falling back to its 16k variant.
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 fallback_dict = {"gpt-3.5-turbo": "gpt-3.5-turbo-16k"}

--- a/docs/completion/web_search.md
+++ b/docs/completion/web_search.md
@@ -632,9 +632,9 @@ Web search costs are defined in `model_prices_and_context_window.json` using two
 - **`search_context_cost_per_query`**: the cost per billable unit (per search context size tier).
 - **`web_search_billing_unit`** *(on Gemini models)*: `"per_query"` (each search query is billed individually) or `"per_prompt"` (default; flat fee per API call that uses search).
 
-```json
+```json keep-model-ids
 {
-    "gemini/gemini-3-flash-preview": {
+    "gemini/{{gemini_flash}}": {
         "web_search_billing_unit": "per_query",
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,

--- a/docs/fine_tuning.md
+++ b/docs/fine_tuning.md
@@ -85,7 +85,7 @@ curl http://localhost:4000/v1/files \
 
 ```python
 ft_job = await client.fine_tuning.jobs.create(
-    model="gpt-35-turbo-1106",                   # Azure OpenAI model you want to fine-tune
+    model="gpt-4.1-2025-04-14",                   # Azure OpenAI model you want to fine-tune
     training_file="file-abc123",                 # file_id from create file response
     extra_headers={"custom-llm-provider": "azure"}, # tell litellm proxy which provider to use
 )
@@ -100,7 +100,7 @@ curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Authorization: Bearer sk-1234" \
     -H "custom-llm-provider: azure" \
     -d '{
-    "model": "gpt-35-turbo-1106",
+    "model": "gpt-4.1-2025-04-14",
     "training_file": "file-abc123"
     }'
 ```
@@ -186,7 +186,7 @@ curl http://localhost:4000/v1/fine_tuning/jobs \
 
 ```json
 {
-  "model": "gpt-4o-mini",
+  "model": "gpt-4.1-mini-2025-04-14",
   "training_file": "file-abcde12345",
   "hyperparameters": {
     "batch_size": 4,

--- a/docs/guides/finetuned_models.md
+++ b/docs/guides/finetuned_models.md
@@ -34,7 +34,7 @@ os.environ["VERTEXAI_LOCATION"] = "us-central1"
 response = completion(
   model="vertex_ai/<your-finetuned-model>",  # e.g. vertex_ai/4965075652664360960
   messages=[{ "content": "Hello, how are you?","role": "user"}],
-  base_model="vertex_ai/gemini-2.5-pro" # the base model - used for routing
+  base_model="vertex_ai/{{gemini_pro}}" # the base model - used for routing
 )
 ```
 
@@ -56,7 +56,7 @@ response = completion(
     vertex_project: <PROJECT_ID>
     vertex_location: <LOCATION>
   model_info:
-    base_model: vertex_ai/gemini-2.5-pro # IMPORTANT
+    base_model: vertex_ai/{{gemini_pro}} # IMPORTANT
 ```
 
 3. Test it! 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,7 +17,7 @@ When we have breaking changes (i.e. going from 1.x.x to 2.x.x), we will document
 - response objects now inherit from `BaseModel` (prev. `OpenAIObject`)
 - *NEW* default exception - `APIConnectionError` (prev. `APIError`)
 - litellm.get_max_tokens() now returns an int not a dict
-    ```python
+    ```python keep-model-ids
     max_tokens = litellm.get_max_tokens("gpt-3.5-turbo") # returns an int not a dict 
     assert max_tokens==4097
     ```

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -134,7 +134,7 @@ The configuration below is only an example. You should adjust the permissions an
 
 Permissions:
 
-```json
+```json keep-model-ids
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/docs/pass_through/vertex_ai.md
+++ b/docs/pass_through/vertex_ai.md
@@ -322,11 +322,11 @@ Create Fine Tuning Job
 
 
 ```shell
-curl http://localhost:4000/vertex_ai/v1/projects/${PROJECT_ID}/locations/us-central1/publishers/google/models/gemini-2.5-flash:tuningJobs \
+curl http://localhost:4000/vertex_ai/v1/projects/${PROJECT_ID}/locations/us-central1/publishers/google/models/{{gemini_flash}}:tuningJobs \
       -H "Content-Type: application/json" \
       -H "x-litellm-api-key: Bearer sk-1234" \
       -d '{
-  "baseModel": "gemini-1.0-pro-002",
+  "baseModel": "{{gemini_flash}}",
   "supervisedTuningSpec" : {
       "training_dataset_uri": "gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl"
   }

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -348,7 +348,7 @@ $ litellm --model {{anthropic_large}}
 curl --location 'http://0.0.0.0:4000/chat/completions' \
 --header 'Content-Type: application/json' \
 --data ' {
-      "model": "claude-3",
+      "model": "anthropic/{{anthropic}}",
       "messages": [
         {
           "role": "user",
@@ -369,7 +369,7 @@ client = openai.OpenAI(
 )
 
 # request sent to model set on litellm proxy, `litellm --model`
-response = client.chat.completions.create(model="claude-3", messages = [
+response = client.chat.completions.create(model="anthropic/{{anthropic}}", messages = [
     {
         "role": "user",
         "content": "this is a test request, write a short poem"
@@ -393,7 +393,7 @@ from langchain.schema import HumanMessage, SystemMessage
 
 chat = ChatOpenAI(
     openai_api_base="http://0.0.0.0:4000", # set openai_api_base to the LiteLLM Proxy
-    model = "claude-3",
+    model = "anthropic/{{anthropic}}",
     temperature=0.1
 )
 
@@ -1138,7 +1138,7 @@ response = completion(
 <Tabs>
 <TabItem value="computer" label="Computer">
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 tools = [
@@ -1173,7 +1173,7 @@ print(resp)
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 tools = [{
@@ -1197,7 +1197,7 @@ print(resp)
 
 1. Setup config.yaml
 
-```yaml
+```yaml keep-model-ids
 - model_name: claude-3-5-sonnet-latest
   litellm_params:
     model: anthropic/claude-3-5-sonnet-latest
@@ -1212,7 +1212,7 @@ litellm --config /path/to/config.yaml
 
 3. Test it! 
 
-```bash
+```bash keep-model-ids
 curl http://0.0.0.0:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_KEY" \
@@ -1494,7 +1494,7 @@ This means **any value other than `"none"` for `reasoning_effort` will automatic
 
 You can disable thinking either by omitting `reasoning_effort` entirely or setting it to `"none"`. LiteLLM will not send a `thinking` field in that case. You can still pass the native `thinking` parameter directly if you wish to explicitly control thinking with a fixed budget on prior models:
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 # Disable thinking on Claude 4.6/4.7
@@ -1633,7 +1633,7 @@ You can also pass the `thinking` parameter to Anthropic models.
 
 ```python
 response = litellm.completion(
-  model="anthropic/claude-3-7-sonnet-20250219",
+  model="anthropic/{{anthropic}}",
   messages=[{"role": "user", "content": "What is the capital of France?"}],
   thinking={"type": "enabled", "budget_tokens": 1024},
 )
@@ -1647,7 +1647,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_KEY" \
   -d '{
-    "model": "anthropic/claude-3-7-sonnet-20250219",
+    "model": "anthropic/{{anthropic}}",
     "messages": [{"role": "user", "content": "What is the capital of France?"}],
     "thinking": {"type": "enabled", "budget_tokens": 1024}
   }'
@@ -1693,7 +1693,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 
 ```python
 response = litellm.completion(
-  model="anthropic/claude-opus-4-6",
+  model="anthropic/{{anthropic_large}}",
   messages=[{"role": "user", "content": "What is the capital of France?"}],
   thinking={"type": "enabled", "budget_tokens": 5000},
 )
@@ -1707,7 +1707,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_KEY" \
   -d '{
-    "model": "anthropic/claude-opus-4-6",
+    "model": "anthropic/{{anthropic_large}}",
     "messages": [{"role": "user", "content": "What is the capital of France?"}],
     "thinking": {"type": "enabled", "budget_tokens": 5000}
   }'
@@ -1720,7 +1720,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 
 Pass `extra_headers: dict` to `litellm.completion`
 
-```python
+```python keep-model-ids
 from litellm import completion
 messages = [{"role": "user", "content": "What is Anthropic?"}]
 response = completion(
@@ -1740,7 +1740,7 @@ The returned completion will _not_ include your "pre-fill" text, since it is par
 
 :::
 
-```python
+```python keep-model-ids
 import os
 from litellm import completion
 
@@ -1769,7 +1769,7 @@ Assistant: {
 ## Usage - "System" messages
 If you're using Anthropic's Claude 2.1, `system` role messages are properly formatted for you.
 
-```python
+```python keep-model-ids
 import os
 from litellm import completion
 
@@ -1816,11 +1816,11 @@ file_data = response.content
 
 encoded_file = base64.b64encode(file_data).decode("utf-8")
 
-## check if model supports pdf input - (2024/11/11) only claude-3-5-haiku-20241022 supports it
-supports_pdf_input("anthropic/claude-3-5-haiku-20241022") # True
+## check if model supports pdf input
+supports_pdf_input("anthropic/{{anthropic}}") # True
 
 response = completion(
-    model="anthropic/claude-3-5-haiku-20241022",
+    model="anthropic/{{anthropic}}",
     messages=[
         {
             "role": "user",
@@ -1846,9 +1846,9 @@ print(response.choices[0])
 1. Add model to config 
 
 ```yaml
-- model_name: claude-3-5-haiku-20241022
+- model_name: {{anthropic}}
   litellm_params:
-    model: anthropic/claude-3-5-haiku-20241022
+    model: anthropic/{{anthropic}}
     api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
@@ -1865,7 +1865,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <YOUR-LITELLM-KEY>" \
   -d '{
-    "model": "claude-3-5-haiku-20241022",
+    "model": "{{anthropic}}",
     "messages": [
       {
         "role": "user",

--- a/docs/providers/anthropic_effort.md
+++ b/docs/providers/anthropic_effort.md
@@ -48,7 +48,7 @@ This gives a much greater degree of control over efficiency.
 <Tabs>
 <TabItem value="python" label="Python">
 
-```python
+```python keep-model-ids
 import litellm
 
 # Works with Claude 4.6 models (no beta header needed)
@@ -64,7 +64,7 @@ response = litellm.completion(
 print(response.choices[0].message.content)
 ```
 
-```python
+```python keep-model-ids
 # Also works with Claude Opus 4.5 (beta header auto-injected)
 response = litellm.completion(
     model="anthropic/claude-opus-4-5-20251101",
@@ -79,7 +79,7 @@ response = litellm.completion(
 </TabItem>
 <TabItem value="typescript" label="TypeScript">
 
-```typescript
+```typescript keep-model-ids
 import Anthropic from "@anthropic-ai/sdk";
 
 const client = new Anthropic({
@@ -107,7 +107,7 @@ console.log(response.content[0].text);
 
 ### Using LiteLLM Proxy
 
-```bash
+```bash keep-model-ids
 curl http://localhost:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
@@ -126,7 +126,7 @@ curl http://localhost:4000/v1/chat/completions \
 <Tabs>
 <TabItem value="46" label="Claude 4.6 (stable)">
 
-```bash
+```bash keep-model-ids
 # Claude 4.6 — no beta header needed
 curl https://api.anthropic.com/v1/messages \
   --header "x-api-key: $ANTHROPIC_API_KEY" \
@@ -148,7 +148,7 @@ curl https://api.anthropic.com/v1/messages \
 </TabItem>
 <TabItem value="45" label="Claude Opus 4.5 (beta)">
 
-```bash
+```bash keep-model-ids
 # Claude Opus 4.5 — requires beta header
 curl https://api.anthropic.com/v1/messages \
   --header "x-api-key: $ANTHROPIC_API_KEY" \
@@ -199,7 +199,7 @@ When using tools, the effort parameter affects both the explanations around tool
 
 Example with tools:
 
-```python
+```python keep-model-ids
 import litellm
 
 response = litellm.completion(
@@ -230,7 +230,7 @@ response = litellm.completion(
 
 The effort parameter works together with extended thinking. When both are enabled, effort controls the token budget across all response types:
 
-```python
+```python keep-model-ids
 import litellm
 
 response = litellm.completion(
@@ -301,7 +301,7 @@ If you're not seeing the header for Opus 4.5:
 
 Accepted values: `"high"`, `"medium"`, `"low"`, and `"max"` (Opus 4.6 only). Any other value will raise a validation error:
 
-```python
+```python keep-model-ids
 # ❌ This will raise an error
 output_config={"effort": "very_low"}
 

--- a/docs/providers/azure/azure.md
+++ b/docs/providers/azure/azure.md
@@ -1330,5 +1330,5 @@ model_list:
       api_key: os.environ/AZURE_API_KEY
       api_version: "2023-07-01-preview"
     model_info:
-      base_model: azure/gpt-4-1106-preview
+      base_model: azure/{{openai_large}}
 ```

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -765,7 +765,7 @@ LiteLLM supports Anthropic's beta features on AWS Bedrock through the `anthropic
 
 **Single Beta Feature**
 
-```python
+```python keep-model-ids
 from litellm import completion
 import os
 
@@ -787,7 +787,7 @@ response = completion(
 
 **Multiple Beta Features**
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 # Combine multiple beta features (comma-separated)
@@ -803,7 +803,7 @@ response = completion(
 
 **Computer Use Tools with Beta Features**
 
-```python
+```python keep-model-ids
 from litellm import completion
 
 # Computer use tools automatically add computer-use-2024-10-22
@@ -828,7 +828,7 @@ response = completion(
 
 **Set on YAML Config**
 
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: claude-sonnet-4-1m
     litellm_params:
@@ -1289,7 +1289,7 @@ The returned completion will _**not**_ include your "pre-fill" text, since it is
 
 :::
 
-```python
+```python keep-model-ids
 import os
 from litellm import completion
 
@@ -1318,7 +1318,7 @@ Assistant: {
 ## Usage - "System" messages
 If you're using Anthropic's Claude 2.1 with Bedrock, `system` role messages are properly formatted for you.
 
-```python
+```python keep-model-ids
 import os
 from litellm import completion
 
@@ -1990,14 +1990,14 @@ print(response.choices[0].message.content)
 
 ## Provisioned throughput models
 To use provisioned throughput Bedrock models pass 
-- `model=bedrock/<base-model>`, example `model=bedrock/anthropic.claude-v2`. Set `model` to any of the [Supported AWS models](#supported-aws-bedrock-models)
+- `model=bedrock/<base-model>`, example `model=bedrock/anthropic.{{anthropic}}`. Set `model` to any of the [Supported AWS models](#supported-aws-bedrock-models)
 - `model_id=provisioned-model-arn` 
 
 Completion
 ```python
 import litellm
 response = litellm.completion(
-    model="bedrock/anthropic.claude-instant-v1",
+    model="bedrock/anthropic.{{anthropic}}",
     model_id="provisioned-model-arn",
     messages=[{"content": "Hello, how are you?", "role": "user"}]
 )

--- a/docs/providers/cometapi.md
+++ b/docs/providers/cometapi.md
@@ -89,7 +89,7 @@ async def completion_call():
         
         print("test acompletion + streaming")
         response = await acompletion(
-            model="cometapi/chatgpt-4o-latest", 
+            model="cometapi/{{openai_large}}", 
             messages=[{"content": "Hello, how are you?", "role": "user"}], 
             stream=True
         )

--- a/docs/providers/github_copilot.md
+++ b/docs/providers/github_copilot.md
@@ -34,7 +34,7 @@ GitHub Copilot uses OAuth device flow for authentication. On first use, you'll b
 from litellm import completion
 
 response = completion(
-    model="github_copilot/gpt-4o",
+    model="github_copilot/gpt-5.2",
     messages=[
         {"role": "system", "content": "You are a helpful coding assistant"},
         {"role": "user", "content": "Write a Python function to calculate fibonacci numbers"}
@@ -47,7 +47,7 @@ print(response)
 from litellm import completion
 
 stream = completion(
-    model="github_copilot/gpt-4o",
+    model="github_copilot/gpt-5.2",
     messages=[{"role": "user", "content": "Explain async/await in Python"}],
     stream=True
 )
@@ -91,9 +91,9 @@ Add the following to your LiteLLM Proxy configuration file:
 
 ```yaml showLineNumbers title="config.yaml"
 model_list:
-  - model_name: github_copilot/gpt-4o
+  - model_name: github_copilot/gpt-5.2
     litellm_params:
-      model: github_copilot/gpt-4o
+      model: github_copilot/gpt-5.2
   - model_name: github_copilot/gpt-5.1-codex
     model_info:
       mode: responses
@@ -128,7 +128,7 @@ client = OpenAI(
 
 # Non-streaming response
 response = client.chat.completions.create(
-    model="github_copilot/gpt-4o",
+    model="github_copilot/gpt-5.2",
     messages=[{"role": "user", "content": "How do I optimize this SQL query?"}]
 )
 
@@ -144,7 +144,7 @@ import litellm
 
 # Configure LiteLLM to use your proxy
 response = litellm.completion(
-    model="litellm_proxy/github_copilot/gpt-4o",
+    model="litellm_proxy/github_copilot/gpt-5.2",
     messages=[{"role": "user", "content": "Review this code for bugs"}],
     api_base="http://localhost:4000",
     api_key="your-proxy-api-key"
@@ -162,7 +162,7 @@ curl http://localhost:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-proxy-api-key" \
   -d '{
-    "model": "github_copilot/gpt-4o",
+    "model": "github_copilot/gpt-5.2",
     "messages": [{"role": "user", "content": "Explain this error message"}]
   }'
 ```

--- a/docs/providers/helicone.md
+++ b/docs/providers/helicone.md
@@ -201,7 +201,7 @@ import litellm
 os.environ["HELICONE_API_KEY"] = "your-helicone-key"
 
 response = litellm.completion(
-    model="helicone/claude-3.5-haiku/anthropic",
+    model="helicone/{{anthropic}}/anthropic",
     messages=[{"role": "user", "content": "Hello"}]
 )
 ```

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -502,7 +502,7 @@ import litellm
 litellm.route_all_chat_openai_to_responses = True
 
 response = litellm.completion(
-    model="gpt-5.4",
+    model="{{openai_large}}",
     messages=[{"role": "user", "content": "What is the capital of France?"}],
     reasoning_effort="low",
 )
@@ -523,7 +523,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Bearer sk-1234' \
 -d '{
-    "model": "gpt-5.4",
+    "model": "{{openai_large}}",
     "messages": [{"role": "user", "content": "What is the capital of France?"}],
     "reasoning_effort": "low"
 }'

--- a/docs/providers/openai/responses_api.md
+++ b/docs/providers/openai/responses_api.md
@@ -14,7 +14,7 @@ import litellm
 
 # Non-streaming response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -28,7 +28,7 @@ import litellm
 
 # Streaming response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     stream=True
 )
@@ -84,7 +84,7 @@ import litellm
 
 # First, create a response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -109,7 +109,7 @@ import litellm
 
 # First, create a response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -135,9 +135,9 @@ print(delete_response)
 
 ```yaml showLineNumbers title="OpenAI Proxy Configuration"
 model_list:
-  - model_name: openai/o1-pro
+  - model_name: openai/{{openai_large}}
     litellm_params:
-      model: openai/o1-pro
+      model: openai/{{openai_large}}
       api_key: os.environ/OPENAI_API_KEY
 ```
 
@@ -163,7 +163,7 @@ client = OpenAI(
 
 # Non-streaming response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 
@@ -182,7 +182,7 @@ client = OpenAI(
 
 # Streaming response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     stream=True
 )
@@ -230,7 +230,7 @@ client = OpenAI(
 
 # First, create a response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 
@@ -255,7 +255,7 @@ client = OpenAI(
 
 # First, create a response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 
@@ -283,7 +283,7 @@ Use the `prompt` parameter to reference a stored prompt template and optionally 
 import litellm
 
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     prompt={
         "id": "pmpt_abc123",
         "version": "2",
@@ -305,7 +305,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:4000", api_key="your-api-key")
 
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     prompt={
         "id": "pmpt_abc123",
         "version": "2",
@@ -368,9 +368,9 @@ print(response.output)
 
 ```yaml showLineNumbers title="OpenAI Proxy Configuration"
 model_list:
-  - model_name: openai/o1-pro
+  - model_name: openai/{{openai_large}}
     litellm_params:
-      model: openai/o1-pro
+      model: openai/{{openai_large}}
       api_key: os.environ/OPENAI_API_KEY
 ```
 
@@ -763,7 +763,7 @@ tools = [
 ]
 
 response = litellm.responses(
-    model="openai/gpt-5.4",
+    model="openai/{{openai_large}}",
     input="Look up invoice INV-2024-001 from the billing system",
     tools=tools,
 )
@@ -789,9 +789,9 @@ for item in response.output:
 
 ```yaml showLineNumbers title="OpenAI Proxy Configuration"
 model_list:
-  - model_name: openai/gpt-5.4
+  - model_name: openai/{{openai_large}}
     litellm_params:
-      model: openai/gpt-5.4
+      model: openai/{{openai_large}}
       api_key: os.environ/OPENAI_API_KEY
 ```
 
@@ -814,7 +814,7 @@ client = OpenAI(
 )
 
 response = client.responses.create(
-    model="openai/gpt-5.4",
+    model="openai/{{openai_large}}",
     input="Look up invoice INV-2024-001 from the billing system",
     tools=[
         {"type": "tool_search"},
@@ -856,7 +856,7 @@ You can also use tool search through the `/v1/chat/completions` endpoint by pref
 import litellm
 
 response = litellm.completion(
-    model="openai/responses/gpt-5.4",
+    model="openai/responses/{{openai_large}}",
     messages=[{"role": "user", "content": "Look up invoice INV-2024-001"}],
     tools=[
         {"type": "tool_search"},
@@ -894,7 +894,7 @@ curl http://localhost:4000/v1/chat/completions \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "openai/responses/gpt-5.4",
+    "model": "openai/responses/{{openai_large}}",
     "messages": [{"role": "user", "content": "Look up invoice INV-2024-001"}],
     "tools": [
       {"type": "tool_search"},

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -3048,7 +3048,7 @@ finetune_settings:
 
 ```python
 ft_job = await client.fine_tuning.jobs.create(
-    model="gemini-1.0-pro-002",                  # Vertex model you want to fine-tune
+    model="{{gemini_flash}}",                  # Vertex model you want to fine-tune
     training_file="gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl",                 # file_id from create file response
     extra_headers={"custom-llm-provider": "vertex_ai"}, # tell litellm proxy which provider to use
 )
@@ -3063,7 +3063,7 @@ curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Authorization: Bearer sk-1234" \
     -H "custom-llm-provider: vertex_ai" \
     -d '{
-    "model": "gemini-1.0-pro-002",
+    "model": "{{gemini_flash}}",
     "training_file": "gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl"
     }'
 ```
@@ -3083,7 +3083,7 @@ Set hyper_parameters, such as `n_epochs`, `learning_rate_multiplier` and `adapte
 ```python
 
 ft_job = client.fine_tuning.jobs.create(
-    model="gemini-1.0-pro-002",                  # Vertex model you want to fine-tune
+    model="{{gemini_flash}}",                  # Vertex model you want to fine-tune
     training_file="gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl",                 # file_id from create file response
     hyperparameters={
         "n_epochs": 3,                      # epoch_count on Vertex
@@ -3103,7 +3103,7 @@ curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Authorization: Bearer sk-1234" \
     -H "custom-llm-provider: vertex_ai" \
     -d '{
-    "model": "gemini-1.0-pro-002",
+    "model": "{{gemini_flash}}",
     "training_file": "gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl",
     "hyperparameters": {
         "n_epochs": 3,

--- a/docs/providers/vertex_partner.md
+++ b/docs/providers/vertex_partner.md
@@ -114,7 +114,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 from litellm import completion
 
 resp = completion(
-    model="vertex_ai/claude-3-7-sonnet-20250219",
+    model="vertex_ai/{{anthropic}}",
     messages=[{"role": "user", "content": "What is the capital of France?"}],
     thinking={"type": "enabled", "budget_tokens": 1024},
 )
@@ -128,9 +128,9 @@ resp = completion(
 1. Setup config.yaml
 
 ```yaml
-- model_name: claude-3-7-sonnet-20250219
+- model_name: {{anthropic}}
   litellm_params:
-    model: vertex_ai/claude-3-7-sonnet-20250219
+    model: vertex_ai/{{anthropic}}
     vertex_ai_project: "my-test-project"
     vertex_ai_location: "us-west-1"
 ```
@@ -148,7 +148,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <YOUR-LITELLM-KEY>" \
   -d '{
-    "model": "claude-3-7-sonnet-20250219",
+    "model": "{{anthropic}}",
     "messages": [{"role": "user", "content": "What is the capital of France?"}],
     "thinking": {"type": "enabled", "budget_tokens": 1024}
   }'
@@ -164,7 +164,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 ModelResponse(
     id='chatcmpl-c542d76d-f675-4e87-8e5f-05855f5d0f5e',
     created=1740470510,
-    model='claude-3-7-sonnet-20250219',
+    model='{{anthropic}}',
     object='chat.completion',
     system_fingerprint=None,
     choices=[

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -628,21 +628,21 @@ Nothing new is needed to express that. Declare one `model_list` entry per rung, 
 
 ```yaml
 model_list:
-  - model_name: gpt-5.4-mini-low
+  - model_name: {{openai_small}}-low
     litellm_params:
-      model: openai/gpt-5.4-mini
+      model: openai/{{openai_small}}
       api_key: os.environ/OPENAI_API_KEY
       reasoning_effort: low
 
   # same model and the same per-token rate as the rung above, more thinking
-  - model_name: gpt-5.4-mini-high
+  - model_name: {{openai_small}}-high
     litellm_params:
-      model: openai/gpt-5.4-mini
+      model: openai/{{openai_small}}
       api_key: os.environ/OPENAI_API_KEY
       reasoning_effort: high
-  - model_name: gpt-5.4-mini-xhigh
+  - model_name: {{openai_small}}-xhigh
     litellm_params:
-      model: openai/gpt-5.4-mini
+      model: openai/{{openai_small}}
       api_key: os.environ/OPENAI_API_KEY
       reasoning_effort: xhigh
 
@@ -658,11 +658,11 @@ model_list:
       drop_params: true
       complexity_router_config:
         tiers:
-          SIMPLE:    gpt-5.4-mini-low
-          MEDIUM:    gpt-5.4-mini-high
-          COMPLEX:   gpt-5.4-mini-xhigh
+          SIMPLE:    {{openai_small}}-low
+          MEDIUM:    {{openai_small}}-high
+          COMPLEX:   {{openai_small}}-xhigh
           REASONING: {{openai_large}}
-      complexity_router_default_model: gpt-5.4-mini-high
+      complexity_router_default_model: {{openai_small}}-high
 ```
 
 Anthropic-family rungs use `thinking` the same way, since it is an ordinary `litellm_params` key:
@@ -687,7 +687,7 @@ router = Router(
         {"model_name": "{{openai_small}}",   "litellm_params": {"model": "{{openai_small}}"}},
         {"model_name": "{{openai_large}}",        "litellm_params": {"model": "{{openai_large}}"}},
         {"model_name": "claude-sonnet", "litellm_params": {"model": "{{anthropic}}"}},
-        {"model_name": "o1-preview",    "litellm_params": {"model": "o1-preview"}},
+        {"model_name": "claude-opus",   "litellm_params": {"model": "{{anthropic_large}}"}},
         {
             "model_name": "smart-router",
             "litellm_params": {
@@ -697,7 +697,7 @@ router = Router(
                         "SIMPLE":    "{{openai_small}}",
                         "MEDIUM":    "{{openai_large}}",
                         "COMPLEX":   "claude-sonnet",
-                        "REASONING": "o1-preview",
+                        "REASONING": "claude-opus",
                     },
                     "session_affinity": True,
                 },

--- a/docs/proxy/caching.md
+++ b/docs/proxy/caching.md
@@ -1171,7 +1171,7 @@ curl -i --location 'http://0.0.0.0:4000/chat/completions' \
     --header 'Authorization: Bearer sk-1234' \
     --header 'Content-Type: application/json' \
     --data '{
-    "model": "gpt-3.5-turbo",
+    "model": "{{openai_small}}",
     "user": "ishan",
     "messages": [
         {

--- a/docs/proxy/cost_tracking.md
+++ b/docs/proxy/cost_tracking.md
@@ -625,13 +625,13 @@ curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end
                 "total_spend": 0.0015265,
                 "metadata": [ # see the spend by unique(key + model)
                     {
-                        "model": "gpt-4",
+                        "model": "{{openai_large}}",
                         "spend": 0.00123,
                         "total_tokens": 28,
                         "api_key": "88dc28.." # the hashed api key
                     },
                     {
-                        "model": "gpt-4",
+                        "model": "{{openai_large}}",
                         "spend": 0.00123,
                         "total_tokens": 28,
                         "api_key": "a73dc2.." # the hashed api key
@@ -643,7 +643,7 @@ curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end
                         "api_key": "898c28.." # the hashed api key
                     },
                     {
-                        "model": "gpt-3.5-turbo",
+                        "model": "{{openai_small}}",
                         "spend": 0.0000825,
                         "total_tokens": 85,
                         "api_key": "84dc28.." # the hashed api key
@@ -696,22 +696,22 @@ Output from script
 # Date: 2024-05-11T00:00:00+00:00
 # Team: local_test_team
 # Total Spend: 0.003675099999999999
-# Metadata:  [{'model': 'gpt-3.5-turbo', 'spend': 0.003675099999999999, 'api_key': 'b94d5e0bc3a71a573917fe1335dc0c14728c7016337451af9714924ff3a729db', 'total_tokens': 3105}]
+# Metadata:  [{'model': '{{openai_small}}', 'spend': 0.003675099999999999, 'api_key': 'b94d5e0bc3a71a573917fe1335dc0c14728c7016337451af9714924ff3a729db', 'total_tokens': 3105}]
 
 # Date: 2024-05-13T00:00:00+00:00
 # Team: Unassigned Team
 # Total Spend: 3.4e-05
-# Metadata:  [{'model': 'gpt-3.5-turbo', 'spend': 3.4e-05, 'api_key': '9569d13c9777dba68096dea49b0b03e0aaf4d2b65d4030eda9e8a2733c3cd6e0', 'total_tokens': 50}]
+# Metadata:  [{'model': '{{openai_small}}', 'spend': 3.4e-05, 'api_key': '9569d13c9777dba68096dea49b0b03e0aaf4d2b65d4030eda9e8a2733c3cd6e0', 'total_tokens': 50}]
 
 # Date: 2024-05-13T00:00:00+00:00
 # Team: central
 # Total Spend: 0.000684
-# Metadata:  [{'model': 'gpt-3.5-turbo', 'spend': 0.000684, 'api_key': '0323facdf3af551594017b9ef162434a9b9a8ca1bbd9ccbd9d6ce173b1015605', 'total_tokens': 498}]
+# Metadata:  [{'model': '{{openai_small}}', 'spend': 0.000684, 'api_key': '0323facdf3af551594017b9ef162434a9b9a8ca1bbd9ccbd9d6ce173b1015605', 'total_tokens': 498}]
 
 # Date: 2024-05-13T00:00:00+00:00
 # Team: local_test_team
 # Total Spend: 0.0005715000000000001
-# Metadata:  [{'model': 'gpt-3.5-turbo', 'spend': 0.0005715000000000001, 'api_key': 'b94d5e0bc3a71a573917fe1335dc0c14728c7016337451af9714924ff3a729db', 'total_tokens': 423}]
+# Metadata:  [{'model': '{{openai_small}}', 'spend': 0.0005715000000000001, 'api_key': 'b94d5e0bc3a71a573917fe1335dc0c14728c7016337451af9714924ff3a729db', 'total_tokens': 423}]
 ```
 
 </TabItem>
@@ -751,13 +751,13 @@ curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end
                 "total_spend": 0.0015265,
                 "metadata": [ # see the spend by unique(key + model)
                     {
-                        "model": "gpt-4",
+                        "model": "{{openai_large}}",
                         "spend": 0.00123,
                         "total_tokens": 28,
                         "api_key": "88dc28.." # the hashed api key
                     },
                     {
-                        "model": "gpt-4",
+                        "model": "{{openai_large}}",
                         "spend": 0.00123,
                         "total_tokens": 28,
                         "api_key": "a73dc2.." # the hashed api key
@@ -769,7 +769,7 @@ curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end
                         "api_key": "898c28.." # the hashed api key
                     },
                     {
-                        "model": "gpt-3.5-turbo",
+                        "model": "{{openai_small}}",
                         "spend": 0.0000825,
                         "total_tokens": 85,
                         "api_key": "84dc28.." # the hashed api key
@@ -867,7 +867,7 @@ curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end
     "total_output_tokens": 27.0,
     "model_details": [
       {
-        "model": "gpt-3.5-turbo",
+        "model": "{{openai_small}}",
         "total_cost": 5.2499999999999995e-05,
         "total_input_tokens": 24,
         "total_output_tokens": 27

--- a/docs/proxy/custom_pricing.md
+++ b/docs/proxy/custom_pricing.md
@@ -179,7 +179,7 @@ model_list:
       api_key: os.environ/AZURE_API_KEY
       api_version: "2023-07-01-preview"
     model_info:
-      base_model: azure/gpt-4-1106-preview
+      base_model: azure/{{openai_large}}
 ```
 
 ### OpenAI Models with Dated Versions

--- a/docs/proxy/debugging.md
+++ b/docs/proxy/debugging.md
@@ -69,7 +69,7 @@ curl -L -X POST 'http://0.0.0.0:4000/chat/completions' \
 This will emit the raw request sent by LiteLLM to the API Provider and raw response received from the API Provider for **just** this request in the logs. 
 
 
-```bash showLineNumbers
+```bash showLineNumbers keep-model-ids
 INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)
 20:14:06 - LiteLLM:WARNING: litellm_logging.py:938 - 
 

--- a/docs/proxy/fallback_management.md
+++ b/docs/proxy/fallback_management.md
@@ -235,7 +235,7 @@ Specifically triggered when a context window exceeded error occurs.
 
 **Use Case:** When the input is too long for the primary model, fallback to a model with a larger context window. The ids below are illustrative and kept for their context window sizes.
 
-```json
+```json keep-model-ids
 {
   "model": "gpt-3.5-turbo",
   "fallback_models": ["gpt-4-32k", "claude-3-opus"],

--- a/docs/proxy/guardrails/grayswan.md
+++ b/docs/proxy/guardrails/grayswan.md
@@ -114,7 +114,7 @@ curl -X POST "http://0.0.0.0:4000/v1/messages?beta=true" \
   -H "Authorization: Bearer token" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "openrouter/anthropic/claude-sonnet-4.5",
+    "model": "openrouter/anthropic/{{anthropic}}",
     "messages": [{"role": "user", "content": "hello"}],
     "litellm_metadata": {
       "guardrails": [
@@ -141,7 +141,7 @@ from openai import OpenAI
 client = OpenAI(api_key="anything", base_url="http://0.0.0.0:4000")
 
 resp = client.responses.create(
-    model="openrouter/anthropic/claude-sonnet-4.5",
+    model="openrouter/anthropic/{{anthropic}}",
     input="hello",
     extra_body={
         "litellm_metadata": {
@@ -168,7 +168,7 @@ from anthropic import Anthropic
 client = Anthropic(api_key="anything", base_url="http://0.0.0.0:4000")
 
 resp = client.messages.create(
-    model="openrouter/anthropic/claude-sonnet-4.5",
+    model="openrouter/anthropic/{{anthropic}}",
     max_tokens=256,
     messages=[{"role": "user", "content": "hello"}],
     extra_body={

--- a/docs/proxy/reliability.md
+++ b/docs/proxy/reliability.md
@@ -43,7 +43,7 @@ fallbacks=[{"{{openai_small}}": ["{{openai_large}}"]}]
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
-```python
+```python keep-model-ids
 from litellm import Router 
 router = Router(
   model_list=[
@@ -75,7 +75,7 @@ router = Router(
 <TabItem value="proxy" label="PROXY">
 
 
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: {{openai_small}}
     litellm_params:
@@ -601,7 +601,7 @@ If all models in a group are in cooldown (e.g. rate limited), LiteLLM will fallb
 This skips any cooldown check for the fallback model.
 
 1. Specify the model ID in `model_info`
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: {{openai_large}}
     litellm_params:
@@ -735,7 +735,7 @@ Filter instances of a model (e.g. gpt-4o-mini) with smaller context windows
 
 The model ids in this example are illustrative and kept for their context window sizes.
 
-```yaml
+```yaml keep-model-ids
 router_settings:
   enable_pre_call_checks: true # 1. Enable pre-call checks
 
@@ -765,7 +765,7 @@ litellm --config /path/to/config.yaml
 
 **3. Test it!**
 
-```python
+```python keep-model-ids
 import openai
 client = openai.OpenAI(
     api_key="anything",
@@ -794,7 +794,7 @@ Fallback to larger models if current model is too small.
 
 The model ids in this example are illustrative and kept for their context window sizes.
 
-```yaml
+```yaml keep-model-ids
 router_settings:
   enable_pre_call_checks: true # 1. Enable pre-call checks
 
@@ -832,7 +832,7 @@ litellm --config /path/to/config.yaml
 
 **3. Test it!**
 
-```python
+```python keep-model-ids
 import openai
 client = openai.OpenAI(
     api_key="anything",
@@ -861,7 +861,7 @@ print(response)
 
 Fallback across providers (e.g. from Azure OpenAI to Anthropic) if you hit content policy violation errors. 
 
-```yaml
+```yaml keep-model-ids
 model_list:
     - model_name: gpt-3.5-turbo-small
       litellm_params:
@@ -886,7 +886,7 @@ litellm_settings:
 You can also set default_fallbacks, in case a specific model group is misconfigured / bad.
 
 
-```yaml
+```yaml keep-model-ids
 model_list:
     - model_name: gpt-3.5-turbo-small
       litellm_params:
@@ -918,7 +918,7 @@ Set 'region_name' of deployment.
 
 **1. Set Config**
 
-```yaml
+```yaml keep-model-ids
 router_settings:
   enable_pre_call_checks: true # 1. Enable pre-call checks
 
@@ -1026,7 +1026,7 @@ By default a fallback configured in `router_settings` runs for every request, ev
 
 Set `general_settings.enforce_fallback_model_access: true` to apply the same key, team and project model access checks to every fallback target before it is tried. Targets the caller may not use are skipped. When no authorized target remains, the caller gets the primary model's own error. Keys that are allowed to call the fallback model keep falling back as before, and the check covers `fallbacks`, `context_window_fallbacks`, `content_policy_fallbacks` and `default_fallbacks`.
 
-```yaml
+```yaml keep-model-ids
 model_list:
   - model_name: gpt-5.6
     litellm_params:

--- a/docs/proxy/timeout.md
+++ b/docs/proxy/timeout.md
@@ -124,7 +124,7 @@ Set `keepalive_seconds` under a deployment's `litellm_params` to keep the connec
 model_list:
   - model_name: claude-opus
     litellm_params:
-      model: anthropic/claude-opus-4-8
+      model: anthropic/{{anthropic_large}}
       api_key: os.environ/ANTHROPIC_API_KEY
       keepalive_seconds: 15
 ```
@@ -146,7 +146,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 model_list:
   - model_name: claude-opus
     litellm_params:
-      model: anthropic/claude-opus-4-8
+      model: anthropic/{{anthropic_large}}
       api_key: os.environ/ANTHROPIC_API_KEY
       keepalive_seconds: 15
       allow_client_keepalive_override: true

--- a/docs/proxy/users.md
+++ b/docs/proxy/users.md
@@ -572,7 +572,7 @@ curl 'http://0.0.0.0:4000/user/new' \
 --header 'Content-Type: application/json' \
 --data-raw '{
   "user_id": "engineer-1",
-  "model_max_budget": {"claude-opus-4-8": {"budget_limit": 200, "time_period": "1mo"}}
+  "model_max_budget": {"{{anthropic_large}}": {"budget_limit": 200, "time_period": "1mo"}}
 }'
 ```
 
@@ -581,7 +581,7 @@ Use `1mo` for a calendar-month budget that resets on the first day of each month
 ```json
 {
     "error": {
-        "message": "LiteLLM User: engineer-1, exceeded budget for model=claude-opus-4-8",
+        "message": "LiteLLM User: engineer-1, exceeded budget for model={{anthropic_large}}",
         "type": "budget_exceeded",
         "param": null,
         "code": "429"

--- a/docs/reasoning_content.md
+++ b/docs/reasoning_content.md
@@ -515,7 +515,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 
 ```python showLineNumbers
 response = litellm.responses(
-  model="vertex_ai/claude-opus-4-8",
+  model="vertex_ai/{{anthropic_large}}",
   input="How many prime numbers are less than 30?",
   reasoning={"effort": "low"},
 )
@@ -529,7 +529,7 @@ curl http://0.0.0.0:4000/v1/responses \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_KEY" \
   -d '{
-    "model": "claude-opus-4-8",
+    "model": "{{anthropic_large}}",
     "input": "How many prime numbers are less than 30?",
     "reasoning": {"effort": "low"}
   }'
@@ -566,7 +566,7 @@ curl http://0.0.0.0:4000/v1/responses \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_KEY" \
   -d '{
-    "model": "claude-opus-4-8",
+    "model": "{{anthropic_large}}",
     "input": "How many prime numbers are less than 30?",
     "thinking": {"type": "adaptive"},
     "output_config": {"effort": "high"}
@@ -590,11 +590,11 @@ Use `litellm.supports_reasoning(model="")` -> returns `True` if model supports r
 import litellm 
 
 # Example models that support reasoning
-assert litellm.supports_reasoning(model="anthropic/claude-3-7-sonnet-20250219") == True
+assert litellm.supports_reasoning(model="anthropic/{{anthropic}}") == True
 assert litellm.supports_reasoning(model="deepseek/deepseek-chat") == True 
 
 # Example models that do not support reasoning
-assert litellm.supports_reasoning(model="openai/gpt-4o-mini") == False 
+assert litellm.supports_reasoning(model="openai/gpt-4.1") == False 
 ```
 </TabItem>
 

--- a/docs/response_api.md
+++ b/docs/response_api.md
@@ -36,7 +36,7 @@ import litellm
 
 # Non-streaming response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -52,7 +52,7 @@ print(response)
     "object": "response",
     "created_at": 1734366691,
     "status": "completed",
-    "model": "o1-pro-2025-01-30",
+    "model": "{{openai_large}}",
     "output": [
         {
             "type": "message",
@@ -82,7 +82,7 @@ import litellm
 
 # Streaming response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     stream=True
 )
@@ -199,7 +199,7 @@ import litellm
 
 # First, create a response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -226,7 +226,7 @@ import litellm
 
 # First, create a response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -261,7 +261,7 @@ import litellm
 
 # First, create a response
 response = litellm.responses(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     max_output_tokens=100
 )
@@ -471,9 +471,9 @@ litellm --config /path/to/config.yaml
 First, add this to your litellm proxy config.yaml:
 ```yaml showLineNumbers title="OpenAI Proxy Configuration"
 model_list:
-  - model_name: openai/o1-pro
+  - model_name: openai/{{openai_large}}
     litellm_params:
-      model: openai/o1-pro
+      model: openai/{{openai_large}}
       api_key: os.environ/OPENAI_API_KEY
 ```
 
@@ -489,7 +489,7 @@ client = OpenAI(
 
 # Non-streaming response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 
@@ -508,7 +508,7 @@ client = OpenAI(
 
 # Streaming response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn.",
     stream=True
 )
@@ -555,7 +555,7 @@ client = OpenAI(
 
 # First, create a response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 
@@ -580,7 +580,7 @@ client = OpenAI(
 
 # First, create a response
 response = client.responses.create(
-    model="openai/o1-pro",
+    model="openai/{{openai_large}}",
     input="Tell me a three sentence bedtime story about a unicorn."
 )
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1136,19 +1136,19 @@ from litellm import Router
 
 model_list = [
 	{
-		"model_name": "o1",
+		"model_name": "{{openai_small}}",
 		"litellm_params": {
-			"model": "o1-preview", 
+			"model": "{{openai_small}}", 
 			"api_key": os.getenv("OPENAI_API_KEY"), 
 			"weight": 1
 		},
 	},
 	{
-		"model_name": "o1",
+		"model_name": "{{openai_small}}",
 		"litellm_params": {
-			"model": "o1-preview", 
+			"model": "{{openai_small}}", 
 			"api_key": os.getenv("OPENAI_API_KEY"), 
-			"weight": 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN o1-preview
+			"weight": 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN THE ONE ABOVE
 		},
 	},
 ]
@@ -1166,16 +1166,16 @@ print(response)
 
 ```yaml
 model_list:
-  - model_name: o1
+  - model_name: {{openai_small}}
     litellm_params:
-      model: o1
+      model: {{openai_small}}
       api_key: os.environ/OPENAI_API_KEY
       weight: 1
-  - model_name: o1
+  - model_name: {{openai_small}}
     litellm_params:
-      model: o1-preview
+      model: {{openai_small}}
       api_key: os.environ/OPENAI_API_KEY
-      weight: 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN o1-preview
+      weight: 2 # 👈 PICK THIS DEPLOYMENT 2x MORE OFTEN THAN THE ONE ABOVE
 ```
 
 </TabItem>
@@ -1780,7 +1780,7 @@ router = Router(model_list=model_list, enable_pre_call_checks=True)
 
 The model ids in this example are illustrative and kept for their context window sizes.
 
-```python
+```python keep-model-ids
 """
 - Give a gpt-3.5-turbo model group with different context windows (4k vs. 16k)
 - Send a 5k prompt
@@ -2011,7 +2011,7 @@ from litellm import Router
 
 model_list = [
 	{ # list of model deployments 
-		"model_name": "gpt-4-preview", # model alias 
+		"model_name": "{{openai_small}}", # model alias 
 		"litellm_params": { # params for litellm completion/embedding call 
 			"model": "azure/chatgpt-v-2", # actual model name
 			"api_key": os.getenv("AZURE_API_KEY"),
@@ -2019,11 +2019,11 @@ model_list = [
 			"api_base": os.getenv("AZURE_API_BASE")
 		},
 		"model_info": {
-			"base_model": "azure/gpt-4-1106-preview" # azure/gpt-4-1106-preview will be used for cost tracking, ensure this exists in litellm model_prices_and_context_window.json
+			"base_model": "azure/{{openai_small}}" # azure/{{openai_small}} will be used for cost tracking, ensure this exists in litellm model_prices_and_context_window.json
 		}
 	}, 
 	{
-		"model_name": "gpt-4-32k", 
+		"model_name": "{{openai_large}}", 
 		"litellm_params": { # params for litellm completion/embedding call 
 			"model": "azure/chatgpt-functioncalling", 
 			"api_key": os.getenv("AZURE_API_KEY"),
@@ -2031,7 +2031,7 @@ model_list = [
 			"api_base": os.getenv("AZURE_API_BASE")
 		},
 		"model_info": {
-			"base_model": "azure/gpt-4-32k" # azure/gpt-4-32k will be used for cost tracking, ensure this exists in litellm model_prices_and_context_window.json
+			"base_model": "azure/{{openai_large}}" # azure/{{openai_large}} will be used for cost tracking, ensure this exists in litellm model_prices_and_context_window.json
 		}
 	}
 ]
@@ -2057,7 +2057,7 @@ litellm.callbacks = [customHandler]
 
 # router completion call
 response = router.completion(
-	model="gpt-4-32k", 
+	model="{{openai_large}}", 
 	messages=[{ "role": "user", "content": "Hi who are you"}]
 )
 ```
@@ -2069,7 +2069,7 @@ You can also set default params for litellm completion/embedding calls. Here's h
 
 The model ids in this example are illustrative and kept for their context window sizes.
 
-```python
+```python keep-model-ids
 from litellm import Router
 
 fallback_dict = {"gpt-4o-mini": "gpt-4.1"}

--- a/docs/tutorials/claude_code_cut_costs.md
+++ b/docs/tutorials/claude_code_cut_costs.md
@@ -147,9 +147,9 @@ model_list:
     litellm_params:
       model: {{anthropic}}
 
-  - model_name: o1-preview
+  - model_name: claude-opus
     litellm_params:
-      model: o1-preview
+      model: {{anthropic_large}}
 
   # Complexity router
   - model_name: smart-router
@@ -160,7 +160,7 @@ model_list:
           SIMPLE: {{openai_small}}
           MEDIUM: {{openai_large}}
           COMPLEX: claude-sonnet
-          REASONING: o1-preview
+          REASONING: claude-opus
       complexity_router_default_model: {{openai_large}}
 ```
 

--- a/docs/tutorials/claude_non_anthropic_models.md
+++ b/docs/tutorials/claude_non_anthropic_models.md
@@ -62,9 +62,9 @@ export LITELLM_MASTER_KEY="sk-1234567890"  # Generate a secure key
 ```yaml
 model_list:
   # Google Gemini
-  - model_name: gemini-3.0-flash-exp
+  - model_name: {{gemini_flash}}
     litellm_params:
-      model: gemini/gemini-3.0-flash-exp
+      model: gemini/{{gemini_flash}}
       api_key: os.environ/GEMINI_API_KEY
 ```
 
@@ -163,7 +163,7 @@ curl -X POST http://0.0.0.0:4000/v1/messages \
 -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
 -H "Content-Type: application/json" \
 -d '{
-    "model": "gemini-3.0-flash-exp",
+    "model": "{{gemini_flash}}",
     "max_tokens": 1000,
     "messages": [{"role": "user", "content": "What is the capital of France?"}]
 }'
@@ -177,7 +177,7 @@ curl -X POST http://0.0.0.0:4000/v1/messages \
 -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
 -H "Content-Type: application/json" \
 -d '{
-    "model": "gemini-3.0-flash-exp",
+    "model": "{{gemini_flash}}",
     "max_tokens": 1000,
     "messages": [{"role": "user", "content": "What is the capital of France?"}]
 }'
@@ -225,7 +225,7 @@ claude --model {{openai_large}}
 claude --model {{openai_small}}
 
 # Use Google Gemini
-claude --model gemini-3.0-flash-exp
+claude --model {{gemini_flash}}
 
 # Use Vertex AI Gemini
 claude --model vertex-gemini-3.8-flash
@@ -253,7 +253,7 @@ On startup, Claude Code will call `GET /v1/models` against your `ANTHROPIC_BASE_
 /model
 ```
 
-and select any LiteLLM-managed model (`{{openai_large}}`, `gemini-3.0-flash-exp`, `anthropic-vertex`, etc.) to switch without restarting the session.
+and select any LiteLLM-managed model (`{{openai_large}}`, `{{gemini_flash}}`, `anthropic-vertex`, etc.) to switch without restarting the session.
 
 :::info Requirements
 

--- a/docs/tutorials/compare_llms.md
+++ b/docs/tutorials/compare_llms.md
@@ -33,7 +33,7 @@ Supported LLMs: https://docs.litellm.ai/docs/providers
 
 ```python
 # Define the list of models to benchmark
-models = ['gpt-3.5-turbo', 'claude-2']
+models = ['{{openai_small}}', '{{anthropic}}']
 
 # Enter LLM API keys
 os.environ['OPENAI_API_KEY'] = ""
@@ -53,7 +53,7 @@ python3 benchmark.py
 ```
 
 ## Expected Output
-```text
+```text keep-model-ids
 Running question: When will BerriAI IPO? for model: claude-2: 100%|████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:13<00:00,  4.41s/it]
 
 Benchmark Results for 'When will BerriAI IPO?':
@@ -151,7 +151,7 @@ os.environ['ANTHROPIC_API_KEY'] = ""
 # using https://api.together.xyz/playground for llama2
 # try any supported LLM here: https://docs.litellm.ai/docs/providers
 
-models = ['togethercomputer/llama-2-70b-chat', 'gpt-3.5-turbo', 'claude-instant-1.2']
+models = ['togethercomputer/llama-2-70b-chat', '{{openai_small}}', '{{anthropic}}']
 data = []
 
 for question in questions: # group by question
@@ -276,7 +276,7 @@ os.environ['TOGETHERAI_API_KEY'] = ""
 os.environ['OPENAI_API_KEY'] = ""
 os.environ['ANTHROPIC_API_KEY'] = ""
 
-models = ['togethercomputer/llama-2-70b-chat', 'gpt-3.5-turbo', 'claude-instant-1.2'] # enter llms to benchmark
+models = ['togethercomputer/llama-2-70b-chat', '{{openai_small}}', '{{anthropic}}'] # enter llms to benchmark
 data_2 = []
 
 for question in questions: # group by question

--- a/docs/tutorials/compare_llms_2.md
+++ b/docs/tutorials/compare_llms_2.md
@@ -76,7 +76,7 @@ os.environ['ANTHROPIC_API_KEY'] = ""
 ```python
 results = [] # for storing results
 
-models = ['gpt-3.5-turbo', 'claude-2'] # define what models you're testing, see: https://docs.litellm.ai/docs/providers
+models = ['{{openai_small}}', '{{anthropic}}'] # define what models you're testing, see: https://docs.litellm.ai/docs/providers
 for question in questions:
     row = [question]
     for model in models:

--- a/docs/tutorials/eval_suites.md
+++ b/docs/tutorials/eval_suites.md
@@ -184,7 +184,7 @@ eval_data = pd.DataFrame(
 with mlflow.start_run() as run:
     system_prompt = "Answer the following question in two sentences"
     logged_model_info = mlflow.openai.log_model(
-        model="gpt-3.5",
+        model="{{openai_small}}",
         task=openai.ChatCompletion,
         artifact_path="model",
         messages=[

--- a/docs/tutorials/model_fallbacks.md
+++ b/docs/tutorials/model_fallbacks.md
@@ -45,7 +45,7 @@ LiteLLM also exposes a `get_max_tokens()` function, which you can use to identif
 
 The model ids in the fallback list below are illustrative and kept for their context window sizes.
 
-```python
+```python keep-model-ids
 import litellm
 from litellm import completion, ContextWindowExceededError, get_max_tokens
 

--- a/docs/tutorials/openai_codex.md
+++ b/docs/tutorials/openai_codex.md
@@ -82,9 +82,9 @@ Ensure your LiteLLM Proxy is properly configured to route to your desired models
 
 ```yaml showLineNumbers
 model_list:
-  - model_name: o3-mini
+  - model_name: gpt-5.3-codex
     litellm_params:
-      model: openai/o3-mini
+      model: openai/gpt-5.3-codex
       api_key: os.environ/OPENAI_API_KEY
   - model_name: {{anthropic}}
     litellm_params:

--- a/docs/tutorials/vertex_ai_pay_go.md
+++ b/docs/tutorials/vertex_ai_pay_go.md
@@ -64,7 +64,7 @@ curl http://localhost:4000/v1/chat/completions \
 Use `x-pass-` so LiteLLM forwards provider-specific headers.
 
 ```bash
-MODEL_ID="gemini-3-pro-preview-0325"
+MODEL_ID="{{gemini_pro}}"
 PROJECT_ID="YOUR_PROJECT_ID"
 
 curl -X POST \


### PR DESCRIPTION
## TLDR

#1201 turned the example model ids into `{{role}}` placeholders filled from `docs-models.json`, but on 51 of the pages it touched, 278 retired ids stayed literal in plain fences (`gpt-3.5-turbo-1106`, `openai/o1-pro`, `claude-opus-4-6`, `gemini-1.0-pro-002`, `github_copilot/gpt-4o`, and so on). This PR sweeps them by hand: 187 lines move to a placeholder or to the newest id of their family, and 54 fences get `keep-model-ids` because the exact id is the point of the example

## User Flow

Before: the flow fails at step 3, the snippet the reader copied targets a retired model

1. Reader opens `GET https://docs.litellm.ai/docs/providers/github_copilot` and copies the first example on the page
2. Reader pastes it into their script and runs `litellm.completion(model="github_copilot/gpt-4o", messages=[...])`
3. The call targets `gpt-4o`, a model the rest of the docs stopped naming after #1201, so the reader gets an older model than the page promises, or a provider error where the id has been retired, and has to go find the current id on their own

After: the flow succeeds at step 3, the snippet names the current model

1. Reader opens `GET https://docs.litellm.ai/docs/providers/github_copilot` and copies the first example on the page
2. Reader pastes it into their script and runs `litellm.completion(model="github_copilot/gpt-5.2", messages=[...])`
3. The call targets Copilot's newest chat-mode model and works as written. On the other 45 pages the placeholder renders the id from `docs-models.json`, so the next model bump is one JSON edit instead of another sweep

## What changed

Every occurrence got one of three treatments. Where the id is just a model, it became the role placeholder: `{{openai_small}}` for the small OpenAI tier (`gpt-3.5-turbo-1106`, `gpt-5.4-mini`, `o1`), `{{openai_large}}` for the large one (`gpt-4`, `gpt-4-32k`, `o1-pro`, `gpt-5.4`, `chatgpt-4o-latest`), `{{anthropic}}` for Sonnet-tier and older Claude ids (`claude-3`, `claude-3-5-haiku-20241022`, `claude-3-7-sonnet-20250219`, `claude-sonnet-4-5-20250514`, `claude-sonnet-4-6`), `{{anthropic_large}}` for Opus (`claude-opus-4-6`, `claude-opus-4-8`, and the `o1-preview` reasoning tier in the auto-router examples), `{{gemini_flash}}` and `{{gemini_pro}}` for the Gemini ids. Provider paths keep their prefix, so `bedrock/anthropic.claude-instant-v1` becomes `bedrock/anthropic.{{anthropic}}` and `helicone/claude-3.5-haiku/anthropic` becomes `helicone/{{anthropic}}/anthropic`

Where no role fits, the line names the newest id of its capability in `model_prices_and_context_window.json`: `github_copilot/gpt-5.2` is the newest chat-mode Copilot id (`gpt-5.3-codex` under that provider is responses-only), `gpt-4.1-2025-04-14` and `gpt-4.1-mini-2025-04-14` are the fine-tune bases, `openai/gpt-5.3-codex` replaces `o3-mini` in the Codex tutorial, and `openai/gpt-4.1` replaces `gpt-4o-mini` as the non-reasoning example in the `supports_reasoning` assertions

Where the exact id is the point of the fence, it stays literal and the fence gets `keep-model-ids`: version-gated features (Anthropic beta headers and hosted tool versions such as `computer_20241022`, the `effort` beta, thinking budgets), captured artifacts (the IAM policy ARN in `oidc.md`, the mock-endpoint log in `debugging.md`, the benchmark output in `compare_llms.md`, the `migration.md` snippet, the Claude 2.1 system-prompt examples), and the blocks #1201 already marked with "the ids below are illustrative and kept for their context window sizes" in `routing.md`, `reliability.md`, `fallback_management.md`, `reliable_completions.md`, and `model_fallbacks.md`

The advisor tool page also needed a prose fix. It said the only supported advisor model was `claude-opus-4-6`; Anthropic's advisor tool doc now lists `claude-opus-5` as an advisor and Opus 4.6+, Sonnet 4.6+, and Haiku 4.5 as executors, so the sentence and the pairing table now read from the placeholders. Sources: https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool and https://code.claude.com/docs/en/advisor

Left literal on purpose, since they are not example defaults: aliases used as `model_name` (`claude-4-sonnet`, `gpt-4o-with-tools`, `claude-3-7-sonnet-thinking`), deployment names (`azure/chatgpt-v-2`, `my-o3-deployment`, the `gpt-4-vision` resource URL), capability-specific ids (`gpt-5-search-api`, `gpt-4o-transcribe`, `gemini-2.5-flash-image`, the embedding models), the `openai/o1-*` wildcard rejection example in `model_access_groups.md`, and `snowflake/claude-sonnet-4-6`, which is the newest Claude the cost map has for that provider

## Linear ticket

Resolves LIT-7037

## Proof

Both CI lints pass on the head:

```
$ python3 scripts/check-docs.py docs
Checked 787 markdown files in: docs
No structural problems found.

$ node scripts/check-writing-style.js docs blog release_notes
Checked 1021 markdown files in: docs, blog, release_notes
No prose em dashes found. 9 vocabulary warnings (run with --warnings to list).
```

Running the site's own remark substitution (`src/remark/docs-models.js`) over the 46 changed pages fills every placeholder, including the ones inside `keep-model-ids` fences, the mermaid node, and the table cells on the advisor page:

```
files=46 role placeholders=1111 unfilled after substitution=0
docs/completion/anthropic_advisor_tool.md:67
  source:   | `{{anthropic}}` | `{{anthropic_large}}` |
  rendered: | `claude-sonnet-5` | `claude-opus-5` |
docs/proxy/auto_routing.md:661
  source:   SIMPLE:    {{openai_small}}-low
  rendered: SIMPLE:    gpt-5.6-luna-low
docs/routing.md:2022
  source:   "base_model": "azure/{{openai_small}}"
  rendered: "base_model": "azure/gpt-5.6-luna"
```

A re-scan of the same 51 pages for plain-fence ids finds only the aliases, deployment names, and capability-specific ids listed above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example model strings and advisor prose; no runtime or API behavior is modified.
> 
> **Overview**
> Follow-up to #1201: **docs examples no longer hard-code retired model IDs** in plain code fences. Literal names like `gpt-3.5-turbo-1106`, `openai/o1-pro`, `claude-opus-4-6`, and `gemini-1.0-pro-002` are replaced with **`docs-models.json` role placeholders** (`{{openai_small}}`, `{{openai_large}}`, `{{anthropic}}`, `{{anthropic_large}}`, `{{gemini_flash}}`, `{{gemini_pro}}`), including provider-prefixed paths and sample JSON responses.
> 
> Where the **exact id is the lesson** (beta tool versions, illustrative context-window fallbacks, captured logs/output), fences gain **`keep-model-ids`** so substitution does not rewrite them. A few pages get **explicit current ids** where roles do not fit (e.g. `github_copilot/gpt-5.2`, fine-tune bases, Codex `gpt-5.3-codex`).
> 
> **`anthropic_advisor_tool.md`** also updates compatibility copy and pairing tables to describe Opus advisor + Sonnet/Haiku/Opus executors via placeholders instead of naming only `claude-opus-4-6`. Auto-router tutorials swap **`o1-preview`** reasoning tiers for **`claude-opus` / `{{anthropic_large}}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27da99a68516ddca5f41efd879a07b674d3095ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->