### PR TITLE
docs(completion): describe developer role hoisting on OpenAI-compatible backends

### DIFF
--- a/docs/completion/developer_role.md
+++ b/docs/completion/developer_role.md
@@ -1,0 +1,57 @@
+# Developer Role
+
+OpenAI's `developer` role carries instructions with higher priority than the user's messages. Most providers have no such role, so LiteLLM translates it per backend before the request leaves the gateway. This page describes what each backend receives when a request carries `developer` messages, on `/v1/chat/completions` and on `/v1/responses` requests served through the chat completions bridge (`use_chat_completions_api: true`)
+
+## What each backend receives
+
+| Backend | What happens to `developer` messages |
+|---|---|
+| OpenAI (`api.openai.com`), o-series models (o1, o3, o4-mini) | Passed through unchanged |
+| OpenAI (`api.openai.com`), every other model, GPT-5 included | Each one becomes a `system` message in the same position |
+| Azure OpenAI | Each one becomes a `system` message in the same position |
+| OpenAI-compatible backends (`openai/` with a custom `api_base`, `custom_openai/`, `hosted_vllm/`, `fireworks_ai/`, `deepseek/`, `together_ai/`, `groq/`, `xai/`, `openrouter/`, `mistral/`, `databricks/`, `azure_ai/`, `litellm_proxy/`, and every other provider built on the OpenAI chat format) | Hoisted to the top and folded into one leading `system` message |
+| Providers with their own message format (Anthropic, Bedrock Converse, Gemini, Vertex AI, Ollama) | Untouched. Their own transformations handle `developer` the way they always have |
+
+## Hoisting on OpenAI-compatible backends
+
+Many open-weight chat templates (Qwen3, DeepSeek, and others served by vLLM, Fireworks, or Together) only accept a `system` message at the very beginning of the conversation. A `developer` message that arrives later, for example a per-turn permissions item from Codex CLI or an instruction re-injected after context compaction, used to be translated to a `system` message in place, and those templates answered `400 System message must be at the beginning`
+
+On OpenAI-compatible backends LiteLLM now moves every `developer` message that appears after the first non-instruction message up to the top of the conversation and merges it, together with any leading `system` or `developer` messages, into a single leading `system` message. The request below
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a terse assistant."},
+    {"role": "user", "content": "Remember the word Paris."},
+    {"role": "developer", "content": "Answer with exactly one word."},
+    {"role": "user", "content": "What is the capital of France?"}
+  ]
+}
+```
+
+reaches the backend as
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a terse assistant.\n\nAnswer with exactly one word."},
+    {"role": "user", "content": "Remember the word Paris."},
+    {"role": "user", "content": "What is the capital of France?"}
+  ]
+}
+```
+
+The rules behind that:
+
+- Plain string contents are joined with a blank line between them
+- A member carrying `cache_control` or Anthropic billing metadata is kept as its own text block instead of being joined, so each cache breakpoint stays on its own block. Whenever any member has list content, the merged message uses list content
+- A `developer` message that closes the conversation right after an `assistant` turn (a follow-up instruction with no user message after it) stays where it is, since moving it would change what the model is asked to answer
+- Client-authored `system` messages are never moved. A `system` message placed mid-conversation is forwarded as sent, and a backend with a system-first template rejects it exactly as it would when called directly
+- Consecutive `system` messages anywhere in the conversation are merged into one, in place
+- The hoisted instruction applies from the start of the conversation rather than from the position the client placed it. Send `system` instead of `developer` when a mid-conversation position matters and the backend accepts it
+
+There is no setting to turn the hoist off. It applies to every provider whose chat format is OpenAI's, which is the same set that already had `developer` rewritten to `system` before; only the position changes
+
+## Native Responses API routes
+
+Backends that implement the Responses API themselves receive the client's `input` items with their own translation. Fireworks folds `instructions`, the leading `system` and `developer` items, and every later `developer` item into the top-level `instructions` field, see [Fireworks AI](../providers/fireworks_ai.md). Other native Responses routes forward `developer` items as they arrive; route a system-first model through the chat completions bridge when its Responses API rejects a later `developer` item

--- a/docs/providers/fireworks_ai.md
+++ b/docs/providers/fireworks_ai.md
@@ -284,7 +284,7 @@ curl http://0.0.0.0:4000/v1/responses \
 
 Multi-turn tool calling works the same way it does against Fireworks directly: send back the `function_call_output` items together with the `previous_response_id` Fireworks returned, and Fireworks continues the conversation server-side
 
-`developer` input items are sent to Fireworks as `system` messages, since Fireworks' Responses API has no developer role on models such as kimi-k3 and qwen3.8. A model whose chat template needs the system message first (qwen3.8) still rejects a developer item placed after the first input item, the same way it does when called directly
+`developer` input items are not sent to Fireworks as messages, since Fireworks' Responses API has no developer role on models such as kimi-k3 and qwen3.8. LiteLLM folds the request's `instructions`, the leading `system` and `developer` items, and every later `developer` item into the top-level `instructions` field, so a model whose chat template needs the system message first (qwen3.8) accepts a developer item placed after the first input item. The same request through the chat completions bridge (`use_chat_completions_api: true`) is handled by the [developer role hoist](../completion/developer_role.md)
 
 ## Document Inlining 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1530,6 +1530,7 @@ const learnSidebar = {
             "completion/message_trimming",
             "completion/prompt_caching",
             "completion/prompt_formatting",
+            "completion/developer_role",
           ],
         },
         {


### PR DESCRIPTION
## TLDR

Adds a Developer Role page under Prompts & Context describing what each backend receives when a request carries `developer` messages once BerriAI/litellm#39852 lands: OpenAI and Azure OpenAI translate to `system` in place (o-series passes through), OpenAI-compatible backends hoist later developer messages into one leading `system` message (a closing developer message after an assistant turn stays put, client `system` messages never move, plain strings join with a blank line, `cache_control` and billing metadata keep their own blocks), and providers with their own message format are untouched. The Fireworks page's developer-item note is refreshed for the native Responses route's `instructions` fold from BerriAI/litellm#40268

Merge after BerriAI/litellm#39852 lands, since the hoist section describes that PR's behavior

## Relevant issues

Documents the fix for BerriAI/litellm#26879

## Linear ticket

Resolves LIT-7069

## Checks

`node scripts/check-writing-style.js docs blog release_notes` and `python3 scripts/check-docs.py docs` pass locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact.
> 
> **Overview**
> Adds a **Developer Role** guide under Prompts & Context that documents how LiteLLM maps OpenAI `developer` messages on `/v1/chat/completions` and chat-completions-bridged `/v1/responses`: per-backend behavior in a summary table, detailed **hoisting** rules for OpenAI-compatible providers (merge late `developer` into one leading `system`, with examples and edge cases like trailing post-assistant instructions and `cache_control`), and a short note on native Responses API handling.
> 
> Updates the Fireworks AI docs so native Responses routes describe folding `developer` (and related instruction content) into the top-level `instructions` field instead of sending them as `system` messages, with a cross-link to the new hoist page for the chat completions bridge.
> 
> Registers `completion/developer_role` in the learn sidebar navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50314562e0fa201d05dbc60088c1bcf6f836637b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->