### PR TITLE
docs: document MongoDB BETA and update 1.101.0rc1 notes

### DIFF
--- a/docs/completion/knowledgebase.md
+++ b/docs/completion/knowledgebase.md
@@ -22,6 +22,7 @@ LiteLLM integrates with vector stores, allowing your models to access your organ
 - [Azure AI Search](/docs/providers/azure_ai_vector_stores) (Vector search with Azure AI Search indexes)
 - [Vertex AI RAG API](https://cloud.google.com/vertex-ai/generative-ai/docs/rag-overview)
 - [Gemini File Search](https://ai.google.dev/gemini-api/docs/file-search)
+- [MongoDB Vector Search (BETA)](../providers/mongodb_vector_stores.md#use-mongodb-in-chat-completions) (Use an existing Atlas or self-managed MongoDB index as context for chat completions)
 - [RAGFlow Datasets](/docs/providers/ragflow_vector_store.md) (Dataset management only, search not supported)
 
 ## Quick Start

--- a/docs/providers/mongodb_vector_stores.md
+++ b/docs/providers/mongodb_vector_stores.md
@@ -1,0 +1,312 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# MongoDB - Vector Store (BETA)
+
+:::warning BETA
+The MongoDB vector store integration is a **BETA** feature. It supports searching existing MongoDB Vector Search indexes. Prepare your collections, indexes, and embedded documents before connecting them to LiteLLM.
+:::
+
+Use documents in MongoDB Atlas or a self-managed MongoDB deployment as context for chat completions. LiteLLM embeds the user's query, searches your index, and passes the retrieved text to your chat model. You can also search directly to retrieve documents and similarity scores without generating an answer.
+
+- [Connect your index](#connect-your-index) through the Admin UI, configuration file, or management API.
+- [Use MongoDB in chat completions](#use-mongodb-in-chat-completions) with curl or the OpenAI Python SDK.
+- [Follow a worked example](../tutorials/mongodb_vector_search.md) using original fictional policy documents in Atlas.
+
+## Before you begin
+
+You need:
+
+- **A MongoDB deployment with Vector Search enabled.** For self-managed deployments, follow MongoDB's [deployment guide](https://www.mongodb.com/docs/search/self-managed/current/) and [version compatibility requirements](https://www.mongodb.com/docs/search/self-managed/current/deployment/compatibility-requirements/). A MongoDB server without Vector Search cannot serve these queries.
+- **A populated collection and a queryable Vector Search index.** Documents must contain both readable text and stored embeddings. If you need to create an index, see MongoDB's [Vector Search index guide](https://www.mongodb.com/docs/vector-search/indexes/vector-search-type/).
+- **A connection string reachable from LiteLLM.** The database user needs permission to search the collection and list its search indexes.
+- **The embedding model used for your documents.** Query embeddings must use the same model and output dimensions as the stored vectors. A different model with the same dimensions can return irrelevant results without an error.
+
+Install the MongoDB dependency in the environment running LiteLLM:
+
+```bash
+pip install 'litellm[proxy,mongodb]'
+```
+
+For direct Python SDK use, install `litellm[mongodb]` and skip to [Search with the Python SDK](#search-with-the-python-sdk).
+
+### Choose your models
+
+For proxy requests, use a configured LiteLLM proxy. Registration through the UI or management API also requires a proxy database. Add your models under **Models** in the Admin UI or in your existing `model_list` configuration:
+
+| Model | Used for | Requirement |
+|---|---|---|
+| Embedding model | Converting each search query into a vector | Must match the model and dimensions used to embed your collection. |
+| Chat model | Generating an answer from retrieved text | A LiteLLM-supported chat model. Only needed for chat completions. |
+
+Configure credentials and any provider-specific settings on each model deployment. MongoDB does not require OpenAI: choose the embedding provider that matches your stored vectors and the chat provider you want to use. The [sample-document example](../tutorials/mongodb_vector_search.md) shows one setup using OpenAI.
+
+## Connect your index
+
+Register the existing index once, then reference it by ID in requests. Replace all values in angle brackets with your deployment's values.
+
+| Value | Where to find it |
+|---|---|
+| `<index-name>` | The exact name of your MongoDB Vector Search index. This becomes the LiteLLM `vector_store_id`. |
+| `<database-name>` / `<collection-name>` | The database and collection containing your documents. |
+| `<vector-field>` | The vector `path` in the index definition. |
+| `<text-field>` | The document field containing readable text, such as `text` or `metadata.body`. |
+| `<embedding-model-name>` | The name of the embedding model registered on your LiteLLM proxy. |
+| `<chat-model-name>` | The name of the chat model registered on your LiteLLM proxy. |
+
+The index must be **READY** and queryable before searching. A registration's display name is independent of its ID. Saving a registration does not create an index, ingest documents, or verify that the connection works.
+
+Choose one registration method:
+
+<Tabs>
+<TabItem value="ui" label="Admin UI">
+
+1. Open **Tools > Vector Stores**, select **Manage Vector Stores**, and click **+ Add Vector Store**.
+2. Select **MongoDB Atlas** as the provider. This connector also supports self-managed MongoDB with Vector Search.
+3. Enter the exact index name as **Vector Store ID**, then fill in **Connection String**, **Database**, and **Collection**.
+4. Select the registered **Embedding Model**. Set **Vector Field Name** and **Text Field** to the fields in your collection. Leave **Candidates Considered** blank to use the default.
+5. Click **Create**, then use **Test Vector Store** to search for something you know is in your documents. Inspect the returned text to verify the connection and field mapping.
+
+Use **Manage Vector Stores** for registration. The separate **Create Vector Store** flow creates a new store on the provider and does not support MongoDB.
+
+</TabItem>
+<TabItem value="config" label="config.yaml">
+
+Set `MONGODB_CONNECTION_STRING` in the proxy's environment. For Atlas, the URI usually starts with `mongodb+srv://`; for self-managed deployments, it usually starts with `mongodb://`. Include the authentication, replica set, and TLS options your deployment requires. Percent-encode special characters in usernames and passwords.
+
+Add this registration to your existing proxy configuration, keeping your `model_list` and authentication settings:
+
+```yaml showLineNumbers title="config.yaml"
+vector_store_registry:
+  - vector_store_name: "<display-name>"
+    litellm_params:
+      vector_store_id: "<index-name>"
+      custom_llm_provider: mongodb
+      mongodb_connection_string: os.environ/MONGODB_CONNECTION_STRING
+      mongodb_database: "<database-name>"
+      mongodb_collection: "<collection-name>"
+      mongodb_text_field: "<text-field>"
+      mongodb_embedding_field: "<vector-field>"
+      litellm_embedding_model: "<embedding-model-name>"
+```
+
+Start or restart the proxy with the updated config:
+
+```bash
+litellm --config config.yaml --port 4000
+```
+
+Environment variables must be available to the running proxy process. For Docker, pass them with `--env-file` or `-e`; a host's `.env` file is not automatically available inside the container.
+
+</TabItem>
+<TabItem value="api" label="Management API">
+
+On a proxy configured with a database, set `LITELLM_API_KEY` to a LiteLLM key with permission to manage vector stores. Replace the proxy URL if needed:
+
+```bash showLineNumbers title="Register an existing MongoDB index"
+curl -X POST 'http://localhost:4000/vector_store/new' \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "vector_store_id": "<index-name>",
+    "custom_llm_provider": "mongodb",
+    "vector_store_name": "<display-name>",
+    "litellm_params": {
+      "mongodb_connection_string": "<mongodb-connection-string>",
+      "mongodb_database": "<database-name>",
+      "mongodb_collection": "<collection-name>",
+      "mongodb_text_field": "<text-field>",
+      "mongodb_embedding_field": "<vector-field>",
+      "litellm_embedding_model": "<embedding-model-name>"
+    }
+  }'
+```
+
+The registration is stored in the LiteLLM database. See [Managed Vector Stores](../vector_stores/managed_vector_stores.md) for management and access controls.
+
+</TabItem>
+</Tabs>
+
+:::note First registration through the UI or management API
+If the proxy started without any registered vector stores, direct search can work before chat retrieval is ready. Wait for the proxy's database sync or restart it after saving the first store before using `file_search` in chat completions. Loading a store through `config.yaml` at startup avoids this initial delay.
+:::
+
+## Use MongoDB in chat completions
+
+Call `/v1/chat/completions` with a `file_search` tool referencing your registered index ID. LiteLLM retrieves the context and calls your chat model in the same request.
+
+Set `LITELLM_API_KEY` to a LiteLLM key with access to the chat model and registered vector store. Replace the proxy URL, model name, index name, and question below with your own values.
+
+<Tabs>
+<TabItem value="chat-curl" label="curl">
+
+```bash showLineNumbers title="Chat with your MongoDB documents"
+curl -X POST 'http://localhost:4000/v1/chat/completions' \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "<chat-model-name>",
+    "messages": [
+      {
+        "role": "system",
+        "content": "Answer using the provided context. If the context does not contain the answer, say you do not know."
+      },
+      {
+        "role": "user",
+        "content": "<question-about-your-documents>"
+      }
+    ],
+    "tools": [
+      {
+        "type": "file_search",
+        "vector_store_ids": ["<index-name>"]
+      }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="chat-python" label="OpenAI Python SDK">
+
+Point the client at your LiteLLM proxy and pass LiteLLM's `file_search` tool through `extra_body`:
+
+```python showLineNumbers title="Chat completions through LiteLLM"
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:4000/v1",
+    api_key=os.environ["LITELLM_API_KEY"],
+)
+
+response = client.chat.completions.create(
+    model="<chat-model-name>",
+    messages=[
+        {
+            "role": "system",
+            "content": "Answer using the provided context. If the context does not contain the answer, say you do not know.",
+        },
+        {"role": "user", "content": "<question-about-your-documents>"},
+    ],
+    extra_body={
+        "tools": [{"type": "file_search", "vector_store_ids": ["<index-name>"]}]
+    },
+)
+
+message = response.model_dump()["choices"][0]["message"]
+print(message["content"])
+
+# Inspect the documents retrieved for this answer.
+for page in (message.get("provider_specific_fields") or {}).get("search_results", []):
+    for result in page["data"]:
+        print(result["file_id"], result["score"], result["content"])
+```
+
+</TabItem>
+</Tabs>
+
+LiteLLM embeds the final user message with the store's configured embedding model, runs MongoDB's `$vectorSearch` aggregation, and adds the retrieved text to the conversation. The chat model then generates the answer in `choices[0].message.content`.
+
+`file_search` on this endpoint is handled by LiteLLM before calling the chat model. Your application does not need to execute a tool call or send a separate search request. Use the exact index name in `vector_store_ids`, not the registration's display name.
+
+### Verify retrieval
+
+Successful retrieval returns its documents at `choices[0].message.provider_specific_fields.search_results`. Inspect their text and scores to confirm that the answer has relevant source material. See [Accessing Search Results](../completion/knowledgebase.md#accessing-search-results-citations) for more examples.
+
+A successful chat response alone does not prove that MongoDB retrieval worked: chat can complete even if retrieval fails. If sources are missing, run a [direct search](#search-the-index-directly) to diagnose the connection independently.
+
+## Search the index directly
+
+Use direct search when you want to retrieve documents without generating a chat response. Set `LITELLM_API_KEY` to a LiteLLM key with access to the registered store.
+
+```bash showLineNumbers title="Search through the proxy"
+curl -X POST 'http://localhost:4000/v1/vector_stores/<index-name>/search' \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "<question-about-your-documents>",
+    "max_num_results": 3
+  }'
+```
+
+Results appear in the response's `data` array:
+
+| Response field | Meaning |
+|---|---|
+| `content` | Text read from your configured `mongodb_text_field`. |
+| `file_id` / `filename` | The MongoDB document's `_id` converted to a string. |
+| `score` | MongoDB's `vectorSearchScore`. Higher values indicate more similar results; the score is not an answer-confidence percentage. |
+
+`max_num_results` defaults to `10` and accepts values from `1` to `50`. Use a query relevant to known documents to check search quality. See the [sample-document tutorial](../tutorials/mongodb_vector_search.md#test-search) for a concrete query and expected result.
+
+## Search with the Python SDK
+
+Pass the connection settings directly to `litellm.vector_stores.search`; proxy registration is not required. Set `MONGODB_CONNECTION_STRING` and your embedding provider's credentials in the SDK process's environment.
+
+```python showLineNumbers title="Search without a proxy"
+import os
+
+import litellm
+
+response = litellm.vector_stores.search(
+    vector_store_id="<index-name>",
+    query="<question-about-your-documents>",
+    custom_llm_provider="mongodb",
+    mongodb_connection_string=os.environ["MONGODB_CONNECTION_STRING"],
+    mongodb_database="<database-name>",
+    mongodb_collection="<collection-name>",
+    mongodb_text_field="<text-field>",
+    mongodb_embedding_field="<vector-field>",
+    litellm_embedding_model="<provider>/<embedding-model>",
+    max_num_results=3,
+)
+
+print(response)
+```
+
+For async usage, call `await litellm.vector_stores.asearch(...)` with the same arguments. In direct SDK calls, use the provider's embedding model name. On the proxy, use the registered embedding model name.
+
+## Settings reference
+
+Pass these in the registered store's `litellm_params`, or as keyword arguments in a direct SDK search.
+
+| Setting | Required | Description |
+|---|---|---|
+| `vector_store_id` | Yes | Exact MongoDB Vector Search index name. |
+| `custom_llm_provider` | Yes | Set to `mongodb`. |
+| `mongodb_connection_string` | Yes | URI beginning with `mongodb://` or `mongodb+srv://`, including the authentication and TLS options your deployment requires. |
+| `mongodb_database` | Yes | Database containing the collection. Required even if the URI contains a database name. |
+| `mongodb_collection` | Yes | Collection containing the documents and vectors. |
+| `litellm_embedding_model` | Yes | Model used to embed queries. Must match the model used for stored vectors. |
+| `mongodb_embedding_field` | No | Vector field covered by the index. Defaults to `embedding`. |
+| `mongodb_text_field` | No | Field containing readable text. Defaults to `text`; supports dotted paths such as `metadata.body`. |
+| `mongodb_num_candidates` | No | Number of candidates considered before returning the top results. Defaults to `max(100, 10 * max_num_results)`. An explicit value must be at least `max_num_results` and at most `10000`. Higher values can improve recall at the cost of latency. |
+| `litellm_embedding_config` | No | Additional embedding-call arguments, such as `dimensions`, `api_key`, or `api_base`. On the proxy, configure these on the embedding model deployment when possible. |
+
+The search `query` must be non-empty and no longer than 32,000 characters. A list of strings is joined with spaces and embedded as a single query.
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---|---|
+| Missing `pymongo` dependency | Install `litellm[mongodb]` in the same environment as the running proxy or SDK. |
+| HTTP 400: missing or non-queryable index | Check the exact database, collection, and index name. Wait for the index to become READY and queryable. |
+| HTTP 400: dimension mismatch or vector field not indexed | Match the query embedding model and dimensions to your documents, and `mongodb_embedding_field` to the index's `path`. |
+| HTTP 400: none of the matched documents has the text field | Set `mongodb_text_field` to the field containing readable text, including its dotted path if nested. |
+| HTTP 400: credentials rejected | Check the URI credentials, authentication database, and database user's permissions. |
+| Atlas reports `bad auth : authentication failed` (code `8000`) | Verify the database user's password and cluster in the saved connection string. This is an authentication failure before index search. The database user is separate from your Atlas website login; see [Atlas connection troubleshooting](https://www.mongodb.com/docs/atlas/troubleshoot-connection/#authentication-to-the-cluster-failed). |
+| HTTP 400: URI cannot be parsed | Percent-encode special characters in credentials. For example, `p@ss/word` becomes `p%40ss%2Fword`. |
+| HTTP 400: TLS file cannot be read | Ensure `tlsCAFile` and `tlsCertificateKeyFile` point to files readable by the LiteLLM process. In a container, use paths inside the container. |
+| HTTP 408: deployment or query timed out | Check hostname resolution and connectivity. On Atlas, check the IP access list and whether the cluster is paused. On self-managed deployments, check the host, port, and firewall. |
+| HTTP 503: connection dropped or refused | Retry after a node restart or replica set failover. If it persists, check connectivity and TLS settings. |
+| Chat returns `Invalid value: 'file_search'` after registering the first store | Wait for database sync or restart the proxy to load the registration before retrying. Confirm `vector_store_ids` contains the registered index ID. |
+
+Timeouts and dropped connections return retryable errors (`408` and `503`). After connectivity is restored, searches can resume without restarting LiteLLM.
+
+## BETA limitations
+
+- **Search only:** create collections and indexes, generate document embeddings, and ingest documents outside LiteLLM. MongoDB does not support LiteLLM's vector store creation, file management, or `/rag/ingest` APIs.
+- **No search filtering or query rewriting:** `filters`, `ranking_options`, and `rewrite_query` are rejected, including `rewrite_query: false`. Provider-specific `mongodb_filter` is also unsupported and rejected.
+- **No automatic embedding through MongoDB:** configure `litellm_embedding_model`; MongoDB's automated embedding integration is not used.
+- **First registration can take time to reach chat requests:** when a running proxy has no vector store registry yet, its first UI or API registration needs database synchronization or a restart before `file_search` works in chat completions.

--- a/docs/tutorials/mongodb_vector_search.md
+++ b/docs/tutorials/mongodb_vector_search.md
@@ -1,0 +1,194 @@
+# Chat with sample documents in MongoDB (BETA)
+
+Create three fictional policy documents, index them in MongoDB Atlas, test semantic search in the LiteLLM Admin UI, and use the results in a chat completion. The sample text below was written for this tutorial and does not describe real company policies.
+
+:::warning BETA
+MongoDB vector stores are a **BETA** feature in LiteLLM. The integration searches existing MongoDB indexes. This tutorial prepares documents using the MongoDB Python driver before registering the index with LiteLLM. See the [integration guide](../providers/mongodb_vector_stores.md) for general setup and limitations.
+:::
+
+## Before you begin
+
+You need:
+
+- An Atlas cluster with Vector Search and capacity for an additional search index, a database user allowed to create and read the demo collection, and permission to create the index.
+- A connection string and network access to the cluster from both your setup script and LiteLLM proxy.
+- A running LiteLLM proxy with `litellm[proxy,mongodb]` installed, a database configured for saved registrations, and access to the Admin UI.
+- An OpenAI API key for the embedding and chat models used in this example. Other providers can be used when both document and query embeddings use the same model and dimensions.
+
+## Add the models to LiteLLM
+
+Under **Models** in the LiteLLM Admin UI, add these deployments with your OpenAI API key, or reuse equivalent deployments already on your proxy:
+
+| Purpose | Provider | Provider model | Name on the proxy |
+|---|---|---|---|
+| Embed documents and search queries | OpenAI | `text-embedding-3-small` | `text-embedding-3-small` |
+| Generate chat answers | OpenAI | `gpt-4o-mini` | `gpt-4o-mini` |
+
+For configuration files, the LiteLLM model identifiers are `openai/text-embedding-3-small` and `openai/gpt-4o-mini`. Set `model_info.mode: embedding` on the embedding deployment so the UI identifies it as an embedding model. Use the embedding model's default **1536 dimensions** for this example.
+
+## Prepare the sample documents
+
+Install the dependencies for the setup script:
+
+```bash
+pip install openai pymongo
+```
+
+Set `MONGODB_CONNECTION_STRING` to your cluster's full URI and `LITELLM_API_KEY` to a LiteLLM key with access to the embedding model. Set `LITELLM_BASE_URL` if your proxy uses a different address:
+
+```bash
+export MONGODB_CONNECTION_STRING='mongodb+srv://<database-user>:<password>@<cluster-hostname>/'
+export LITELLM_API_KEY='<litellm-api-key>'
+export LITELLM_BASE_URL='http://localhost:4000/v1'
+```
+
+Use the database user's credentials, which are separate from your Atlas website login. Percent-encode special characters in the username and password.
+
+Save this as `prepare_documents.py` and run it with `python prepare_documents.py`. It embeds the original sample text through the proxy's embeddings API and inserts the documents using PyMongo. It stops if the demo collection already exists, so it does not overwrite existing data.
+
+```python title="prepare_documents.py"
+import os
+
+from openai import OpenAI
+from pymongo import MongoClient
+
+samples = [
+    {
+        "_id": "projector-booking",
+        "text": "For this fictional demo, projectors may be reserved for 45 minutes. Include reservation code DEMO-7321 with every projector booking.",
+    },
+    {
+        "_id": "desk-reservation",
+        "text": "For this fictional demo, standing desks can be reserved for two hours. Cancel a desk reservation at least 15 minutes before it starts.",
+    },
+    {
+        "_id": "visitor-badges",
+        "text": "For this fictional demo, visitors collect badges at the welcome desk. Return each badge before leaving the building.",
+    },
+]
+
+with MongoClient(os.environ["MONGODB_CONNECTION_STRING"]) as mongo:
+    database = mongo["litellm_docs_demo"]
+    if "policies" in database.list_collection_names():
+        raise RuntimeError("Demo collection already exists. Use a fresh database for this tutorial.")
+
+    with OpenAI(
+        base_url=os.environ.get("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+        api_key=os.environ["LITELLM_API_KEY"],
+    ) as client:
+        embeddings = client.embeddings.create(
+            model="text-embedding-3-small",
+            input=[document["text"] for document in samples],
+        )
+
+    for item in embeddings.data:
+        samples[item.index]["embedding"] = item.embedding
+
+    collection = database.create_collection("policies")
+    collection.insert_many(samples)
+    print("Inserted three sample documents into litellm_docs_demo.policies.")
+```
+
+Document insertion is performed by the setup script, outside LiteLLM's vector store API. LiteLLM's MongoDB integration does not support `/rag/ingest` or vector store file upload.
+
+## Prepare the Atlas index
+
+In Atlas, create a **Vector Search** index on `litellm_docs_demo.policies` named `litellm_demo_policy_idx`, using this definition:
+
+```json title="Vector Search index definition"
+{
+  "fields": [
+    {
+      "type": "vector",
+      "path": "embedding",
+      "numDimensions": 1536,
+      "similarity": "cosine"
+    }
+  ]
+}
+```
+
+Wait until it is **READY** and queryable. If you change the database, collection, or index name, use those values throughout the remaining steps.
+
+## Register the index in the Admin UI
+
+Open **Tools > Vector Stores > Manage Vector Stores > + Add Vector Store**, then enter:
+
+| UI field | Value |
+|---|---|
+| Provider | MongoDB Atlas |
+| Vector Store Name | `MongoDB Demo Policies` |
+| Vector Store ID | `litellm_demo_policy_idx` |
+| Connection String | The same `MONGODB_CONNECTION_STRING` value used for the setup script. |
+| Database | `litellm_docs_demo` |
+| Collection | `policies` |
+| Embedding Model | `text-embedding-3-small` |
+| Vector Field Name | `embedding` |
+| Text Field | `text` |
+| Candidates Considered | Leave blank. |
+
+Click **Create**. If this index is already registered on your proxy, select the existing registration for the next step. Keep the query embedding model the same as the model used in the setup script; the chat model can be changed independently.
+
+## Test search
+
+In **Test Vector Store**, select **MongoDB Demo Policies** and run:
+
+```text
+How long can I book a projector, and which reservation code should I use?
+```
+
+Look for the document with ID `projector-booking`. Its text should contain **45 minutes** and **DEMO-7321**. Expand the result to inspect the retrieved text. Similarity scores can vary.
+
+You can run the same search through the API. Use a LiteLLM key with access to this store; replace `http://localhost:4000` if your proxy uses a different address:
+
+```bash
+curl -X POST 'http://localhost:4000/v1/vector_stores/litellm_demo_policy_idx/search' \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "How long can I book a projector, and which reservation code should I use?",
+    "max_num_results": 3
+  }'
+```
+
+This checks the connection, query embedding, index, and returned text together. Use a question about the sample documents to evaluate relevance.
+
+## Use the documents in a chat completion
+
+If this is the first vector store registered on a running proxy, wait for the proxy's database sync or restart it before testing chat. See the [first-registration note](../providers/mongodb_vector_stores.md#connect-your-index).
+
+Use a LiteLLM key with access to both the store and the chat model:
+
+```bash
+curl -X POST 'http://localhost:4000/v1/chat/completions' \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {
+        "role": "system",
+        "content": "Use the provided demo policies to answer the question. If there is no relevant context, say you do not know."
+      },
+      {
+        "role": "user",
+        "content": "How long can I book a projector, and which reservation code should I use?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "file_search",
+        "vector_store_ids": ["litellm_demo_policy_idx"]
+      }
+    ]
+  }'
+```
+
+Verify both parts of the response:
+
+- `choices[0].message.content` answers **45 minutes** and **DEMO-7321**.
+- `choices[0].message.provider_specific_fields.search_results` includes the `projector-booking` document and its text.
+
+A successful chat response alone does not prove retrieval worked. Check the source results to confirm that MongoDB supplied the context. The [general chat guide](../providers/mongodb_vector_stores.md#use-mongodb-in-chat-completions) includes a Python example that prints these results.
+
+For your own collection, replace the database, collection, index, field names, and embedding model using the [MongoDB integration guide](../providers/mongodb_vector_stores.md#connect-your-index).

--- a/docs/vector_stores/index.md
+++ b/docs/vector_stores/index.md
@@ -41,6 +41,7 @@ Support for the unified endpoints varies by provider. `Search` is `POST /v1/vect
 | `azure_ai` (Azure AI Search) | Yes | No | [Setup](../providers/azure_ai_vector_stores.md) |
 | `gemini` (File Search) | Yes | Yes | [Setup](../providers/gemini_file_search.md) |
 | `milvus` | Yes | Yes | [Setup](../providers/milvus_vector_stores.md) |
+| `mongodb` (BETA) | Yes | No | Searches existing MongoDB Vector Search indexes on Atlas or self-managed deployments. [Setup](../providers/mongodb_vector_stores.md), [chat completions](../providers/mongodb_vector_stores.md#use-mongodb-in-chat-completions), [worked example](../tutorials/mongodb_vector_search.md) |
 | `pg_vector` | Yes | Yes | Requires the [litellm-pgvector](../completion/knowledgebase.md) connector |
 | `s3_vectors` | Yes | No | Create via [/rag/ingest](../rag_ingest.md), [Setup](../providers/s3_vectors.md) |
 | `valkey` | Yes | No | Searches an existing valkey-search index, [setup](../providers/valkey_vector_stores.md) |

--- a/docs/vector_stores/managed_vector_stores.md
+++ b/docs/vector_stores/managed_vector_stores.md
@@ -3,14 +3,14 @@ import TabItem from '@theme/TabItem';
 
 # LiteLLM Managed Vector Stores
 
-Register an existing provider vector store (Bedrock Knowledge Base, Vertex AI Search datastore, Azure AI Search index, Milvus collection, Valkey search index, ...) with LiteLLM, so that every consumer of the proxy can use it through one OpenAI-compatible API without knowing the provider or holding its credentials.
+Register an existing provider vector store (Bedrock Knowledge Base, Vertex AI Search datastore, Azure AI Search index, Milvus collection, Valkey search index, [MongoDB Vector Search index (BETA)](../providers/mongodb_vector_stores.md), ...) with LiteLLM, so that every consumer of the proxy can use it through one OpenAI-compatible API without knowing the provider or holding its credentials.
 
 A managed vector store is a mapping, stored in `config.yaml` or in the LiteLLM database, of:
 
 | Field | Required | Description |
 |---|---|---|
 | `vector_store_id` | Yes | The id clients will reference, typically the provider's own store id (Knowledge Base id, datastore id, index name) |
-| `custom_llm_provider` | Yes | Which provider backend to route to, e.g. `bedrock`, `vertex_ai/search_api`, `azure_ai`, `milvus`, `valkey`, `gemini`, `openai`, `pg_vector` |
+| `custom_llm_provider` | Yes | Which provider backend to route to, e.g. `bedrock`, `vertex_ai/search_api`, `azure_ai`, `milvus`, `mongodb` (BETA), `valkey`, `gemini`, `openai`, `pg_vector` |
 | `vector_store_name` | No | Human readable name shown in the UI |
 | `vector_store_description` | No | Description shown in the UI |
 | `vector_store_metadata` | No | Free-form metadata object |
@@ -60,7 +60,7 @@ curl -X POST 'http://localhost:4000/vector_store/new' \
   }'
 ```
 
-The store is written to the LiteLLM database and is immediately usable; no restart needed. The response echoes the stored object with sensitive `litellm_params` values redacted.
+The store is written to the LiteLLM database and is immediately available to direct search; no restart needed. If the proxy started with no registered vector stores, chat retrieval for its first UI or API registration becomes available after database synchronization or a proxy restart. The response echoes the stored object with sensitive `litellm_params` values redacted.
 
 </TabItem>
 <TabItem value="ui" label="Admin UI">

--- a/docs/vector_stores/search.md
+++ b/docs/vector_stores/search.md
@@ -168,6 +168,38 @@ print(response)
 
 </TabItem>
 
+<TabItem value="mongodb-provider" label="MongoDB Provider (BETA)">
+
+#### Using MongoDB (BETA)
+
+Search an existing MongoDB Vector Search index on Atlas or a self-managed deployment. Install `litellm[mongodb]`, then set `MONGODB_CONNECTION_STRING` and your embedding provider's credentials. Replace the placeholders with your index, collection fields, and the model used to embed your documents.
+
+```python showLineNumbers title="Search Vector Store - MongoDB Provider (BETA)"
+import os
+
+import litellm
+
+response = await litellm.vector_stores.asearch(
+    vector_store_id="<index-name>",  # Exact MongoDB Vector Search index name
+    query="<question-about-your-documents>",
+    custom_llm_provider="mongodb",
+    mongodb_connection_string=os.environ["MONGODB_CONNECTION_STRING"],
+    mongodb_database="<database-name>",
+    mongodb_collection="<collection-name>",
+    mongodb_text_field="<text-field>",
+    mongodb_embedding_field="<vector-field>",
+    litellm_embedding_model="<provider>/<embedding-model>",
+    max_num_results=3,
+)
+print(response)
+```
+
+The embedding model must match the one used for the stored vectors. This BETA integration supports search only; index creation, ingestion, filters, ranking options, and query rewriting are not supported.
+
+[MongoDB setup and reference](../providers/mongodb_vector_stores.md) · [Sample-document example](../tutorials/mongodb_vector_search.md)
+
+</TabItem>
+
 <TabItem value="valkey-provider" label="Valkey Provider">
 
 #### Using Valkey

--- a/release_notes/v1.101.0rc1/index.md
+++ b/release_notes/v1.101.0rc1/index.md
@@ -114,7 +114,7 @@ pip install litellm==1.101.0rc1
 | Provider | Supported LiteLLM Endpoints | Description |
 | --- | --- | --- |
 | [QwenCloud and Qwen AI Platform](../../docs/providers/qwencloud) | `/chat/completions`, `/embeddings`, `/rerank`, `/images/generations` | `qwencloud/` (international) and `qwen_ai_platform/` (mainland) prefixes over the DashScope implementation, with 45 priced entries each |
-| [MongoDB](../../docs/completion/knowledgebase) | `/v1/vector_stores/search`, `/v1/rag/query`, chat `vector_store_ids` | Vector store provider running `$vectorSearch` on Atlas and self-managed deployments, shipped in every proxy image |
+| [MongoDB Vector Search (BETA)](../../docs/providers/mongodb_vector_stores) | `/v1/vector_stores/{id}/search`, `/v1/chat/completions` with `file_search` | Search existing Atlas or self-managed MongoDB indexes and use retrieved documents as chat context. Collection/index creation and document ingestion are not supported through LiteLLM. |
 | [Alice](../../docs/proxy/guardrails/alice) | Guardrails (`pre_call`, `post_call`) | Guardrail provider (formerly ActiveFence) enforcing ALLOW, BLOCK, MASK, or DETECT verdicts with the application chosen per virtual key |
 
 ### New LLM API Endpoints (6 new endpoints)
@@ -297,7 +297,7 @@ The maintenance pass touched 306 existing entries, concentrated in OpenRouter (4
 - **[Batches](../../docs/batches)**
     - Enforce team isolation on provider-format batch ids: retrieve, cancel, and output or error file reads on another team's batch now return 403, while ids with no ownership row keep passing through - [PR #33536](https://github.com/BerriAI/litellm/pull/33536)
 - **[Vector Stores](../../docs/completion/knowledgebase)**
-    - Add a `mongodb` vector store provider running `$vectorSearch` through pymongo on Atlas and self-managed deployments, selectable in the Admin UI, installable with `pip install 'litellm[mongodb]'` and shipped in every proxy Docker image - [PR #39811](https://github.com/BerriAI/litellm/pull/39811), [PR #39994](https://github.com/BerriAI/litellm/pull/39994)
+    - Add **MongoDB Vector Search (BETA)**: register an existing Atlas or self-managed index through the Admin UI, configuration file, or management API, then search directly or use `file_search` in chat completions. The query embedding model must match the stored vectors. See the [setup guide](../../docs/providers/mongodb_vector_stores), [chat-completions examples](../../docs/providers/mongodb_vector_stores#use-mongodb-in-chat-completions), and [sample-document tutorial](../../docs/tutorials/mongodb_vector_search) - [PR #39811](https://github.com/BerriAI/litellm/pull/39811), [PR #39994](https://github.com/BerriAI/litellm/pull/39994)
 - **OCR**
     - Add Cohere Parse on `/v1/ocr` for `cohere/parse-v5.0` and Azure AI Foundry `Cohere-parse-v5` deployments, billed at $0.0015 a page, with health checks probing each OCR deployment with a document its provider accepts - [PR #39862](https://github.com/BerriAI/litellm/pull/39862)
 - **Agents and A2A**

--- a/sidebars.js
+++ b/sidebars.js
@@ -1174,6 +1174,7 @@ const sidebars = {
         "providers/milvus_vector_stores",
         "providers/mistral",
         "providers/minimax",
+        "providers/mongodb_vector_stores",
         "providers/moonshot",
         "providers/morph",
         "providers/nebius",
@@ -1685,6 +1686,7 @@ const learnSidebar = {
           items: [
             "tutorials/prompt_caching",
             "tutorials/file_search_responses_api",
+            "tutorials/mongodb_vector_search",
             "tutorials/anthropic_file_usage",
             "tutorials/gemini_realtime_with_audio",
             "tutorials/litellm_proxy_aporia",


### PR DESCRIPTION
Document MongoDB Vector Search as a BETA integration, including registration through the Admin UI, configuration file, and management API; embedding-model requirements; direct search; and chat completions with `file_search`. Add a separate tutorial using original fictional policy documents.

Update the existing MongoDB entries in the 1.101.0rc1 release notes to label the feature BETA, correct the search endpoint, and link the setup guide, chat-completions examples, and tutorial. Document search-only limitations and the first-registration synchronization behavior.

Implementation: BerriAI/litellm#39811.

## Validation

- `npm run build`.
- Repository writing-style and documentation-structure checks.
- Python, JSON, YAML, and shell example syntax checks; `git diff --check`.
- Confirmed #39811 is included in the `v1.101.0-rc.1` tag and the existing Docker tag `1.101.0-rc.1` resolves on GHCR.
- The integration's direct search and chat retrieval were previously verified against real MongoDB and embedding/chat providers.

## Remaining verification

Draft pending full search/chat verification of the new fictional-data tutorial. Its exact setup script successfully generated embeddings and inserted all three documents. Atlas rejected the additional search index because the cluster has reached its index limit, and the previous local MongoDB instance is unavailable. The temporary Atlas collection was removed.
