### PR TITLE
docs: document the allow_litellm_changed_by_header opt-in for audit log attribution

### DIFF
--- a/docs/proxy/multiple_admins.md
+++ b/docs/proxy/multiple_admins.md
@@ -122,20 +122,40 @@ litellm_settings:
 
 ### Attribute Management changes to Users
 
-Call management endpoints on behalf of a user. (Useful when connecting proxy to your development platform).
+Call management endpoints on behalf of a user, and have the audit log attribute the change to them instead of to the calling key's `user_id`. (Useful when connecting proxy to your development platform).
 
-## 1. Set `LiteLLM-Changed-By` in request headers
+:::warning Opt in required since v1.84.0
+
+Before v1.84.0 the `LiteLLM-Changed-By` header was honored unconditionally, which let any caller rewrite audit attribution. Since v1.84.0 the proxy ignores the header unless the calling key, or its team, has `allow_litellm_changed_by_header: true` in its metadata; without the opt in, `changed_by` falls back to the calling key's `user_id`. The master key cannot opt in because it has no stored metadata, so send the header with an admin virtual key
+
+:::
+
+#### 1. Allow your admin key to set the header
+
+Set `allow_litellm_changed_by_header: true` in the metadata of the admin virtual key that will send the header. Setting it on the key's team metadata instead opts in every key on that team
+
+```shell
+curl -X POST 'http://0.0.0.0:4000/key/update' \
+    -H 'Authorization: Bearer sk-1234' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "key": "sk-my-admin-key",
+        "metadata": {"allow_litellm_changed_by_header": true}
+    }'
+```
+
+#### 2. Set `LiteLLM-Changed-By` in request headers
 
 Set the 'user_id' in request headers, when calling a management endpoint. [View Full List](https://litellm-api.up.railway.app/#/team%20management).
 
-- Update Team budget with master key. 
+- Update Team budget with the opted-in admin key. 
 - Attribute change to 'krrish@berri.ai'. 
 
-**👉 Key change:** Passing `-H 'LiteLLM-Changed-By: krrish@berri.ai'`
+**Key change:** Passing `-H 'LiteLLM-Changed-By: krrish@berri.ai'`
 
 ```shell
 curl -X POST 'http://0.0.0.0:4000/team/update' \
-    -H 'Authorization: Bearer sk-1234' \
+    -H 'Authorization: Bearer sk-my-admin-key' \
     -H 'LiteLLM-Changed-By: krrish@berri.ai' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -144,7 +164,7 @@ curl -X POST 'http://0.0.0.0:4000/team/update' \
     }'
 ```
 
-## 2. Emitted Audit Log 
+#### 3. Emitted Audit Log 
 
 ```bash
 {
@@ -179,7 +199,7 @@ curl -X POST 'http://0.0.0.0:4000/team/update' \
 
 ### `changed_by`
 - **Type:** `String`
-- **Description:** The `user_id` that performed the audited action. If `LiteLLM-Changed-By` Header is passed then `changed_by=<value passed for LiteLLM-Changed-By header>`
+- **Description:** The `user_id` that performed the audited action. If the `LiteLLM-Changed-By` header is passed and the calling key or its team has `allow_litellm_changed_by_header: true` in its metadata, then `changed_by=<value passed for LiteLLM-Changed-By header>`
 
 ### `changed_by_api_key`
 - **Type:** `String`

--- a/release_notes/v1.84.0/index.md
+++ b/release_notes/v1.84.0/index.md
@@ -180,6 +180,17 @@ This release tightens a number of defaults across auth, ingress, callbacks, MCP,
   )
   ```
 
+#### `LiteLLM-Changed-By` audit attribution requires opt-in
+- **What changed:** Audit logs only honor the `LiteLLM-Changed-By` header when the calling key (or its team) carries `allow_litellm_changed_by_header: true` in its metadata. Without the opt-in, `changed_by` falls back to the calling key's `user_id`. Previously the header was honored unconditionally, which let any caller rewrite audit attribution.
+- **Who is affected:** Platforms that call management endpoints on behalf of users and rely on the header for the audit trail's Changed By value. The master key cannot opt in (it has no stored metadata); send the header with an admin virtual key instead.
+- **Restore prior behavior:** Set the opt-in on the key that sends the header (or on its team):
+  ```shell
+  curl -X POST 'http://0.0.0.0:4000/key/update' \
+      -H 'Authorization: Bearer sk-1234' \
+      -H 'Content-Type: application/json' \
+      -d '{"key": "<admin key that sends the header>", "metadata": {"allow_litellm_changed_by_header": true}}'
+  ```
+
 #### Error responses no longer leak re-raised local parameters
 - **What changed:** Broad `except` handlers in the response-utils path used to render the captured request parameters into the re-raised error message. Those parameters can carry credentials, so they're now dropped from the rendered message.
 - **Who is affected:** Any client that parsed credential-shaped fields out of a 5xx error body. The error response shape is otherwise unchanged.


### PR DESCRIPTION
Since v1.84.0 the proxy only honors the `LiteLLM-Changed-By` header when the calling key or its team has `allow_litellm_changed_by_header: true` in its metadata (BerriAI/litellm commits 842eea0131, 119c70b576, f48dfdbdd9). The gate exists because the header previously let any caller rewrite audit attribution, but it shipped undocumented: `docs/proxy/multiple_admins.md` still said the header always wins, and its example sends the header with the master key, which can never opt in because the master key carries no stored metadata. This surfaced as a customer report of the header being ignored on v1.99.1

This PR rewrites the "Attribute Management changes to Users" section with the opt-in requirement, a `/key/update` step that sets the metadata, and a warning that the master key cannot opt in, and it updates the `changed_by` field description in the API spec section to match. It also adds an entry to the v1.84.0 release notes under Important Behavior Changes, following that file's existing entry format (what changed, who is affected, how to restore prior behavior) since the release already documents its behavior changes in that section

Resolves LIT-7539
