### PR TITLE
docs(auto-router): per-session savings endpoint and the Claude Code status line

### DIFF
--- a/docs/learn/autorouter_cli.md
+++ b/docs/learn/autorouter_cli.md
@@ -57,3 +57,15 @@ claude
 ```
 
 For the full reference, including recovery from an unclean shutdown and important caveats, see the [autorouter CLI README](https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm/proxy/client/cli/README.md#qa-complexity-based-auto-routing-against-your-real-proxy).
+
+## 6. Watch the Routed Model and Savings in the Status Line
+
+`lite autoroute up` also installs a status line for Claude Code (`~/.litellm/statusline.py`, registered as `statusLine` in `~/.claude/settings.json` unless you already run one). After each turn it names the tier model that actually answered and, once the proxy has recorded the session, what the session cost against the router's savings baseline, the priciest model in the hardest tier:
+
+```
+autorouter · Routed to: claude-haiku-4-5  -80% vs Claude Opus 5
+LiteLLM       █████░░░░░░░░░░░░░░░░░░░ $0.03
+Claude Opus 5 ████████████████████████ $0.15
+```
+
+The wizard's generated router sets `return_raw_model_name: true`, which is what lets the transcript, and so the status line, name the tier model rather than the `autorouter` alias. The cost lines come from [`GET /auto_router/session`](/docs/proxy/auto_routing#per-session-savings), cached for five seconds. `lite autoroute down` restores your previous settings, status line included.

--- a/docs/proxy/auto_routing.md
+++ b/docs/proxy/auto_routing.md
@@ -530,6 +530,32 @@ writes = 0 if warm else cache_creation
 
 :::
 
+## Per-session savings
+
+`GET /auto_router/session?session_id=<id>` returns the reported savings for one session: what its last turn ran on and what the session has cost against the router's baseline. It reads the per-session rollup the spend flush maintains, never the spend logs, and it is scoped to the caller's own key, so any virtual key can ask about its own sessions and gets a 404 for everyone else's. The session id is the one the client sent, for example Claude Code's `x-claude-code-session-id` header or Codex's thread id; see [session tracking](./logging_spec.md).
+
+```bash
+curl "$LITELLM_PROXY_URL/auto_router/session?session_id=cf712ab8-4c7c-4d48-ba91-eed54bc2956b" \
+  -H "Authorization: Bearer sk-..."
+```
+
+```json
+{
+  "session_id": "cf712ab8-4c7c-4d48-ba91-eed54bc2956b",
+  "router_name": "smart-router",
+  "router_type": "complexity",
+  "turns": 3,
+  "last_model": "{{openai_large}}",
+  "spend": 0.14,
+  "saved_spend": 0.08,
+  "baseline_spend": 0.22,
+  "baseline_model": "{{openai_large}}",
+  "baseline_models": {"{{openai_large}}": 3}
+}
+```
+
+`baseline_spend` is `spend` plus `saved_spend`, the estimated single-model cost. `baseline_model` is the baseline those turns were actually priced against, recorded turn by turn on the rollup, so it keeps naming the right counterfactual after the router is reconfigured or removed; `baseline_models` counts the turns priced against each baseline, and more than one entry means the baseline changed mid-session and `baseline_spend` mixes both. `baseline_model` is `null` when no turn recorded a baseline: sessions from before the proxy recorded it, and adaptive or quality routers, which derive no baseline. A session with no flushed auto-routed turn yet is a 404, which is also what an older proxy returns, so a client can treat both the same way. The `lite` CLI's [Claude Code status line and Codex hook](../tutorials/claude_code_autorouter.md#show-the-routed-model-and-savings-in-the-status-line) are built on this endpoint.
+
 ## Alias `litellm_params` on the router
 
 `drop_params`, `cache_control_injection_points`, and any other `litellm_params` set on the auto router deployment itself are merged into the outbound request when the router picks a tier. Values the caller passes explicitly on a request win over the alias defaults.

--- a/docs/proxy/cli_sso.md
+++ b/docs/proxy/cli_sso.md
@@ -197,7 +197,7 @@ The key expires after `LITELLM_CLI_JWT_EXPIRATION_HOURS` (24 hours by default, s
 
 `lite auth print-token` prints the current key to stdout and nothing else (diagnostics go to stderr). It renews the key first when it is about to expire, so a tool that calls it always gets a key that works
 
-Claude Code can run it as its [`apiKeyHelper`](https://code.claude.com/docs/en/settings). `lite login --pkce --config-claude` writes that for you: it sets `env.ANTHROPIC_BASE_URL` to the proxy and `apiKeyHelper` to `lite auth print-token` (with the absolute path to `lite` and the proxy URL) in `~/.claude/settings.json`, and leaves your other settings alone. To do it by hand:
+Claude Code can run it as its [`apiKeyHelper`](https://code.claude.com/docs/en/settings) if you wire that up by hand. Note that Claude Code re-runs the helper on every credential refresh, each run is a full `lite` start, and on macOS that start checks the login keychain, so a machine whose keychain does not resolve gets a "Keychain Not Found" prompt per run. `lite login --pkce --config-claude` writes the login's key into `~/.claude/settings.json` as a static `ANTHROPIC_AUTH_TOKEN` instead (re-run it when the key expires), and `lite configure claude --api-key` does the same with a long-lived virtual key. By hand:
 
 ```json title="~/.claude/settings.json"
 {

--- a/docs/tutorials/claude_code_autorouter.md
+++ b/docs/tutorials/claude_code_autorouter.md
@@ -85,6 +85,26 @@ curl -X POST $LITELLM_PROXY_URL/key/generate \
 
 Model discovery lists whatever the key can reach, and Claude Desktop's **Test connection** then probes `/v1/messages` with one of the discovered models rather than with the one you selected. A broadly scoped key turns that into a connection failure on some unrelated deployment, which reads as a broken router. Scoping the key to `claude-auto` makes discovery return exactly one model and the probe hit the router itself. Wildcard route names are worth checking here too, since a literal `claude-*` entry in `model_list` is published verbatim in `/v1/models` and 404s when a client probes it.
 
+## Show the routed model and savings in the status line
+
+Claude Code's own status line only knows the model name it requested, `claude-auto`. To see the tier that actually answered, and what the session has cost against the router's savings baseline, let the `lite` CLI wire Claude Code up instead of exporting the variables by hand:
+
+```bash
+lite --base-url https://your-litellm-proxy.com configure claude --api-key sk-... --model claude-auto
+```
+
+Besides the proxy URL and key (written as a static `ANTHROPIC_AUTH_TOKEN`; the command needs a long-lived virtual key and refuses a `lite login` credential, which expires within a day), this installs `~/.litellm/statusline.py` and registers it as Claude Code's `statusLine` (unless you already run one). `--model` pins `claude-auto` both as the row Claude Code starts on and as `ANTHROPIC_MODEL`, so `claude -c` and `claude --resume` stay on the router: a resumed session otherwise re-sends the tier model its transcript recorded, which a key scoped to `claude-auto` cannot reach. Each turn then ends with:
+
+```
+claude-auto · Routed to: claude-haiku-4-5  -80% vs Claude Opus 5
+LiteLLM       █████░░░░░░░░░░░░░░░░░░░ $0.03
+Claude Opus 5 ████████████████████████ $0.15
+```
+
+Two things make this work. The routed model is read from Claude Code's transcript, which records the `model` field of each response, so the router needs `return_raw_model_name: true` (see [reading the picked model from the response](../proxy/auto_routing.md#reading-the-picked-model-from-the-response)); without it the line shows `claude-auto`. The cost lines come from [`GET /auto_router/session`](../proxy/auto_routing.md#per-session-savings), which any virtual key may call for its own sessions, and the baseline is the priciest model in the router's hardest tier, the same counterfactual the [reported savings](../proxy/auto_routing.md#reported-savings) use. The spend flush is asynchronous, so the numbers land a second or two after each turn.
+
+`lite codex` registers the same script as a Codex `Stop` hook for that launch, so Codex prints the same block as a system message after every turn. Codex asks once to trust the hook and remembers the answer. `lite unconfigure claude` removes the status line only while it still points at that script.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |


### PR DESCRIPTION
Companion docs for BerriAI/litellm#40330 (LIT-7356: routed model and savings in the Claude Code status line and as a Codex Stop hook).

- `docs/proxy/auto_routing.md`: new "Per-session savings" section documenting `GET /auto_router/session`, its key scoping, the 404 semantics and the response fields
- `docs/tutorials/claude_code_autorouter.md`: new section on getting the routed model and savings into Claude Code's status line through `lite configure claude`, why the router needs `return_raw_model_name`, and the Codex Stop hook
- `docs/learn/autorouter_cli.md`: step 6, what `lite autoroute up` shows in the status line

Merge after BerriAI/litellm#40330 (which is stacked on #40319) lands.