### PR TITLE
docs: clarify 12-vs-9 task scope in subtask routing post

### DIFF
--- a/blog/subtask_type_routing/index.md
+++ b/blog/subtask_type_routing/index.md
@@ -72,7 +72,7 @@ Exploration goes to a fast, cheap model. Verification, where the model mostly ne
 
 ## Results
 
-We ran mini-SWE-agent on 9 SWE-bench Verified tasks, once against fixed `anthropic/claude-opus-5` and once against the router above, and scored both with the official SWE-bench harness. Costs are the sum of every LLM call as reported by the gateway.
+We ran mini-SWE-agent on 12 SWE-bench Verified tasks, once against fixed `anthropic/claude-opus-5` and once against the router above, and scored both with the official SWE-bench harness. Costs are the sum of every LLM call as reported by the gateway. Fixed Opus only resolved 9 of the 12, so the head-to-head comparison below is restricted to those 9 for a fair fight.
 
 Across the 9 tasks both configurations solved:
 


### PR DESCRIPTION
## Summary
- The results section runs mini-SWE-agent on 12 tasks but fixed Opus only resolved 9 of them, so the head-to-head comparison table is scoped to those 9 while the cost breakdown further down covers all 12 turns/cost. That split wasn't stated, making the two tables look inconsistent.
- Adds one sentence explaining the scope so the numbers read as consistent instead of contradictory.

## Test plan
- [x] Read through the full post to confirm all task-count references (12 run, 9 resolved by fixed Opus, 382 turns across 12) now agree