### PR TITLE
docs(access_control): mark organization endpoints as enterprise-gated

### DIFF
--- a/docs/proxy/access_control.md
+++ b/docs/proxy/access_control.md
@@ -354,9 +354,13 @@ Here's the quick version:
 | Create organizations | ❌ | ❌ |
 | View all platform spend | ❌ | ❌ |
 
-## Onboarding Organizations 
+## Onboarding Organizations
 
-✨ **This is a Premium Feature**
+<EnterpriseFeature feature="Organization management">
+
+On a proxy without `LITELLM_LICENSE`, every `/organization/*` endpoint and `PATCH /v2/organization/{organization_id}` return a 403, including read-only calls such as `/organization/list` and `/organization/info`. Existing organizations stay in the database and their budgets keep applying to requests. Setting `LITELLM_LICENSE` restores access with no migration; see [how to set up and verify an Enterprise license](/docs/enterprise#how-do-i-set-up-and-verify-an-enterprise-license).
+
+</EnterpriseFeature>
 
 ### 1. Creating a new Organization
 


### PR DESCRIPTION
BerriAI/litellm#40613 gates every `/organization/*` route and `PATCH /v2/organization/{organization_id}` on an Enterprise license, so an unlicensed proxy returns 403 on them, reads included. The Onboarding Organizations section of the RBAC page walks through `/organization/new` with only a one-line Premium note, which does not tell a self-hosted user the API will refuse the call.

This swaps that line for the standard `<EnterpriseFeature>` banner, states that reads are gated and that existing organizations and their budgets are kept, and links the license setup FAQ.

Hold the merge until BerriAI/litellm#40613 merges.
