### PR TITLE
docs: deploy MongoDB vector search through the optional beta sidecar

### DIFF
--- a/docs/providers/mongodb_vector_stores.md
+++ b/docs/providers/mongodb_vector_stores.md
@@ -75,13 +75,14 @@ Add this optional service to the Compose project running LiteLLM:
 services:
   mongodb-sidecar:
     image: ghcr.io/berriai/litellm-mongodb:v0.1.0-beta.1
+    network_mode: service:litellm
     environment:
       MONGODB_CONNECTION_STRING: ${MONGODB_CONNECTION_STRING:?required}
       MONGODB_SIDECAR_API_KEY: ${MONGODB_SIDECAR_API_KEY:?required}
     restart: unless-stopped
 ```
 
-Connect both services to the same private Compose network and pass `MONGODB_SIDECAR_API_KEY` to the LiteLLM service. Use `http://mongodb-sidecar:8080` as `api_base`; `localhost` inside a LiteLLM container points to that container. No host port is needed for the sidecar in this deployment.
+Replace `litellm` in `network_mode` with the name of your existing LiteLLM service, and pass `MONGODB_SIDECAR_API_KEY` to that service. Sharing the network namespace lets LiteLLM use `http://127.0.0.1:8080` as `api_base`. No host port is needed for the sidecar in this deployment. For separate network namespaces, expose the sidecar through HTTPS instead.
 
 </TabItem>
 <TabItem value="helm" label="Kubernetes / Helm">
@@ -140,7 +141,9 @@ Monitor `/health/readiness` for MongoDB connectivity. A MongoDB readiness probe 
 
 Each secret can alternatively be mounted read-only and referenced with `MONGODB_CONNECTION_STRING_FILE` or `MONGODB_SIDECAR_API_KEY_FILE`. Set either the value or its file variable, never both. Files must be readable by container user 10001. For MongoDB TLS, include options such as `tlsCAFile` or `tlsCertificateKeyFile` in the URI and mount the files at those paths inside the sidecar. Certificate verification remains enabled by default.
 
