### PR TITLE
docs: encrypted reasoning stripping on a model group change

### DIFF
--- a/docs/proxy/load_balancing.md
+++ b/docs/proxy/load_balancing.md
@@ -424,4 +424,6 @@ router_settings:
 
 This ensures requests containing encrypted content are routed to the deployment that created them, while other requests continue to load balance normally.
 
+If a follow-up is routed to a different model group entirely (an auto-router tier change, or a client switching `model` mid-session) and no deployment there shares the originating `(api_base, api_key)`, the encrypted reasoning items are dropped and the visible conversation is forwarded, so the request succeeds on the new group with fresh reasoning.
+
 **[Learn more about Encrypted Content Affinity →](../response_api.md#encrypted-content-affinity-multi-region-load-balancing)**

--- a/docs/response_api.md
+++ b/docs/response_api.md
@@ -1293,6 +1293,8 @@ The `encrypted_content_affinity` pre-call check routes follow-up requests contai
    - If found → decodes `model_id`, pins to originating deployment, bypasses rate limits
    - If no encoded items → normal load balancing
 
+3. **Model group change** (before request): when the follow-up is routed to a different model group than the one that produced the encrypted items, for example an auto-router that classified this turn into another tier, or a client that switched `model` between turns, and no deployment in the new group shares the originating `(api_base, api_key)`, LiteLLM strips the encrypted reasoning items (keeping their readable summary text) and sends the visible conversation to the new group. The new model reasons fresh on that turn instead of the request failing. Reasoning continuity across turns is preserved only while the router keeps the session on the originating group; on an auto-router, `session_affinity` pins the tier for the session if that matters more than per-turn routing
+
 ### Configuration
 
 <Tabs>


### PR DESCRIPTION
## Summary

Documents the router behavior shipped in BerriAI/litellm#40280 (LIT-7195): when a Responses API follow-up that carries encrypted reasoning is routed to a different model group than the one that produced it, and no deployment there shares the originating `(api_base, api_key)`, the encrypted reasoning is stripped and the visible conversation is forwarded so the request succeeds on the new group with fresh reasoning. This covers the auto-router tier-change case, where the earlier behavior was a 503.

Adds a short paragraph to the encrypted-content-affinity section of the Responses API page and a matching note in the load-balancing guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
