### PR TITLE
docs(claude_code): distinguish x-api-key BYOK from /login OAuth forwarding

### DIFF
--- a/docs/proxy/forward_client_headers.md
+++ b/docs/proxy/forward_client_headers.md
@@ -112,7 +112,7 @@ general_settings:
   forward_llm_provider_auth_headers: true  # Enable BYOK
 ```
 
-For **Claude Code** with `/login` and your own Anthropic key, see [Claude Code BYOK](../tutorials/claude_code_byok.md). Use `ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: sk-12345"` to pass your LiteLLM key while your Anthropic key (from `/login`) is forwarded as `x-api-key`.
+For **Claude Code**, see [Claude Code BYOK](../tutorials/claude_code_byok.md). Use `ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: sk-12345"` to pass your LiteLLM key. A configured Anthropic API key is sent as `x-api-key` and needs `forward_llm_provider_auth_headers` above to be forwarded; `/login` instead sends an OAuth token as `Authorization: Bearer <token>`, which LiteLLM forwards regardless of this setting.
 
 Client request:
 ```bash

--- a/docs/tutorials/claude_code_byok.md
+++ b/docs/tutorials/claude_code_byok.md
@@ -1,12 +1,12 @@
 # Claude Code with Bring Your Own Key (BYOK)
 
-Use Claude Code with your own Anthropic API key through the LiteLLM proxy. When you use Claude's `/login` with your Anthropic account, your API key is sent as `x-api-key`. With BYOK enabled, LiteLLM forwards your key to Anthropic instead of using proxy-configured keys, so you pay Anthropic directly while still benefiting from LiteLLM's routing, logging, and guardrails.
+Use Claude Code with your own Anthropic credentials through the LiteLLM proxy. Claude Code authenticates to Anthropic one of two ways: `/login` sends an OAuth token as `Authorization: Bearer <token>` (tied to your Claude.ai Free, Pro, Max, or Enterprise seat), while a configured Anthropic API key is sent as `x-api-key`. LiteLLM forwards either credential to Anthropic instead of using proxy-configured keys, so you pay Anthropic directly while still benefiting from LiteLLM's routing, logging, and guardrails.
 
 ## How It Works
 
-1. **Claude Code `/login`** — You sign in with your Anthropic account; Claude Code sends your Anthropic API key as `x-api-key`.
-2. **LiteLLM authentication** — You pass your LiteLLM proxy key via `ANTHROPIC_CUSTOM_HEADERS` so the proxy can authenticate and track your usage.
-3. **Key forwarding** — With `forward_llm_provider_auth_headers: true`, LiteLLM forwards your `x-api-key` to Anthropic, giving it precedence over any proxy-configured keys.
+1. **Claude Code authentication**: with `/login`, Claude Code sends your Anthropic OAuth token as `Authorization: Bearer <token>`; with a configured API key, it sends `x-api-key` instead.
+2. **LiteLLM authentication**: you pass your LiteLLM proxy key via `ANTHROPIC_CUSTOM_HEADERS` (e.g. `x-litellm-api-key`) so the proxy can authenticate and track your usage without touching the Anthropic credential headers above.
+3. **Key forwarding**: LiteLLM forwards the OAuth `Authorization` header to Anthropic automatically. The `x-api-key` path additionally needs `forward_llm_provider_auth_headers: true`, since LiteLLM strips `x-api-key` by default.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Use Claude Code with your own Anthropic API key through the LiteLLM proxy. When 
 
 ## Step 1: Configure LiteLLM Proxy
 
-Enable forwarding of LLM provider auth headers so your Anthropic key takes precedence:
+If you're authenticating with an Anthropic API key rather than `/login`, enable forwarding of LLM provider auth headers so your key takes precedence:
 
 ```yaml title="config.yaml"
 model_list:
@@ -26,12 +26,12 @@ model_list:
       # No api_key needed — client's key will be used
 
 litellm_settings:
-  forward_llm_provider_auth_headers: true  # Required for BYOK
+  forward_llm_provider_auth_headers: true  # Required for the x-api-key path; not needed for /login
 ```
 
 :::info Why `forward_llm_provider_auth_headers`?
 
-By default, LiteLLM strips `x-api-key` from client requests for security. Setting this to `true` allows client-provided provider keys (like your Anthropic key from `/login`) to be forwarded to Anthropic, overriding any proxy-configured keys.
+By default, LiteLLM strips `x-api-key` from client requests for security. Setting this to `true` allows a client-provided Anthropic API key to be forwarded to Anthropic, overriding any proxy-configured key. This setting only governs `x-api-key` and similar provider-key headers; it has no effect on `/login`, which authenticates via an `Authorization: Bearer` OAuth token that LiteLLM forwards regardless of this setting, provided you authenticate to the proxy with a different header (such as `x-litellm-api-key`) rather than `Authorization`.
 
 :::
 
@@ -68,8 +68,9 @@ export ANTHROPIC_BASE_URL="http://localhost:4000"
 # Model name from your config
 export ANTHROPIC_MODEL="{{anthropic}}"
 
-# LiteLLM proxy auth — this is added to every request
-# Use x-litellm-api-key so the proxy authenticates you; your Anthropic key goes via x-api-key from /login
+# LiteLLM proxy auth: this is added to every request
+# Use x-litellm-api-key so the proxy authenticates you; your Anthropic credential goes
+# via Authorization (from /login) or x-api-key (if you configured a key directly)
 export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: sk-12345"
 ```
 