-Keep the service on a private network. If the HTTP hop crosses an untrusted network, use an HTTPS reverse proxy. `api_base` can include that proxy's path prefix; omit `/v1`. Check `/health/liveness` for the HTTP process and `/health/readiness` for a bounded MongoDB ping. See the [sidecar operations guide](https://github.com/BerriAI/litellm-mongodb#operations) for timeouts, connection pooling, and releases.
+LiteLLM requires HTTPS for remote sidecars. HTTP is accepted only for a literal loopback IP, such as `127.0.0.1` or `[::1]`, when both processes share a host or network namespace. This keeps the sidecar bearer key and query data off unencrypted network hops. For a separate sidecar host or Deployment, use an HTTPS reverse proxy with a certificate trusted by LiteLLM; `api_base` can include the proxy's path prefix, without `/v1`. Keep the service's HTTP port private behind that proxy.
+
+Check `/health/liveness` for the HTTP process and `/health/readiness` for a bounded MongoDB ping. See the [sidecar operations guide](https://github.com/BerriAI/litellm-mongodb#operations) for timeouts, connection pooling, and releases.
 
 ## Connect your index
 
@@ -183,7 +186,7 @@ vector_store_registry:
     litellm_params:
       vector_store_id: "<index-name>"
       custom_llm_provider: mongodb
-      api_base: http://mongodb-sidecar:8080
+      api_base: http://127.0.0.1:8080
       api_key: os.environ/MONGODB_SIDECAR_API_KEY
       mongodb_database: "<database-name>"
       mongodb_collection: "<collection-name>"
@@ -214,7 +217,7 @@ curl -X POST 'http://localhost:4000/vector_store/new' \
     "custom_llm_provider": "mongodb",
     "vector_store_name": "<display-name>",
     "litellm_params": {
-      "api_base": "http://mongodb-sidecar:8080",
+      "api_base": "http://127.0.0.1:8080",
       "api_key": "<sidecar-api-key>",
       "mongodb_database": "<database-name>",
       "mongodb_collection": "<collection-name>",
@@ -379,7 +382,7 @@ Pass these in the registered store's `litellm_params`, or as keyword arguments i
 |---|---|---|
 | `vector_store_id` | Yes | Exact MongoDB Vector Search index name. |
 | `custom_llm_provider` | Yes | Set to `mongodb`. |
-| `api_base` | Yes | Sidecar HTTP(S) origin or reverse-proxy path prefix. Do not append `/v1`. |
+| `api_base` | Yes | Sidecar HTTPS origin or reverse-proxy path prefix. HTTP is supported only for literal loopback IPs. Do not append `/v1`. |
 | `api_key` | Yes | Sidecar bearer key. Can also be supplied through `MONGODB_SIDECAR_API_KEY` in the LiteLLM environment. |
 | `mongodb_database` | Yes | Database containing the collection. Required even if the URI contains a database name. |
 | `mongodb_collection` | Yes | Collection containing the documents and vectors. |

--- a/docs/providers/mongodb_vector_stores.md
+++ b/docs/providers/mongodb_vector_stores.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 # MongoDB - Vector Store (BETA)
 
 :::warning BETA
-The MongoDB vector store integration is a **BETA** feature. It supports searching existing MongoDB Vector Search indexes. Prepare your collections, indexes, and embedded documents before connecting them to LiteLLM.
+The MongoDB vector store integration is a **BETA** feature. It supports searching existing MongoDB Vector Search indexes through the optional [LiteLLM MongoDB sidecar](https://github.com/BerriAI/litellm-mongodb). Prepare your collections, indexes, and embedded documents before connecting them to LiteLLM.
 :::
 
 Use documents in MongoDB Atlas or a self-managed MongoDB deployment as context for chat completions. LiteLLM embeds the user's query, searches your index, and passes the retrieved text to your chat model. You can also search directly to retrieve documents and similarity scores without generating an answer.
@@ -19,16 +19,20 @@ You need:
 
 - **A MongoDB deployment with Vector Search enabled.** For self-managed deployments, follow MongoDB's [deployment guide](https://www.mongodb.com/docs/search/self-managed/current/) and [version compatibility requirements](https://www.mongodb.com/docs/search/self-managed/current/deployment/compatibility-requirements/). A MongoDB server without Vector Search cannot serve these queries.
 - **A populated collection and a queryable Vector Search index.** Documents must contain both readable text and stored embeddings. If you need to create an index, see MongoDB's [Vector Search index guide](https://www.mongodb.com/docs/vector-search/indexes/vector-search-type/).
-- **A connection string reachable from LiteLLM.** The database user needs permission to search the collection and list its search indexes.
+- **A connection string reachable from the sidecar.** The database user needs permission to search the collection and list its search indexes. Allow the sidecar host through your database's network rules.
 - **The embedding model used for your documents.** Query embeddings must use the same model and output dimensions as the stored vectors. A different model with the same dimensions can return irrelevant results without an error.
 
-Install the MongoDB dependency in the environment running LiteLLM:
+Install LiteLLM normally. The MongoDB driver runs only in the separate sidecar:
 
 ```bash
-pip install 'litellm[proxy,mongodb]'
+pip install 'litellm[proxy]'
 ```
 
-For direct Python SDK use, install `litellm[mongodb]` and skip to [Search with the Python SDK](#search-with-the-python-sdk).
+For direct Python SDK use, install `litellm`, deploy the sidecar, then follow [Search with the Python SDK](#search-with-the-python-sdk). Neither the SDK nor the standard LiteLLM images need PyMongo. LiteLLM does not start or install the sidecar automatically.
+
+:::note RC configuration change
+If you tried MongoDB in `v1.101.0-rc.1`, move `mongodb_connection_string` to the sidecar's `MONGODB_CONNECTION_STRING` environment variable. Replace it in your LiteLLM registration with `api_base` and `api_key`. Existing MongoDB data and indexes stay in place; application search and chat requests stay the same. This integration remains BETA.
+:::
 
 ### Choose your models
 
@@ -40,6 +44,103 @@ For proxy requests, use a configured LiteLLM proxy. Registration through the UI 
 | Chat model | Generating an answer from retrieved text | A LiteLLM-supported chat model. Only needed for chat completions. |
 
 Configure credentials and any provider-specific settings on each model deployment. MongoDB does not require OpenAI: choose the embedding provider that matches your stored vectors and the chat provider you want to use. The [sample-document example](../tutorials/mongodb_vector_search.md) shows one setup using OpenAI.
+
+## Deploy the sidecar
+
+Run one sidecar per MongoDB connection string. Multiple LiteLLM registrations can use that sidecar for databases, collections, and indexes accessible to its MongoDB user. The sidecar runs the official MongoDB driver; LiteLLM continues to generate query embeddings through your configured model and route chat requests normally.
+
+Set `MONGODB_CONNECTION_STRING` and a strong `MONGODB_SIDECAR_API_KEY` in the sidecar's deployment secrets. Give LiteLLM the same sidecar key. Keep MongoDB credentials and TLS files in the sidecar environment.
+
+<Tabs>
+<TabItem value="docker" label="Docker">
+
+For a LiteLLM proxy or SDK running on the same host:
+
+```bash
+docker run --rm --name mongodb-sidecar \
+  -p 127.0.0.1:8080:8080 \
+  -e MONGODB_CONNECTION_STRING \
+  -e MONGODB_SIDECAR_API_KEY \
+  ghcr.io/berriai/litellm-mongodb:v0.1.0-beta.1
+```
+
+Use `http://127.0.0.1:8080` as the Sidecar URL. Pin the release tag or digest. The image supports Linux amd64 and arm64 and runs as user `10001:10001`.
+
+</TabItem>
+<TabItem value="compose" label="Docker Compose">
+
+Add this optional service to the Compose project running LiteLLM:
+
+```yaml
+services:
+  mongodb-sidecar:
+    image: ghcr.io/berriai/litellm-mongodb:v0.1.0-beta.1
+    environment:
+      MONGODB_CONNECTION_STRING: ${MONGODB_CONNECTION_STRING:?required}
+      MONGODB_SIDECAR_API_KEY: ${MONGODB_SIDECAR_API_KEY:?required}
+    restart: unless-stopped
+```
+
+Connect both services to the same private Compose network and pass `MONGODB_SIDECAR_API_KEY` to the LiteLLM service. Use `http://mongodb-sidecar:8080` as `api_base`; `localhost` inside a LiteLLM container points to that container. No host port is needed for the sidecar in this deployment.
+
+</TabItem>
+<TabItem value="helm" label="Kubernetes / Helm">
+
+Create a Kubernetes Secret named `mongodb-sidecar` in the LiteLLM namespace with keys `connection-string` and `api-key`. For the LiteLLM `litellm-helm` chart, add the sidecar through its existing `extraContainers` setting:
+
+```yaml title="values-mongodb.yaml"
+extraEnvVars:
+  - name: MONGODB_SIDECAR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mongodb-sidecar
+        key: api-key
+extraContainers:
+  - name: mongodb-sidecar
+    image: ghcr.io/berriai/litellm-mongodb:v0.1.0-beta.1
+    ports:
+      - name: mongodb-http
+        containerPort: 8080
+    env:
+      - name: MONGODB_CONNECTION_STRING
+        valueFrom:
+          secretKeyRef:
+            name: mongodb-sidecar
+            key: connection-string
+      - name: MONGODB_SIDECAR_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: mongodb-sidecar
+            key: api-key
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      runAsGroup: 10001
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+    livenessProbe:
+      httpGet:
+        path: /health/liveness
+        port: mongodb-http
+    startupProbe:
+      httpGet:
+        path: /health/liveness
+        port: mongodb-http
+      failureThreshold: 30
+      periodSeconds: 2
+```
+
+Merge these values with your existing chart configuration, preserving any existing extra environment variables and containers. Set the MongoDB registration's `api_base` to `http://127.0.0.1:8080`; containers in the same Pod share the network. No additional Service or mandatory chart dependency is needed.
+
+Monitor `/health/readiness` for MongoDB connectivity. A MongoDB readiness probe on a container in the LiteLLM Pod would remove the entire Pod from service during a MongoDB outage, affecting other providers. Use a separate sidecar Deployment and Service if MongoDB needs independent readiness, scaling, or availability.
+
+</TabItem>
+</Tabs>
+
+Each secret can alternatively be mounted read-only and referenced with `MONGODB_CONNECTION_STRING_FILE` or `MONGODB_SIDECAR_API_KEY_FILE`. Set either the value or its file variable, never both. Files must be readable by container user 10001. For MongoDB TLS, include options such as `tlsCAFile` or `tlsCertificateKeyFile` in the URI and mount the files at those paths inside the sidecar. Certificate verification remains enabled by default.
+
+Keep the service on a private network. If the HTTP hop crosses an untrusted network, use an HTTPS reverse proxy. `api_base` can include that proxy's path prefix; omit `/v1`. Check `/health/liveness` for the HTTP process and `/health/readiness` for a bounded MongoDB ping. See the [sidecar operations guide](https://github.com/BerriAI/litellm-mongodb#operations) for timeouts, connection pooling, and releases.
 
 ## Connect your index
 
@@ -62,8 +163,8 @@ Choose one registration method:
 <TabItem value="ui" label="Admin UI">
 
 1. Open **Tools > Vector Stores**, select **Manage Vector Stores**, and click **+ Add Vector Store**.
-2. Select **MongoDB Atlas** as the provider. This connector also supports self-managed MongoDB with Vector Search.
-3. Enter the exact index name as **Vector Store ID**, then fill in **Connection String**, **Database**, and **Collection**.
+2. Select **MongoDB (BETA)** as the provider. This connector also supports self-managed MongoDB with Vector Search.
+3. Enter the exact index name as **Vector Store ID**, then fill in **Sidecar URL**, **Sidecar API Key**, **Database**, and **Collection**.
 4. Select the registered **Embedding Model**. Set **Vector Field Name** and **Text Field** to the fields in your collection. Leave **Candidates Considered** blank to use the default.
 5. Click **Create**, then use **Test Vector Store** to search for something you know is in your documents. Inspect the returned text to verify the connection and field mapping.
 
@@ -72,7 +173,7 @@ Use **Manage Vector Stores** for registration. The separate **Create Vector Stor
 </TabItem>
 <TabItem value="config" label="config.yaml">
 
-Set `MONGODB_CONNECTION_STRING` in the proxy's environment. For Atlas, the URI usually starts with `mongodb+srv://`; for self-managed deployments, it usually starts with `mongodb://`. Include the authentication, replica set, and TLS options your deployment requires. Percent-encode special characters in usernames and passwords.
+Set `MONGODB_SIDECAR_API_KEY` in the proxy's environment to the key configured on the sidecar. Use a Sidecar URL reachable from the proxy process.
 
 Add this registration to your existing proxy configuration, keeping your `model_list` and authentication settings:
 
@@ -82,7 +183,8 @@ vector_store_registry:
     litellm_params:
       vector_store_id: "<index-name>"
       custom_llm_provider: mongodb
-      mongodb_connection_string: os.environ/MONGODB_CONNECTION_STRING
+      api_base: http://mongodb-sidecar:8080
+      api_key: os.environ/MONGODB_SIDECAR_API_KEY
       mongodb_database: "<database-name>"
       mongodb_collection: "<collection-name>"
       mongodb_text_field: "<text-field>"
@@ -112,7 +214,8 @@ curl -X POST 'http://localhost:4000/vector_store/new' \
     "custom_llm_provider": "mongodb",
     "vector_store_name": "<display-name>",
     "litellm_params": {
-      "mongodb_connection_string": "<mongodb-connection-string>",
+      "api_base": "http://mongodb-sidecar:8080",
+      "api_key": "<sidecar-api-key>",
       "mongodb_database": "<database-name>",
       "mongodb_collection": "<collection-name>",
       "mongodb_text_field": "<text-field>",
@@ -242,7 +345,7 @@ Results appear in the response's `data` array:
 
 ## Search with the Python SDK
 
-Pass the connection settings directly to `litellm.vector_stores.search`; proxy registration is not required. Set `MONGODB_CONNECTION_STRING` and your embedding provider's credentials in the SDK process's environment.
+Pass the sidecar settings directly to `litellm.vector_stores.search`; proxy registration is not required. Set `MONGODB_SIDECAR_API_KEY` and your embedding provider's credentials in the SDK process's environment. The MongoDB URI belongs in the separately deployed sidecar.
 
 ```python showLineNumbers title="Search without a proxy"
 import os
@@ -253,7 +356,8 @@ response = litellm.vector_stores.search(
     vector_store_id="<index-name>",
     query="<question-about-your-documents>",
     custom_llm_provider="mongodb",
-    mongodb_connection_string=os.environ["MONGODB_CONNECTION_STRING"],
+    api_base="http://127.0.0.1:8080",
+    api_key=os.environ["MONGODB_SIDECAR_API_KEY"],
     mongodb_database="<database-name>",
     mongodb_collection="<collection-name>",
     mongodb_text_field="<text-field>",
@@ -275,7 +379,8 @@ Pass these in the registered store's `litellm_params`, or as keyword arguments i
 |---|---|---|
 | `vector_store_id` | Yes | Exact MongoDB Vector Search index name. |
 | `custom_llm_provider` | Yes | Set to `mongodb`. |
-| `mongodb_connection_string` | Yes | URI beginning with `mongodb://` or `mongodb+srv://`, including the authentication and TLS options your deployment requires. |
+| `api_base` | Yes | Sidecar HTTP(S) origin or reverse-proxy path prefix. Do not append `/v1`. |
+| `api_key` | Yes | Sidecar bearer key. Can also be supplied through `MONGODB_SIDECAR_API_KEY` in the LiteLLM environment. |
 | `mongodb_database` | Yes | Database containing the collection. Required even if the URI contains a database name. |
 | `mongodb_collection` | Yes | Collection containing the documents and vectors. |
 | `litellm_embedding_model` | Yes | Model used to embed queries. Must match the model used for stored vectors. |
@@ -290,16 +395,17 @@ The search `query` must be non-empty and no longer than 32,000 characters. A lis
 
 | Symptom | What to check |
 |---|---|
-| Missing `pymongo` dependency | Install `litellm[mongodb]` in the same environment as the running proxy or SDK. |
+| Old configuration asks for `pymongo` or `mongodb_connection_string` | Use the LiteLLM release containing the BETA sidecar adapter, deploy the sidecar, and configure `api_base` and `api_key`. |
+| HTTP 401: sidecar authentication failed | Match LiteLLM's `api_key` to the sidecar's `MONGODB_SIDECAR_API_KEY`. This is separate from your MongoDB password and LiteLLM client key. |
 | HTTP 400: missing or non-queryable index | Check the exact database, collection, and index name. Wait for the index to become READY and queryable. |
 | HTTP 400: dimension mismatch or vector field not indexed | Match the query embedding model and dimensions to your documents, and `mongodb_embedding_field` to the index's `path`. |
 | HTTP 400: none of the matched documents has the text field | Set `mongodb_text_field` to the field containing readable text, including its dotted path if nested. |
-| HTTP 400: credentials rejected | Check the URI credentials, authentication database, and database user's permissions. |
+| HTTP 400: credentials rejected | Check the sidecar's URI credentials, authentication database, and database user's permissions. |
 | Atlas reports `bad auth : authentication failed` (code `8000`) | Verify the database user's password and cluster in the saved connection string. This is an authentication failure before index search. The database user is separate from your Atlas website login; see [Atlas connection troubleshooting](https://www.mongodb.com/docs/atlas/troubleshoot-connection/#authentication-to-the-cluster-failed). |
-| HTTP 400: URI cannot be parsed | Percent-encode special characters in credentials. For example, `p@ss/word` becomes `p%40ss%2Fword`. |
-| HTTP 400: TLS file cannot be read | Ensure `tlsCAFile` and `tlsCertificateKeyFile` point to files readable by the LiteLLM process. In a container, use paths inside the container. |
+| Sidecar fails to start: invalid URI or missing secret | Check the sidecar environment and secret-file mounts. Percent-encode special characters in URI credentials; for example, `p@ss/word` becomes `p%40ss%2Fword`. |
+| TLS file cannot be read | Ensure `tlsCAFile` and `tlsCertificateKeyFile` point to files readable by the sidecar process. In a container, use paths inside the sidecar container. |
 | HTTP 408: deployment or query timed out | Check hostname resolution and connectivity. On Atlas, check the IP access list and whether the cluster is paused. On self-managed deployments, check the host, port, and firewall. |
-| HTTP 503: connection dropped or refused | Retry after a node restart or replica set failover. If it persists, check connectivity and TLS settings. |
+| HTTP 503: connection dropped or refused | Check that the sidecar is running and its URL is reachable, then check MongoDB connectivity and TLS settings. Retry after a node restart or replica set failover. |
 | Chat returns `Invalid value: 'file_search'` after registering the first store | Wait for database sync or restart the proxy to load the registration before retrying. Confirm `vector_store_ids` contains the registered index ID. |
 
 Timeouts and dropped connections return retryable errors (`408` and `503`). After connectivity is restored, searches can resume without restarting LiteLLM.

--- a/docs/tutorials/mongodb_vector_search.md
+++ b/docs/tutorials/mongodb_vector_search.md
@@ -116,7 +116,7 @@ Wait until it is **READY** and queryable. If you change the database, collection
 
 Follow the [sidecar deployment guide](../providers/mongodb_vector_stores.md#deploy-the-sidecar) for Docker, Compose, or Kubernetes. Set the sidecar's `MONGODB_CONNECTION_STRING` to the URI used by the setup script, and set `MONGODB_SIDECAR_API_KEY` to a strong secret shared with LiteLLM. The URI and any MongoDB TLS files stay in the sidecar.
 
-For a proxy running on the Docker host, use `http://127.0.0.1:8080` as the Sidecar URL. For Compose, use `http://mongodb-sidecar:8080` on the shared network. Confirm the sidecar's `/health/readiness` endpoint returns HTTP 200 before registering the index.
+For a proxy running on the Docker host, use `http://127.0.0.1:8080` as the Sidecar URL. The Compose example shares LiteLLM's network namespace and uses the same loopback URL. Remote sidecars require HTTPS. Confirm the sidecar's `/health/readiness` endpoint returns HTTP 200 before registering the index.
 
 ## Register the index in the Admin UI
 

--- a/docs/tutorials/mongodb_vector_search.md
+++ b/docs/tutorials/mongodb_vector_search.md
@@ -11,8 +11,8 @@ MongoDB vector stores are a **BETA** feature in LiteLLM. The integration searche
 You need:
 
 - An Atlas cluster with Vector Search and capacity for an additional search index, a database user allowed to create and read the demo collection, and permission to create the index.
-- A connection string and network access to the cluster from both your setup script and LiteLLM proxy.
-- A running LiteLLM proxy with `litellm[proxy,mongodb]` installed, a database configured for saved registrations, and access to the Admin UI.
+- A connection string and network access to the cluster from both your setup script and the MongoDB sidecar.
+- A running LiteLLM proxy with `litellm[proxy]` installed, a database configured for saved registrations, and access to the Admin UI.
 - An OpenAI API key for the embedding and chat models used in this example. Other providers can be used when both document and query embeddings use the same model and dimensions.
 
 ## Add the models to LiteLLM
@@ -28,9 +28,11 @@ For configuration files, the LiteLLM model identifiers are `openai/text-embeddin
 
 ## Prepare the sample documents
 
-Install the dependencies for the setup script:
+Install the dependencies in a separate setup environment. PyMongo is used to prepare the sample data; it is not a dependency of the LiteLLM proxy or SDK:
 
 ```bash
+python -m venv .venv-mongodb-setup
+source .venv-mongodb-setup/bin/activate
 pip install openai pymongo
 ```
 
@@ -110,16 +112,23 @@ In Atlas, create a **Vector Search** index on `litellm_docs_demo.policies` named
 
 Wait until it is **READY** and queryable. If you change the database, collection, or index name, use those values throughout the remaining steps.
 
+## Deploy the MongoDB sidecar
+
+Follow the [sidecar deployment guide](../providers/mongodb_vector_stores.md#deploy-the-sidecar) for Docker, Compose, or Kubernetes. Set the sidecar's `MONGODB_CONNECTION_STRING` to the URI used by the setup script, and set `MONGODB_SIDECAR_API_KEY` to a strong secret shared with LiteLLM. The URI and any MongoDB TLS files stay in the sidecar.
+
+For a proxy running on the Docker host, use `http://127.0.0.1:8080` as the Sidecar URL. For Compose, use `http://mongodb-sidecar:8080` on the shared network. Confirm the sidecar's `/health/readiness` endpoint returns HTTP 200 before registering the index.
+
 ## Register the index in the Admin UI
 
 Open **Tools > Vector Stores > Manage Vector Stores > + Add Vector Store**, then enter:
 
 | UI field | Value |
 |---|---|
-| Provider | MongoDB Atlas |
+| Provider | MongoDB (BETA) |
 | Vector Store Name | `MongoDB Demo Policies` |
 | Vector Store ID | `litellm_demo_policy_idx` |
-| Connection String | The same `MONGODB_CONNECTION_STRING` value used for the setup script. |
+| Sidecar URL | The sidecar address reachable from your LiteLLM proxy. |
+| Sidecar API Key | The sidecar's `MONGODB_SIDECAR_API_KEY` value. |
 | Database | `litellm_docs_demo` |
 | Collection | `policies` |
 | Embedding Model | `text-embedding-3-small` |


### PR DESCRIPTION
MongoDB Vector Search now runs through an optional sidecar, keeping the MongoDB driver out of LiteLLM installations. Update the provider guide and worked tutorial with Docker, Compose, and Helm deployment, sidecar credentials, SDK/UI/API configuration, health checks, and troubleshooting

Keep the integration explicitly BETA and include a short `v1.101.0-rc.1` configuration callout. Existing MongoDB data and application search/chat requests stay unchanged. Require HTTPS for remote service connections and use loopback HTTP for colocated processes. Document readiness separately from Pod liveness so a MongoDB outage does not take unrelated LiteLLM traffic out of service

Runtime cutover: https://github.com/BerriAI/litellm/pull/40203

Service: https://github.com/BerriAI/litellm-mongodb

Validation: full Docusaurus production build passes. Both changed files pass structural and writing checks. Real UI registration/search/chat and public sync/async SDK searches have been exercised through the sidecar. Final image publication, anonymous access, and deployment-shape verification are in progress

The runtime PR's environment-variable documentation checks read this repository's default branch, so this documentation must land before those checks can pass
