### PR TITLE
docs(realtime): document Azure GA vs beta protocol selection and gpt-realtime

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -139,7 +139,7 @@ async with client.realtime.connect(model="azure-gpt-realtime") as connection:
             break
 ```
 
-To pin one protocol regardless of what the client sends, set `realtime_protocol` on the deployment or `LITELLM_AZURE_REALTIME_PROTOCOL` in the proxy's environment. The deployment setting wins over the environment variable, and both win over the client header
+To pin one protocol regardless of what the client sends, set `realtime_protocol` on the deployment or `LITELLM_AZURE_REALTIME_PROTOCOL` in the proxy's environment. The deployment setting wins over the environment variable, and both win over the client header. The realtime health check (`/health` on a `mode: realtime` deployment, and the Admin UI's Test Connect) has no client header to read, so it probes the GA endpoint unless one of those pins the protocol
 
 ```yaml
 model_list:

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -41,6 +41,14 @@ model_list:
       api_key: os.environ/AZURE_SWEDEN_API_KEY
       api_base: os.environ/AZURE_SWEDEN_API_BASE
 
+  - model_name: azure-gpt-realtime
+    litellm_params:
+      model: azure/gpt-realtime
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE
+    model_info:
+      mode: realtime
+
   - model_name: openai-gpt-4o-realtime-audio
     litellm_params:
       model: openai/gpt-4o-realtime-preview-2024-10-01
@@ -108,6 +116,43 @@ ws.on("message", function incoming(message) {
 ws.on("error", function handleError(error) {
     console.error("Error: ", error);
 });
+```
+
+## Azure: GA vs beta realtime protocol
+
+Azure exposes two realtime upstreams. The GA endpoint (`/openai/v1/realtime?model=<deployment>`) speaks the GA event schema (`session.type`, `output_modalities`, nested `audio`), and the older beta endpoint (`/openai/realtime?api-version=2024-10-01-preview&deployment=<deployment>`) speaks the beta schema (`modalities`, `voice`, flat audio formats). Sending a GA-shaped `session.update` to the beta endpoint fails with `Unknown parameter: 'session.type'`
+
+LiteLLM picks the upstream from the client connection. A client that sends the `OpenAI-Beta: realtime=v1` header (the openai SDK's `client.beta.realtime.connect`) is bridged to the beta endpoint. A client without that header (the openai SDK's `client.realtime.connect`, and most voice agent frameworks) is bridged to the GA endpoint. Transcription sessions (`intent=transcription`) always use GA
+
+```python
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(base_url="http://0.0.0.0:4000", api_key="sk-1234")
+
+async with client.realtime.connect(model="azure-gpt-realtime") as connection:
+    await connection.session.update(
+        session={"type": "realtime", "output_modalities": ["audio"], "instructions": "Please assist the user."}
+    )
+    async for event in connection:
+        print(event.type)
+        if event.type == "session.updated":
+            break
+```
+
+To pin one protocol regardless of what the client sends, set `realtime_protocol` on the deployment or `LITELLM_AZURE_REALTIME_PROTOCOL` in the proxy's environment. The deployment setting wins over the environment variable, and both win over the client header
+
+```yaml
+model_list:
+  - model_name: azure-gpt-realtime
+    litellm_params:
+      model: azure/gpt-realtime
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE
+      realtime_protocol: beta # or GA
+```
+
+```bash
+export LITELLM_AZURE_REALTIME_PROTOCOL=beta # or GA
 ```
 
 ## Guardrails


### PR DESCRIPTION
## TLDR

Documents how the proxy picks Azure's GA or beta realtime upstream from the client connection (BerriAI/litellm#40615), the `realtime_protocol` and `LITELLM_AZURE_REALTIME_PROTOCOL` overrides, and adds a `gpt-realtime` Azure deployment example

## Relates to

BerriAI/litellm#40615

## Notes

Merge after BerriAI/litellm#40615 lands so the docs never describe behavior the proxy does not ship yet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **`docs/realtime.md`** to cover Azure realtime GA vs beta routing and a **`azure/gpt-realtime`** deployment example.
> 
> The OpenAI + Azure config tab now includes an **`azure-gpt-realtime`** entry with `mode: realtime`. A new **Azure: GA vs beta realtime protocol** section explains the two upstream URLs and event schemas, how the proxy chooses beta (e.g. `OpenAI-Beta: realtime=v1`) vs GA (e.g. `client.realtime.connect`), and that transcription always uses GA. It documents pinning via **`realtime_protocol`** on the deployment or **`LITELLM_AZURE_REALTIME_PROTOCOL`**, precedence over client headers, and that realtime health checks default to GA without a pin. Includes a Python GA `session.update` example and YAML/env snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03c2fc1592d847e4e099d50de7316f12393ff7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->