### PR TITLE
docs(env vars): document LITELLM_ECS_LOGS and LITELLM_SERVICE_NAME

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1190,6 +1190,8 @@ router_settings:
 | LITELLM_LOCAL_MODEL_COST_MAP | Local configuration for model cost mapping in LiteLLM
 | LITELLM_LOCAL_POLICY_TEMPLATES | When set to "true", uses local backup policy templates instead of fetching from GitHub. Policy templates are fetched from https://raw.githubusercontent.com/BerriAI/litellm/main/policy_templates.json by default, with automatic fallback to local backup on failure
 | LITELLM_LOG | Enable detailed logging for LiteLLM
+| LITELLM_ECS_LOGS | Set to `true` to format all LiteLLM logs (and uvicorn's access/error logs) as JSON conforming to the Elastic Common Schema (ECS) v8.x, for ingestion into the Elastic Stack or Datadog's ECS mode. Takes precedence over `JSON_LOGS`. Can also be turned on at runtime via `litellm._logging._turn_on_ecs()`
+| LITELLM_SERVICE_NAME | Overrides the `service.name` field emitted by ECS-formatted logs when `LITELLM_ECS_LOGS` is set. Default is `litellm`
 | LITELLM_MODEL_COST_MAP_URL | URL for fetching model cost map data. Default is https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 | LITELLM_LOG_FILE | File path to write LiteLLM logs to. When set, logs will be written to both console and the specified file
 | LITELLM_LOGGER_NAME | Name for OTEL logger 


### PR DESCRIPTION
## Summary

Adds LITELLM_ECS_LOGS and LITELLM_SERVICE_NAME to the environment variables reference table in config_settings.md. Both are read in litellm/_logging.py as part of the ECS-formatted logging feature added in BerriAI/litellm#29689, and that PR's documentation_test_env_keys.py CI check requires every env var litellm reads to be documented somewhere in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)