### PR TITLE
docs: add API Route provider documentation

### DIFF
--- a/docs/providers/api_route.md
+++ b/docs/providers/api_route.md
@@ -1,0 +1,31 @@
+# API Route
+
+[API Route](https://www.api-route.com/) is an OpenAI-compatible multi-model AI API gateway. See the [API Route documentation](https://www.api-route.com/docs/overview) for setup details.
+
+## API Key and Base URL
+
+Get your API key and base URL from API Access in the API Route dashboard, then set these environment variables:
+
+```python
+import os
+
+os.environ["API_ROUTE_API_KEY"] = "your-api-key"
+os.environ["API_ROUTE_BASE_URL"] = "your-api-base-url"
+```
+
+You can also pass `api_key` and `api_base` directly to `litellm.completion`.
+
+## Usage
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="api_route/your-model-name",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+print(response.choices[0].message.content)
+```
+
+API Route supports chat completions, streaming, and tool calling through LiteLLM's OpenAI-compatible implementation.

--- a/docs/providers/api_route.md
+++ b/docs/providers/api_route.md
@@ -4,16 +4,19 @@
 
 ## API Key and Base URL
 
-Get your API key and base URL from API Access in the API Route dashboard, then set these environment variables:
+Get your API key from API Access in the API Route dashboard, then set the API key environment variable:
 
 ```python
 import os
 
 os.environ["API_ROUTE_API_KEY"] = "your-api-key"
-os.environ["API_ROUTE_BASE_URL"] = "your-api-base-url"
 ```
 
-You can also pass `api_key` and `api_base` directly to `litellm.completion`.
+The API base defaults to `https://global.api-route.com/v1`. To use another API Route endpoint, set `API_ROUTE_BASE_URL` or pass `api_base` directly to `litellm.completion`.
+
+```python
+os.environ["API_ROUTE_BASE_URL"] = "your-api-base-url"  # optional
+```
 
 ## Usage
 

--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -564,6 +564,8 @@ router_settings:
 | ATHINA_BASE_URL | Base URL for Athina service (defaults to `https://log.athina.ai`)
 | AUTH_STRATEGY | Strategy used for authentication (e.g., OAuth, API key)
 | AUTO_REDIRECT_UI_LOGIN_TO_SSO | Flag to enable automatic redirect of UI login page to SSO when SSO is configured. Default is **false**
+| API_ROUTE_API_KEY | API key for authenticating with the API Route service |
+| API_ROUTE_BASE_URL | Base URL for the API Route service. Defaults to `https://global.api-route.com/v1` |
 | AUDIO_SPEECH_CHUNK_SIZE | Chunk size for audio speech processing. Default is 1024
 | ANTHROPIC_API_KEY | API key for Anthropic service. Uses `x-api-key` header for authentication.
 | ANTHROPIC_AUTH_TOKEN | Alternative auth token for Anthropic service. Uses `Authorization: Bearer` header instead of `x-api-key`. Used as fallback when `ANTHROPIC_API_KEY` is not set.


### PR DESCRIPTION
## Summary

Add API Route provider documentation.

## Changes

- Add API Route provider page
- Document API_ROUTE_API_KEY
- Document API_ROUTE_BASE_URL
- Add LiteLLM usage example

## Related PR

- BerriAI/litellm#40024