### PR TITLE
docs(vertex_batch): note that raw gs:// output ids need a proxy admin key

### DIFF
--- a/docs/providers/vertex_batch.md
+++ b/docs/providers/vertex_batch.md
@@ -216,6 +216,10 @@ Once the batch is completed, retrieve the results using the `output_file_id` fro
 
 **Important:** The `output_file_id` must be URL encoded when used in the request path.
 
+:::warning Proxy admin key required for raw `gs://` ids
+Since v1.90.0, `GET /files/{file_id}/content` only serves a raw `gs://` output id to a proxy admin key (the master key or a key with the `proxy_admin` role). Any other key gets a `403` telling it to use the LiteLLM managed file id. To read batch results with a non-admin key, upload the file with `target_model_names` set (see [managed batches](../proxy/managed_batches)) so the proxy hands back a managed `file-...` id, and pass that id to every later call instead of the `gs://` path
+:::
+
 <Tabs>
 <TabItem value="python" label="Python">
 


### PR DESCRIPTION
## TLDR

Adds a warning to step 5 of the Vertex batch guide: since v1.90.0 a raw `gs://` output id on `GET /files/{file_id}/content` needs a proxy admin key, and other keys get a 403 pointing at the managed `file-...` id they get by uploading with `target_model_names`. Pairs with BerriAI/litellm#40621, which restores the admin-key read; hold the merge until that PR lands so the doc never describes behavior the proxy does not have yet

## Relevant issues

BerriAI/litellm#40621

## Linear ticket

Resolves LIT-7343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Vertex batch guide; no application or proxy code is modified.
> 
> **Overview**
> Adds a **warning** in the Vertex batch guide (step 5, get file content) so readers know how `GET /files/{file_id}/content` behaves **since v1.90.0**.
> 
> The note states that a raw `gs://` `output_file_id` is only readable with a **proxy admin** key (master key or `proxy_admin` role); other keys receive a **403** and must use the LiteLLM managed `file-...` id instead. It points integrators at uploading with `target_model_names` and the [managed batches](../proxy/managed_batches) flow when they cannot use an admin key.
> 
> This is documentation aligned with the proxy behavior restored in the companion code PR; it does not change runtime code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bacfa966d637e0b0e870652d33359761338ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->