### PR TITLE
docs(mistral): document Voxtral text to speech on /v1/audio/speech

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -384,6 +384,100 @@ curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
 --form 'model="voxtral"'
 ```
 
+## Text to Speech
+
+Mistral's Voxtral TTS models turn text into audio through `litellm.speech()` and the proxy's `/v1/audio/speech` route. Both `mistral/voxtral-mini-tts-2603` and `mistral/voxtral-mini-tts-latest` are supported
+
+### SDK Usage
+
+```python
+from litellm import speech
+import os
+
+os.environ["MISTRAL_API_KEY"] = ""
+
+response = speech(
+    model="mistral/voxtral-mini-tts-2603",
+    input="The quick brown fox jumped over the lazy dog.",
+    voice="alloy",
+)
+
+response.stream_to_file("speech.mp3")
+```
+
+### Voices
+
+`voice` takes either an OpenAI voice name or a native Mistral voice id. LiteLLM maps the six OpenAI names onto Mistral voices, so an integration written against OpenAI TTS keeps working without a change:
+
+| OpenAI voice | Mistral voice     |
+|--------------|-------------------|
+| `alloy`      | `en_paul_neutral` |
+| `echo`       | `gb_oliver_neutral` |
+| `fable`      | `en_paul_cheerful` |
+| `onyx`       | `en_paul_confident` |
+| `nova`       | `gb_jane_sarcasm` |
+| `shimmer`    | `gb_jane_sarcasm` |
+
+Any other value passes through to Mistral untouched, so a native id such as `en_paul_excited` works as-is. `GET https://api.mistral.ai/v1/audio/voices` lists every voice your account can use
+
+### Response Formats
+
+`response_format` accepts `mp3`, `wav`, `pcm`, `flac`, and `opus`, and defaults to `mp3` when you leave it out. LiteLLM sets the response `content-type` to match the format you asked for, so `opus` comes back as `audio/ogg` and the other four as `audio/mpeg`, `audio/wav`, `audio/pcm`, and `audio/flac`
+
+### Voice Cloning
+
+Pass a base64 encoded audio sample as `ref_audio` and leave `voice` out, and Voxtral speaks the input in the sampled voice:
+
+```python
+import base64
+from litellm import speech
+
+with open("sample.wav", "rb") as sample:
+    ref_audio = base64.b64encode(sample.read()).decode()
+
+response = speech(
+    model="mistral/voxtral-mini-tts-2603",
+    input="This sentence comes back in the sampled voice.",
+    ref_audio=ref_audio,
+)
+
+response.stream_to_file("cloned.mp3")
+```
+
+### Unsupported Parameters
+
+Mistral's speech API rejects `speed` and `instructions` with a 422, so LiteLLM drops both before sending the request instead of failing it. A call that passes either one still returns audio, generated from the parameters Mistral does accept
+
+### Usage with LiteLLM Proxy
+
+```yaml
+model_list:
+  - model_name: voxtral-tts
+    litellm_params:
+      model: mistral/voxtral-mini-tts-2603
+      api_key: os.environ/MISTRAL_API_KEY
+```
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/audio/speech' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "voxtral-tts",
+    "input": "The quick brown fox jumped over the lazy dog.",
+    "voice": "alloy"
+}' \
+--output speech.mp3
+```
+
+### Cost Tracking
+
+Voxtral TTS is priced per input character, at the `input_cost_per_character` rate in the [model cost map](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json). LiteLLM counts the non-whitespace characters of `input`, so a 19 character sentence holding 2 spaces is billed as 17 characters
+
 ## Sample Usage - Embedding
 ```python
 from litellm import embedding

--- a/docs/text_to_speech.md
+++ b/docs/text_to_speech.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 | Fallbacks | ✅ | Works between supported models |
 | Loadbalancing | ✅ | Works between supported models |
 | Guardrails | ✅ | Applies to input text (non-streaming only) |
-| Supported Providers | OpenAI, Azure OpenAI, Vertex AI, AWS Polly, ElevenLabs , MiniMax |
+| Supported Providers | OpenAI, Azure OpenAI, Vertex AI, AWS Polly, ElevenLabs , MiniMax, Mistral |
 
 ## **LiteLLM Python SDK Usage**
 ### Quick Start 
