### PR TITLE
docs(release_notes): promote v1.100.0 to stable

### DIFF
--- a/docs/auto_router/feature_history.md
+++ b/docs/auto_router/feature_history.md
@@ -23,9 +23,9 @@ Merged after the v1.100.0 release candidate was cut. Available in `v1.101.0-dev`
 
 Posts: [Route on Context Size and Modality](/blog/auto-router-more-routing-configurations), [Mid-Task Stall Escalation](/blog/auto-router-stall-escalation).
 
-## v1.100.0 (release candidate)
+## v1.100.0
 
-[GitHub pre-release](https://github.com/BerriAI/litellm/releases/tag/v1.100.0-rc.1), [Release notes](/release_notes/v1.100.0rc1/v1-100-0-rc-1)
+[GitHub release](https://github.com/BerriAI/litellm/releases/tag/v1.100.0), [Release notes](/release_notes/v1.100.0/v1-100-0)
 
 - **Custom tier sets.** Define your own tiers for the LLM classifier, preview the exact classifier prompt, keyword rules follow renames. [#38602](https://github.com/BerriAI/litellm/pull/38602), [#38603](https://github.com/BerriAI/litellm/pull/38603), [#38605](https://github.com/BerriAI/litellm/pull/38605).
 - **Heuristic-first chaining.** `classifier_type: heuristic_first` scores locally and calls the LLM classifier only when needed. [#38428](https://github.com/BerriAI/litellm/pull/38428).

--- a/release_notes/index.md
+++ b/release_notes/index.md
@@ -10,11 +10,11 @@ LiteLLM ships new releases regularly with new provider support, performance impr
 
 ## Latest Release
 
-### [v1.99.0: Dark Mode, CLI OAuth Login & Batch Billing](/release_notes/v1.99.0/v1-99-0)
+### [v1.100.0: Access Group Budgets, Together AI Sync & Custom Router Tiers](/release_notes/v1.100.0/v1-100-0)
 
-_September 1, 2026_
+_September 6, 2026_
 
-The Admin UI's migration off antd and Tremor is complete, with `@tremor/react`, `antd` and `@ant-design/icons` dropped from the dashboard's dependencies and the dashboard now on React 19; dark mode ships with a light/dark/system toggle, semantic status tokens, and theme-aware logos, surfaces and code blocks; `lite login` becomes a real OAuth flow with authorization code plus PKCE, storing the credential and refresh token in the OS keychain, and `lite login --config-claude` wires up Claude Code at login; batch spend is accounted for end to end, with enqueued-token rate limiting that refunds on completion, atomic cost claims so multi-pod polling cannot double-bill, and billing for cancelled and failed batches that still produced output; provisioned throughput can be declared in `config.yaml`; and the complexity router becomes operator-configurable with custom classifier plugins, tier sets, and per-model reasoning effort. This stable also folds in the v1.99.0-rc.2 fixes.
+Model access groups can carry one shared budget enforced across every deployment in the group, tracked in a per-window spend table, settable from the dashboard, and with opt-in rollover of unused headroom; Together AI moves onto a dedicated config with `api.together.ai` as the default endpoint, `reasoning_effort` mapped per model class, cache-read pricing, and a daily sync that keeps the registry priced against the live serverless catalog; the complexity router's tier set becomes operator-defined end to end, with custom classifier tiers, a preview of the classifier prompt, heuristic-first chaining, a dry run on `/auto_router/test_routing`, and classifier cost counted in savings; the MCP gateway gains RFC 7662 `/introspect` for session tokens, RS256-signed session tokens, bulk import of Anthropic MCP connectors, and enforcement of toolsets attached to teams, organizations and users; Grounding with Bing Search arrives as a search provider alongside 242 new models, including `gemini-3.5-transcribe`, the xAI `grok-4.20` family, 24 Mistral entries, RunwayML `gen4.5` and the Seedance 2 family; and `GET /public/v1/model_hub` exposes a paginated public listing of the models the proxy serves. This stable also carries the Docker base image fix for glibc 2.44 that landed after the rc.1 cut.
 
 ---
 
@@ -22,6 +22,7 @@ The Admin UI's migration off antd and Tremor is complete, with `@tremor/react`, 
 
 | Version                             | Date         | Highlights                                                 |
 | ----------------------------------- | ------------ | ---------------------------------------------------------- |
+| [v1.100.0](/release_notes/v1.100.0/v1-100-0) | Sep 6, 2026  | Access group budgets, Together AI overhaul, custom auto-router tiers |
 | [v1.99.0](/release_notes/v1.99.0/v1-99-0)   | Sep 1, 2026  | Dark mode, CLI OAuth login, end-to-end batch billing       |
 | [v1.98.0](/release_notes/v1.98.0/v1-98-0)   | Aug 22, 2026 | Provisioned throughput billing, auto-router shadow evals, callable routing groups |
 | [v1.97.0](/release_notes/v1.97.0/v1-97-0)   | Aug 15, 2026 | Tool-result guardrails, auto-router deployment affinity, admin viewer parity |

--- a/release_notes/v1.100.0/index.md
+++ b/release_notes/v1.100.0/index.md
@@ -1,7 +1,7 @@
 ---
-title: "v1.100.0rc1 - Access Group Budgets, Together AI Sync & Custom Router Tiers"
-slug: "v1-100-0-rc-1"
-date: 2026-08-31T10:00:00
+title: "v1.100.0 - Access Group Budgets, Together AI Sync & Custom Router Tiers"
+slug: "v1-100-0"
+date: 2026-09-06T00:00:00
 authors:
   - name: Krrish Dholakia
     title: CEO, LiteLLM
@@ -30,18 +30,24 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:1.100.0-rc.1
+docker.litellm.ai/berriai/litellm:1.100.0
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ```bash
-pip install litellm==1.100.0rc1
+pip install litellm==1.100.0
 ```
 
 </TabItem>
 </Tabs>
+
+:::note
+
+PyPI and Docker artifacts for this release were built from different SHAs, but are expected to be functionally the same. PyPI was built from [`10631eb`](https://github.com/BerriAI/litellm/commit/10631eb834c7802aa61611e807474170b8a4d425) and Docker from [`e4f2526`](https://github.com/BerriAI/litellm/commit/e4f25265704e2b2c6cf6e81be2e4c5cffff896f4).
+
+:::
 
 :::danger Breaking Changes
 
@@ -68,6 +74,13 @@ pip install litellm==1.100.0rc1
 - **Operator-defined auto-router tiers** - the complexity router's tier set is now editable end to end: custom classifier-defined tiers, a preview of the exact classifier prompt an edited tier set sends, heuristic-first classifier chaining, a dry run of a real request body on `/auto_router/test_routing` before saving, and classifier cost counted in savings and benchmarks
 - **MCP gateway session hardening** - RFC 7662 introspection lets an external gateway validate LiteLLM session tokens, session tokens can be signed asymmetrically with RS256, Anthropic MCP connectors can be bulk-imported via API and admin UI, and toolsets attached to teams, orgs and users are enforced
 - **242 new models** - day-0 support for `gemini-3.5-transcribe` and `transcribe-live` on Gemini and Vertex, the xAI `grok-4.20` family and `grok-imagine` image models, 24 Mistral entries spanning Voxtral audio, Ministral, OCR 3 and 4 and the Code and Vibe CLI lines, RunwayML `gen4.5`, `veo3.1` and the Seedance 2 family, and Grounding with Bing Search as a new search provider
+
+## Included after the v1.100.0-rc.1 cut
+
+This stable also carries the one change that landed on the release line after the rc.1 cut:
+
+- **Docker**
+    - Bump wolfi-base for glibc 2.44 and pin the image builds' apk python to 3.13, so the images build again after Wolfi rolled its python package forward - [PR #39992](https://github.com/BerriAI/litellm/pull/39992) (cherry-pick of [PR #38917](https://github.com/BerriAI/litellm/pull/38917) and [PR #38973](https://github.com/BerriAI/litellm/pull/38973))
 
 ## New Providers and Endpoints
 
@@ -571,9 +584,9 @@ Documentation now lives in [BerriAI/litellm-docs](https://github.com/BerriAI/lit
 
 ### PR roll-up by ownership area
 
-PRs by ownership area (total: 391)
+PRs by ownership area (total: 392)
 
-- Other (CI / chore / tests / build / version bumps): 69
+- Other (CI / chore / tests / build / version bumps): 70
 - Performance: 55
 - Spend / Budgets / Rate Limits: 53
 - UI: 53
@@ -613,4 +626,4 @@ The rest of the window closed coverage gaps and hardened what already runs. Fort
 
 ## Full Changelog
 
-https://github.com/BerriAI/litellm/compare/v1.99.0-rc.1...v1.100.0-rc.1
+https://github.com/BerriAI/litellm/compare/v1.99.0...v1.100.0


### PR DESCRIPTION
Promotes the v1.100.0rc1 release notes to stable, following the v1.99.0 promotion (#1091): folder renamed to v1.100.0, title, slug, date, Docker tag, pip install and Full Changelog range moved onto the stable form, and the changelog landing page now leads with v1.100.0

The one change that reached the release line after the rc.1 cut is listed in a dedicated 'Included after the v1.100.0-rc.1 cut' section: the Docker wolfi-base bump for glibc 2.44 and the apk python 3.13 pin (BerriAI/litellm#39992, a cherry-pick of #38917 and #38973). The ownership roll-up moves 391 to 392 accordingly

A note above Breaking Changes states that PyPI and Docker artifacts for this release were built from different SHAs but are expected to be functionally the same: PyPI from 10631eb (the rc.1 commit) and Docker from e4f2526 (rc.1 plus the Docker fix)

The Docker tag in the deploy block (1.100.0) is verified live on GHCR, and the v1.100.0 GitHub release is published, so the Full Changelog compare link resolves

The auto-router feature history page linked the rc1 notes path, which the folder rename would have turned into a broken link under onBrokenLinks: throw, so its v1.100.0 section now points at the stable GitHub release and release notes
