### PR TITLE
docs(skills-gateway): document installing proxy skills into other agents

### DIFF
--- a/docs/skills_gateway.md
+++ b/docs/skills_gateway.md
@@ -87,6 +87,36 @@ Then install any skill:
 /plugin marketplace add grill-me
 ```
 
+### 5. Install in other agents
+
+Agents other than Claude Code install skills through the [`skills` CLI](https://github.com/vercel-labs/skills), which reads an [Agent Skills discovery index](https://agentskills.io) from the proxy. Serving that index is opt-in:
+
+```yaml title="config.yaml"
+litellm_settings:
+  public_skills_index: true
+```
+
+It is off by default. The CLI sends no credentials, so the index and the archives it points at are served without a LiteLLM key, and anyone who can reach the proxy can read every skill uploaded through `POST /v1/skills`. Turn it on only on a proxy whose skills you are happy to publish
+
+With it on, point any agent at the proxy:
+
+```bash
+npx skills add https://your-proxy -a gemini-cli
+npx skills add https://your-proxy -a cursor
+```
+
+The CLI reads `GET /.well-known/agent-skills/index.json`, downloads each skill from `GET /v1/skills/{skill_id}/archive`, checks the bytes against the `sha256` digest the index published, and writes the skill into that agent's skills directory. Run `npx skills add --help` for the list of agent names it accepts
+
+The index covers skills uploaded as a zip through `POST /v1/skills`. An upload with no `SKILL.md` at the root of its archive is left out, since discovery clients have no manifest to read
+
+Skills registered as a git source (the `POST /claude-code/plugins` flow above) work differently, because LiteLLM stores the source URL rather than the skill's files. Agents install those from the git URL directly:
+
+```bash
+npx skills add https://github.com/mattpocock/skills -a gemini-cli
+```
+
+`GET /public/skill_hub` returns that URL in each skill's `source` field. Some agents also ship their own installer for git URLs, such as `gemini skills install https://github.com/mattpocock/skills`, so check the agent's own docs
+
 ## Skill fields
 
 | Field | Description |
@@ -109,3 +139,5 @@ Then install any skill:
 | `POST /claude-code/plugins/{name}/disable` | Required | Unpublish a skill |
 | `GET /public/skill_hub` | None | List public skills |
 | `GET /claude-code/marketplace.json` | None | Claude Code marketplace manifest |
+| `GET /.well-known/agent-skills/index.json` | None | Agent Skills discovery index, needs `public_skills_index: true` |
+| `GET /v1/skills/{skill_id}/archive` | None | Download an uploaded skill as a zip, needs `public_skills_index: true` |


### PR DESCRIPTION
Documents how to install skills the proxy holds into agents other than Claude Code, which is the surface litellm#40043 adds

The Skills Gateway page already covered registering a git-sourced skill and installing it in Claude Code through the marketplace endpoint. It said nothing about Gemini CLI, Cursor, Kiro and the rest, which all install through the `skills` CLI and read an Agent Skills discovery index rather than a Claude Code marketplace manifest

New section covers turning on `public_skills_index`, what that exposes (the index and the archives it points at are served with no LiteLLM key, so it is off by default), and `npx skills add https://your-proxy -a <agent>`. It also separates the two kinds of registered skill: a zip uploaded through `POST /v1/skills` is served from the index, while a git-sourced skill registered through `POST /claude-code/plugins` is installed from its own URL, since LiteLLM stores the source rather than the files. The API reference table gains the two new routes

Both commands in the new section were run against a live proxy on the litellm#40043 branch, and `gemini skills install` is quoted the way the Gemini CLI docs write it

This should merge after litellm#40043, since the setting it documents does not exist before that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or configuration behavior changes in this PR.
> 
> **Overview**
> Adds **§5 Install in other agents** to the Skills Gateway doc, covering non–Claude Code agents (Gemini CLI, Cursor, etc.) that use the [`skills` CLI](https://github.com/vercel-labs/skills) and the Agent Skills discovery index instead of the Claude Code marketplace.
> 
> Documents opt-in **`public_skills_index: true`** in `config.yaml`, including that the index and zip archives are served **without auth** and expose skills uploaded via `POST /v1/skills`. Shows **`npx skills add https://your-proxy -a <agent>`**, the index/archive flow (`/.well-known/agent-skills/index.json`, `sha256` verification), and that zip uploads need a root **`SKILL.md`** to appear in the index.
> 
> Clarifies **git-registered skills** (`POST /claude-code/plugins`) are installed from their source URL (with examples and **`GET /public/skill_hub`** `source` field), not from the discovery index. The **API reference** table adds the two unauthenticated routes gated by `public_skills_index`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb1d4707d8a2851cbe07f18026e19e12a8517467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->