### PR TITLE
docs(bedrock_batches): list every Bedrock model the Batch API supports

### DIFF
--- a/docs/providers/bedrock_batches.md
+++ b/docs/providers/bedrock_batches.md
@@ -271,7 +271,39 @@ When a `target_model_names` is specified, the file is written to the S3 bucket c
 
 ### What models are supported?
 
-LiteLLM only supports Bedrock Anthropic Models for Batch API. If you want other bedrock models file an issue [here](https://github.com/BerriAI/litellm/issues/new/choose).
+Any Bedrock model that AWS lists for [batch inference](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference-supported.html) works, as long as LiteLLM can translate the OpenAI-format records in your input file into that model's request body. Today that covers Anthropic Claude models, Amazon Nova models (each record is written in the Converse request shape Nova expects), Amazon Titan Text Embeddings V2 for `/v1/embeddings` records, and the OpenAI-compatible Bedrock models such as `openai.gpt-oss-120b-1:0`, Qwen, and DeepSeek, whose records are passed through as OpenAI-style chat bodies. Chat records can use `/v1/chat/completions`, `/v1/completions`, or `/v1/responses` as their `url`; completions and responses records are converted to chat requests before upload. Titan Text Embeddings V2 is the only embedding model translated today.
+
+Use the model id AWS accepts for batch jobs in your region. Most current models only run batch jobs through a cross-region inference profile, so the id usually carries the `us.` (or `eu.`, `apac.`) prefix, for example `us.amazon.nova-lite-v1:0` rather than `amazon.nova-lite-v1:0`. Bedrock also rejects jobs with fewer than 100 records regardless of the model.
+
+A non-Anthropic batch model is configured the same way as the Claude example above:
+
+```yaml showLineNumbers title="litellm_config.yaml"
+model_list:
+  - model_name: "bedrock-batch-nova"
+    litellm_params:
+      model: bedrock/us.amazon.nova-lite-v1:0
+      s3_bucket_name: litellm-proxy
+      s3_region_name: us-east-1
+      s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_batch_role_arn: arn:aws:iam::123456789012:role/LiteLLMBedrockBatchRole
+    model_info:
+      mode: batch
+  - model_name: "bedrock-batch-titan-embeddings"
+    litellm_params:
+      model: bedrock/amazon.titan-embed-text-v2:0
+      s3_bucket_name: litellm-proxy
+      s3_region_name: us-east-1
+      s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_batch_role_arn: arn:aws:iam::123456789012:role/LiteLLMBedrockBatchRole
+    model_info:
+      mode: batch
+```
+
+Records in the input file then reference the `model_name` (`{"model": "bedrock-batch-nova", ...}`), the upload sets `target_model_names` to that same name, and the batch is created with `endpoint` set to `/v1/chat/completions` for chat models or `/v1/embeddings` for the embeddings model. The IAM role in `aws_batch_role_arn` needs `bedrock:InvokeModel` on every model you run batch jobs with.
+
+If you need a Bedrock model LiteLLM does not translate yet, for example another embedding model, file an issue [here](https://github.com/BerriAI/litellm/issues/new/choose).
 
 ### How do I use a custom KMS encryption key?
 


### PR DESCRIPTION
## TLDR

The Bedrock Batch API FAQ told readers that only Anthropic models work and to file an issue for anything else, while the proxy has been writing Amazon Nova records in the Converse shape since BerriAI/litellm#21656, translating Titan Text Embeddings V2 records for `/v1/embeddings`, and passing the OpenAI-compatible Bedrock models (gpt-oss, Qwen, DeepSeek) through as chat bodies. This rewrites the "What models are supported?" answer in `docs/providers/bedrock_batches.md` to list what works today, adds a config example for Nova Lite and Titan Text Embeddings V2, points at AWS's batch inference model list plus the two rules that trip people up (most models only run batch jobs through a cross-region inference profile id, and Bedrock rejects jobs under 100 records), and keeps the "file an issue" pointer for models LiteLLM does not translate yet

Checked locally with `lint:writing` and `lint:docs` clean

## User Flow

Before: a reader planning a Nova batch job stops at the FAQ, reads that only Anthropic models are supported, and files an issue instead of running the job that already works

1. Open https://docs.litellm.ai/docs/providers/bedrock_batches and scroll to the FAQ "What models are supported?"
2. Read "LiteLLM only supports Bedrock Anthropic Models for Batch API. If you want other bedrock models file an issue here"
3. Click the link, land on https://github.com/BerriAI/litellm/issues/new/choose, and file a feature request for Nova batch support that already exists

After: the same reader sees the supported list, copies the Nova config, uploads the file, and gets 100 completed records back

1. Open https://docs.litellm.ai/docs/providers/bedrock_batches and scroll to the FAQ "What models are supported?"
2. Read that Anthropic Claude, Amazon Nova, Titan Text Embeddings V2 (for `/v1/embeddings` records), and the OpenAI-compatible Bedrock models work, with a config block for `bedrock/us.amazon.nova-lite-v1:0` and `bedrock/amazon.titan-embed-text-v2:0`
3. Copy that block into the proxy config, `POST http://localhost:4000/v1/files` with `purpose=batch` and `target_model_names=bedrock-batch-nova`, then `POST http://localhost:4000/v1/batches` with the returned `input_file_id` and `endpoint: /v1/chat/completions`, and get back a batch object with `status: validating`
4. `GET http://localhost:4000/v1/batches/{batch_id}` reports `status: completed` with `request_counts.completed: 100`, and `GET http://localhost:4000/v1/files/{output_file_id}/content` returns the 100 Nova responses

## Linear ticket

Resolves LIT-7465

## Screenshots / Proof of Fix

Before, the live page at https://docs.litellm.ai/docs/providers/bedrock_batches#what-models-are-supported:

![pr1408-3851e1a2fd-before_faq.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr1408-3851e1a2fd-before_faq.png)

After, the branch served by `npm run start` at http://127.0.0.1:55652/docs/providers/bedrock_batches#what-models-are-supported:

![pr1408-3851e1a2fd-after_faq.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr1408-3851e1a2fd-after_faq.png)

Every model claim in the new answer was then run for real against BerriAI/litellm at `bc77aa05d2` (the current `litellm_internal_staging` tip), booted with `--num_workers 2` on port 33609 with a Postgres database, in AWS account 654278500801, region us-east-1, with real Bedrock batch spend. The proxy config is the one the new FAQ shows, with `openai.gpt-oss-20b-1:0` added as the OpenAI-compatible model:

```yaml
model_list:
  - model_name: bedrock-batch-nova
    litellm_params:
      model: bedrock/us.amazon.nova-lite-v1:0
      aws_profile_name: default
      aws_region_name: us-east-1
      s3_bucket_name: litellm-lit6460-files-qa
      s3_region_name: us-east-1
      aws_batch_role_arn: arn:aws:iam::654278500801:role/litellm-lit6460-batch-svc
    model_info:
      mode: batch
  - model_name: bedrock-batch-gpt-oss
    litellm_params:
      model: bedrock/openai.gpt-oss-20b-1:0
      (same aws_*, s3_* and aws_batch_role_arn fields)
    model_info:
      mode: batch
  - model_name: bedrock-batch-titan-embeddings
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v2:0
      (same aws_*, s3_* and aws_batch_role_arn fields)
    model_info:
      mode: batch
general_settings:
  store_model_in_db: false
```

Input files: 100 chat records each for Nova and gpt-oss, 100 `/v1/embeddings` records for Titan

```
$ head -1 nova_in.jsonl
{"custom_id": "req-0", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "bedrock-batch-nova", "messages": [{"role": "user", "content": "In one sentence, state one fact about the moon (#0)."}], "max_tokens": 60, "temperature": 0.2}}
$ head -1 titan_in.jsonl
{"custom_id": "emb-0", "method": "POST", "url": "/v1/embeddings", "body": {"model": "bedrock-batch-titan-embeddings", "input": "One fact about the moon (#0)", "dimensions": 256}}
```

Upload and create, one block per model (`$KEY` is the proxy master key):

```
$ curl -s http://127.0.0.1:33609/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=bedrock-batch-nova -F file=@nova_in.jsonl | jq -c '{id: .id[:40], filename, purpose, status}'
{"id":"bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3Rl","filename":"litellm-bedrock-files-us.amazon.nova-lite-v1-0-73e45c12-498c-4537-b6bb-26e60745e1db.jsonl","purpose":"batch","status":"uploaded"}
$ curl -s http://127.0.0.1:33609/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"input_file_id": "<file id above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}' | jq -c '{object, endpoint, status}'
{"object":"batch","endpoint":"/v1/chat/completions","status":"validating"}
```

```
$ curl -s http://127.0.0.1:33609/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=bedrock-batch-gpt-oss -F file=@gptoss_in.jsonl | jq -c '{filename, status}'
{"filename":"litellm-bedrock-files-openai.gpt-oss-20b-1-0-5169c4a0-03a8-4118-9621-0704c3c8b06a.jsonl","status":"uploaded"}
$ curl -s http://127.0.0.1:33609/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"input_file_id": "<file id above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}' | jq -c '{object, endpoint, status}'
{"object":"batch","endpoint":"/v1/chat/completions","status":"validating"}
```

```
$ curl -s http://127.0.0.1:33609/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=bedrock-batch-titan-embeddings -F file=@titan_in.jsonl | jq -c '{filename, status}'
{"filename":"litellm-bedrock-files-amazon.titan-embed-text-v2-0-85a31a8a-0f90-4a93-aea2-08fc2c540d29.jsonl","status":"uploaded"}
$ curl -s http://127.0.0.1:33609/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"input_file_id": "<file id above>", "endpoint": "/v1/embeddings", "completion_window": "24h"}' | jq -c '{object, endpoint, status}'
{"object":"batch","endpoint":"/v1/embeddings","status":"validating"}
```

What landed in the S3 bucket is the per-model request shape the FAQ describes (the Converse shape for Nova, an OpenAI chat body for gpt-oss, the Titan v2 `inputText` body for embeddings):

```
$ aws s3 cp s3://litellm-lit6460-files-qa/litellm-bedrock-files-us.amazon.nova-lite-v1-0-73e45c12-498c-4537-b6bb-26e60745e1db.jsonl - | head -1
{"recordId": "req-0", "modelInput": {"messages": [{"role": "user", "content": [{"text": "In one sentence, state one fact about the moon (#0)."}]}], "inferenceConfig": {"maxTokens": 60, "temperature": 0.2}}}
$ aws s3 cp s3://litellm-lit6460-files-qa/litellm-bedrock-files-openai.gpt-oss-20b-1-0-5169c4a0-03a8-4118-9621-0704c3c8b06a.jsonl - | head -1
{"recordId": "req-0", "modelInput": {"messages": [{"role": "user", "content": "In one sentence, state one fact about the moon (#0)."}], "max_tokens": 60, "temperature": 0.2}}
$ aws s3 cp s3://litellm-lit6460-files-qa/litellm-bedrock-files-amazon.titan-embed-text-v2-0-85a31a8a-0f90-4a93-aea2-08fc2c540d29.jsonl - | head -1
{"recordId": "emb-0", "modelInput": {"inputText": "One fact about the moon (#0)", "dimensions": 256}}
```

Bedrock ran the jobs (`model-invocation-job/fczi7ev9z03g` for gpt-oss, `tatuj443pzzx` for Titan, `vr7xbw5d52vx` for Nova) and the proxy reports them complete with 100 of 100 records:

```
$ curl -s http://127.0.0.1:33609/v1/batches/$GPTOSS_BATCH -H "Authorization: Bearer $KEY" | jq -c '{status, request_counts}'
{"status":"completed","request_counts":{"completed":100,"failed":0,"total":100}}
$ curl -s http://127.0.0.1:33609/v1/files/$GPTOSS_OUTPUT_FILE/content -H "Authorization: Bearer $KEY" -H "custom-llm-provider: bedrock" | wc -l
     100
$ curl -s http://127.0.0.1:33609/v1/files/$GPTOSS_OUTPUT_FILE/content -H "Authorization: Bearer $KEY" -H "custom-llm-provider: bedrock" | grep '"recordId":"req-0"' | cut -c1-700
{"modelInput":{"messages":[{"role":"user","content":"In one sentence, state one fact about the moon (#0)."}],"max_tokens":60,"temperature":0.2},"modelOutput":{"choices":[{"finish_reason":"length","index":0,"logprobs":null,"message":{"content":"<reasoning>The user: \"In one sentence, state one fact about the moon (#0).\" They want a fact about the moon. They want one sentence. The #0 might indicate a reference to a fact list? But they just want a fact. So respond with a sentence: \"The</reasoning>","refusal":null,"role":"assistant"}}],"created":1789076699,"id":"chatcmpl-01582fe2-b947-4dc5-8dd9-801cddbf9e81","model":"arn:aws:bedrock:us-east-1::foundation-model/openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"flex","usage":{"completion_tokens":60,"prompt_tokens":80,...}},"recordId":"req-0"}
```

```
$ curl -s http://127.0.0.1:33609/v1/batches/$TITAN_BATCH -H "Authorization: Bearer $KEY" | jq -c '{status, request_counts}'
{"status":"completed","request_counts":{"completed":100,"failed":0,"total":100}}
$ curl -s http://127.0.0.1:33609/v1/files/$TITAN_OUTPUT_FILE/content -H "Authorization: Bearer $KEY" -H "custom-llm-provider: bedrock" | wc -l
     100
$ curl -s http://127.0.0.1:33609/v1/files/$TITAN_OUTPUT_FILE/content -H "Authorization: Bearer $KEY" -H "custom-llm-provider: bedrock" | head -1 | jq -c '{modelInput, dims: (.modelOutput.embedding | length), first3: .modelOutput.embedding[:3], recordId}'
{"modelInput":{"inputText":"One fact about the moon (#0)","dimensions":256},"dims":256,"first3":[-0.008066956885159016,0.03650752454996109,0.07706110924482346],"recordId":"emb-0"}
```

The Nova job is still queued on the Bedrock side (`Submitted` since 21:35Z and still `Submitted` at 22:35Z, so the proxy keeps answering `validating`); its retrieve and output will be added here once it completes. The same account completed a `us.amazon.nova-lite-v1:0` batch job through this code path on 2026-09-01 (Bedrock job `vzu8tysl94ra`, 8 minutes end to end), which backs the Nova line in the FAQ beyond the accepted job and the Converse-shaped record above

Proof gaps, both low: the Nova output leg is pending on Bedrock's queue as described above, and Qwen and DeepSeek are named in the FAQ from AWS's batch inference model list and the shared passthrough code path rather than a live run here, since only gpt-oss was run for that group

Caveats seen along the way, none caused by this PR:

- `GET /v1/batches/{id}` for the Titan job answers `endpoint: /v1/chat/completions` even though it was created with `/v1/embeddings`; the retrieve path fills the field with a constant. Left alone here, tracked in LIT-7516
- gpt-oss spends its `max_tokens` on `<reasoning>` text at 60 tokens, so those records finish with `length`; a real run would set a higher budget. Left alone
- A `POST /v1/batches` that fails after Bedrock accepted the job (here a 500 from a stale Prisma client in the QA rig) leaves a running, billed job with no LiteLLM batch id: two extra jobs completed this way. Left alone, tracked in LIT-7521
- Batch output records are Bedrock's raw `modelInput`/`modelOutput` lines rather than OpenAI batch output objects, which is the documented behavior of the Bedrock backend today. Left alone

- [x] 3851e1a2fde9557e71e1ef1f3e63cec6c19052af passes /live-pr-risk
