### PR TITLE
docs: remove upcoming routing item from main features

### DIFF
--- a/docs/auto_router/index.md
+++ b/docs/auto_router/index.md
@@ -27,7 +27,6 @@ Already testing it? Share your results in [discussion #32168](https://github.com
 - **Three classifiers.** Sub-millisecond heuristic scorer, a small LLM, or keyword rules.
 - **Savings reported per request.** Against an all-frontier baseline, in the logs and in Cost Optimization.
 - **Agent-safe.** Prompt caching, context-window escalation, modality routing, mid-task stall escalation, and optional session pinning.
-- **Harness-aware classification.** Recognize Claude Code and Codex request formats, preserve delegated tasks, and inspect what the classifier received. [Coming in the next release](/docs/auto_router/feature_history#coming-in-next-release)
 
 ## Results
 


### PR DESCRIPTION
Removes the upcoming harness-aware classification bullet from the Auto Router overview's main features list. The update remains under Coming in Next Release in Feature History

The changed page passes strict writing and structural checks, and the diff contains one deleted line
