### PR TITLE
docs: document safety identifier enforcement

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -1158,6 +1158,7 @@ router_settings:
 | LITELLM_DEV_ENV_HOT_RELOAD | Internal flag the proxy sets on itself when started with `--reload`, signalling reloaded workers to re-read `.env` with `override=True` so edits to existing keys take effect on reload. Not meant to be set by users
 | LITELLM_DONT_SHOW_FEEDBACK_BOX | Flag to hide feedback box in LiteLLM UI
 | LITELLM_DROP_PARAMS | Parameters to drop in LiteLLM requests
+| LITELLM_ENFORCE_SAFETY_IDENTIFIER | When set to `true`, hash the authenticated `user_id` with SHA-256 and enforce it as the safety identifier for `acompletion` and `aresponses` requests. Client-provided values are overwritten. Defaults to disabled
 | LITELLM_MODIFY_PARAMS | Parameters to modify in LiteLLM requests
 | LITELLM_EMAIL | Email associated with LiteLLM account
 | LITELLM_FAVICON_URL | Custom URL for the LiteLLM UI favicon. When set, overrides the default favicon


### PR DESCRIPTION
## Summary

Document the `LITELLM_ENFORCE_SAFETY_IDENTIFIER` environment variable used by LiteLLM proxy safety identifier enforcement.

The setting is disabled by default. When enabled, the proxy hashes the authenticated `user_id` with SHA-256 and applies it to `acompletion` and `aresponses` requests. Client-provided values are overwritten.

Related LiteLLM PR: [BerriAI/litellm#40086](https://github.com/BerriAI/litellm/pull/40086)

## Validation

- `npm run lint:writing` passed
- `npm run lint:docs` passed
- `npm run build` passed; only pre-existing site warnings were reported