@@ -106,6 +106,7 @@ litellm --config /path/to/config.yaml
 | Gemini      |   [Usage](#gemini-text-to-speech)                 |
 | ElevenLabs  |   [Usage](../docs/providers/elevenlabs#text-to-speech-tts)                 |
 | MiniMax     |   [Usage](/docs/providers/minimax)                 |
+| Mistral     |   [Usage](/docs/providers/mistral#text-to-speech)                 |
 
 ## `/audio/speech` to `/chat/completions` Bridge
 


### PR DESCRIPTION
## TLDR

Adds a Text to Speech section to the Mistral provider page for `mistral/voxtral-mini-tts-2603` and `mistral/voxtral-mini-tts-latest`, covering the `litellm.speech()` call, the proxy config plus a curl to `/v1/audio/speech`, the OpenAI voice aliases, the five `response_format` values, `ref_audio` voice cloning, the two parameters LiteLLM drops, and how spend is counted. Mistral also joins the Supported Providers table on the Text to Speech page so the section is reachable from there

## User Flow

**Before**: someone wanting Mistral TTS finds nothing about it and has to read the source

1. Opens `https://docs.litellm.ai/docs/text_to_speech` and reads the Supported Providers table: OpenAI, Azure OpenAI, Azure AI Speech, AWS Polly, Vertex AI, Gemini, ElevenLabs, MiniMax. No Mistral row, so the page reads as if Mistral TTS is unsupported
2. Opens `https://docs.litellm.ai/docs/providers/mistral`, finds Audio Transcription and nothing at all about `/v1/audio/speech`
3. Guesses a config, POSTs to `/v1/audio/speech` with `"voice": "alloy"`, and gets audio back, with no way to know which Mistral voice `alloy` resolved to or what else `voice` accepts
4. Adds `"speed": 1.5` to slow the read down, gets a 200 and audio at the same speed, and has no way to tell whether the parameter was applied
5. Never discovers `ref_audio` voice cloning, because nothing on the site mentions it
6. Reads `litellm/llms/mistral/audio_speech/transformation.py` or files a support ticket to answer any of the above

**After**: the same person gets every answer off one page

1. Opens `https://docs.litellm.ai/docs/text_to_speech`, sees Mistral in the Supported Providers table, and clicks through to `https://docs.litellm.ai/docs/providers/mistral#text-to-speech`
2. Copies the SDK snippet, runs `speech(model="mistral/voxtral-mini-tts-2603", input=..., voice="alloy")`, and writes a playable `speech.mp3`
3. Copies the proxy config and the curl, POSTs to `http://0.0.0.0:4000/v1/audio/speech`, and gets a 200 with `content-type: audio/mpeg`
4. Reads the Voices table, sees `alloy` resolves to `en_paul_neutral`, and switches to a native id such as `en_paul_excited` knowing it passes straight through
5. Reads Response Formats, sets `"response_format": "opus"`, and gets a 200 with `content-type: audio/ogg`
6. Reads Voice Cloning, sends a base64 sample as `ref_audio` with no `voice`, and gets the input read back in the sampled voice
7. Reads Unsupported Parameters and learns that `speed` and `instructions` are dropped before the call, so the 200 in step 4 of the Before flow was audio at the default speed
8. Reads Cost Tracking and can match `x-litellm-response-cost` to the non-whitespace character count of `input`

## QA

Docs build and the two repo linters, on this branch:

```bash
npm run build          # [SUCCESS] Generated static files in "build".
npm run lint:docs      # Checked 787 markdown files in: docs -> No structural problems found.
npm run lint:writing   # Checked 1023 markdown files -> No prose em dashes found.
```

Every claim on the page was checked against a live proxy running the Voxtral TTS code from BerriAI/litellm#38755, on a random high port, with a real `MISTRAL_API_KEY`. The page's own curl, verbatim except for the port and key:

```bash
$ curl --location 'http://0.0.0.0:44264/v1/audio/speech' \
  --header 'Authorization: Bearer sk-1234' \
  --header 'Content-Type: application/json' \
  --data '{
      "model": "voxtral-tts",
      "input": "The quick brown fox jumped over the lazy dog.",
      "voice": "alloy"
  }' \
  --output speech.mp3 --write-out 'http=%{http_code} bytes=%{size_download} ctype=%{content_type}\n'
http=200 bytes=19337 ctype=audio/mpeg

$ file speech.mp3
speech.mp3: Audio file with ID3 version 2.4.0, contains:
- MPEG ADTS, layer III, v2,  80 kbps, 22.05 kHz, Monaural
```

Every `response_format` the section lists, through the same proxy, with the `content-type` it came back as:

```bash
$ for FMT in mp3 wav pcm flac opus; do
    curl -s -o out.$FMT -w "$FMT http=%{http_code} bytes=%{size_download} ctype=%{content_type}\n" \
      http://0.0.0.0:44264/v1/audio/speech -H 'Authorization: Bearer sk-1234' \
      -H 'Content-Type: application/json' \
      -d "{\"model\":\"voxtral-tts\",\"input\":\"format check\",\"voice\":\"en_paul_neutral\",\"response_format\":\"$FMT\"}"
    echo "    $(file -b out.$FMT | head -1)"
  done
mp3 http=200 bytes=8319 ctype=audio/mpeg
    Audio file with ID3 version 2.4.0, contains:
wav http=200 bytes=57644 ctype=audio/wav
    RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz
pcm http=200 bytes=84480 ctype=audio/pcm
    data
flac http=200 bytes=43130 ctype=audio/flac
    FLAC audio bitstream data, 24 bit, mono, 24 kHz, length unknown
opus http=200 bytes=4401 ctype=audio/ogg
    Ogg data, Opus audio, version 0.1, mono, 24000 Hz (Input Sample Rate)
```

The two dropped parameters. Mistral itself rejects both, so the section's claim is that LiteLLM strips them rather than passing them on:

```bash
$ curl -s https://api.mistral.ai/v1/audio/speech -H "Authorization: Bearer $MISTRAL_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"model":"voxtral-mini-tts-2603","input":"hi","voice_id":"en_paul_neutral","speed":1.5}'
{"object":"error","message":{"detail":[{"type":"extra_forbidden","loc":["body","speed"],"msg":"Extra inputs are not permitted",...}]},"type":"invalid_request_error"}

$ curl -s -o out_drop.mp3 -w 'http=%{http_code} bytes=%{size_download} ctype=%{content_type}\n' \
  http://0.0.0.0:44264/v1/audio/speech -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"voxtral-tts","input":"drop check","voice":"alloy","speed":1.5,"instructions":"sound cheerful"}'
http=200 bytes=5358 ctype=audio/mpeg
```

`ref_audio` cloning with no `voice`, and the `-latest` model, both through the proxy:

```
refaudio_novoice: http=200 bytes=12092 ctype=audio/mpeg cost=0.000416
voxtral-tts-latest (voice=nova): http=200 bytes=13026 ctype=audio/mpeg cost=0.000176
```

The SDK snippets from the section, run against the same code:

```
alloy -> 16467 bytes
native wav (voxtral-mini-tts-latest, gb_oliver_neutral) -> 73004 bytes, RIFF WAVE 16 bit mono 24000 Hz
ref_audio -> 9311 bytes
speed + instructions -> 9595 bytes
```

The Cost Tracking wording comes from a controlled sweep of `x-litellm-response-cost` against inputs of known length, which is what showed that whitespace is not billed:

```
chars=1  cost=1.6e-05    -> 1 unit
chars=10 cost=0.00016    -> 10 units   (no spaces)
chars=19 cost=0.000272   -> 17 units   (2 spaces)
chars=44 cost=0.000576   -> 36 units   (8 spaces)
```

The voice alias table was checked against `GET https://api.mistral.ai/v1/audio/voices`, which returns 10 built-in voices. All six alias targets are real slugs on that list, and an unknown value comes back as `404 {"message":"Voice 'zz_not_a_voice' not found.","type":"invalid_voice","code":"1902"}`, which is why the section says other values pass through untouched

## Linear ticket

Resolves LIT-7001

## Caveats (if any)

- The code this documents is in BerriAI/litellm#38755, which is still open. Merging this page before that PR lands would have docs.litellm.ai describe an endpoint that answers `Unable to map the custom llm provider=mistral` on every released version, so this should merge after #38755 does
- The ticket asked for "billed per input character". The page says non-whitespace characters instead, because that is what the sweep above measured. If the intent is to bill raw characters, the wording here is right about today's behavior and the code is what would change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this diff.
> 
> **Overview**
> Documents **Mistral Voxtral TTS** (`mistral/voxtral-mini-tts-2603` and `-latest`) for `litellm.speech()` and the proxy **`/v1/audio/speech`** endpoint.
> 
> The new **Text to Speech** section on the Mistral provider page covers SDK and proxy/curl examples, OpenAI→Mistral **voice** aliases, **`response_format`** values and content-types, **`ref_audio`** voice cloning, stripping of unsupported **`speed`** / **`instructions`**, and **cost tracking** (non-whitespace character billing).
> 
> The main **Text to Speech** doc now lists **Mistral** in Supported Providers and links to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada64025007aeabdeafae4538bf1f888ad7fdc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->