### PR TITLE
docs: preserve MongoDB sidecar connectivity across Compose restarts

### DIFF
--- a/docs/providers/mongodb_vector_stores.md
+++ b/docs/providers/mongodb_vector_stores.md
@@ -76,13 +76,31 @@ services:
   mongodb-sidecar:
     image: ghcr.io/berriai/litellm-mongodb:v0.1.0-beta.1
     network_mode: service:litellm
+    depends_on:
+      litellm:
+        condition: service_started
+        restart: true
     environment:
       MONGODB_CONNECTION_STRING: ${MONGODB_CONNECTION_STRING:?required}
       MONGODB_SIDECAR_API_KEY: ${MONGODB_SIDECAR_API_KEY:?required}
     restart: unless-stopped
 ```
 
-Replace `litellm` in `network_mode` with the name of your existing LiteLLM service, and pass `MONGODB_SIDECAR_API_KEY` to that service. Sharing the network namespace lets LiteLLM use `http://127.0.0.1:8080` as `api_base`. No host port is needed for the sidecar in this deployment. For separate network namespaces, expose the sidecar through HTTPS instead.
+Use Docker Compose 2.17 or later. Replace `litellm` in `network_mode` and `depends_on` with the name of your existing LiteLLM service, and pass `MONGODB_SIDECAR_API_KEY` to that service. Sharing the network namespace lets LiteLLM use `http://127.0.0.1:8080` as `api_base`. No host port is needed for the sidecar in this deployment. For separate network namespaces, expose the sidecar through HTTPS instead.
+
+Restart LiteLLM through Compose so the sidecar also restarts and joins its network namespace:
+
+```bash
+docker compose restart litellm
+```
+
+After changing the LiteLLM image or container configuration, recreate both services:
+
+```bash
+docker compose up -d --force-recreate litellm mongodb-sidecar
+```
+
+The dependency's `restart: true` applies to Compose operations; Docker's automatic restart policy and a direct `docker restart` do not restart dependent services. If LiteLLM restarts outside Compose, run `docker compose restart mongodb-sidecar` after LiteLLM starts. Otherwise the sidecar can remain attached to the previous network namespace and MongoDB searches fail. Use a separate HTTPS deployment when the services need independent restart and recovery. See Docker's [dependency restart behavior](https://docs.docker.com/reference/compose-file/services/#depends_on).
 
 </TabItem>
 <TabItem value="helm" label="Kubernetes / Helm">


### PR DESCRIPTION
Restarting the LiteLLM container can leave its MongoDB sidecar attached to the previous network namespace, causing searches to return503. Add an explicit Compose restart dependency and document coordinated restart/recreation commands, including recovery after a restart outside Compose.

Verified against the published BETA image with real MongoDB search: Compose restart and forced container recreation preserve persisted registrations and restore search. Thirteen management lifecycle comparisons match the direct-driver baseline. The docs build, structure check, and writing check pass. This follows the deployment guide merged in#1265; runtime code and the published image are unchanged.