@@ -96,26 +97,29 @@ x-litellm-user-id: my-user-id"
 
 2. Use **`/login`** and sign in with your Anthropic account (or use your API key directly).
 
-3. Claude Code will send:
-   - `x-api-key`: Your Anthropic API key (from `/login`)
-   - `x-litellm-api-key`: Your LiteLLM key (from `ANTHROPIC_CUSTOM_HEADERS`)
+3. Claude Code sends `x-litellm-api-key` (your LiteLLM key, from `ANTHROPIC_CUSTOM_HEADERS`) plus one of the following, depending on how you authenticated in step 2:
+   - `Authorization: Bearer <oauth-token>`, if you used `/login`
+   - `x-api-key`, if you configured an Anthropic API key directly
 
-4. LiteLLM authenticates you via `x-litellm-api-key`, then forwards `x-api-key` to Anthropic. Your Anthropic key takes precedence over any proxy-configured key.
+4. LiteLLM authenticates you via `x-litellm-api-key`. It forwards the OAuth `Authorization` header to Anthropic automatically; forwarding `x-api-key` additionally requires `forward_llm_provider_auth_headers: true`. Either way, your Anthropic credential takes precedence over any proxy-configured key.
 
 ## Summary
 
-| Header | Source | Purpose |
-|--------|--------|---------|
-| `x-api-key` | Claude Code `/login` (Anthropic key) | Sent to Anthropic for API calls |
-| `x-litellm-api-key` | `ANTHROPIC_CUSTOM_HEADERS` | Proxy authentication, tracking, rate limits |
+| Header | Source | Purpose | Needs `forward_llm_provider_auth_headers`? |
+|--------|--------|---------|---------|
+| `Authorization: Bearer <token>` | Claude Code `/login` (OAuth) | Sent to Anthropic for API calls | No, forwarded by default |
+| `x-api-key` | Configured Anthropic API key | Sent to Anthropic for API calls | Yes |
+| `x-litellm-api-key` | `ANTHROPIC_CUSTOM_HEADERS` | Proxy authentication, tracking, rate limits | N/A |
 
 ## Troubleshooting
 
 ### Requests fail with "invalid x-api-key"
 
+This applies to the configured-API-key path, not `/login`.
+
 - Ensure `forward_llm_provider_auth_headers: true` is set in `litellm_settings` (or `general_settings`).
 - Restart the LiteLLM proxy after changing the config.
-- Verify you completed `/login` in Claude Code so your Anthropic key is being sent.
+- Verify your Anthropic API key is configured correctly on the client.
 
 ### Proxy returns 401
 
@@ -123,6 +127,8 @@ x-litellm-user-id: my-user-id"
 - Ensure the LiteLLM key is valid and has access to the model.
 
 ### Proxy key is used instead of my Anthropic key
+
+This applies to the `x-api-key` path; the OAuth `Authorization` header from `/login` is forwarded regardless of this setting.
 
 - Confirm `forward_llm_provider_auth_headers: true` is in your config.
 - The setting can be in `litellm_settings` or `general_settings` depending on your config structure.


### PR DESCRIPTION
Fixes [LIT-6940](https://linear.app/litellm-ai/issue/LIT-6940/docs-claude-code-byok-tutorial-wrongly-says-forward-llm-provider-auth). Both the BYOK tutorial and the Claude Code section of the header-forwarding page claimed that `/login` sends the Anthropic credential as `x-api-key` and that `forward_llm_provider_auth_headers: true` is required for it. Neither is true, and a customer on Pylon #8028 hit the confusion directly.

Claude Code has two credential paths. `/login` produces an Anthropic OAuth token sent as `Authorization: Bearer <token>`, and `clean_headers` in `litellm/proxy/litellm_pre_call_utils.py` preserves that value whenever it matches `is_anthropic_oauth_key()`, gated only on whether `Authorization` was the header used to authenticate to the proxy. A configured Anthropic API key is sent as `x-api-key`, which LiteLLM strips unless `forward_llm_provider_auth_headers` is on. The setting therefore governs the API-key path only.

The tutorial now presents both paths side by side, including a summary-table column for whether each header needs the flag, and the troubleshooting entries say which path they apply to. The header-forwarding page gets the same correction in its Claude Code sentence. One nuance worth noting for review: the OAuth forward holds only when you authenticate to the proxy with a different header such as `x-litellm-api-key`, which the docs now state.

Related follow-up, not touched here: `docs/tutorials/claude_code_max_subscription.md` separately claims `forward_client_headers_to_llm_api: true` is required to forward the OAuth token, and the same code path shows the forward does not depend on that setting either.
