### PR TITLE
docs(mcp): document the scoped-request denial for empty MCP intersections

### DIFF
--- a/docs/mcp_control.md
+++ b/docs/mcp_control.md
@@ -50,7 +50,7 @@ Permissions can be set at six distinct levels. When more than one level applies 
 
 If no level has a list, the request can access **every** MCP server (open by default).
 
-A key bound to an agent (`agent_id` passed to `/key/generate`) gets the same treatment as a request carrying `x-litellm-agent-id`: the agent's list is intersected with the key's on every request the key makes. Granting a server to the key alone is not enough; the agent must also hold the grant (via the Admin UI agent edit form or `PATCH /v1/agents/{agent_id}`), otherwise requests scoped to that server are denied with an error naming the agent.
+A key bound to an agent (`agent_id` passed to `/key/generate`) gets the same treatment as a request carrying `x-litellm-agent-id`: the agent's list is intersected with the key's on every request the key makes. Granting a server to the key alone is not enough; the agent must also hold the grant (via the Admin UI agent edit form or `PATCH /v1/agents/{agent_id}`), otherwise requests scoped to that server are denied with an error naming the agent. See [Denied Scoped Access](#denied-scoped-access) for the exact error and how a scoped denial differs from an unscoped one.
 
 ```mermaid
 flowchart TD
@@ -639,6 +639,20 @@ This configuration in Cursor IDE settings will limit tool access to only the spe
 
 </TabItem>
 </Tabs>
+
+---
+
+### Denied Scoped Access
+
+An unscoped request, one with no `/mcp/<server_or_group>` URL path and no `x-mcp-servers` header, that resolves to an empty set of allowed servers still returns a normal `200` with `tools: []`; the caller simply has no MCP tools available. A scoped request, one that names a server, access group, or comma-separated list through either method above, is held to a stricter rule: if it resolves to zero allowed servers, LiteLLM raises `403` instead of returning an empty tool list, since a silent `200` on a scoped request reads as "this server exists and has no tools" rather than "you cannot reach it."
+
+The `403` body is `{"error": "<message>"}`. A name that matches no registered server at all and a name that matches a real server or access group the caller cannot reach both raise the same generic message, `The key is not allowed to access the requested MCP servers: <names>`, so scoping can never be used to probe whether a server name exists. The one case that gets a more specific message is a key bound to an agent (via `x-litellm-agent-id` or a key-level `agent_id`): if the request would have resolved once the agent's binding is set aside, the error names the agent and the exact server or access group it withholds, for example:
+
+```text
+MCP server 'github' is not available to this key: the key is bound to agent 'agent-123', whose MCP grants do not include this server. Add the server to the agent's object_permission.mcp_servers (edit the agent in the Admin UI or PATCH /v1/agents/agent-123), or use a key that is not bound to the agent.
+```
+
+An access group produces the same message shape, naming the group and `object_permission.mcp_access_groups` instead. If the request would still resolve to nothing with the agent's binding set aside, for instance because the key or team itself denies the server, or the name matches nothing at all, LiteLLM falls back to the generic message.
 
 ### Grouping MCPs (Access Groups)
 


### PR DESCRIPTION
Closes the remaining part of [LIT-6415](https://linear.app/litellm-ai/issue/LIT-6415/docs-document-mcp-permission-intersection-for-agent-bound-keys-and-mcp). The ticket's original ask, that agent-bound keys get the same permission intersection as the `x-litellm-agent-id` header, already shipped in #1110, so this does not restate it. What was still undocumented is what a caller actually sees when the intersection comes out empty.

An unscoped request still returns `200` with `tools: []`. A scoped request, one naming a server or access group through a `/mcp/<name>` path or the `x-mcp-servers` header, now raises `403` instead, because a silent empty list on a scoped request reads as "this server has no tools" rather than "you cannot reach it". A key bound to an agent that withholds the server gets a message naming the agent and how to grant it; everything else gets a generic message.

Note that the ticket's claim that unknown server names "stay silently empty so scoping cannot be used to probe for server existence" is backwards. `raise_denied_scoped_mcp_access` in `litellm/proxy/_experimental/mcp_server/server.py` raises the byte-identical generic 403 for unknown names and for real-but-unauthorized names, and `test_scoped_list_unknown_name_raises_same_generic_403_as_unauthorized` asserts it; that identical response is what prevents probing. The text here follows the code.

Left as a draft for one reason. The behavior is not released yet: PR BerriAI/litellm#39234 is on `litellm_internal_staging` as `26d589cd28` and no tag contains it, with `v1.100.0` and `v1.101.0-rc.1` both predating it. The section is written in the present tense, so it needs a "From v<version>" qualifier in the style this page already uses for `auto_router_routing_compression` before it merges. Happy to add that as soon as the target release is settled.
