### PR TITLE
docs(bedrock_mantle): document region precedence, the region-prefixed model form, and GovCloud pricing

### DIFF
--- a/docs/providers/bedrock_mantle.md
+++ b/docs/providers/bedrock_mantle.md
@@ -313,11 +313,15 @@ asyncio.run(main())
 
 The API base URL is `https://bedrock-mantle.{region}.api.aws/v1`. Region is resolved in this order:
 
-1. `BEDROCK_MANTLE_REGION` env var
-2. `AWS_REGION` env var
-3. Default: `us-east-1`
+1. `aws_region_name` on the deployment (or passed as a kwarg)
+2. A region prefix in the model name, e.g. `bedrock_mantle/us-gov-west-1/xai.grok-4.3`
+3. `BEDROCK_MANTLE_REGION` env var
+4. `AWS_REGION_NAME` env var, then `AWS_REGION`
+5. Default: `us-east-1`
 
-**Supported regions:** `us-east-1`, `us-east-2`, `us-west-2`, `eu-west-1`, `eu-west-2`, `eu-central-1`, `eu-south-1`, `eu-north-1`, `ap-northeast-1`, `ap-south-1`, `ap-southeast-3`, `sa-east-1`
+An explicit `api_base` (or `BEDROCK_MANTLE_API_BASE`) replaces the derived URL entirely. The model-name prefix is stripped before the request is sent, so `bedrock_mantle/us-gov-west-1/xai.grok-4.3` calls `xai.grok-4.3` in `us-gov-west-1`; it is recognized for the regions LiteLLM knows for Bedrock, and `aws_region_name` works for every region
+
+**Supported regions:** `us-east-1`, `us-east-2`, `us-west-2`, `eu-west-1`, `eu-west-2`, `eu-central-1`, `eu-south-1`, `eu-north-1`, `ap-northeast-1`, `ap-south-1`, `ap-southeast-3`, `sa-east-1`, and `us-gov-west-1` (AWS GovCloud)
 
 ```python
 import os
@@ -330,6 +334,27 @@ response = completion(
     api_base="https://bedrock-mantle.eu-west-1.api.aws/v1",
 )
 ```
+
+### GovCloud pricing
+
+Cost tracking uses the served region. When the price map has a row for `bedrock_mantle/{region}/{model}` (today the `us-gov-west-1` rows), that row prices the call instead of the commercial one, whether the region came from `aws_region_name` or from the model prefix. Both of these deployments bill `xai.grok-4.3` at the GovCloud rate:
+
+```yaml
+model_list:
+  - model_name: grok-4.3-gov
+    litellm_params:
+      model: bedrock_mantle/xai.grok-4.3
+      aws_region_name: us-gov-west-1
+      aws_access_key_id: os.environ/AWS_GOV_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_GOV_SECRET_ACCESS_KEY
+  - model_name: grok-4.3-gov-prefixed
+    litellm_params:
+      model: bedrock_mantle/us-gov-west-1/xai.grok-4.3
+      aws_access_key_id: os.environ/AWS_GOV_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_GOV_SECRET_ACCESS_KEY
+```
+
+A deployment that sets `base_model` or its own `input_cost_per_token` / `output_cost_per_token` is priced from that row alone; the served region is not applied on top of it
 
 ## Usage with LiteLLM Proxy
 


### PR DESCRIPTION
## TLDR

The Bedrock Mantle page listed a region precedence that the code no longer follows and did not mention the `bedrock_mantle/<region>/<model>` form or GovCloud pricing, both of which land in BerriAI/litellm#39846

Changes on `docs/providers/bedrock_mantle.md`:

- Region precedence now matches the code: `aws_region_name`, then the model-name region prefix, then `BEDROCK_MANTLE_REGION`, `AWS_REGION_NAME`, `AWS_REGION`, and the `us-east-1` default, with an explicit `api_base` replacing the derived URL
- The supported regions list gains `us-gov-west-1`
- A new GovCloud pricing subsection explains that the served region picks the `bedrock_mantle/<region>/<model>` price row, with a config example for both ways of naming the region, and that `base_model` or custom-priced deployments keep their own row

Checked locally with `lint:writing` and `lint:docs` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **Bedrock Mantle** provider docs so they match current behavior from BerriAI/litellm#39846 instead of the old env-only region story.
> 
> **Region Configuration** now documents the full resolution order (`aws_region_name` → region in the model string → `BEDROCK_MANTLE_REGION` → `AWS_REGION_NAME` / `AWS_REGION` → `us-east-1`), that `api_base` / `BEDROCK_MANTLE_API_BASE` overrides the derived URL, and the `bedrock_mantle/<region>/<model>` form (prefix stripped on the wire). **Supported regions** adds `us-gov-west-1`.
> 
> A new **GovCloud pricing** section explains region-aware cost rows (`bedrock_mantle/{region}/{model}`), with proxy `model_list` examples for `aws_region_name` vs prefixed models, and notes that custom `base_model` or per-token costs are not overridden by served region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6e5a529b3ee96d8dc027dc88d93388044d391a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->