### PR TITLE
docs: add New Relic to observability integrations index

### DIFF
--- a/docs/integrations/observability_index.md
+++ b/docs/integrations/observability_index.md
@@ -25,6 +25,7 @@ items={[
   { icon: "🏋️", title: "Weights & Biases", description: "ML experiment tracking.", to: "/docs/observability/wandb_integration" },
   { icon: "📉", title: "PostHog", description: "Product analytics.", to: "/docs/observability/posthog_integration" },
   { icon: "🔭", title: "Splunk Observability Cloud", description: "OTLP traces to Splunk.", to: "/docs/observability/splunk_observability_cloud" },
+  { icon: "🔴", title: "New Relic", description: "Application Performance Monitoring and AI Monitoring.", to: "/docs/observability/newrelic" },
 ]}
 />
 


### PR DESCRIPTION
## Why

The observability overview card grid at `docs/integrations/observability_index.md` lists vendors for observability integration, but was missing New Relic. LiteLLM already ships a New Relic integration and has complete documentation at `docs/observability/newrelic.md`.

## Scope

Added one card for New Relic to the observability integrations grid that matches the existing card format:
- Icon emoji: 🔴
- Title: New Relic
- Description: Application Performance Monitoring and AI Monitoring.
- Path: /docs/observability/newrelic

## Verification

The referenced documentation page returns HTTP 200: https://docs.litellm.ai/docs/observability/newrelic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw