### PR TITLE
docs(proxy): document the unified custom_key_policy key hook

### DIFF
--- a/docs/proxy/config_settings.md
+++ b/docs/proxy/config_settings.md
@@ -330,6 +330,7 @@ router_settings:
 | alerting_args | dict | Args for Slack Alerting [Doc on Slack Alerting](./alerting.md) |
 | custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom-keygenerate) |
 | custom_key_update | str | Custom function for key updates. Required if `custom_key_generate` policies should also apply to key edits [Doc on custom key update](./virtual_keys.md#custom-keyupdate) |
+| custom_key_policy | str | Custom function that runs on every key operation (generate, update, regenerate) with the operation and the effective key state [Doc on custom key policy](./virtual_keys.md#custom-key-policy-one-hook-for-every-key-operation) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |
 | embedding_model | str | The default model to use for embeddings - ignores model set in request |
 | alert_to_webhook_url | Dict[str] | [Specify a webhook url for each alert type.](./alerting.md#map-slack-channels-to-alert-type) |

--- a/docs/proxy/virtual_keys.md
+++ b/docs/proxy/virtual_keys.md
@@ -538,13 +538,13 @@ general_settings:
 
 :::warning
 
-`custom_key_generate` only runs on `/key/generate`. Key edits (`/key/update`, `/key/bulk_update`, `/team/key/bulk_update`, and editing a key in the Admin UI, which calls `/key/update`) skip it, so a user can create a compliant key and then edit it out of compliance, e.g. remove its expiration date. Set [`custom_key_update`](#custom-keyupdate) as well if your policy should also hold on edits.
+`custom_key_generate` only runs on `/key/generate`. Key edits (`/key/update`, `/key/bulk_update`, `/team/key/bulk_update`, and editing a key in the Admin UI, which calls `/key/update`) skip it, so a user can create a compliant key and then edit it out of compliance, e.g. remove its expiration date. Set [`custom_key_update`](#custom-keyupdate) as well if your policy should also hold on edits, or use [`custom_key_policy`](#custom-key-policy-one-hook-for-every-key-operation), the recommended single hook that runs on every key operation, regenerate included.
 
 :::
 
 ### Custom /key/update
 
-If you enforce a policy with `custom_key_generate`, set `custom_key_update` to keep enforcing it when keys are edited. It runs on `/key/update`, `/key/bulk_update`, and `/team/key/bulk_update`. The Admin UI edit key flow calls `/key/update`, so this also covers edits made from the UI.
+If you enforce a policy with `custom_key_generate`, set `custom_key_update` to keep enforcing it when keys are edited. It runs on `/key/update`, `/key/bulk_update`, and `/team/key/bulk_update`. The Admin UI edit key flow calls `/key/update`, so this also covers edits made from the UI. For one hook that covers generate, update, and regenerate against the merged key state, see [`custom_key_policy`](#custom-key-policy-one-hook-for-every-key-operation).
 
 #### 1. Write a custom `custom_update_key_fn`
 
@@ -582,6 +582,52 @@ async def custom_update_key_fn(data: UpdateKeyRequest) -> dict:
 general_settings:
   custom_key_generate: custom_auth.custom_generate_key_fn
   custom_key_update: custom_auth.custom_update_key_fn
+```
+
+### Custom key policy (one hook for every key operation)
+
+`custom_key_generate` and `custom_key_update` each see only the raw request of their own endpoint, so a rule like "every key expires within seven days" has to be written twice, and neither hook sees the key it is changing or the absolute expiry a relative `duration` turns into. `custom_key_policy` is one hook that runs on every key operation and receives the operation plus the effective key state: the existing key merged with the requested changes, with a relative `duration` already turned into an absolute `expires`. Write the rule once and it holds whichever endpoint or Admin UI action changes the key.
+
+#### 1. Write a custom `custom_key_policy_fn`
+
+The input is a single parameter, `policy_request`. `policy_request.operation` is one of `"generate"`, `"update"`, or `"regenerate"`. `policy_request.existing_key` is the key row as stored today, `None` on generate. `policy_request.effective_key` is the row as it will be written after the operation: existing values overlaid with the requested changes, `duration` turned into `expires`, `budget_duration` into `budget_reset_at`, `organization_id` into `org_id`, and metadata-style request fields such as `tags` and `guardrails` folded into `metadata`. `policy_request.request` is the request body as received, the same object the legacy hooks get, for a rule that wants the relative duration string.
+
+The output contract is the same as `custom_generate_key_fn`: return `{"decision": True}` to allow the operation, or `{"decision": False, "message": "..."}` to deny it. Denied operations fail with a `403` carrying the message.
+
+This policy caps every key at seven days from now. `effective_key.expires` is an absolute UTC datetime, or `None` for a key that never expires, so the same check holds for a fresh key, an edit that extends `duration`, and a regenerate.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+MAX_KEY_LIFETIME = timedelta(days=7)
+
+
+async def custom_key_policy_fn(policy_request) -> dict:
+    expires = policy_request.effective_key.expires
+    if expires is None or expires > datetime.now(timezone.utc) + MAX_KEY_LIFETIME:
+        return {
+            "decision": False,
+            "message": f"This violates LiteLLM Proxy Rules. Keys must expire within {MAX_KEY_LIFETIME.days} days.",
+        }
+    return {"decision": True}
+```
+
+#### 2. Pass the filepath (relative to the config.yaml)
+
+```yaml
+general_settings:
+  custom_key_policy: custom_auth.custom_key_policy_fn
+```
+
+The hook runs on `/key/generate`, `/key/service-account/generate`, `/key/update`, `/key/bulk_update`, `/team/key/bulk_update`, and `/key/{key}/regenerate`, which covers the Admin UI create, edit, and regenerate key flows. It runs after the request is validated and, on generate, after `default_key_generate_params` and `upperbound_key_generate_params` are applied, right before the key is written, so `effective_key` is what the database would hold if the policy allows the operation.
+
+`custom_key_generate` and `custom_key_update` keep working unchanged. When they are configured alongside `custom_key_policy`, they run first on the raw request and each can deny on its own; the policy then runs on the effective key state. All three can be set at once:
+
+```yaml
+general_settings:
+  custom_key_generate: custom_auth.custom_generate_key_fn
+  custom_key_update: custom_auth.custom_update_key_fn
+  custom_key_policy: custom_auth.custom_key_policy_fn
 ```
 
 ### Upperbound /key/generate params


### PR DESCRIPTION
## TLDR

Documents the new `general_settings.custom_key_policy` hook for proxy virtual keys: one policy function that runs on every key operation (`/key/generate`, `/key/service-account/generate`, `/key/update`, `/key/bulk_update`, `/team/key/bulk_update`, and `/key/{key}/regenerate`, so every Admin UI create, edit, and regenerate flow) and receives the operation plus the effective key state, meaning the existing key merged with the requested changes with a relative `duration` already turned into an absolute `expires`. The new section in the virtual keys page explains the `policy_request` contract (`operation`, `existing_key`, `effective_key`, `request`), the `{"decision", "message"}` return shape and its `403`, where in the request path the hook runs, and that the legacy `custom_key_generate` and `custom_key_update` hooks keep working unchanged and run first when also configured, with a worked example that caps every key at seven days. The two legacy sections now point at it as the recommended single hook, and the config settings table gains a `custom_key_policy` row. It pairs with the litellm code PR on branch `litellm_unified_key_policy_hook`; the code PR is being opened separately, and this docs PR merges after it lands

## Linear ticket

Resolves LIT-7524

## Preview

`docs/proxy/virtual_keys.md` gains the "Custom key policy (one hook for every key operation)" section between "Custom /key/update" and "Upperbound /key/generate params", plus one pointer sentence in each of the two legacy hook sections. `docs/proxy/config_settings.md` gains the `custom_key_policy` row right after `custom_key_update` in the `general_settings` table, linking to the new section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior in this PR.
> 
> **Overview**
> Adds documentation for **`general_settings.custom_key_policy`**, a unified virtual-key policy hook that runs on generate, update, and regenerate with the **effective merged key state** (including absolute `expires` from relative `duration`).
> 
> **`docs/proxy/virtual_keys.md`** gains a full section covering the `policy_request` contract (`operation`, `existing_key`, `effective_key`, `request`), the `{"decision", "message"}` / `403` behavior, covered routes (including Admin UI flows), ordering when used with `custom_key_generate` and `custom_key_update`, and a seven-day expiry example. The legacy generate/update sections and their warning now point readers to this hook as the recommended approach.
> 
> **`docs/proxy/config_settings.md`** adds a **`custom_key_policy`** row to the `general_settings` reference table, linked to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396ce5e41af1dfeecf240eac6d3b198f6d3d2f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->