### PR TITLE
analytics: send docs pageviews to the canonical litellm.ai GA4 property

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -313,7 +313,13 @@ const config = {
         gtag:
           process.env.NODE_ENV === 'production'
             ? {
-                trackingID: 'G-K7K215ZVNC',
+                // Two GA4 destinations. G-K7K215ZVNC is the docs property and
+                // stays first: plugin-google-gtag uses trackingID[0] for the
+                // gtag.js loader URL and emits one gtag('config', ...) per id.
+                // G-G3LG9H6J6B is the canonical litellm.ai property, also on the
+                // Webflow marketing site, so a visitor moving between
+                // www.litellm.ai and docs.litellm.ai stays in one session.
+                trackingID: ['G-K7K215ZVNC', 'G-G3LG9H6J6B'],
                 anonymizeIP: true,
               }
             : undefined,


### PR DESCRIPTION
## What

Adds `G-G3LG9H6J6B` as a second GA4 destination alongside the existing docs property `G-K7K215ZVNC`.

## Why

`docs.litellm.ai` is a subdomain of `litellm.ai`, and most CTAs on the marketing site point at the docs quickstart — but the two sites reported into separate GA4 properties, so that journey (`www.litellm.ai` → docs quickstart) was unattributable. A visitor looked like a bounce on the marketing site and an unattributed direct arrival on docs.

With the same measurement ID on both, sessions stitch across the subdomains. No cross-domain configuration is needed: gtag's default cookie domain is the registrable domain (`litellm.ai`), so the `_ga` cookie is already shared.

## Behaviour

`@docusaurus/plugin-google-gtag` normalises `trackingID` to an array and, per its 3.8.1 source:

- loads a **single** `gtag/js` loader using `trackingID[0]` — `G-K7K215ZVNC` stays first, so the loader URL is byte-identical to today's;
- emits one `gtag('config', …)` per ID;
- fires `gtag('event', 'page_view')` on SPA route changes with no `send_to`, so client-side navigations reach both destinations.

The docs property keeps collecting exactly as before; nothing about its history changes.

## Verifying

CI here runs the writing-style and structure checks but doesn't build the site, so the Vercel preview is the real check. On the preview, page source should contain both IDs, and the network tab should show two `/g/collect` requests — one per `tid`.

Note previews build with `NODE_ENV=production`, so the gtag plugin is active in them (as it already is today).
