### PR TITLE
docs(config-settings): document DEFAULT_COOLDOWN_REDIS_READ_INTERVAL_SECONDS

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -864,6 +864,7 @@ router_settings:
 | DEFAULT_CHUNK_OVERLAP | Default chunk overlap for RAG text splitters. Default is 200
 | DEFAULT_CHUNK_SIZE | Default chunk size for RAG text splitters. Default is 1000
 | DEFAULT_CLIENT_DISCONNECT_CHECK_TIMEOUT_SECONDS | Timeout in seconds for checking client disconnection. Default is 1
+| DEFAULT_COOLDOWN_REDIS_READ_INTERVAL_SECONDS | How often each worker re-reads deployment cooldowns from Redis, in seconds. A lower value lets a cooldown set by one replica reach the others sooner, at the cost of more Redis reads. Default is 1
 | DEFAULT_COOLDOWN_TIME_SECONDS | Duration in seconds to cooldown a model after failures. Default is 5
 | DEFAULT_CRON_JOB_LOCK_TTL_SECONDS | Time-to-live for cron job locks in seconds. Default is 60 (1 minute)
 | DEFAULT_DATAFORSEO_LOCATION_CODE | Default location code for DataForSEO search API. Default is 2250 (France)


### PR DESCRIPTION
Adds the environment variable row for `DEFAULT_COOLDOWN_REDIS_READ_INTERVAL_SECONDS`, which BerriAI/litellm#40025 introduces

The litellm repo's `tests/documentation_tests/test_env_keys.py` gate fails on that PR until this row exists, since every env var read under `litellm/` has to be mentioned somewhere in these docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the env var reference table; no runtime or config behavior is modified in this PR.
> 
> **Overview**
> Adds **`DEFAULT_COOLDOWN_REDIS_READ_INTERVAL_SECONDS`** to the proxy environment-variables reference in `config_settings.md`, alongside the other `DEFAULT_*` cooldown settings.
> 
> The new row documents how often each worker polls Redis for deployment cooldown state (default **1** second), including the tradeoff between faster cross-replica cooldown propagation and more Redis reads. This satisfies the litellm documentation gate that requires every env var read under `litellm/` to appear in these docs, unblocking the upstream change that introduces the variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63aad4c46486a6fee6a1e0d70bd7acbe428382b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->