### PR TITLE
docs(blog): fix stall-escalation post date

### DIFF
--- a/blog/autorouter_stall_escalation/index.md
+++ b/blog/autorouter_stall_escalation/index.md
@@ -1,7 +1,7 @@
 ---
 slug: auto-router-stall-escalation
 title: "Auto-Router: Escalate a Task That Gets Stuck"
-date: 2026-09-08T10:00:00
+date: 2026-09-04T10:00:00
 authors:
   - moe
 image: ./hero.png


### PR DESCRIPTION
The stall-escalation post's frontmatter date was 2026-09-08, three days after PR #1211 actually merged it (2026-09-05). Every other recent blog post's frontmatter date matches its commit date; this one didn't, so it was showing as future-dated (and sorting/publishing wrong) on the live site.

Corrects it to 2026-09-04 to match when the PR landed.