### PR TITLE
docs: document complexity router response headers

### DIFF
--- a/docs/proxy/response_headers.md
+++ b/docs/proxy/response_headers.md
@@ -86,6 +86,19 @@ model_list:
 
 For a request to an [auto router](./auto_routing.md), the body `model` is the router alias the client called and the headers above still name the deployment that answered. Clients that cannot read response headers, including streaming consumers, can set `return_raw_model_name` on the router to get the picked tier in the body `model` field instead; see [reading the picked model from the response](./auto_routing.md#reading-the-picked-model-from-the-response).
 
+Complexity auto routers also return the recorded routing decision as response headers:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `x-litellm-complexity-router-tier` | string | Selected complexity tier |
+| `x-litellm-complexity-router-cause` | string | Routing mechanism that selected the tier, such as `heuristic_scorer`, `heuristic_v2`, `llm_classifier`, or a keyword rule |
+| `x-litellm-complexity-router-score` | float | Recorded heuristic score |
+| `x-litellm-complexity-router-reasoning-effort` | string | `reasoning_effort` configured on the selected tier |
+
+Each header appears only when its value is present in the recorded routing decision for the successful attempt. The score is absent on routes that do not record one, including keyword and LLM-classifier decisions. The reasoning-effort header reports the selected tier's configured override; it does not report the model's default effort or the classifier model's reasoning effort. Invalid or non-ASCII text values are omitted. Raw heuristic signals, matched keywords, and the complete tier parameter map are not exposed
+
+These headers are available on streaming and non-streaming requests to `/v1/chat/completions`, `/v1/responses`, and `/v1/messages`. They are absent after a fallback to a plain model group. HTTP headers cannot change after a stream commits
+
 ### More examples (illustrative)
 
 | Header | Example | Meaning |


### PR DESCRIPTION
## Summary

Documents the built-in complexity router response headers for the selected tier, routing cause, heuristic score, and configured tier reasoning effort. It also records omission and streaming fallback behavior.

Gateway implementation: https://github.com/BerriAI/litellm/tree/litellm_routing_response_headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)