### PR TITLE
chore(compat-matrix): refresh for v1.100.0 + claude-code 2.1.228

### DIFF
--- a/src/data/compatibility-matrix.json
+++ b/src/data/compatibility-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-08-31T06:14:29Z",
-  "litellm_version": "v1.98.0",
+  "generated_at": "2026-09-10T06:46:02Z",
+  "litellm_version": "v1.100.0",
   "claude_code_version": "2.1.228",
   "providers": [
     "anthropic",
@@ -22,7 +22,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -43,7 +44,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -64,7 +66,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -85,7 +88,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -106,7 +110,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -127,7 +132,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -148,7 +154,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -169,7 +176,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -190,7 +198,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -211,7 +220,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -232,7 +242,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -253,7 +264,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s"
         },
         "vertex_ai": {
           "status": "pass"
@@ -295,7 +307,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-haiku-4-5-bedrock-converse] tool_search probe failed: status 500: {\"error\":{\"message\":\"litellm.APIConnectionError: 'NoneType' object has no attribute 'access_key'\\nTraceback (most recent call last):\\n  File \\\"/home/mateo/litellm-cron-worktree/litellm/main.py\\\", line 5782, in completion\\n    response = _complete_bedrock(_dispatch_ctx)\\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/home/mateo/litellm-cron-worktree/litellm/main.py\\\", line 4059, in _com"
         },
         "vertex_ai": {
           "status": "pass"
@@ -316,7 +329,8 @@
           "status": "pass"
         },
         "bedrock_converse": {
-          "status": "pass"
+          "status": "fail",
+          "error": "[claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; api_status=500; text=API Error: 500 litellm.APIConnectionError: 'NoneType' object has no attribute 'access_key'\nTraceback (most recent call last):\n  File \"/home/mateo/litellm-cron-worktree/litellm/main.py\", line 5782, in completion\n    response = _complete_bedrock(_dispatch_ctx)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/mateo/litellm-cron-worktree/litellm/main.py\", line 4059, in _complete_bedrock\n    response = bedrock_converse_chat_completion.completion(\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/mateo/litellm-cron-worktree/litellm/llms/bedrock/chat/converse_handler.py\", line 377, in completion\n    (\"aws_access_key_id\", credentials.access_key),\n                          ^^^^^^^^^^^^^^^^^^^^^^\nAttributeError: 'NoneType' object has no attribute 'access_key'\n. R...(truncated)"
         },
         "vertex_ai": {
           "status": "pass"


### PR DESCRIPTION
Automated daily refresh of the Claude Code compatibility matrix.

> [!WARNING]
> **Auto-merge disabled:** one or more cells regressed green→red versus the
> currently-published matrix. Review the diff before merging.

```
detected 14 green->red regression(s):
  - Basic messaging (non-streaming) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Basic messaging (streaming) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Long context (1M) [bedrock_converse]: pass -> fail ([claude-sonnet-4-6-bedrock-converse] claude CLI failed: exit=1; api_status=500; text=API Error: 500 litellm.APIConnectionError: 'NoneType' object has no attribu)
  - PDF document input [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Prompt caching (1h TTL) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Prompt caching (5m TTL) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Structured outputs [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Thinking [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Extended thinking + tool use [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Tool search (MCP discovery) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] tool_search probe failed: status 500: {"error":{"message":"litellm.APIConnectionError: 'NoneType' object has no attribute 'a)
  - Tool use [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Tool use (streaming / fine-grained) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Vision [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
  - Web search (server tool) [bedrock_converse]: pass -> fail ([claude-haiku-4-5-bedrock-converse] claude CLI timed out after 120.0s)
```

| Field | Value |
| --- | --- |
| litellm_version | `v1.100.0` |
| claude_code_version | `2.1.228` |
| generated_at | `2026-09-10T06:46:02Z` |

## Per-feature results

- **Basic messaging (non-streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Basic messaging (streaming)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (5m TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Vision**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Thinking**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Tool use (streaming / fine-grained)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Extended thinking + tool use**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **PDF document input**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Prompt caching (1h TTL)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Web search (server tool)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Structured outputs**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **count_tokens endpoint**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=pass, vertex_ai=pass, azure=pass
- **Tool search (MCP discovery)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass
- **Long context (1M)**: anthropic=pass, bedrock_invoke=pass, bedrock_converse=fail, vertex_ai=pass, azure=pass

---

Generated by `tests/claude_code/cron_vm/run_daily.sh`. Close without merging if the diff looks wrong; the next cron run will reopen with fresh results.