### PR TITLE
docs: catch conda and homebrew Python version spellings in the python-literal lint

### DIFF
--- a/docs/proxy_server.md
+++ b/docs/proxy_server.md
@@ -327,7 +327,7 @@ Credits [@Nathan](https://gist.github.com/CUexter) for this tutorial.
 ```shell
 git clone https://github.com/OpenBMB/ChatDev.git
 cd ChatDev
-conda create -n ChatDev_conda_env python=3.9 -y
+conda create -n ChatDev_conda_env python={{python_version}} -y
 conda activate ChatDev_conda_env
 uv add -r requirements.txt
 ```
@@ -562,7 +562,7 @@ Credits [@Nathan](https://gist.github.com/CUexter) for this tutorial.
 ```shell
 git clone https://github.com/OpenBMB/ChatDev.git
 cd ChatDev
-conda create -n ChatDev_conda_env python=3.9 -y
+conda create -n ChatDev_conda_env python={{python_version}} -y
 conda activate ChatDev_conda_env
 uv add -r requirements.txt
 ```

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -16,7 +16,7 @@ Every check here is deterministic and fails the build:
   github-alert        a GitHub-style "> [!NOTE]" alert, which Docusaurus renders as a plain quote
   multiple-h1         more than one H1 in a page
   model-literal       a fenced block hardcodes a model id from docs-models.json instead of its {{role}} placeholder
-  python-literal      a Python version is written out (python3.12, python:3.12-slim, Python 3.12+) instead of {{python_version}} or {{python_min_version}}
+  python-literal      a Python version is written out (python3.12, python:3.12-slim, python=3.12, Python 3.12+) instead of {{python_version}} or {{python_min_version}}
   model-role-unknown  a {{placeholder}} that looks like a docs-models.json role but is not one, which the build would print literally
 
 Usage:
@@ -442,8 +442,9 @@ MODEL_TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z0-9_]+)\s*\}\}")
 MODEL_LITERAL_RE = re.compile(
     r"(?<![A-Za-z0-9:@-])(?:" + "|".join(re.escape(i) for i in sorted(MODEL_ROLES, key=len, reverse=True)) + r")(?![A-Za-z0-9@-]|[.:][0-9])"
 ) if MODEL_ROLES else re.compile(r"(?!x)x")
-# python3.12, python-3.12, python:3.12-slim and Python 3.12+; `python3 -m venv` and wheel tags such as cp312 are not versions.
-PYTHON_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9.])[Pp]ython[-:_ ]?3\.\d{1,2}(?![0-9])")
+# python3.12, python-3.12, python:3.12-slim, python=3.12 (conda), python@3.12 (homebrew) and Python 3.12+;
+# `python3 -m venv` and wheel tags such as cp312 are not versions.
+PYTHON_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9.])[Pp]ython[-:=@_ ]?3\.\d{1,2}(?![0-9])")
 
 
 def python_literal_message(literal):


### PR DESCRIPTION
#1230 added the `python-literal` rule so a spelled-out Python version has to be a deliberate choice, but its separator class only covers `-`, `:`, `_` and a space. The conda form `python=3.9` and the homebrew form `python@3.11` go straight through, and the repo has two live instances of the first: the ChatDev tutorial in `docs/proxy_server.md` tells you to run `conda create -n ChatDev_conda_env python=3.9 -y`, twice.

Adding `=` and `@` to the class catches both forms. On the current tree that surfaces exactly those two lines and nothing else, so no other page needs a new `keep-python-version` escape.

Both lines get `{{python_version}}` rather than an escape, because 3.9 is stale rather than intentional: ChatDev's own quickstart asks for Python 3.12+ now, and litellm's floor is 3.10, so the version in that block sat below both. 3.13 satisfies them, and the block follows docs-models.json from here on.

Verification: `python3 scripts/check-docs.py docs` reports those two errors with the widened regex and is clean again once the two lines change, across all 787 files, and `node scripts/check-writing-style.js docs blog release_notes` is clean. A probe page covering `python=3.9`, `python@3.11`, `python:3.12-slim`, `python3.11`, `Python 3.12+`, both `keep-python-version` escapes, `cp312` and `python3 -m venv` fires on the five real versions and stays quiet on the rest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a docs lint regex only; no runtime or security impact.
> 
> **Overview**
> Extends the docs **`python-literal`** check in `scripts/check-docs.py` so spelled-out Python versions also match **conda** (`python=3.x`) and **Homebrew** (`python@3.x`) forms, not only `-`, `:`, `_`, and space. The rule text and inline comments are updated to document those patterns.
> 
> **`docs/proxy_server.md`** replaces hardcoded `python=3.9` in both ChatDev setup blocks with `{{python_version}}`, clearing the new lint hits and dropping a version that was below current ChatDev and LiteLLM floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4cc1161d675252fbbf8332214a86ec87da75be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->